### PR TITLE
[DataFactory] Add alternateKeyName property to Dynamics Sink

### DIFF
--- a/eng/mgmt/mgmtmetadata/datafactory_resource-manager.txt
+++ b/eng/mgmt/mgmtmetadata/datafactory_resource-manager.txt
@@ -3,12 +3,12 @@ AutoRest installed successfully.
 Commencing code generation
 Generating CSharp code
 Executing AutoRest command
-cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/datafactory/resource-manager/readme.md --csharp --version=latest --reflect-api-versions --tag=package-2018-06 --csharp-sdks-folder=D:\dzy\azure-sdk-for-net\sdk
-2019-09-06 11:26:35 UTC
+cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/datafactory/resource-manager/readme.md --csharp --version=latest --reflect-api-versions --tag=package-2018-06 --csharp-sdks-folder=C:\Users\zhenqxu\Source\Repos\azure-sdk-for-net\sdk
+2019-09-11 09:24:33 UTC
 Azure-rest-api-specs repository information
 GitHub fork: Azure
 Branch:      master
-Commit:      b92dda5961d95de9c7beeb1df008b43a57b4a29b
+Commit:      49a38e6bc534fec5b09a245568c8f66e9d3acb2c
 AutoRest information
 Requested version: latest
 Bootstrapper version:    autorest@2.0.4283

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/CommonDataServiceForAppsSink.cs
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/CommonDataServiceForAppsSink.cs
@@ -52,10 +52,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ignore null values from input dataset (except key fields) during
         /// write operation. Default is false. Type: boolean (or Expression
         /// with resultType boolean).</param>
-        public CommonDataServiceForAppsSink(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object maxConcurrentConnections = default(object), object ignoreNullValues = default(object))
+        /// <param name="alternateKeyName">The logical name of the alternative
+        /// key which will be used when upserting records</param>
+        public CommonDataServiceForAppsSink(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object maxConcurrentConnections = default(object), object ignoreNullValues = default(object), object alternateKeyName = default(object))
             : base(additionalProperties, writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait, maxConcurrentConnections)
         {
             IgnoreNullValues = ignoreNullValues;
+            AlternateKeyName = alternateKeyName;
             CustomInit();
         }
         /// <summary>
@@ -78,6 +81,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         [JsonProperty(PropertyName = "ignoreNullValues")]
         public object IgnoreNullValues { get; set; }
+
+        /// <summary>
+        /// Gets or sets the logical name of the alternative key which will be
+        /// used when upserting records
+        /// </summary>
+        [JsonProperty(PropertyName = "alternateKeyName")]
+        public object AlternateKeyName { get; set; }
 
         /// <summary>
         /// The write behavior for the operation.

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/CommonDataServiceForAppsSink.cs
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/CommonDataServiceForAppsSink.cs
@@ -52,8 +52,9 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ignore null values from input dataset (except key fields) during
         /// write operation. Default is false. Type: boolean (or Expression
         /// with resultType boolean).</param>
