### PR TITLE
[Event Hubs Client] Track Two: Third Preview (Documentation and Changelog)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Release History
 
+## 5.0.0-preview.3 (2019-08-06)
+
+### Consuming Events
+
+- The full set of system properties was reintroduced to the `EventData` for events received from the service.  In addition to the well-known properties for identifying an event's place in the partition (`Offset`, `SequenceNumber`, and `EnqueuedTime`), any additional metadata sent as part of an event will appear in the `SystemProperties` dictionary.
+
+- The `EventHubConsumer` can be configured to track information about the last event to be enqueued into its associated partition in order to allow for monitoring the backlog of events to be processed without the need to make explicit calls to request partition properties from the `EventHubClient`.
+
+- Consuming events using `SubscribeToEvents` has been refactored for better performance and lower resource use. 
+
+### Event Processor
+
+- Creation of an `EventProcessor` has been refined with the goal of allowing simpler use for standard scenarios while maintaining flexibility for complex ones.  The `EventProcessor` is now able to manage partition processor instances for implementations with a default constructor.
+
+- The `EventProcessor` will now coordinate with other active `EventProcessor` instances for a given Event Hub and consumer group in order to share partitions and ensure that processing work is balanced between them.  `EventProcessor` instances may be activated or deactivated independently and the remaining processors will redistribute partitions as needed.
+
+- The interface for processing partitions has been changed to a base class, in order to allow developers to make the decision which of the available methods they would like to override, rather than being forced to implement each one.
+
+### General
+
+- The client library for Event Hubs is now emitting diagnostics information for distributed tracing.  _(see: [proposal](https://github.com/w3c/trace-context-amqp/blob/411fdeabea45d36db827b7097235549b30fac8e8/spec/20-AMQP_FORMAT.md))_
+
+- Some public types were scoped in a way that made them difficult to mock for library consumers.  These have been re-scoped to `protected internal` for better testability.  `EventData` and metadata types were the significant instances.
+
 ## 5.0.0-preview.2 (2019-08-06)
 
 ### General
@@ -25,13 +49,13 @@
 - Added a means to subscribe to the events exposed by an `EventHubConsumer` in the form of an asynchronous iterator.   Using the iterator, consumers are able to use the familiar `foreach` pattern to enumerate events as they are available and process them.  Optionally, consumers may specify a maximum time to wait for events to arrive which, when exceeded, will emit a null event if none were available, returning control to the loop and allowing cancellation or other processing needs.
 
 - Introduced the initial concept of a new version of the `EventProcessor`, intended as a neutral framework for processing events across all partitions for a given Event Hub and in the context of a specific Consumer Group.  This early preview is intended to allow consumers to test the new design using a single instance that does not persist checkpoints to any durable store.
-	
+
 ### Exceptions
 
 - Created an exception hierarchy that incorporates the exceptions exposed by the legacy client library, covering the same set of scenarios with minor changes to naming to better clarify the context.
 
 - Ensured that custom Event Hubs exceptions are properly translated to the new versions, no longer exposing legacy exception types.
-	
+
 ### Retries and timeouts
 
 - Removed the exposed retry policies in favor of a set of retry options based on the options found in `Azure.Core` in order to keep the API familiar.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CONTRIBUTING.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing 
+# Contributing
 
 Thank you for your interest in contributing to the Event Hubs client library.  As an open source effort, we're excited to welcome feedback and contributions from the community.  A great first step in sharing your thoughts and understanding where help is needed would be to take a look at the [open issues](https://github.com/Azure/azure-sdk-for-net/issues?q=is%3Aopen+is%3Aissue+label%3AClient+label%3A%22Event+Hubs%22).
 
@@ -33,19 +33,19 @@ The Live tests read information from the following environment variables:
 
 `EVENT_HUBS_RESOURCEGROUP`  
  The name of the Azure resource group that contains the Event Hubs namespace
-   
+
 `EVENT_HUBS_SUBSCRIPTION`  
  The identifier (GUID) of the Azure subscription to which the service principal belongs
-    
+
 `EVENT_HUBS_TENANT`  
  The identifier (GUID) of the Azure Active Directory tenant that contains the service principal
 
 `EVENT_HUBS_CLIENT`  
  The identifier (GUID) of the Azure Active Directory application that is associated with the service principal
-   
+
 `EVENT_HUBS_SECRET`  
  The client secret (password) of the Azure Active Directory application that is associated with the service principal
-   
+
 To make setting up your environment easier, a [PowerShell script](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/assets/live-tests-azure-setup.ps1) is included in the repository and will create and/or configure the needed Azure resources.  To use this script, open a PowerShell instance and login to your Azure account using `Login-AzAccount`, then execute the script.  You will need to provide some information, after which the script will configure the Azure resources and then output the set of environment variables with the correct values for running tests.
 
 The simplest way to get started is to execute the script with your subscription name and then follow the prompts:
@@ -60,7 +60,7 @@ Help for the full set of parameters and additional information is available by s
 ./live-tests-azure-setup -Help
 ```
 
-### Samples 
+### Samples
 
 In order to run the samples interactively, you'll need an Event Hubs namespace and an Event Hub with at least one partition.  Each sample will take a connection string and Event Hub name as parameters when executing, which can either be supplied directly as part of development or can be specified to the console application host in the `Samples` project, either using command line arguments or entered in response to prompts.
 


### PR DESCRIPTION
# Summary

The intent of these changes is to update documentation for the preview 3 release.

# Last Upstream Rebase

Friday, September 6, 2019 4:33pm (EDT)

# Related and Follow-Up Issues

- [[Epic] Release Event Hubs Track 2 Library Preview 3 for .Net](https://github.com/Azure/azure-sdk-for-net/issues/7141) (#7141)  
- [Review and update documentation](https://github.com/Azure/azure-sdk-for-net/issues/7183) (#7183)  