### PR TITLE
[Event Hubs Client] Track Two: Third Preview (Documentation Fixes)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 5.0.0-preview.3 (2019-08-06)
+## 5.0.0-preview.3 (2019-09-06)
 
 ### Consuming Events
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/README.md
@@ -12,7 +12,7 @@ The Azure Event Hubs client library allows for publishing and consuming of Azure
 
 - Receive events from one or more publishers, transform them to better meet the needs of your ecosystem, then publish the transformed events to a new stream for consumers to observe.
 
-[Source code](.) | [Package (NuGet)](https://www.nuget.org/packages/Azure.Messaging.EventHubs/) | [API reference documentation](https://azure.github.io/azure-sdk-for-net/api/EventHubs/Azure.Messaging.EventHubs.html) | [Product documentation](https://docs.microsoft.com/en-us/azure/event-hubs/)
+[Source code](.) | [Package (NuGet)](https://www.nuget.org/packages/Azure.Messaging.EventHubs/) | [API reference documentation](https://azure.github.io/azure-sdk-for-net/api/Azure.Messaging.EventHubs.html) | [Product documentation](https://docs.microsoft.com/en-us/azure/event-hubs/)
 
 ## Getting started
 


### PR DESCRIPTION
# Summary

The intent of these changes is to fix minor issues in the change log and read me files.

# Last Upstream Rebase

Wednesday, September 11, 2019 11:47am (EDT)

# Related and Follow-Up Issues

- [[Epic] Release Event Hubs Track 2 Library Preview 3 for .Net](https://github.com/Azure/azure-sdk-for-net/issues/7141) (#7141)  

