### PR TITLE
Update docs for TrackLastEnqueuedEventInformation

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -105,11 +105,9 @@ namespace Azure.Messaging.EventHubs
         /// </summary>
         ///
         /// <remarks>
-        ///   This property is only populated for events received using an EventHubConsumer which was created with the
-        ///   option "TrackLastEnqueuedEventInformation" enabled.
+        ///   This property is only populated for events received using an <see cref="EventHubConsumer" /> which was created when
+        ///   <see cref="EventHubConsumerOptions.TrackLastEnqueuedEventInformation" /> is enabled.
         /// </remarks>
-        ///
-        /// <seealso cref="EventHubConsumerOptions.TrackLastEnqueuedEventInformation" />
         ///
         protected internal long? LastPartitionSequenceNumber { get; }
 
@@ -119,11 +117,9 @@ namespace Azure.Messaging.EventHubs
         /// </summary>
         ///
         /// <remarks>
-        ///   This property is only populated for events received using an EventHubConsumer which was created with the
-        ///   option "TrackLastEnqueuedEventInformation" enabled.
+        ///   This property is only populated for events received using an <see cref="EventHubConsumer" /> which was created when
+        ///   <see cref="EventHubConsumerOptions.TrackLastEnqueuedEventInformation" /> is enabled.
         /// </remarks>
-        ///
-        /// <seealso cref="EventHubConsumerOptions.TrackLastEnqueuedEventInformation" />
         ///
         protected internal long? LastPartitionOffset { get; }
 
@@ -133,11 +129,9 @@ namespace Azure.Messaging.EventHubs
         /// </summary>
         ///
         /// <remarks>
-        ///   This property is only populated for events received using an EventHubConsumer which was created with the
-        ///   option "TrackLastEnqueuedEventInformation" enabled.
+        ///   This property is only populated for events received using an <see cref="EventHubConsumer" /> which was created when
+        ///   <see cref="EventHubConsumerOptions.TrackLastEnqueuedEventInformation" /> is enabled.
         /// </remarks>
-        ///
-        /// <seealso cref="EventHubConsumerOptions.TrackLastEnqueuedEventInformation" />
         ///
         protected internal DateTimeOffset? LastPartitionEnqueuedTime { get; }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -100,13 +100,13 @@ namespace Azure.Messaging.EventHubs
         public string PartitionKey { get; }
 
         /// <summary>
-        ///   The sequence number that was last enqueued into the Event Hub partition from which this
+        ///   The sequence number of the event that was last enqueued into the Event Hub partition from which this
         ///   event was received.
         /// </summary>
         ///
         /// <remarks>
-        ///   This property is only populated for events received from the Event Hubs service and when
-        ///   partition metrics have been requested.
+        ///   This property is only populated for events received using an EventHubConsumer which was created with the
+        ///   option "TrackLastEnqueuedEventInformation" enabled.
         /// </remarks>
         ///
         /// <seealso cref="EventHubConsumerOptions.TrackLastEnqueuedEventInformation" />
@@ -114,13 +114,13 @@ namespace Azure.Messaging.EventHubs
         protected internal long? LastPartitionSequenceNumber { get; }
 
         /// <summary>
-        ///   The offset that was last enqueued into the Event Hub partition from which this event was
+        ///   The offset of the event that was last enqueued into the Event Hub partition from which this event was
         ///   received.
         /// </summary>
         ///
         /// <remarks>
-        ///   This property is only populated for events received from the Event Hubs service and when
-        ///   partition metrics have been requested.
+        ///   This property is only populated for events received using an EventHubConsumer which was created with the
+        ///   option "TrackLastEnqueuedEventInformation" enabled.
         /// </remarks>
         ///
         /// <seealso cref="EventHubConsumerOptions.TrackLastEnqueuedEventInformation" />
@@ -133,8 +133,8 @@ namespace Azure.Messaging.EventHubs
         /// </summary>
         ///
         /// <remarks>
-        ///   This property is only populated for events received from the Event Hubs service and when
-        ///   partition metrics have been requested.
+        ///   This property is only populated for events received using an EventHubConsumer which was created with the
+        ///   option "TrackLastEnqueuedEventInformation" enabled.
         /// </remarks>
         ///
         /// <seealso cref="EventHubConsumerOptions.TrackLastEnqueuedEventInformation" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumer.cs
@@ -106,15 +106,16 @@ namespace Azure.Messaging.EventHubs
         public string Identifier => Options?.Identifier;
 
         /// <summary>
-        ///   A set of information about the enqueued state of a partition, as observed by the consumer as
+        ///   A set of information about the last enqueued event of a partition, as observed by the consumer as
         ///   events are received from the Event Hubs service.
         /// </summary>
         ///
