### PR TITLE
[EventHubs] Blob Partition Manager

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/samples/Azure.Messaging.EventHubs.CheckpointStore.Blob.Samples.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/samples/Azure.Messaging.EventHubs.CheckpointStore.Blob.Samples.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.0.0-preview.3" />
+    <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="System.Reflection.TypeExtensions" />
     <PackageReference Include="System.Net.WebSockets.Client" />
     <PackageReference Include="System.ValueTuple" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/samples/Azure.Messaging.EventHubs.CheckpointStore.Blob.Samples.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/samples/Azure.Messaging.EventHubs.CheckpointStore.Blob.Samples.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.0.0-preview.3" />
     <PackageReference Include="System.Reflection.TypeExtensions" />
     <PackageReference Include="System.Net.WebSockets.Client" />
     <PackageReference Include="System.ValueTuple" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/src/Azure.Messaging.EventHubs.CheckpointStore.Blob.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/src/Azure.Messaging.EventHubs.CheckpointStore.Blob.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.0.0-preview.3" />
+    <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="System.Reflection.TypeExtensions" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/src/Azure.Messaging.EventHubs.CheckpointStore.Blob.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/src/Azure.Messaging.EventHubs.CheckpointStore.Blob.csproj
@@ -28,6 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.0.0-preview.3" />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="System.Reflection.TypeExtensions" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/src/BlobMetadataKey.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/src/BlobMetadataKey.cs
@@ -4,7 +4,7 @@
 namespace Azure.Messaging.EventHubs.CheckpointStore.Blob
 {
     /// <summary>
-    ///   The set of keys to access or modify blobs' metadata.
+    ///   The set of keys to access or modify metadata for a blob.
     /// </summary>
     ///
     /// <remarks>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/src/BlobMetadataKey.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/src/BlobMetadataKey.cs
@@ -7,15 +7,20 @@ namespace Azure.Messaging.EventHubs.CheckpointStore.Blob
     ///   The set of keys to access or modify blobs' metadata.
     /// </summary>
     ///
+    /// <remarks>
+    ///   The current storage SDK throws an exception when the key contains
+    ///   an uppercase letter.
+    /// </remarks>
+    ///
     internal static class BlobMetadataKey
     {
         /// <summary>The key to the owner identifier metadata.</summary>
-        public const string OwnerIdentifier = "OwnerId";
+        public const string OwnerIdentifier = "owner_id";
 
         /// <summary>The key to the offset metadata.</summary>
-        public const string Offset = "Offset";
+        public const string Offset = "offset";
 
         /// <summary>The key to the sequence number metadata.</summary>
-        public const string SequenceNumber = "SequenceNumber";
+        public const string SequenceNumber = "sequence_number";
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/src/BlobMetadataKey.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/src/BlobMetadataKey.cs
@@ -10,12 +10,12 @@ namespace Azure.Messaging.EventHubs.CheckpointStore.Blob
     internal static class BlobMetadataKey
     {
         /// <summary>The key to the owner identifier metadata.</summary>
-        public static readonly string OwnerIdentifier = "OwnerId";
+        public const string OwnerIdentifier = "OwnerId";
 
         /// <summary>The key to the offset metadata.</summary>
-        public static readonly string Offset = "Offset";
+        public const string Offset = "Offset";
 
         /// <summary>The key to the sequence number metadata.</summary>
-        public static readonly string SequenceNumber = "SequenceNumber";
+        public const string SequenceNumber = "SequenceNumber";
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/src/BlobMetadataKey.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/src/BlobMetadataKey.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Messaging.EventHubs.CheckpointStore.Blob
+{
+    /// <summary>
+    ///   The set of keys to access or modify blobs' metadata.
+    /// </summary>
+    ///
+    internal static class BlobMetadataKey
+    {
+        /// <summary>The key to the owner identifier metadata.</summary>
+        public static readonly string OwnerIdentifier = "OwnerId";
+
+        /// <summary>The key to the offset metadata.</summary>
+        public static readonly string Offset = "Offset";
+
+        /// <summary>The key to the sequence number metadata.</summary>
+        public static readonly string SequenceNumber = "SequenceNumber";
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/src/BlobPartitionManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/src/BlobPartitionManager.cs
@@ -132,7 +132,8 @@ namespace Azure.Messaging.EventHubs.Processor
 
                 try
                 {
-                    var response = await blobClient.UploadAsync(Stream.Null, metadata: metadata, blobAccessConditions: blobAccessConditions);
+                    var emptyStream = new MemoryStream(new byte[0]);
+                    var response = await blobClient.UploadAsync(emptyStream, metadata: metadata, blobAccessConditions: blobAccessConditions);
 
                     ownership.LastModifiedTime = response.Value.LastModified;
                     ownership.ETag = response.Value.ETag.ToString();

--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/src/BlobPartitionManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/src/BlobPartitionManager.cs
@@ -63,7 +63,7 @@ namespace Azure.Messaging.EventHubs.CheckpointStore.Blob
                 Prefix = prefix
             };
 
-            await foreach (var response in ContainerClient.GetBlobsAsync(options))
+            await foreach (var response in ContainerClient.GetBlobsAsync(options).ConfigureAwait(false))
             {
                 var blob = response.Value;
 
@@ -138,7 +138,7 @@ namespace Azure.Messaging.EventHubs.CheckpointStore.Blob
 
                         try
                         {
-                            response = await blobClient.UploadAsync(new MemoryStream(new byte[0]), metadata: metadata, blobAccessConditions: blobAccessConditions);
+                            response = await blobClient.UploadAsync(new MemoryStream(new byte[0]), metadata: metadata, blobAccessConditions: blobAccessConditions).ConfigureAwait(false);
                         }
                         catch (StorageRequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.BlobAlreadyExists)
                         {
@@ -160,7 +160,7 @@ namespace Azure.Messaging.EventHubs.CheckpointStore.Blob
 
                         try
                         {
-                            response = await blobClient.SetMetadataAsync(metadata, blobAccessConditions);
+                            response = await blobClient.SetMetadataAsync(metadata, blobAccessConditions).ConfigureAwait(false);
                         }
                         catch (StorageRequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.BlobNotFound)
                         {
@@ -215,7 +215,7 @@ namespace Azure.Messaging.EventHubs.CheckpointStore.Blob
 
             try
             {
-                currentBlob = (await blobClient.GetPropertiesAsync()).Value;
+                currentBlob = (await blobClient.GetPropertiesAsync().ConfigureAwait(false)).Value;
             }
             catch (StorageRequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.BlobNotFound)
             {
@@ -242,7 +242,7 @@ namespace Azure.Messaging.EventHubs.CheckpointStore.Blob
 
                 try
                 {
-                    await blobClient.SetMetadataAsync(metadata, accessConditions);
+                    await blobClient.SetMetadataAsync(metadata, accessConditions).ConfigureAwait(false);
 
                     Log($"Checkpoint with partition id = '{ checkpoint.PartitionId }' updated.");
                 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/src/BlobPartitionManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/src/BlobPartitionManager.cs
@@ -7,12 +7,12 @@ using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Azure.Core.Http;
-using Azure.Messaging.EventHubs.CheckpointStore.Blob;
+using Azure.Messaging.EventHubs.Processor;
 using Azure.Storage;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 
-namespace Azure.Messaging.EventHubs.Processor
+namespace Azure.Messaging.EventHubs.CheckpointStore.Blob
 {
     /// <summary>
     ///   A storage blob service that keeps track of checkpoints and ownership.
@@ -36,7 +36,9 @@ namespace Azure.Messaging.EventHubs.Processor
         public BlobPartitionManager(BlobContainerClient blobContainerClient,
                                     Action<string> logger = null)
         {
-            ContainerClient = blobContainerClient;
+            // TODO: instead of manually checking the instance, make use of the Guard class once it's available.
+
+            ContainerClient = blobContainerClient ?? throw new ArgumentNullException(nameof(blobContainerClient));
             Logger = logger;
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/src/BlobPartitionManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/src/BlobPartitionManager.cs
@@ -1,0 +1,252 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Azure.Core.Http;
+using Azure.Messaging.EventHubs.CheckpointStore.Blob;
+using Azure.Storage;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+
+namespace Azure.Messaging.EventHubs.Processor
+{
+    /// <summary>
+    ///   A storage blob service that keeps track of checkpoints and ownership.
+    /// </summary>
+    ///
+    public sealed class BlobPartitionManager : PartitionManager
+    {
+        /// <summary>The client used to interact with the Azure Blob Storage service.</summary>
+        private readonly BlobContainerClient ContainerClient;
+
+        /// <summary>Logs activities performed by this partition manager.</summary>
+        private Action<string> Logger;
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="BlobPartitionManager"/> class.
+        /// </summary>
+        ///
+        /// <param name="blobContainerClient">The client used to interact with the Azure Blob Storage service.</param>
+        /// <param name="logger">Logs activities performed by this partition manager.</param>
+        ///
+        public BlobPartitionManager(BlobContainerClient blobContainerClient,
+                                    Action<string> logger = null)
+        {
+            ContainerClient = blobContainerClient;
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///   Retrieves a complete ownership list from the storage blob service.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the specific Event Hub the ownership are associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership are associated with.</param>
+        ///
+        /// <returns>An enumerable containing all the existing ownership for the associated Event Hub and consumer group.</returns>
+        ///
+        public override async Task<IEnumerable<PartitionOwnership>> ListOwnershipAsync(string eventHubName,
+                                                                                       string consumerGroup)
+        {
+            List<PartitionOwnership> ownershipList = new List<PartitionOwnership>();
+
+            var prefix = $"{ eventHubName }/{ consumerGroup }/";
+            var options = new GetBlobsOptions
+            {
+                IncludeMetadata = true,
+                Prefix = prefix
+            };
+
+            await foreach (var response in ContainerClient.GetBlobsAsync(options))
+            {
+                var blob = response.Value;
+
+                // In case this key does not exist, ownerIdentifier is set to null.  This will force the PartitionOwnership constructor
+                // to throw an exception.
+
+                blob.Metadata.TryGetValue(BlobMetadataKey.OwnerIdentifier, out var ownerIdentifier);
+
+                long? offset = null;
+                long? sequenceNumber = null;
+
+                if (blob.Metadata.TryGetValue(BlobMetadataKey.Offset, out var str) && Int64.TryParse(str, out var result))
+                {
+                    offset = result;
+                }
+
+                if (blob.Metadata.TryGetValue(BlobMetadataKey.SequenceNumber, out str) && Int64.TryParse(str, out result))
+                {
+                    sequenceNumber = result;
+                }
+
+                ownershipList.Add(new InnerPartitionOwnership(
+                    eventHubName,
+                    consumerGroup,
+                    ownerIdentifier,
+                    blob.Name.Substring(prefix.Length),
+                    offset,
+                    sequenceNumber,
+                    blob.Properties.LastModified,
+                    blob.Properties.ETag.ToString()
+                ));
+            }
+
+            return ownershipList;
+        }
+
+        /// <summary>
+        ///   Tries to claim a list of specified ownership.
+        /// </summary>
+        ///
+        /// <param name="partitionOwnership">An enumerable containing all the ownership to claim.</param>
+        ///
+        /// <returns>An enumerable containing the successfully claimed ownership.</returns>
+        ///
+        public override async Task<IEnumerable<PartitionOwnership>> ClaimOwnershipAsync(IEnumerable<PartitionOwnership> partitionOwnership)
+        {
+            var claimedOwnership = new List<PartitionOwnership>();
+            var metadata = new Dictionary<string, string>();
+
+            foreach (var ownership in partitionOwnership)
+            {
+                metadata[BlobMetadataKey.OwnerIdentifier] = ownership.OwnerIdentifier;
+                metadata[BlobMetadataKey.Offset] = ownership.Offset?.ToString() ?? String.Empty;
+                metadata[BlobMetadataKey.SequenceNumber] = ownership.SequenceNumber?.ToString() ?? String.Empty;
+
+                var blobAccessConditions = new BlobAccessConditions();
+
+                if (ownership.ETag == null)
+                {
+                    blobAccessConditions.HttpAccessConditions = new HttpAccessConditions { IfNoneMatch = new ETag("*") };
+                }
+                else
+                {
+                    blobAccessConditions.HttpAccessConditions = new HttpAccessConditions { IfMatch = new ETag(ownership.ETag) };
+                }
+
+                var blobName = $"{ ownership.EventHubName }/{ ownership.ConsumerGroup }/{ ownership.PartitionId }";
+                var blobClient = ContainerClient.GetBlobClient(blobName);
+
+                try
+                {
+                    var response = await blobClient.UploadAsync(Stream.Null, metadata: metadata, blobAccessConditions: blobAccessConditions);
+
+                    ownership.LastModifiedTime = response.Value.LastModified;
+                    ownership.ETag = response.Value.ETag.ToString();
+
+                    claimedOwnership.Add(ownership);
+
+                    Log($"Ownership with partition id = '{ownership.PartitionId}' claimed.");
+                }
+                catch (StorageRequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.ConditionNotMet)
+                {
+                    Log($"Ownership with partition id = '{ownership.PartitionId}' is not claimable.");
+                }
+            }
+
+            return claimedOwnership;
+        }
+
+        /// <summary>
+        ///   Updates the checkpoint using the given information for the associated partition and consumer group in the storage blob service.
+        /// </summary>
+        ///
+        /// <param name="checkpoint">The checkpoint containing the information to be stored.</param>
+        ///
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        ///
+        public override async Task UpdateCheckpointAsync(Checkpoint checkpoint)
+        {
+            var blobName = $"{ checkpoint.EventHubName }/{ checkpoint.ConsumerGroup }/{ checkpoint.PartitionId }";
+            var blobClient = ContainerClient.GetBlobClient(blobName);
+
+            BlobProperties currentBlob;
+
+            try
+            {
+                currentBlob = (await blobClient.GetPropertiesAsync()).Value;
+            }
+            catch (StorageRequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.BlobNotFound)
+            {
+                Log($"Checkpoint with partition id = '{checkpoint.PartitionId}' could not be updated because no associated ownership was found.");
+                return;
+            }
+
+            // In case this key does not exist, ownerIdentifier is set to null.  The OwnerIdentifier in Checkpoint cannot
+            // be null as well, so we won't be able to update the associated ownership.
+
+            currentBlob.Metadata.TryGetValue(BlobMetadataKey.OwnerIdentifier, out var ownerIdentifier);
+
+            if (ownerIdentifier == checkpoint.OwnerIdentifier)
+            {
+                var metadata = new Dictionary<string, string>()
+                {
+                    { BlobMetadataKey.OwnerIdentifier, checkpoint.OwnerIdentifier },
+                    { BlobMetadataKey.Offset, checkpoint.Offset.ToString() },
+                    { BlobMetadataKey.SequenceNumber, checkpoint.SequenceNumber.ToString() }
+                };
+
+                var accessConditions = new BlobAccessConditions();
+                accessConditions.HttpAccessConditions = new HttpAccessConditions { IfMatch = currentBlob.ETag };
+
+                try
+                {
+                    await blobClient.SetMetadataAsync(metadata, accessConditions);
+
+                    Log($"Checkpoint with partition id = '{checkpoint.PartitionId}' updated.");
+                }
+                catch(StorageRequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.ConditionNotMet)
+                {
+                    Log($"Checkpoint with partition id = '{checkpoint.PartitionId}' could not be updated because eTag has changed.");
+                }
+            }
+            else
+            {
+                Log($"Checkpoint with partition id = '{checkpoint.PartitionId}' could not be updated because owner has changed.");
+            }
+        }
+
+        /// <summary>
+        ///   Sends a log message to the current logger, if provided by the user.
+        /// </summary>
+        ///
+        /// <param name="message">The log message to send.</param>
+        ///
+        private void Log(string message) => Logger?.Invoke(message);
+
+        /// <summary>
+        ///   A workaround so we can create <see cref="PartitionOwnership"/> instances.
+        ///   This class can be removed once the following issue has been closed: https://github.com/Azure/azure-sdk-for-net/issues/7585
+        /// </summary>
+        ///
+        private class InnerPartitionOwnership : PartitionOwnership
+        {
+            /// <summary>
+            ///   Initializes a new instance of the <see cref="InnerPartitionOwnership"/> class.
+            /// </summary>
+            ///
+            /// <param name="eventHubName">The name of the specific Event Hub this partition ownership is associated with, relative to the Event Hubs namespace that contains it.</param>
+            /// <param name="consumerGroup">The name of the consumer group this partition ownership is associated with.</param>
+            /// <param name="ownerIdentifier">The identifier of the associated <see cref="EventProcessor{T}" /> instance.</param>
+            /// <param name="partitionId">The identifier of the Event Hub partition this partition ownership is associated with.</param>
+            /// <param name="offset">The offset of the last <see cref="EventData" /> received by the associated partition processor.</param>
+            /// <param name="sequenceNumber">The sequence number of the last <see cref="EventData" /> received by the associated partition processor.</param>
+            /// <param name="lastModifiedTime">The date and time, in UTC, that the last update was made to this ownership.</param>
+            /// <param name="eTag">The entity tag needed to update this ownership.</param>
+            ///
+            public InnerPartitionOwnership(string eventHubName,
+                                           string consumerGroup,
+                                           string ownerIdentifier,
+                                           string partitionId,
+                                           long? offset = null,
+                                           long? sequenceNumber = null,
+                                           DateTimeOffset? lastModifiedTime = null,
+                                           string eTag = null) : base(eventHubName, consumerGroup, ownerIdentifier, partitionId, offset, sequenceNumber, lastModifiedTime, eTag)
+            {
+            }
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/tests/BlobPartitionManager/BlobPartitionManagerLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/tests/BlobPartitionManager/BlobPartitionManagerLiveTests.cs
@@ -858,7 +858,7 @@ namespace Azure.Messaging.EventHubs.CheckpointStore.Blob.Tests
         }
 
         /// <summary>
-        ///   A workaround so we can create <see cref="Checkpoint"/> instances.
+        ///   A workaround so we can create <see cref="Checkpoint" /> instances.
         /// </summary>
         ///
         private class MockCheckpoint : Checkpoint

--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/tests/BlobPartitionManager/BlobPartitionManagerLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/tests/BlobPartitionManager/BlobPartitionManagerLiveTests.cs
@@ -1,0 +1,702 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.CheckpointStore.Blob.Tests.Infrastructure;
+using Azure.Messaging.EventHubs.Processor;
+using Azure.Storage.Blobs;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.CheckpointStore.Blob.Tests
+{
+    /// <summary>
+    ///   The suite of live tests for the <see cref="BlobPartitionManager" />
+    ///   class.
+    /// </summary>
+    ///
+    /// <remarks>
+    ///   These tests have a dependency on live Azure services and may
+    ///   incur costs for the associated Azure subscription.
+    /// </remarks>
+    ///
+    [TestFixture]
+    //[Category(TestCategory.Live)]
+    //[Category(TestCategory.DisallowVisualStudioLiveUnitTesting)]
+    public class BlobPartitionManagerLiveTests
+    {
+        /// <summary>
+        ///    Verifies functionality of the <see cref="BlobPartitionManager.ListOwnershipAsync" />
+        ///    method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ListOwnershipAsyncReturnsEmptyIEnumerableWhenThereAreNoOwnership()
+        {
+            await using (var storageScope = await StorageScope.CreateAsync())
+            {
+                var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
+                var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
+
+                var partitionManager = new BlobPartitionManager(containerClient);
+                var ownership = await partitionManager.ListOwnershipAsync("eventHubName", "consumerGroup");
+
+                Assert.That(ownership, Is.Not.Null.And.Empty);
+            }
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="BlobPartitionManager.ClaimOwnershipAsync" />
+        ///    method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task FirstOwnershipClaimSucceeds()
+        {
+            await using (var storageScope = await StorageScope.CreateAsync())
+            {
+                var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
+                var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
+
+                var partitionManager = new BlobPartitionManager(containerClient);
+                var ownershipList = new List<PartitionOwnership>();
+                var ownership =
+                    new MockPartitionOwnership
+                    (
+                        "eventHubName",
+                        "consumerGroup",
+                        "ownerIdentifier",
+                        "partitionId"
+                    );
+
+                ownershipList.Add(ownership);
+
+                await partitionManager.ClaimOwnershipAsync(ownershipList);
+
+                var storedOwnership = await partitionManager.ListOwnershipAsync("eventHubName", "consumerGroup");
+
+                Assert.That(storedOwnership, Is.Not.Null);
+                Assert.That(storedOwnership.Count, Is.EqualTo(1));
+                Assert.That(storedOwnership.Single(), Is.EqualTo(ownership));
+            }
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="BlobPartitionManager.ClaimOwnershipAsync" />
+        ///    method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("invalidETag")]
+        public async Task OwnershipClaimFailsWhenETagIsInvalid(string eTag)
+        {
+            await using (var storageScope = await StorageScope.CreateAsync())
+            {
+                var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
+                var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
+
+                var partitionManager = new BlobPartitionManager(containerClient);
+                var ownershipList = new List<PartitionOwnership>();
+                var firstOwnership =
+                    new MockPartitionOwnership
+                    (
+                        "eventHubName",
+                        "consumerGroup",
+                        "ownerIdentifier",
+                        "partitionId",
+                        offset: 1
+                    );
+
+                ownershipList.Add(firstOwnership);
+
+                await partitionManager.ClaimOwnershipAsync(ownershipList);
+
+                ownershipList.Clear();
+
+                var secondOwnership =
+                    new MockPartitionOwnership
+                    (
+                        "eventHubName",
+                        "consumerGroup",
+                        "ownerIdentifier",
+                        "partitionId",
+                        offset: 2,
+                        eTag: eTag
+                    );
+
+                ownershipList.Add(secondOwnership);
+
+                await partitionManager.ClaimOwnershipAsync(ownershipList);
+
+                var storedOwnership = await partitionManager.ListOwnershipAsync("eventHubName", "consumerGroup");
+
+                Assert.That(storedOwnership, Is.Not.Null);
+                Assert.That(storedOwnership.Count, Is.EqualTo(1));
+                Assert.That(storedOwnership.Single(), Is.EqualTo(firstOwnership));
+            }
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="BlobPartitionManager.ClaimOwnershipAsync" />
+        ///    method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task OwnershipClaimSucceedsWhenETagIsValid()
+        {
+            await using (var storageScope = await StorageScope.CreateAsync())
+            {
+                var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
+                var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
+
+                var partitionManager = new BlobPartitionManager(containerClient);
+                var ownershipList = new List<PartitionOwnership>();
+                var firstOwnership =
+                    new MockPartitionOwnership
+                    (
+                        "eventHubName",
+                        "consumerGroup",
+                        "ownerIdentifier",
+                        "partitionId",
+                        offset: 1
+                    );
+
+                ownershipList.Add(firstOwnership);
+
+                await partitionManager.ClaimOwnershipAsync(ownershipList);
+
+                // ETag must have been set by the partition manager.
+
+                var eTag = firstOwnership.ETag;
+
+                ownershipList.Clear();
+
+                var secondOwnership =
+                    new MockPartitionOwnership
+                    (
+                        "eventHubName",
+                        "consumerGroup",
+                        "ownerIdentifier",
+                        "partitionId",
+                        offset: 2,
+                        eTag: eTag
+                    );
+
+                ownershipList.Add(secondOwnership);
+
+                await partitionManager.ClaimOwnershipAsync(ownershipList);
+
+                var storedOwnership = await partitionManager.ListOwnershipAsync("eventHubName", "consumerGroup");
+
+                Assert.That(storedOwnership, Is.Not.Null);
+                Assert.That(storedOwnership.Count, Is.EqualTo(1));
+                Assert.That(storedOwnership.Single(), Is.EqualTo(secondOwnership));
+            }
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="BlobPartitionManager.ClaimOwnershipAsync" />
+        ///    method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ClaimOwnershipAsyncCanClaimMultipleOwnership()
+        {
+            await using (var storageScope = await StorageScope.CreateAsync())
+            {
+                var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
+                var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
+
+                var partitionManager = new BlobPartitionManager(containerClient);
+                var ownershipList = new List<PartitionOwnership>();
+                var ownershipCount = 5;
+
+                for (int i = 0; i < ownershipCount; i++)
+                {
+                    ownershipList.Add(
+                        new MockPartitionOwnership
+                        (
+                            "eventHubName",
+                            "consumerGroup",
+                            "ownerIdentifier",
+                            $"partitionId { i }"
+                        ));
+                }
+
+                await partitionManager.ClaimOwnershipAsync(ownershipList);
+
+                var storedOwnership = await partitionManager.ListOwnershipAsync("eventHubName", "consumerGroup");
+
+                Assert.That(storedOwnership, Is.Not.Null);
+                Assert.That(storedOwnership.Count, Is.EqualTo(ownershipCount));
+                Assert.That(storedOwnership.OrderBy(ownership => ownership.PartitionId).SequenceEqual(ownershipList), Is.True);
+            }
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="BlobPartitionManager.ClaimOwnershipAsync" />
+        ///    method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ClaimOwnershipAsyncReturnsOnlyTheSuccessfullyClaimedOwnership()
+        {
+            await using (var storageScope = await StorageScope.CreateAsync())
+            {
+                var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
+                var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
+
+                var partitionManager = new BlobPartitionManager(containerClient);
+                var ownershipList = new List<PartitionOwnership>();
+                var ownershipCount = 5;
+
+                for (int i = 0; i < ownershipCount; i++)
+                {
+                    ownershipList.Add(
+                        new MockPartitionOwnership
+                        (
+                            "eventHubName",
+                            "consumerGroup",
+                            "ownerIdentifier",
+                            $"partitionId { i }"
+                        ));
+                }
+
+                await partitionManager.ClaimOwnershipAsync(ownershipList);
+
+                // The ETags must have been set by the partition manager.
+
+                var eTags = ownershipList.Select(ownership => ownership.ETag).ToList();
+
+                ownershipList.Clear();
+
+                // Use a valid eTag when 'i' is odd.  This way, we can expect 'ownershipCount / 2' successful
+                // claims (rounded down).
+
+                var expectedClaimedCount = ownershipCount / 2;
+
+                for (int i = 0; i < ownershipCount; i++)
+                {
+                    ownershipList.Add(
+                        new MockPartitionOwnership
+                        (
+                            "eventHubName",
+                            "consumerGroup",
+                            "ownerIdentifier",
+                            $"partitionId { i }",
+                            offset: i,
+                            eTag: i % 2 == 1 ? eTags[i] : null
+                        ));
+                }
+
+                var claimedOwnership = await partitionManager.ClaimOwnershipAsync(ownershipList);
+
+                Assert.That(claimedOwnership, Is.Not.Null);
+                Assert.That(claimedOwnership.Count, Is.EqualTo(expectedClaimedCount));
+                Assert.That(claimedOwnership.OrderBy(ownership => ownership.Offset).SequenceEqual(ownershipList.Where(ownership => ownership.Offset % 2 == 1)), Is.True);
+            }
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="BlobPartitionManager.ClaimOwnershipAsync" />
+        ///    method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task OwnershipClaimDoesNotInterfereWithOtherConsumerGroups()
+        {
+            await using (var storageScope = await StorageScope.CreateAsync())
+            {
+                var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
+                var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
+
+                var partitionManager = new BlobPartitionManager(containerClient);
+                var ownershipList = new List<PartitionOwnership>();
+                var firstOwnership =
+                    new MockPartitionOwnership
+                    (
+                        "eventHubName",
+                        "consumerGroup1",
+                        "ownerIdentifier",
+                        "partitionId"
+                    );
+
+                ownershipList.Add(firstOwnership);
+
+                await partitionManager.ClaimOwnershipAsync(ownershipList);
+
+                // ETag must have been set by the partition manager.
+
+                var eTag = firstOwnership.ETag;
+
+                ownershipList.Clear();
+
+                var secondOwnership =
+                    new MockPartitionOwnership
+                    (
+                        "eventHubName",
+                        "consumerGroup2",
+                        "ownerIdentifier",
+                        "partitionId",
+                        eTag: eTag
+                    );
+
+                ownershipList.Add(secondOwnership);
+
+                await partitionManager.ClaimOwnershipAsync(ownershipList);
+
+                var storedOwnership1 = await partitionManager.ListOwnershipAsync("eventHubName", "consumerGroup1");
+                var storedOwnership2 = await partitionManager.ListOwnershipAsync("eventHubName", "consumerGroup2");
+
+                Assert.That(storedOwnership1, Is.Not.Null);
+                Assert.That(storedOwnership1.Count, Is.EqualTo(1));
+                Assert.That(storedOwnership1.Single(), Is.EqualTo(firstOwnership));
+
+                Assert.That(storedOwnership2, Is.Not.Null);
+                Assert.That(storedOwnership2.Count, Is.EqualTo(1));
+                Assert.That(storedOwnership2.Single(), Is.EqualTo(secondOwnership));
+            }
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="BlobPartitionManager.ClaimOwnershipAsync" />
+        ///    method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task OwnershipClaimDoesNotInterfereWithOtherEventHubs()
+        {
+            await using (var storageScope = await StorageScope.CreateAsync())
+            {
+                var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
+                var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
+
+                var partitionManager = new BlobPartitionManager(containerClient);
+                var ownershipList = new List<PartitionOwnership>();
+                var firstOwnership =
+                    new MockPartitionOwnership
+                    (
+                        "eventHubName1",
+                        "consumerGroup",
+                        "ownerIdentifier",
+                        "partitionId"
+                    );
+
+                ownershipList.Add(firstOwnership);
+
+                await partitionManager.ClaimOwnershipAsync(ownershipList);
+
+                // ETag must have been set by the partition manager.
+
+                var eTag = firstOwnership.ETag;
+
+                ownershipList.Clear();
+
+                var secondOwnership =
+                    new MockPartitionOwnership
+                    (
+                        "eventHubName2",
+                        "consumerGroup",
+                        "ownerIdentifier",
+                        "partitionId",
+                        eTag: eTag
+                    );
+
+                ownershipList.Add(secondOwnership);
+
+                await partitionManager.ClaimOwnershipAsync(ownershipList);
+
+                var storedOwnership1 = await partitionManager.ListOwnershipAsync("eventHubName1", "consumerGroup");
+                var storedOwnership2 = await partitionManager.ListOwnershipAsync("eventHubName2", "consumerGroup");
+
+                Assert.That(storedOwnership1, Is.Not.Null);
+                Assert.That(storedOwnership1.Count, Is.EqualTo(1));
+                Assert.That(storedOwnership1.Single(), Is.EqualTo(firstOwnership));
+
+                Assert.That(storedOwnership2, Is.Not.Null);
+                Assert.That(storedOwnership2.Count, Is.EqualTo(1));
+                Assert.That(storedOwnership2.Single(), Is.EqualTo(secondOwnership));
+            }
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="BlobPartitionManager.UpdateCheckpointAsync" />
+        ///    method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CheckpointUpdateFailsWhenAssociatedOwnershipDoesNotExist()
+        {
+            await using (var storageScope = await StorageScope.CreateAsync())
+            {
+                var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
+                var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
+
+                var partitionManager = new BlobPartitionManager(containerClient);
+
+                await partitionManager.UpdateCheckpointAsync(new MockCheckpoint
+                    ("eventHubName", "consumerGroup", "ownerIdentifier", "partitionId", offset: 10, sequenceNumber: 20));
+
+                var storedOwnership = await partitionManager.ListOwnershipAsync("eventHubName", "consumerGroup");
+
+                Assert.That(storedOwnership, Is.Not.Null);
+                Assert.That(storedOwnership, Is.Empty);
+            }
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="BlobPartitionManager.UpdateCheckpointAsync" />
+        ///    method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CheckpointUpdateFailsWhenOwnerChanges()
+        {
+            await using (var storageScope = await StorageScope.CreateAsync())
+            {
+                var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
+                var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
+
+                var partitionManager = new BlobPartitionManager(containerClient);
+                var originalOwnership = new MockPartitionOwnership
+                    ("eventHubName", "consumerGroup", "ownerIdentifier1", "partitionId", offset: 1, sequenceNumber: 2, lastModifiedTime: DateTimeOffset.UtcNow);
+
+                await partitionManager.ClaimOwnershipAsync(new List<PartitionOwnership>()
+                {
+                    originalOwnership
+                });
+
+                // ETag must have been set by the partition manager.
+
+                var originalLastModifiedTime = originalOwnership.LastModifiedTime;
+                var originalETag = originalOwnership.ETag;
+
+                await partitionManager.UpdateCheckpointAsync(new MockCheckpoint
+                    ("eventHubName", "consumerGroup", "ownerIdentifier2", "partitionId", 10, 20));
+
+                // Make sure the ownership hasn't changed.
+
+                var storedOwnership = await partitionManager.ListOwnershipAsync("eventHubName", "consumerGroup");
+
+                Assert.That(storedOwnership, Is.Not.Null);
+                Assert.That(storedOwnership.Count, Is.EqualTo(1));
+                Assert.That(storedOwnership.Single(), Is.EqualTo(originalOwnership));
+
+                Assert.That(originalOwnership.OwnerIdentifier, Is.EqualTo("ownerIdentifier1"));
+                Assert.That(originalOwnership.Offset, Is.EqualTo(1));
+                Assert.That(originalOwnership.SequenceNumber, Is.EqualTo(2));
+                Assert.That(originalOwnership.LastModifiedTime, Is.EqualTo(originalLastModifiedTime));
+                Assert.That(originalOwnership.ETag, Is.EqualTo(originalETag));
+            }
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="BlobPartitionManager.UpdateCheckpointAsync" />
+        ///    method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CheckpointUpdateUpdatesOwnershipInformation()
+        {
+            await using (var storageScope = await StorageScope.CreateAsync())
+            {
+                var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
+                var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
+
+                var partitionManager = new BlobPartitionManager(containerClient);
+                var originalOwnership = new MockPartitionOwnership
+                    ("eventHubName", "consumerGroup", "ownerIdentifier", "partitionId", offset: 1, sequenceNumber: 2, lastModifiedTime: DateTimeOffset.UtcNow.Subtract(TimeSpan.FromMinutes(1)));
+
+                await partitionManager.ClaimOwnershipAsync(new List<PartitionOwnership>()
+                {
+                    originalOwnership
+                });
+
+                // ETag must have been set by the partition manager.
+
+                var originalLastModifiedTime = originalOwnership.LastModifiedTime;
+                var originalETag = originalOwnership.ETag;
+
+                await partitionManager.UpdateCheckpointAsync(new MockCheckpoint
+                    ("eventHubName", "consumerGroup", "ownerIdentifier", "partitionId", 10, 20));
+
+                // Make sure the ownership has changed, even though the instance should be the same.
+
+                var storedOwnership = await partitionManager.ListOwnershipAsync("eventHubName", "consumerGroup");
+
+                Assert.That(storedOwnership, Is.Not.Null);
+                Assert.That(storedOwnership.Count, Is.EqualTo(1));
+                Assert.That(storedOwnership.Single(), Is.EqualTo(originalOwnership));
+
+                Assert.That(originalOwnership.Offset, Is.EqualTo(10));
+                Assert.That(originalOwnership.SequenceNumber, Is.EqualTo(20));
+                Assert.That(originalOwnership.LastModifiedTime, Is.GreaterThan(originalLastModifiedTime));
+                Assert.That(originalOwnership.ETag, Is.Not.EqualTo(originalETag));
+            }
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="BlobPartitionManager.UpdateCheckpointAsync" />
+        ///    method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CheckpointUpdateDoesNotInterfereWithOtherConsumerGroups()
+        {
+            await using (var storageScope = await StorageScope.CreateAsync())
+            {
+                var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
+                var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
+
+                var partitionManager = new BlobPartitionManager(containerClient);
+
+                var ownership1 = new MockPartitionOwnership
+                    ("eventHubName", "consumerGroup1", "ownerIdentifier", "partitionId", offset: 1);
+                var ownership2 = new MockPartitionOwnership
+                    ("eventHubName", "consumerGroup2", "ownerIdentifier", "partitionId", offset: 1);
+
+                await partitionManager.ClaimOwnershipAsync(new List<PartitionOwnership>()
+                {
+                    ownership1,
+                    ownership2
+                });
+
+                await partitionManager.UpdateCheckpointAsync(new MockCheckpoint
+                    ("eventHubName", "consumerGroup1", "ownerIdentifier", "partitionId", 10, 20));
+
+                Assert.That(ownership1.Offset, Is.EqualTo(10));
+                Assert.That(ownership2.Offset, Is.EqualTo(1));
+            }
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="BlobPartitionManager.UpdateCheckpointAsync" />
+        ///    method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CheckpointUpdateDoesNotInterfereWithOtherEventHubs()
+        {
+            await using (var storageScope = await StorageScope.CreateAsync())
+            {
+                var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
+                var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
+
+                var partitionManager = new BlobPartitionManager(containerClient);
+
+                var ownership1 = new MockPartitionOwnership
+                    ("eventHubName1", "consumerGroup", "ownerIdentifier", "partitionId", offset: 1);
+                var ownership2 = new MockPartitionOwnership
+                    ("eventHubName2", "consumerGroup", "ownerIdentifier", "partitionId", offset: 1);
+
+                await partitionManager.ClaimOwnershipAsync(new List<PartitionOwnership>()
+                {
+                    ownership1,
+                    ownership2
+                });
+
+                await partitionManager.UpdateCheckpointAsync(new MockCheckpoint
+                    ("eventHubName1", "consumerGroup", "ownerIdentifier", "partitionId", 10, 20));
+
+                Assert.That(ownership1.Offset, Is.EqualTo(10));
+                Assert.That(ownership2.Offset, Is.EqualTo(1));
+            }
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="BlobPartitionManager.UpdateCheckpointAsync" />
+        ///    method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CheckpointUpdateDoesNotInterfereWithOtherPartitions()
+        {
+            await using (var storageScope = await StorageScope.CreateAsync())
+            {
+                var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
+                var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
+
+                var partitionManager = new BlobPartitionManager(containerClient);
+
+                var ownership1 = new MockPartitionOwnership
+                    ("eventHubName", "consumerGroup", "ownerIdentifier", "partitionId1", offset: 1);
+                var ownership2 = new MockPartitionOwnership
+                    ("eventHubName", "consumerGroup", "ownerIdentifier", "partitionId2", offset: 1);
+
+                await partitionManager.ClaimOwnershipAsync(new List<PartitionOwnership>()
+                {
+                    ownership1,
+                    ownership2
+                });
+
+                await partitionManager.UpdateCheckpointAsync(new MockCheckpoint
+                    ("eventHubName", "consumerGroup", "ownerIdentifier", "partitionId1", 10, 20));
+
+                Assert.That(ownership1.Offset, Is.EqualTo(10));
+                Assert.That(ownership2.Offset, Is.EqualTo(1));
+            }
+        }
+
+        /// <summary>
+        ///   A workaround so we can create <see cref="PartitionOwnership"/> instances.
+        ///   This class can be removed once the following issue has been closed: https://github.com/Azure/azure-sdk-for-net/issues/7585
+        /// </summary>
+        ///
+        private class MockPartitionOwnership : PartitionOwnership
+        {
+            /// <summary>
+            ///   Initializes a new instance of the <see cref="MockPartitionOwnership"/> class.
+            /// </summary>
+            ///
+            /// <param name="eventHubName">The name of the specific Event Hub this partition ownership is associated with, relative to the Event Hubs namespace that contains it.</param>
+            /// <param name="consumerGroup">The name of the consumer group this partition ownership is associated with.</param>
+            /// <param name="ownerIdentifier">The identifier of the associated <see cref="EventProcessor{T}" /> instance.</param>
+            /// <param name="partitionId">The identifier of the Event Hub partition this partition ownership is associated with.</param>
+            /// <param name="offset">The offset of the last <see cref="EventData" /> received by the associated partition processor.</param>
+            /// <param name="sequenceNumber">The sequence number of the last <see cref="EventData" /> received by the associated partition processor.</param>
+            /// <param name="lastModifiedTime">The date and time, in UTC, that the last update was made to this ownership.</param>
+            /// <param name="eTag">The entity tag needed to update this ownership.</param>
+            ///
+            public MockPartitionOwnership(string eventHubName,
+                                          string consumerGroup,
+                                          string ownerIdentifier,
+                                          string partitionId,
+                                          long? offset = null,
+                                          long? sequenceNumber = null,
+                                          DateTimeOffset? lastModifiedTime = null,
+                                          string eTag = null) : base(eventHubName, consumerGroup, ownerIdentifier, partitionId, offset, sequenceNumber, lastModifiedTime, eTag)
+            {
+            }
+        }
+
+        /// <summary>
+        ///   A workaround so we can create <see cref="Checkpoint"/> instances.
+        /// </summary>
+        ///
+        private class MockCheckpoint : Checkpoint
+        {
+            /// <summary>
+            ///   Initializes a new instance of the <see cref="MockPartitionOwnership"/> class.
+            /// </summary>
+            ///
+            /// <param name="eventHubName">The name of the specific Event Hub this partition ownership is associated with, relative to the Event Hubs namespace that contains it.</param>
+            /// <param name="consumerGroup">The name of the consumer group this partition ownership is associated with.</param>
+            /// <param name="ownerIdentifier">The identifier of the associated <see cref="EventProcessor{T}" /> instance.</param>
+            /// <param name="partitionId">The identifier of the Event Hub partition this partition ownership is associated with.</param>
+            /// <param name="offset">The offset of the last <see cref="EventData" /> received by the associated partition processor.</param>
+            /// <param name="sequenceNumber">The sequence number of the last <see cref="EventData" /> received by the associated partition processor.</param>
+            ///
+            public MockCheckpoint(string eventHubName,
+                                  string consumerGroup,
+                                  string ownerIdentifier,
+                                  string partitionId,
+                                  long offset,
+                                  long sequenceNumber) : base(eventHubName, consumerGroup, ownerIdentifier, partitionId, offset, sequenceNumber)
+            {
+            }
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/tests/BlobPartitionManager/BlobPartitionManagerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/tests/BlobPartitionManager/BlobPartitionManagerTests.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.CheckpointStore.Blob.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="BlobPartitionManager" />
+    ///   class.
+    /// </summary>
+    ///
+    public class BlobPartitionManagerTests
+    {
+        /// <summary>
+        ///    Verifies functionality of the <see cref="BlobPartitionManager" />
+        ///    constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorValidatesTheBlobContainerClient()
+        {
+            Assert.That(() => new BlobPartitionManager(null), Throws.InstanceOf<ArgumentException>());
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/tests/BlobPartitionManager/BlobPartitionManagerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/tests/BlobPartitionManager/BlobPartitionManagerTests.cs
@@ -19,7 +19,7 @@ namespace Azure.Messaging.EventHubs.CheckpointStore.Blob.Tests
         /// </summary>
         ///
         [Test]
-        public void ConstructorValidatesTheBlobContainerClient()
+        public void ConstructorRequiresBlobContainerClient()
         {
             Assert.That(() => new BlobPartitionManager(null), Throws.InstanceOf<ArgumentException>());
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/tests/Infrastructure/PartitionOwnershipExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/tests/Infrastructure/PartitionOwnershipExtensions.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Messaging.EventHubs.Processor;
+
+namespace Azure.Messaging.EventHubs.CheckpointStore.Blob.Tests
+{
+    /// <summary>
+    ///   The set of extension methods for the <see cref="PartitionOwnership" />
+    ///   class.
+    /// </summary>
+    ///
+    internal static class PartitionOwnershipExtensions
+    {
+        /// <summary>
+        ///   Compares ownership information between two instances to determine if the
+        ///   instances represent the same ownership.
+        /// </summary>
+        ///
+        /// <param name="instance">The instance that this method was invoked on.</param>
+        /// <param name="other">The other partition ownership to consider.</param>
+        ///
+        /// <returns><c>true</c>, if the two ownership are structurally equivalent; otherwise, <c>false</c>.</returns>
+        ///
+        public static bool IsEquivalentTo(this PartitionOwnership instance,
+                                          PartitionOwnership other)
+        {
+            // If the ownership are the same instance, they're equal.  This should only happen
+            // if both are null or they are the exact same instance.
+
+            if (Object.ReferenceEquals(instance, other))
+            {
+                return true;
+            }
+
+            // If one or the other is null, then they cannot be equal, since we know that
+            // they are not both null.
+
+            if ((instance == null) || (other == null))
+            {
+                return false;
+            }
+
+            // If the contents of each attribute are equal, the instances are
+            // equal.
+
+            return
+            (
+                instance.EventHubName == other.EventHubName
+                && instance.ConsumerGroup == other.ConsumerGroup
+                && instance.OwnerIdentifier == other.OwnerIdentifier
+                && instance.PartitionId == other.PartitionId
+                && instance.Offset == other.Offset
+                && instance.SequenceNumber == other.SequenceNumber
+                && instance.LastModifiedTime == other.LastModifiedTime
+                && instance.ETag == other.ETag
+            );
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/tests/Infrastructure/PartitionOwnershipExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/tests/Infrastructure/PartitionOwnershipExtensionsTests.cs
@@ -1,0 +1,257 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Azure.Messaging.EventHubs.Processor;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.CheckpointStore.Blob.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="PartitionOwnershipExtensions" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class EventPositionExtensionsTests
+    {
+        /// <summary>
+        ///   Provides test cases for the equality tests.
+        /// </summary>
+        ///
+        public static IEnumerable<object[]> IsEquivalentToDetectsEqualEventPositionsCases()
+        {
+            var date = DateTimeOffset.Parse("1975-04-04T00:00:00Z");
+
+            yield return new object[] { EventPosition.Earliest, EventPosition.Earliest };
+            yield return new object[] { EventPosition.Latest, EventPosition.Latest };
+            yield return new object[] { EventPosition.FromOffset(1975), EventPosition.FromOffset(1975) };
+            yield return new object[] { EventPosition.FromSequenceNumber(42), EventPosition.FromSequenceNumber(42) };
+            yield return new object[] { EventPosition.FromEnqueuedTime(date), EventPosition.FromEnqueuedTime(date) };
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionOwnershipExtensions.IsEquivalentTo" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEquivalentToDetectsEventHubName()
+        {
+            var first = new MockPartitionOwnership("eventHubName1", "consumerGroup", "ownerIdentifier", "partitionId");
+            var second = new MockPartitionOwnership("eventHubName2", "consumerGroup", "ownerIdentifier", "partitionId");
+
+            Assert.That(first.IsEquivalentTo(second), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionOwnershipExtensions.IsEquivalentTo" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEquivalentToDetectsConsumerGroup()
+        {
+            var first = new MockPartitionOwnership("eventHubName", "consumerGroup1", "ownerIdentifier", "partitionId");
+            var second = new MockPartitionOwnership("eventHubName", "consumerGroup2", "ownerIdentifier", "partitionId");
+
+            Assert.That(first.IsEquivalentTo(second), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionOwnershipExtensions.IsEquivalentTo" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEquivalentToDetectsOwnerIdentifier()
+        {
+            var first = new MockPartitionOwnership("eventHubName", "consumerGroup", "ownerIdentifier1", "partitionId");
+            var second = new MockPartitionOwnership("eventHubName", "consumerGroup", "ownerIdentifier2", "partitionId");
+
+            Assert.That(first.IsEquivalentTo(second), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionOwnershipExtensions.IsEquivalentTo" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEquivalentToDetectsPartitionId()
+        {
+            var first = new MockPartitionOwnership("eventHubName", "consumerGroup", "ownerIdentifier", "partitionId1");
+            var second = new MockPartitionOwnership("eventHubName", "consumerGroup", "ownerIdentifier", "partitionId2");
+
+            Assert.That(first.IsEquivalentTo(second), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionOwnershipExtensions.IsEquivalentTo" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(10, 20)]
+        [TestCase(10, null)]
+        public void IsEquivalentToDetectsOffset(long? offset1, long? offset2)
+        {
+            var first = new MockPartitionOwnership("eventHubName", "consumerGroup", "ownerIdentifier", "partitionId", offset: offset1);
+            var second = new MockPartitionOwnership("eventHubName", "consumerGroup", "ownerIdentifier", "partitionId", offset: offset2);
+
+            Assert.That(first.IsEquivalentTo(second), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionOwnershipExtensions.IsEquivalentTo" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(10, 20)]
+        [TestCase(10, null)]
+        public void IsEquivalentToDetectsSequenceNumber(long? sequenceNumber1, long? sequenceNumber2)
+        {
+            var first = new MockPartitionOwnership("eventHubName", "consumerGroup", "ownerIdentifier", "partitionId", sequenceNumber: sequenceNumber1);
+            var second = new MockPartitionOwnership("eventHubName", "consumerGroup", "ownerIdentifier", "partitionId", sequenceNumber: sequenceNumber2);
+
+            Assert.That(first.IsEquivalentTo(second), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionOwnershipExtensions.IsEquivalentTo" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEquivalentToDetectsLastModifiedTime()
+        {
+            var first = new MockPartitionOwnership("eventHubName", "consumerGroup", "ownerIdentifier", "partitionId", lastModifiedTime: DateTimeOffset.Parse("1975-04-04T00:00:00Z"));
+            var second = new MockPartitionOwnership("eventHubName", "consumerGroup", "ownerIdentifier", "partitionId", lastModifiedTime: DateTimeOffset.Parse("1975-04-04T01:00:00Z"));
+
+            Assert.That(first.IsEquivalentTo(second), Is.False);
+
+            var third = new MockPartitionOwnership("eventHubName", "consumerGroup", "ownerIdentifier", "partitionId", lastModifiedTime: null);
+
+            Assert.That(first.IsEquivalentTo(third), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionOwnershipExtensions.IsEquivalentTo" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEquivalentToDetectsETag()
+        {
+            var first = new MockPartitionOwnership("eventHubName", "consumerGroup", "ownerIdentifier", "partitionId", eTag: "eTag1");
+            var second = new MockPartitionOwnership("eventHubName", "consumerGroup", "ownerIdentifier", "partitionId", eTag: "eTag2");
+
+            Assert.That(first.IsEquivalentTo(second), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionOwnershipExtensions.IsEquivalentTo" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEquivalentToDetectsEqualPartitionOwnership()
+        {
+            var first = new MockPartitionOwnership("eventHubName", "consumerGroup", "ownerIdentifier", "partitionId", 10, 20, DateTimeOffset.Parse("1975-04-04T00:00:00Z"), "eTag");
+            var second = new MockPartitionOwnership("eventHubName", "consumerGroup", "ownerIdentifier", "partitionId", 10, 20, DateTimeOffset.Parse("1975-04-04T00:00:00Z"), "eTag");
+
+            Assert.That(first.IsEquivalentTo(second), Is.True);
+
+            // Set the optional parameters to null.
+
+            first = new MockPartitionOwnership("eventHubName", "consumerGroup", "ownerIdentifier", "partitionId");
+            second = new MockPartitionOwnership("eventHubName", "consumerGroup", "ownerIdentifier", "partitionId");
+
+            Assert.That(first.IsEquivalentTo(second), Is.True);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionOwnershipExtensions.IsEquivalentTo" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEquivalentToDetectsSameInstance()
+        {
+            var first = new MockPartitionOwnership("eventHubName", "consumerGroup", "ownerIdentifier", "partitionId");
+
+            Assert.That(first.IsEquivalentTo(first), Is.True);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionOwnershipExtensions.IsEquivalentTo" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEquivalentToDetectsTwoNulls()
+        {
+            Assert.That(((PartitionOwnership)null).IsEquivalentTo(null), Is.True);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionOwnershipExtensions.IsEquivalentTo" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEquivalentToDetectsNullInstance()
+        {
+            var first = new MockPartitionOwnership("eventHubName", "consumerGroup", "ownerIdentifier", "partitionId");
+
+            Assert.That(((PartitionOwnership)null).IsEquivalentTo(first), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionOwnershipExtensions.IsEquivalentTo" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEquivalentToDetectsNullArgument()
+        {
+            var first = new MockPartitionOwnership("eventHubName", "consumerGroup", "ownerIdentifier", "partitionId");
+
+            Assert.That(first.IsEquivalentTo(null), Is.False);
+        }
+
+        /// <summary>
+        ///   A workaround so we can create <see cref="PartitionOwnership"/> instances.
+        ///   This class can be removed once the following issue has been closed: https://github.com/Azure/azure-sdk-for-net/issues/7585
+        /// </summary>
+        ///
+        private class MockPartitionOwnership : PartitionOwnership
+        {
+            /// <summary>
+            ///   Initializes a new instance of the <see cref="MockPartitionOwnership"/> class.
+            /// </summary>
+            ///
+            /// <param name="eventHubName">The name of the specific Event Hub this partition ownership is associated with, relative to the Event Hubs namespace that contains it.</param>
+            /// <param name="consumerGroup">The name of the consumer group this partition ownership is associated with.</param>
+            /// <param name="ownerIdentifier">The identifier of the associated <see cref="EventProcessor{T}" /> instance.</param>
+            /// <param name="partitionId">The identifier of the Event Hub partition this partition ownership is associated with.</param>
+            /// <param name="offset">The offset of the last <see cref="EventData" /> received by the associated partition processor.</param>
+            /// <param name="sequenceNumber">The sequence number of the last <see cref="EventData" /> received by the associated partition processor.</param>
+            /// <param name="lastModifiedTime">The date and time, in UTC, that the last update was made to this ownership.</param>
+            /// <param name="eTag">The entity tag needed to update this ownership.</param>
+            ///
+            public MockPartitionOwnership(string eventHubName,
+                                          string consumerGroup,
+                                          string ownerIdentifier,
+                                          string partitionId,
+                                          long? offset = null,
+                                          long? sequenceNumber = null,
+                                          DateTimeOffset? lastModifiedTime = null,
+                                          string eTag = null) : base(eventHubName, consumerGroup, ownerIdentifier, partitionId, offset, sequenceNumber, lastModifiedTime, eTag)
+            {
+            }
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/InMemoryPartitionManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/InMemoryPartitionManager.cs
@@ -62,7 +62,7 @@ namespace Azure.Messaging.EventHubs.Processor
         }
 
         /// <summary>
-        ///   Tries to claim a list of specified ownership.
+        ///   Attempts to claim ownership of partitions for processing.
         /// </summary>
         ///
         /// <param name="partitionOwnership">An enumerable containing all the ownership to claim.</param>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/PartitionManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/PartitionManager.cs
@@ -31,7 +31,7 @@ namespace Azure.Messaging.EventHubs.Processor
                                                                                  string consumerGroup);
 
         /// <summary>
-        ///   Tries to claim a list of specified ownership.
+        ///   Attempts to claim ownership of partitions for processing.
         /// </summary>
         ///
         /// <param name="partitionOwnership">An enumerable containing all the ownership to claim.</param>


### PR DESCRIPTION
These changes include:

- `BlobPartitionManager` class: an implementation of `PartitionManager` that makes use of a `BlobContainerClient` to communicate with the Azure Storage service. It manages the partition ownership used by `EventProcessor` instances.

- `BlobPartitionManager` tests: most of them are live and were imported from the `InMemoryPartitionManager` ones. Some changes needed to be done and a few tests were added.

Related future action items:

 - `PartitionOwnership` derived classes (3 in total) should be removed from the code once #7585 is solved.

- Update the `BlobPartitionManager` constructor once the `Guard` class is available in the project.