-        /// <param name="alternateKeyName">The logical name of the alternative
-        /// key which will be used when upserting records</param>
+        /// <param name="alternateKeyName">The logical name of the alternate
+        /// key which will be used when upserting records. Type: string (or
+        /// Expression with resultType string).</param>
         public CommonDataServiceForAppsSink(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object maxConcurrentConnections = default(object), object ignoreNullValues = default(object), object alternateKeyName = default(object))
             : base(additionalProperties, writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait, maxConcurrentConnections)
         {
@@ -83,8 +84,9 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         public object IgnoreNullValues { get; set; }
 
         /// <summary>
-        /// Gets or sets the logical name of the alternative key which will be
-        /// used when upserting records
+        /// Gets or sets the logical name of the alternate key which will be
+        /// used when upserting records. Type: string (or Expression with
+        /// resultType string).
         /// </summary>
         [JsonProperty(PropertyName = "alternateKeyName")]
         public object AlternateKeyName { get; set; }

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/DynamicsCrmSink.cs
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/DynamicsCrmSink.cs
@@ -50,8 +50,9 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ignore null values from input dataset (except key fields) during
         /// write operation. Default is false. Type: boolean (or Expression
         /// with resultType boolean).</param>
-        /// <param name="alternateKeyName">The logical name of the alternative
-        /// key which will be used when upserting records</param>
+        /// <param name="alternateKeyName">The logical name of the alternate
+        /// key which will be used when upserting records. Type: string (or
+        /// Expression with resultType string).</param>
         public DynamicsCrmSink(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object maxConcurrentConnections = default(object), object ignoreNullValues = default(object), object alternateKeyName = default(object))
             : base(additionalProperties, writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait, maxConcurrentConnections)
         {
@@ -81,8 +82,9 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         public object IgnoreNullValues { get; set; }
 
         /// <summary>
-        /// Gets or sets the logical name of the alternative key which will be
-        /// used when upserting records
+        /// Gets or sets the logical name of the alternate key which will be
+        /// used when upserting records. Type: string (or Expression with
+        /// resultType string).
         /// </summary>
         [JsonProperty(PropertyName = "alternateKeyName")]
         public object AlternateKeyName { get; set; }

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/DynamicsCrmSink.cs
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/DynamicsCrmSink.cs
@@ -50,10 +50,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ignore null values from input dataset (except key fields) during
         /// write operation. Default is false. Type: boolean (or Expression
         /// with resultType boolean).</param>
-        public DynamicsCrmSink(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object maxConcurrentConnections = default(object), object ignoreNullValues = default(object))
+        /// <param name="alternateKeyName">The logical name of the alternative
+        /// key which will be used when upserting records</param>
+        public DynamicsCrmSink(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object maxConcurrentConnections = default(object), object ignoreNullValues = default(object), object alternateKeyName = default(object))
             : base(additionalProperties, writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait, maxConcurrentConnections)
         {
             IgnoreNullValues = ignoreNullValues;
+            AlternateKeyName = alternateKeyName;
             CustomInit();
         }
         /// <summary>
@@ -76,6 +79,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         [JsonProperty(PropertyName = "ignoreNullValues")]
         public object IgnoreNullValues { get; set; }
+
+        /// <summary>
+        /// Gets or sets the logical name of the alternative key which will be
+        /// used when upserting records
+        /// </summary>
+        [JsonProperty(PropertyName = "alternateKeyName")]
+        public object AlternateKeyName { get; set; }
 
         /// <summary>
         /// The write behavior for the operation.

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/DynamicsSink.cs
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/DynamicsSink.cs
@@ -50,10 +50,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// null values from input dataset (except key fields) during write
         /// operation. Default is false. Type: boolean (or Expression with
         /// resultType boolean).</param>
-        public DynamicsSink(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object maxConcurrentConnections = default(object), object ignoreNullValues = default(object))
+        /// <param name="alternateKeyName">The logical name of the alternative
+        /// key which will be used when upserting records</param>
+        public DynamicsSink(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object maxConcurrentConnections = default(object), object ignoreNullValues = default(object), object alternateKeyName = default(object))
             : base(additionalProperties, writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait, maxConcurrentConnections)
         {
             IgnoreNullValues = ignoreNullValues;
+            AlternateKeyName = alternateKeyName;
             CustomInit();
         }
         /// <summary>
@@ -76,6 +79,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         [JsonProperty(PropertyName = "ignoreNullValues")]
         public object IgnoreNullValues { get; set; }
+
+        /// <summary>
+        /// Gets or sets the logical name of the alternative key which will be
+        /// used when upserting records
+        /// </summary>
+        [JsonProperty(PropertyName = "alternateKeyName")]
+        public object AlternateKeyName { get; set; }
 
         /// <summary>
         /// The write behavior for the operation.

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/DynamicsSink.cs
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/DynamicsSink.cs
@@ -50,8 +50,9 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// null values from input dataset (except key fields) during write
         /// operation. Default is false. Type: boolean (or Expression with
         /// resultType boolean).</param>
-        /// <param name="alternateKeyName">The logical name of the alternative
-        /// key which will be used when upserting records</param>
+        /// <param name="alternateKeyName">The logical name of the alternate
+        /// key which will be used when upserting records. Type: string (or
+        /// Expression with resultType string).</param>
         public DynamicsSink(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object maxConcurrentConnections = default(object), object ignoreNullValues = default(object), object alternateKeyName = default(object))
             : base(additionalProperties, writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait, maxConcurrentConnections)
         {
@@ -81,8 +82,9 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         public object IgnoreNullValues { get; set; }
 
         /// <summary>
-        /// Gets or sets the logical name of the alternative key which will be
-        /// used when upserting records
+        /// Gets or sets the logical name of the alternate key which will be
+        /// used when upserting records. Type: string (or Expression with
+        /// resultType string).
         /// </summary>
         [JsonProperty(PropertyName = "alternateKeyName")]
         public object AlternateKeyName { get; set; }

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/SdkInfo_DataFactoryManagementClient.cs
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/SdkInfo_DataFactoryManagementClient.cs
@@ -39,10 +39,10 @@ namespace Microsoft.Azure.Management.DataFactory
       // BEGIN: Code Generation Metadata Section
       public static readonly String AutoRestVersion = "latest";
       public static readonly String AutoRestBootStrapperVersion = "autorest@2.0.4283";
-      public static readonly String AutoRestCmdExecuted = "cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/datafactory/resource-manager/readme.md --csharp --version=latest --reflect-api-versions --tag=package-2018-06 --csharp-sdks-folder=D:\\dzy\\azure-sdk-for-net\\sdk";
+      public static readonly String AutoRestCmdExecuted = "cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/datafactory/resource-manager/readme.md --csharp --version=latest --reflect-api-versions --tag=package-2018-06 --csharp-sdks-folder=C:\\Users\\zhenqxu\\Source\\Repos\\azure-sdk-for-net\\sdk";
       public static readonly String GithubForkName = "Azure";
       public static readonly String GithubBranchName = "master";
-      public static readonly String GithubCommidId = "b92dda5961d95de9c7beeb1df008b43a57b4a29b";
+      public static readonly String GithubCommidId = "49a38e6bc534fec5b09a245568c8f66e9d3acb2c";
       public static readonly String CodeGenerationErrors = "";
       public static readonly String GithubRepoName = "azure-rest-api-specs";
       // END: Code Generation Metadata Section

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Microsoft.Azure.Management.DataFactory.csproj
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Microsoft.Azure.Management.DataFactory.csproj
@@ -8,9 +8,11 @@
     <Version>4.1.4</Version>
     <AssemblyName>Microsoft.Azure.Management.DataFactory</AssemblyName>
     <PackageTags>Microsoft Azure resource management;Data Factory;ADF;</PackageTags>
-    <PackageReleaseNotes><![CDATA[
+    <PackageReleaseNotes>
+  <![CDATA[
 - Added outputColumns property to Office365Source
 - Added support for ORC dataset in ADF
+- Added alternateKeyName property to DynamicsSink, DynamicsCrmSink and CommonDataServiceForAppsSinkCommonDataServiceForAppsSink
             ]]></PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/changelog.md
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/changelog.md
@@ -4,6 +4,7 @@
 ###  Feature Additions
 - Added outputColumns property to Office365Source
 - Added support for ORC dataset in ADF
+- Added alternateKeyName property to DynamicsSink, DynamicsCrmSink and CommonDataServiceForAppsSinkCommonDataServiceForAppsSink
 
 ## Version 4.1.2
 ###  Feature Additions

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/tests/JsonSamples/PipelineJsonSamples.cs
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/tests/JsonSamples/PipelineJsonSamples.cs
@@ -2160,7 +2160,8 @@ namespace DataFactory.Tests.JsonSamples
                     sink: {
                         type: ""DynamicsSink"",
                         writeBehavior: ""Upsert"",
-                        ignoreNullValues: false
+                        ignoreNullValues: false,
+                        alternateKeyName: ""keyName""
                     }
                 }
             }
@@ -4564,7 +4565,8 @@ namespace DataFactory.Tests.JsonSamples
             ""type"": ""DynamicsCrmSink"",
             ""writeBehavior"": ""Upsert"",
             ""writeBatchSize"": 5000,
-            ""ignoreNullValues"": true
+            ""ignoreNullValues"": true,
+            ""alternateKeyName"": ""keyName""
           }
         },
         ""inputs"": [
@@ -4599,7 +4601,8 @@ namespace DataFactory.Tests.JsonSamples
             ""type"": ""CommonDataServiceForAppsSink"",
             ""writeBehavior"": ""Upsert"",
             ""writeBatchSize"": 5000,
-            ""ignoreNullValues"": true
+            ""ignoreNullValues"": true,
+            ""alternateKeyName"": ""keyName""
           }
         },
         ""inputs"": [


### PR DESCRIPTION
Add a new property alternateKeyName to dynamics sink, dynamicscrm sink and commondataserviceforapp sink.
[public swagger PR link](https://github.com/Azure/azure-rest-api-specs/pull/7185)