### PR TITLE
[Event Hubs Blob Checkpoint Store] Release Preparation

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/Directory.Build.props
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/Directory.Build.props
@@ -32,7 +32,7 @@
     <!-- Disable the custom analyzer; it is currently in development and based against draft standards. -->
     <EnableClientSdkAnalyzers>false</EnableClientSdkAnalyzers>
 
-    <!-- If there was no override specified, assume a project reference to Azure.Messaging.EventHubs -->
-    <UseProjectReferenceToAzureEventHubs Condition="'$(UseProjectReferenceToAzureEventHubs)' == ''">true</UseProjectReferenceToAzureEventHubs>
+    <!-- If there was no override specified, set the type of reference to use for Azure.Messaging.EventHubs -->
+    <UseProjectReferenceToAzureEventHubs Condition="'$(UseProjectReferenceToAzureEventHubs)' == ''">false</UseProjectReferenceToAzureEventHubs>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
# Summary

The intent of these changes is to prepare for the release of the blobs checkpoint store by setting its reference to the main Event Hubs client library package, rather than the project referenced used for local development.

# Last Upstream Rebase

Saturday, September 14, 2019 5:38am (EDT)

# Related and Follow-Up Issues

- [[Epic] Release Event Hubs Track 2 Library Preview 3 for .Net](https://github.com/Azure/azure-sdk-for-net/issues/7141) (#7141)  