-        /// <value><c>null</c>, if the information was not requested; otherwise, the last observed set of partition metrics.</value>
+        /// <value><c>null</c>, if the information was not requested via the "TrackLastEnqueuedEventInformation" option;
+        ///  otherwise, information on the last enqueued event of a partition like sequence number, offset and enqueued time.</value>
         ///
         /// <remarks>
-        ///   When metrics are requested, each event received from the Event Hubs service will carry metadata
-        ///   about the state of a partition that it otherwise would not.  This results in a small amount of
+        ///   When information on the last enqueued information is requested to be tracked, each event received from the Event Hubs
+        ///   service will carry metadata about the state of a partition that it otherwise would not. This results in a small amount of
         ///   additional network bandwidth consumption that is generally a favorable trade-off when considered
         ///   against periodically making requests for partition properties using the Event Hub client.
         /// </remarks>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumer.cs
@@ -110,17 +110,17 @@ namespace Azure.Messaging.EventHubs
         ///   events are received from the Event Hubs service.
         /// </summary>
         ///
-        /// <value><c>null</c>, if the information was not requested via the "TrackLastEnqueuedEventInformation" option;
-        ///  otherwise, information on the last enqueued event of a partition like sequence number, offset and enqueued time.</value>
+        /// <value>
+        ///   <c>null</c>, if the information was not requested by setting <see cref="EventHubConsumerOptions.TrackLastEnqueuedEventInformation" />;
+        ///   otherwise, the properties describing the most recently enqueued event in the partition.
+        /// </value>
         ///
         /// <remarks>
-        ///   When information on the last enqueued information is requested to be tracked, each event received from the Event Hubs
-        ///   service will carry metadata about the state of a partition that it otherwise would not. This results in a small amount of
+        ///   When information about the partition's last enqueued event is being tracked, each event received from the Event Hubs
+        ///   service will carry metadata about the partition that it otherwise would not. This results in a small amount of
         ///   additional network bandwidth consumption that is generally a favorable trade-off when considered
         ///   against periodically making requests for partition properties using the Event Hub client.
         /// </remarks>
-        ///
-        /// <seealso cref="EventHubConsumerOptions.TrackLastEnqueuedEventInformation" />
         ///
         public LastEnqueuedEventProperties LastEnqueuedEventInformation => InnerConsumer.LastEnqueuedEventInformation;
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerOptions.cs
@@ -112,15 +112,15 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
-        ///   Indicates whether or not the consumer requests metrics for the state of its
+        ///   Indicates whether or not the consumer is expected to keep receive information on the last enqueued event on its
         ///   partition each time that events are received.
         /// </summary>
         ///
         /// <value><c>true</c> if metrics are requested when events are received; otherwise, <c>false</c>.</value>
         ///
         /// <remarks>
-        ///   When metrics are requested, each event received from the Event Hubs service will carry metadata
-        ///   about the state of a partition that it otherwise would not.  This results in a small amount of
+        ///   When information on the last enqueued information is requested to be tracked, each event received from the Event Hubs
+        ///   service will carry metadata about the state of a partition that it otherwise would not. This results in a small amount of
         ///   additional network bandwidth consumption that is generally a favorable trade-off when considered
         ///   against periodically making requests for partition properties using the Event Hub client.
         /// </remarks>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerOptions.cs
@@ -112,18 +112,19 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
-        ///   Indicates whether or not the consumer is expected to keep receive information on the last enqueued event on its
-        ///   partition each time that events are received.
+        ///     Indicates whether or not the consumer should request information on the last enqueued event on its
+        ///     associated partition, and track that information as events are received.
         /// </summary>
         ///
-        /// <value><c>true</c> if metrics are requested when events are received; otherwise, <c>false</c>.</value>
+        /// <value><c>true</c> if information about the partition's last event should be requested and tracked; otherwise, <c>false</c>.</value>
         ///
         /// <remarks>
-        ///   When information on the last enqueued information is requested to be tracked, each event received from the Event Hubs
-        ///   service will carry metadata about the state of a partition that it otherwise would not. This results in a small amount of
+        ///   When information about the partition's last enqueued event is being tracked, each event received from the Event Hubs
+        ///   service will carry metadata about the partition that it otherwise would not. This results in a small amount of
         ///   additional network bandwidth consumption that is generally a favorable trade-off when considered
         ///   against periodically making requests for partition properties using the Event Hub client.
         /// </remarks>
+        ///
         ///
         public bool TrackLastEnqueuedEventInformation { get; set; } = true;
 


### PR DESCRIPTION
This PR tweaks the docs around the `TrackLastEnqueuedEventInformation` feature that are needed when it got renamed to its current state