### PR TITLE
Support reading from secondary storage on retries

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClientOptions.cs
@@ -3,7 +3,6 @@
 // license information.
 
 using System;
-using Azure.Core;
 using Azure.Core.Pipeline;
 using Azure.Storage.Blobs.Models;
 
@@ -66,6 +65,38 @@ namespace Azure.Storage.Blobs
             Version = version;
             CustomerProvidedKey = customerProvidedKey;
             this.Initialize();
+        }
+
+        /// <summary>
+        /// Gets or sets the secondary storage <see cref="Uri"/> that can be read from for the storage account if the
+        /// account is enabled for RA-GRS.
+        /// 
+        /// If this property is set, the secondary Uri will be used for GET or HEAD requests during retries.
+        /// If the status of the response from the secondary Uri is a 404, then subsequent retries for 
+        /// the request will not use the secondary Uri again, as this indicates that the resource
+        /// may not have propagated there yet. Otherwise, subsequent retries will alternate back and forth
+        /// between primary and secondary Uri.
+        /// </summary>
+        public Uri GeoRedundantSecondaryUri { get; set; }
+
+        /// <summary>
+        /// Create an HttpPipeline from BlobClientOptions.
+        /// </summary>
+        /// <param name="authentication">Optional authentication policy.</param>
+        /// <returns>An HttpPipeline to use for Storage requests.</returns>
+        internal HttpPipeline Build(HttpPipelinePolicy authentication = null)
+        {
+            return this.Build(authentication, this.GeoRedundantSecondaryUri);
+        }
+
+        /// <summary>
+        /// Create an HttpPipeline from BlobClientOptions.
+        /// </summary>
+        /// <param name="credentials">Optional authentication credentials.</param>
+        /// <returns>An HttpPipeline to use for Storage requests.</returns>
+        internal HttpPipeline Build(object credentials)
+        {
+           return this.Build(credentials, this.GeoRedundantSecondaryUri);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClientOptions.cs
@@ -86,7 +86,7 @@ namespace Azure.Storage.Blobs
         /// <returns>An HttpPipeline to use for Storage requests.</returns>
         internal HttpPipeline Build(HttpPipelinePolicy authentication = null)
         {
-            return this.Build(authentication, this.GeoRedundantSecondaryUri);
+            return this.Build(authentication, GeoRedundantSecondaryUri);
         }
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace Azure.Storage.Blobs
         /// <returns>An HttpPipeline to use for Storage requests.</returns>
         internal HttpPipeline Build(object credentials)
         {
-           return this.Build(credentials, this.GeoRedundantSecondaryUri);
+           return this.Build(credentials, GeoRedundantSecondaryUri);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -108,9 +108,9 @@ namespace Azure.Storage.Blobs
         {
             var conn = StorageConnectionString.Parse(connectionString);
             var builder = new BlobUriBuilder(conn.BlobEndpoint) { ContainerName = containerName };
-            this._uri = builder.Uri;
+            _uri = builder.Uri;
             options ??= new BlobClientOptions();
-            this._pipeline = options.Build(conn.Credentials);
+            _pipeline = options.Build(conn.Credentials);
         }
 
         /// <summary>
@@ -173,9 +173,9 @@ namespace Azure.Storage.Blobs
         /// </param>
         internal BlobContainerClient(Uri containerUri, HttpPipelinePolicy authentication, BlobClientOptions options)
         {
-            this._uri = containerUri;
+            _uri = containerUri;
             options ??= new BlobClientOptions();
-            this._pipeline = options.Build(authentication);
+            _pipeline = options.Build(authentication);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -108,8 +108,9 @@ namespace Azure.Storage.Blobs
         {
             var conn = StorageConnectionString.Parse(connectionString);
             var builder = new BlobUriBuilder(conn.BlobEndpoint) { ContainerName = containerName };
-            _uri = builder.Uri;
-            _pipeline = (options ?? new BlobClientOptions()).Build(conn.Credentials);
+            this._uri = builder.Uri;
+            options ??= new BlobClientOptions();
+            this._pipeline = options.Build(conn.Credentials);
         }
 
         /// <summary>
@@ -172,8 +173,9 @@ namespace Azure.Storage.Blobs
         /// </param>
         internal BlobContainerClient(Uri containerUri, HttpPipelinePolicy authentication, BlobClientOptions options)
         {
-            _uri = containerUri;
-            _pipeline = (options ?? new BlobClientOptions()).Build(authentication);
+            this._uri = containerUri;
+            options ??= new BlobClientOptions();
+            this._pipeline = options.Build(authentication);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
@@ -89,9 +89,9 @@ namespace Azure.Storage.Blobs
         public BlobServiceClient(string connectionString, BlobClientOptions options)
         {
             var conn = StorageConnectionString.Parse(connectionString);
-            this._uri = conn.BlobEndpoint;
+            _uri = conn.BlobEndpoint;
             options ??= new BlobClientOptions();
-            this._pipeline = options.Build(conn.Credentials);
+            _pipeline = options.Build(conn.Credentials);
         }
 
         /// <summary>
@@ -168,9 +168,9 @@ namespace Azure.Storage.Blobs
         /// </param>
         internal BlobServiceClient(Uri serviceUri, HttpPipelinePolicy authentication, BlobClientOptions options)
         {
-            this._uri = serviceUri;
+            _uri = serviceUri;
             options ??= new BlobClientOptions();
-            this._pipeline = options.Build(authentication);
+            _pipeline = options.Build(authentication);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
@@ -89,8 +89,9 @@ namespace Azure.Storage.Blobs
         public BlobServiceClient(string connectionString, BlobClientOptions options)
         {
             var conn = StorageConnectionString.Parse(connectionString);
-            _uri = conn.BlobEndpoint;
-            _pipeline = (options ?? new BlobClientOptions()).Build(conn.Credentials);
+            this._uri = conn.BlobEndpoint;
+            options ??= new BlobClientOptions();
+            this._pipeline = options.Build(conn.Credentials);
         }
 
         /// <summary>
@@ -167,8 +168,9 @@ namespace Azure.Storage.Blobs
         /// </param>
         internal BlobServiceClient(Uri serviceUri, HttpPipelinePolicy authentication, BlobClientOptions options)
         {
-            _uri = serviceUri;
-            _pipeline = (options ?? new BlobClientOptions()).Build(authentication);
+            this._uri = serviceUri;
+            options ??= new BlobClientOptions();
+            this._pipeline = options.Build(authentication);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
@@ -39,9 +39,9 @@ namespace Azure.Storage.Blobs.Test
             var containerName = GetNewContainerName();
             var blobName = GetNewBlobName();
 
-            var blob1 = this.InstrumentClient(new BlobClient(connectionString.ToString(true), containerName, blobName, this.GetOptions()));
+            BlobClient blob1 = InstrumentClient(new BlobClient(connectionString.ToString(true), containerName, blobName, GetOptions()));
 
-            var blob2 = this.InstrumentClient(new BlobClient(connectionString.ToString(true), containerName, blobName));
+            BlobClient blob2 = InstrumentClient(new BlobClient(connectionString.ToString(true), containerName, blobName));
 
             var builder1 = new BlobUriBuilder(blob1.Uri);
             var builder2 = new BlobUriBuilder(blob2.Uri);

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
@@ -39,13 +39,20 @@ namespace Azure.Storage.Blobs.Test
             var containerName = GetNewContainerName();
             var blobName = GetNewBlobName();
 
-            BlobClient blob = InstrumentClient(new BlobClient(connectionString.ToString(true), containerName, blobName, GetOptions()));
+            var blob1 = this.InstrumentClient(new BlobClient(connectionString.ToString(true), containerName, blobName, this.GetOptions()));
 
-            var builder = new BlobUriBuilder(blob.Uri);
+            var blob2 = this.InstrumentClient(new BlobClient(connectionString.ToString(true), containerName, blobName));
 
-            Assert.AreEqual(containerName, builder.ContainerName);
-            Assert.AreEqual(blobName, builder.BlobName);
-            Assert.AreEqual("accountName", builder.AccountName);
+            var builder1 = new BlobUriBuilder(blob1.Uri);
+            var builder2 = new BlobUriBuilder(blob2.Uri);
+
+            Assert.AreEqual(containerName, builder1.ContainerName);
+            Assert.AreEqual(blobName, builder1.BlobName);
+            Assert.AreEqual("accountName", builder1.AccountName);
+
+            Assert.AreEqual(containerName, builder2.ContainerName);
+            Assert.AreEqual(blobName, builder2.BlobName);
+            Assert.AreEqual("accountName", builder2.AccountName);
         }
 
         #region Upload

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -80,13 +80,13 @@ namespace Azure.Storage.Test.Shared
                 new BlobServiceClient(
                     new Uri(config.BlobServiceEndpoint),
                     new StorageSharedKeyCredential(config.AccountName, config.AccountKey),
-                    this.GetOptions()));
+                    GetOptions()));
         
              
         private BlobServiceClient GetSecondaryReadServiceClient(TenantConfiguration config, int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
         {
-            var options = this.GetSecondaryStorageOptions(config, out testExceptionPolicy, numberOfReadFailuresToSimulate, simulate404, enabledRequestMethods);
-            return this.InstrumentClient(
+            BlobClientOptions options = GetSecondaryStorageOptions(config, out testExceptionPolicy, numberOfReadFailuresToSimulate, simulate404, enabledRequestMethods);
+            return InstrumentClient(
                  new BlobServiceClient(
                     new Uri(config.BlobServiceEndpoint),
                     new StorageSharedKeyCredential(config.AccountName, config.AccountKey),
@@ -95,8 +95,8 @@ namespace Azure.Storage.Test.Shared
 
         private BlobBaseClient GetSecondaryReadBlobBaseClient(TenantConfiguration config, int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
         {
-            var options = this.GetSecondaryStorageOptions(config, out testExceptionPolicy, numberOfReadFailuresToSimulate, simulate404, enabledRequestMethods);
-            return this.InstrumentClient(
+            BlobClientOptions options = GetSecondaryStorageOptions(config, out testExceptionPolicy, numberOfReadFailuresToSimulate, simulate404, enabledRequestMethods);
+            return InstrumentClient(
                  new BlobBaseClient(
                     new Uri(config.BlobServiceEndpoint),
                     new StorageSharedKeyCredential(config.AccountName, config.AccountKey),
@@ -105,10 +105,10 @@ namespace Azure.Storage.Test.Shared
 
         private BlobContainerClient GetSecondaryReadBlobContainerClient(TenantConfiguration config, int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
         {
-            var options = this.GetSecondaryStorageOptions(config, out testExceptionPolicy, numberOfReadFailuresToSimulate, simulate404, enabledRequestMethods);
+            BlobClientOptions options = GetSecondaryStorageOptions(config, out testExceptionPolicy, numberOfReadFailuresToSimulate, simulate404, enabledRequestMethods);
             Uri uri = new Uri(config.BlobServiceEndpoint);
-            string containerName = this.GetNewContainerName();
-            return this.InstrumentClient(
+            string containerName = GetNewContainerName();
+            return InstrumentClient(
                  new BlobContainerClient(
                     uri.AppendToPath(containerName),
                     new StorageSharedKeyCredential(config.AccountName, config.AccountKey),
@@ -122,7 +122,7 @@ namespace Azure.Storage.Test.Shared
             bool simulate404 = false,
             List<RequestMethod> trackedRequestMethods = null)
         {
-            var options = this.GetOptions();
+            BlobClientOptions options = GetOptions();
             options.GeoRedundantSecondaryUri = new Uri(config.BlobServiceSecondaryEndpoint);
             options.Retry.MaxRetries = 4;
             testExceptionPolicy = new TestExceptionPolicy(numberOfReadFailuresToSimulate, options.GeoRedundantSecondaryUri, simulate404, trackedRequestMethods);
@@ -141,13 +141,13 @@ namespace Azure.Storage.Test.Shared
             => GetServiceClientFromSharedKeyConfig(TestConfigDefault);
 
         public BlobServiceClient GetServiceClient_SecondaryAccount_ReadEnabledOnRetry(int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
-            => this.GetSecondaryReadServiceClient(this.TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404, enabledRequestMethods);
+            => GetSecondaryReadServiceClient(TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404, enabledRequestMethods);
 
         public BlobBaseClient GetBlobBaseClient_SecondaryAccount_ReadEnabledOnRetry(int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
-    => this.GetSecondaryReadBlobBaseClient(this.TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404, enabledRequestMethods);
+    => GetSecondaryReadBlobBaseClient(TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404, enabledRequestMethods);
 
         public BlobContainerClient GetBlobContainerClient_SecondaryAccount_ReadEnabledOnRetry(int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
-    => this.GetSecondaryReadBlobContainerClient(this.TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404, enabledRequestMethods);
+    => GetSecondaryReadBlobContainerClient(TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404, enabledRequestMethods);
         
         public BlobServiceClient GetServiceClient_SecondaryAccount_SharedKey()
             => GetServiceClientFromSharedKeyConfig(TestConfigSecondary);

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -12,7 +12,7 @@ using Azure.Core.Testing;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
-using Azure.Storage.Common;
+using Azure.Storage.Common.Test;
 using Azure.Storage.Sas;
 
 namespace Azure.Storage.Test.Shared
@@ -23,6 +23,12 @@ namespace Azure.Storage.Test.Shared
         public readonly string GarbageETag = "\"garbage\"";
         public readonly string ReceivedLeaseId = "received";
 
+        protected string SecondaryStorageTenantPrimaryHost() =>
+            new Uri(TestConfigSecondary.BlobServiceEndpoint).Host;
+
+        protected string SecondaryStorageTenantSecondaryHost() =>
+            new Uri(TestConfigSecondary.BlobServiceSecondaryEndpoint).Host;
+                
         public BlobTestBase(bool async) : this(async, null) { }
 
         public BlobTestBase(bool async, RecordedTestMode? mode = null)
@@ -74,7 +80,55 @@ namespace Azure.Storage.Test.Shared
                 new BlobServiceClient(
                     new Uri(config.BlobServiceEndpoint),
                     new StorageSharedKeyCredential(config.AccountName, config.AccountKey),
-                    GetOptions()));
+                    this.GetOptions()));
+        
+             
+        private BlobServiceClient GetSecondaryReadServiceClient(TenantConfiguration config, int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
+        {
+            var options = this.GetSecondaryStorageOptions(config, out testExceptionPolicy, numberOfReadFailuresToSimulate, simulate404, enabledRequestMethods);
+            return this.InstrumentClient(
+                 new BlobServiceClient(
+                    new Uri(config.BlobServiceEndpoint),
+                    new StorageSharedKeyCredential(config.AccountName, config.AccountKey),
+                    options));
+        }
+
+        private BlobBaseClient GetSecondaryReadBlobBaseClient(TenantConfiguration config, int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
+        {
+            var options = this.GetSecondaryStorageOptions(config, out testExceptionPolicy, numberOfReadFailuresToSimulate, simulate404, enabledRequestMethods);
+            return this.InstrumentClient(
+                 new BlobBaseClient(
+                    new Uri(config.BlobServiceEndpoint),
+                    new StorageSharedKeyCredential(config.AccountName, config.AccountKey),
+                    options));
+        }
+
+        private BlobContainerClient GetSecondaryReadBlobContainerClient(TenantConfiguration config, int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
+        {
+            var options = this.GetSecondaryStorageOptions(config, out testExceptionPolicy, numberOfReadFailuresToSimulate, simulate404, enabledRequestMethods);
+            Uri uri = new Uri(config.BlobServiceEndpoint);
+            string containerName = this.GetNewContainerName();
+            return this.InstrumentClient(
+                 new BlobContainerClient(
+                    uri.AppendToPath(containerName),
+                    new StorageSharedKeyCredential(config.AccountName, config.AccountKey),
+                    options));
+        }
+
+        private BlobClientOptions GetSecondaryStorageOptions(
+            TenantConfiguration config,
+            out TestExceptionPolicy testExceptionPolicy,
+            int numberOfReadFailuresToSimulate = 1,
+            bool simulate404 = false,
+            List<RequestMethod> trackedRequestMethods = null)
+        {
+            var options = this.GetOptions();
+            options.GeoRedundantSecondaryUri = new Uri(config.BlobServiceSecondaryEndpoint);
+            options.Retry.MaxRetries = 4;
+            testExceptionPolicy = new TestExceptionPolicy(numberOfReadFailuresToSimulate, options.GeoRedundantSecondaryUri, simulate404, trackedRequestMethods);
+            options.AddPolicy(testExceptionPolicy, HttpPipelinePosition.PerRetry);
+            return options;
+        }
 
         private BlobServiceClient GetServiceClientFromOauthConfig(TenantConfiguration config) =>
             InstrumentClient(
@@ -86,6 +140,15 @@ namespace Azure.Storage.Test.Shared
         public BlobServiceClient GetServiceClient_SharedKey()
             => GetServiceClientFromSharedKeyConfig(TestConfigDefault);
 
+        public BlobServiceClient GetServiceClient_SecondaryAccount_ReadEnabledOnRetry(int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
+            => this.GetSecondaryReadServiceClient(this.TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404, enabledRequestMethods);
+
+        public BlobBaseClient GetBlobBaseClient_SecondaryAccount_ReadEnabledOnRetry(int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
+    => this.GetSecondaryReadBlobBaseClient(this.TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404, enabledRequestMethods);
+
+        public BlobContainerClient GetBlobContainerClient_SecondaryAccount_ReadEnabledOnRetry(int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
+    => this.GetSecondaryReadBlobContainerClient(this.TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404, enabledRequestMethods);
+        
         public BlobServiceClient GetServiceClient_SecondaryAccount_SharedKey()
             => GetServiceClientFromSharedKeyConfig(TestConfigSecondary);
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/Ctor_ConnectionString.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/Ctor_ConnectionString.json
@@ -1,6 +1,6 @@
 {
   "Entries": [],
   "Variables": {
-    "RandomSeed": "662610179"
+    "RandomSeed": "1318859060"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/Ctor_ConnectionStringAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/Ctor_ConnectionStringAsync.json
@@ -1,6 +1,6 @@
 {
   "Entries": [],
   "Variables": {
-    "RandomSeed": "1712196240"
+    "RandomSeed": "1007865767"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/Ctor_Uri.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/Ctor_Uri.json
@@ -1,0 +1,4 @@
+{
+  "Entries": [],
+  "Variables": {}
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/Ctor_UriAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/Ctor_UriAsync.json
@@ -1,0 +1,4 @@
+{
+  "Entries": [],
+  "Variables": {}
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/DownloadAsync_ReadFromSecondaryStorage.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/DownloadAsync_ReadFromSecondaryStorage.json
@@ -1,0 +1,190 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-203f76d2-014b-04b6-2ccc-d883dfc63254?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-641c0ec715d0694a876c25c3674cd522-989ac896fafbc248-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "3f3261f7-067b-91d6-3eb7-bcfe10f45010",
+        "x-ms-date": "Wed, 18 Sep 2019 19:49:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:49:12 GMT",
+        "ETag": "\u00220x8D73C7147A6DF7C\u0022",
+        "Last-Modified": "Wed, 18 Sep 2019 19:49:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "3f3261f7-067b-91d6-3eb7-bcfe10f45010",
+        "x-ms-request-id": "bb785089-c01e-0097-605a-6e1b03000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-203f76d2-014b-04b6-2ccc-d883dfc63254\u002ftest-blob-1fce4d18-7d21-9b3e-8598-de07170e7e2a",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "traceparent": "00-e8c7b3441e2e9f4f9e1432c33698e5c6-5557b2e004c20e4b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "9942673f-9f80-e0da-1599-21474b32acbc",
+        "x-ms-date": "Wed, 18 Sep 2019 19:49:12 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "CX0INkyldSwP\u002bpAPx0vWnEaIi32U8tiXt5V5OOlpNJvrKWCwh08DUusFMIB2xsny4SC3h2jSexakcH63Kz1Cpsb0I57rJRX2hDmRjsJXIfHLh1fJsawzGa1JDBbQSyauw4m6gaIrB7sKwAMvQOxTTE6N7KTmefQawQrxoRn\u002bJjgT48s5naBOoH\u002bbvvCpA9jA9b\u002fHQ1\u002bByEqVn8CXOWahDJrKHF0hGq6uPkskSroDcb0yMKtZNuLYkRqBo\u002f7ftmYZ\u002brJW3ud7n9sRGQQUXH2PkS4CZQm6R9W38YpCn3ewzoflC1AIrZLWt5DQSB3exDWc8hLP3VFcXrLdnu1cOABkYEt9LlEthuObK6546v\u002b32SxVpa1k4PA2iK2dKw\u002bkeX6QbOfSYZbkb2svNLGj43OzJcTBB5JS\u002f39aRqajj1vT9rEv6H4X5XiWcTZBNaw\u002fk6Q56gVK43LrPWxoeBrvQN8QWz3\u002fc\u002fv0nEBMKpZcEcrTG7MBaqVViRI\u002fRKoSrm1epjBXMdluPx\u002bpRE7F\u002frjbjyyhlFxm7tU5utIqwC9R4u3T7oRlBODxZNyUWCVWkItZY7R9cBoQ\u002bLdaHXYHQ37wV2Jh8hA0dotMsDCA0paw4ilG0Fx603HSwvXMCuZp6SBdowDC9Z57Je0pMcDpjyYhqjpNwHIhdYTxji8aaGuk48cPIy6W7e2Ly6tvUaKw6TLPq2CrGyitOy180WZuYL2ChE352Wz3i7xNwvTHsiThQKX8SrwK\u002bMeeYucAGRyHHGvu7cxUtw\u002fF2CCjXlkz5okJmpDBchYAd4uGWneF9nGgxaaJ2MVXjYmVN3KcZppuante93\u002bLxapU7nVBzlyXQOGuApizqg3Dsg0HKzqkZBDxF\u002fD7Jv\u002fyFQD8NOpQFr4s\u002ffaQ7WQBu8BumkVxg5pvsIpkT7ZsnBnivO2YtnUjc5xO2y1EE3as8FwwjYy5gJFmjYNg68YIv2HcrTF2aARKSyepI6hsKp0Tt15ZPA6NKDtbMinywofVRRvLZ2VFNYdY5UJkEF3p\u002bWLmTDRnr4NTT4T1GzbaWIif092NoMM3zoHXAFbLKBjecTjHC3VTbZaXeBfgTxpRfo26xTyAXFmern6ykK4tiCZsF6r9EkwTTGZG9SirVn5nhYHIEWPbXRXfKF32odzoau\u002fxdDhvU2xBpnjWOmcx81j\u002fSgosZHfCkbmVHunuHKqKXYo4uuJG9zIVhmrqBSOtrjUF91bRvAV4LuN\u002b2jSCUorOS9zc\u002bDh1uVLYFt4M14uW53Cz6SRTuKGFv4v\u002byB3\u002bkzTfHLlH0bX8jz4E\u002baUna1ZX6PPDzmllepM6Vzmtd\u002fA12YOqLbvRTxW7t1rmT7\u002f8XVM0p\u002bApOsTKeaImDHp8Tw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "iJUt\u002bnpUUE5DvduoraoEbA==",
+        "Date": "Wed, 18 Sep 2019 19:49:12 GMT",
+        "ETag": "\u00220x8D73C7147C1292F\u0022",
+        "Last-Modified": "Wed, 18 Sep 2019 19:49:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "9942673f-9f80-e0da-1599-21474b32acbc",
+        "x-ms-content-crc64": "mFrWzVD3BoM=",
+        "x-ms-request-id": "bb7850c7-c01e-0097-115a-6e1b03000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002ftest-container-203f76d2-014b-04b6-2ccc-d883dfc63254\u002ftest-blob-1fce4d18-7d21-9b3e-8598-de07170e7e2a",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-198daf00d5e4d4498b7269a0c3382072-8ffb18211dcd1f4e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "b0c84255-e5cc-34aa-6418-d0deaec9c06c",
+        "x-ms-date": "Wed, 18 Sep 2019 19:49:12 GMT",
+        "x-ms-range": "bytes=0-",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "225",
+        "Content-Type": "application\u002fxml",
+        "Date": "Wed, 18 Sep 2019 19:49:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "b0c84255-e5cc-34aa-6418-d0deaec9c06c",
+        "x-ms-error-code": "ContainerNotFound",
+        "x-ms-request-id": "98595139-101e-000c-435a-6edcf1000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": [
+        "\ufeff\u003c?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003e\u003cError\u003e\u003cCode\u003eContainerNotFound\u003c\u002fCode\u003e\u003cMessage\u003eThe specified container does not exist.\n",
+        "RequestId:98595139-101e-000c-435a-6edcf1000000\n",
+        "Time:2019-09-18T19:49:13.6633403Z\u003c\u002fMessage\u003e\u003c\u002fError\u003e"
+      ]
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-203f76d2-014b-04b6-2ccc-d883dfc63254\u002ftest-blob-1fce4d18-7d21-9b3e-8598-de07170e7e2a",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-198daf00d5e4d4498b7269a0c3382072-8ffb18211dcd1f4e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "b0c84255-e5cc-34aa-6418-d0deaec9c06c",
+        "x-ms-date": "Wed, 18 Sep 2019 19:49:12 GMT",
+        "x-ms-range": "bytes=0-",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023\u002f1024",
+        "Content-Type": "application\u002foctet-stream",
+        "Date": "Wed, 18 Sep 2019 19:49:14 GMT",
+        "ETag": "\u00220x8D73C7147C1292F\u0022",
+        "Last-Modified": "Wed, 18 Sep 2019 19:49:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-blob-content-md5": "iJUt\u002bnpUUE5DvduoraoEbA==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "b0c84255-e5cc-34aa-6418-d0deaec9c06c",
+        "x-ms-creation-time": "Wed, 18 Sep 2019 19:49:12 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "bb7852b7-c01e-0097-5c5a-6e1b03000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-tag-count": "0",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": "CX0INkyldSwP\u002bpAPx0vWnEaIi32U8tiXt5V5OOlpNJvrKWCwh08DUusFMIB2xsny4SC3h2jSexakcH63Kz1Cpsb0I57rJRX2hDmRjsJXIfHLh1fJsawzGa1JDBbQSyauw4m6gaIrB7sKwAMvQOxTTE6N7KTmefQawQrxoRn\u002bJjgT48s5naBOoH\u002bbvvCpA9jA9b\u002fHQ1\u002bByEqVn8CXOWahDJrKHF0hGq6uPkskSroDcb0yMKtZNuLYkRqBo\u002f7ftmYZ\u002brJW3ud7n9sRGQQUXH2PkS4CZQm6R9W38YpCn3ewzoflC1AIrZLWt5DQSB3exDWc8hLP3VFcXrLdnu1cOABkYEt9LlEthuObK6546v\u002b32SxVpa1k4PA2iK2dKw\u002bkeX6QbOfSYZbkb2svNLGj43OzJcTBB5JS\u002f39aRqajj1vT9rEv6H4X5XiWcTZBNaw\u002fk6Q56gVK43LrPWxoeBrvQN8QWz3\u002fc\u002fv0nEBMKpZcEcrTG7MBaqVViRI\u002fRKoSrm1epjBXMdluPx\u002bpRE7F\u002frjbjyyhlFxm7tU5utIqwC9R4u3T7oRlBODxZNyUWCVWkItZY7R9cBoQ\u002bLdaHXYHQ37wV2Jh8hA0dotMsDCA0paw4ilG0Fx603HSwvXMCuZp6SBdowDC9Z57Je0pMcDpjyYhqjpNwHIhdYTxji8aaGuk48cPIy6W7e2Ly6tvUaKw6TLPq2CrGyitOy180WZuYL2ChE352Wz3i7xNwvTHsiThQKX8SrwK\u002bMeeYucAGRyHHGvu7cxUtw\u002fF2CCjXlkz5okJmpDBchYAd4uGWneF9nGgxaaJ2MVXjYmVN3KcZppuante93\u002bLxapU7nVBzlyXQOGuApizqg3Dsg0HKzqkZBDxF\u002fD7Jv\u002fyFQD8NOpQFr4s\u002ffaQ7WQBu8BumkVxg5pvsIpkT7ZsnBnivO2YtnUjc5xO2y1EE3as8FwwjYy5gJFmjYNg68YIv2HcrTF2aARKSyepI6hsKp0Tt15ZPA6NKDtbMinywofVRRvLZ2VFNYdY5UJkEF3p\u002bWLmTDRnr4NTT4T1GzbaWIif092NoMM3zoHXAFbLKBjecTjHC3VTbZaXeBfgTxpRfo26xTyAXFmern6ykK4tiCZsF6r9EkwTTGZG9SirVn5nhYHIEWPbXRXfKF32odzoau\u002fxdDhvU2xBpnjWOmcx81j\u002fSgosZHfCkbmVHunuHKqKXYo4uuJG9zIVhmrqBSOtrjUF91bRvAV4LuN\u002b2jSCUorOS9zc\u002bDh1uVLYFt4M14uW53Cz6SRTuKGFv4v\u002byB3\u002bkzTfHLlH0bX8jz4E\u002baUna1ZX6PPDzmllepM6Vzmtd\u002fA12YOqLbvRTxW7t1rmT7\u002f8XVM0p\u002bApOsTKeaImDHp8Tw=="
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-203f76d2-014b-04b6-2ccc-d883dfc63254?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-c4955f3101076d41926197e9e15b405d-2db60b6830cbbe49-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "08f14717-fc6a-15ef-cd1d-6968c5f89973",
+        "x-ms-date": "Wed, 18 Sep 2019 19:49:14 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:49:14 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "08f14717-fc6a-15ef-cd1d-6968c5f89973",
+        "x-ms-request-id": "bb7852c8-c01e-0097-6b5a-6e1b03000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1497437601",
+    "Storage_TestConfigSecondary": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttp:\u002f\u002fstorageteglazatesting.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.table.core.windows.net\n\n\n\n\nhttp:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f;QueueEndpoint=http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f;TableEndpoint=http:\u002f\u002fstorageteglazatesting.table.core.windows.net\u002f;FileEndpoint=http:\u002f\u002fstorageteglazatesting.file.core.windows.net\u002f;BlobSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f;QueueSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f;TableSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\u002f;FileSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\u002f;AccountName=storageteglazatesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/DownloadAsync_ReadFromSecondaryStorageAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/DownloadAsync_ReadFromSecondaryStorageAsync.json
@@ -1,0 +1,190 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-d8caf62e-0230-9a4b-23ff-20ad735f6c2c?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0daa83e4d6ea3b4c8ac105be51583589-619c71f18fe7f344-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "5f17e349-f59d-4a95-4a2f-ecf4b2d77b9d",
+        "x-ms-date": "Wed, 18 Sep 2019 19:49:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:49:32 GMT",
+        "ETag": "\u00220x8D73C7153B1396E\u0022",
+        "Last-Modified": "Wed, 18 Sep 2019 19:49:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "5f17e349-f59d-4a95-4a2f-ecf4b2d77b9d",
+        "x-ms-request-id": "5e260ea1-f01e-0068-185a-6e2b9e000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-d8caf62e-0230-9a4b-23ff-20ad735f6c2c\u002ftest-blob-e86ece87-88c9-8e62-b840-0499739a8eec",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "traceparent": "00-e25991a540688d47aee253a0087ad6cb-0c405b7b9d726e49-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "6c65076e-c6e3-67d0-b8bd-5eec5d6ee5a6",
+        "x-ms-date": "Wed, 18 Sep 2019 19:49:33 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "gKkU\u002fUsiTQhbz8s6xJgQHtUWZJBIDI8SpbfRyjqmSTR6oDLg8Cy\u002bJ5YPBM4pWoWxHs0fm3PrVXQZAVeUUILNtIWXwCNlLy6pWDz6OQfB6UsxH6tth63Ajku\u002bxu7UKtcTQU9IkpliS\u002b6edUM38RxsWBgMYjHWXy3Y1jHYp2k\u002f1S1l5ve3eFaxz9O9zhFpiJ0vUW3Wx8ilPeIhcLtniaSFX6AV0goltODBW5JdGZEcbk2UqFX7aQ1lv6gVlgiaSUUvN29wU7aTCpyNFGw1SCRRBQFu0\u002bBOivaTsBNhDx7YJhFMLeEhqxuXAZ64bVSgMHaEw5AHLHVk4a153aOjMfp\u002bte5b6BtCL1nl1tJClRyh84Cc3UyN0fmb50w0qM549M\u002bkOrhmREdaQpQ2IVaiIkuQ1\u002bkjBlSu8OT0vwDPDoeLbeIDnVtkO644QZq3VrCj\u002bcUApNDkVO179knUcYVGizQMq7Nzn4TwK5s76sS59pk0UMY7zmm3phn0h6cRkMoo8rZmq6v8MFlAEHg0qWopwv\u002bwoCC\u002fCrzKVQWafhjd3pvREvgNUkruNyBt\u002b77xgvyuy8SnYfCpaef5nFWlYrFAYjHcYpdxG2\u002b1wWgAUg7\u002b2NMJ67NTNX2rKKgRFLX1SdRvLJmMFR9kPa9U8p\u002bHqBfY\u002b8SCnHf\u002b7Sy0MDruYAe6v3iTkSV1ccOzpK4D\u002fkPdJH\u002bQOBnxcq1dcD5s2OTlddyomjIn8xfxY4kAzvfI\u002bu7p1gy6XSftyE3LNiDnCZnfzi7RW2MQtjFon9WP8aO1lHZPggLYKhe0utLlXL33ClnwIQDJ95\u002bL2SDbUb5SXtepFaGpl4aWB6MWHKCRKllzcZR7n8\u002bj7J3XxKji\u002fNhZYlz7PEYcTXPSWRpcstr\u002b\u002ba7GZ\u002bAq1r4HBSkD0tLetArKvblElu4SVyMgqUW1RznD2Mr6G5X3Loyd8zYdGHqh9KUQkfUgumO\u002fsw\u002b9CSx4Ub7vQPkH45h00o4tpqK49T\u002bpf7SgpbZEoh5nOmiGOiVfJKF3LdiAmRAMm75m8xPBB77PE4l42KwIq57boKkw7ZhozYEAQMdnKOajkwn33a4KpjOqtieb50z1b4I5pfhn3K4m\u002fSWSwMb2aOuj1ESjEM3v0Pp1hjdwzOY1C9FFLYLtPLdb0d\u002bJeOVts047\u002bBIHUl60StT\u002b8VV2tTE\u002bXbT0sTpotpiMRz\u002ftZVgUCNLpNdTTLblzkOOu7kpi5BuuShsweAIT0kJ6egoexuR76eiCjX9cai\u002f7gSFXusdNKmMjPxo95JDQ1WORWbKvVMn\u002bMgVh31acUt\u002frNfbguxd6LFCm\u002b4fJPgVYsrccyhF9TC1YWYjC7EsMh\u002b07Ua\u002bZ8BpLFyxiCFhBNPMACS2efw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "xcOIISVzWGNRfav8oewXlw==",
+        "Date": "Wed, 18 Sep 2019 19:49:32 GMT",
+        "ETag": "\u00220x8D73C7153D42E19\u0022",
+        "Last-Modified": "Wed, 18 Sep 2019 19:49:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "6c65076e-c6e3-67d0-b8bd-5eec5d6ee5a6",
+        "x-ms-content-crc64": "sC\u002bPX3OMLDU=",
+        "x-ms-request-id": "5e260f1e-f01e-0068-025a-6e2b9e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002ftest-container-d8caf62e-0230-9a4b-23ff-20ad735f6c2c\u002ftest-blob-e86ece87-88c9-8e62-b840-0499739a8eec",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-450c1f68e443c14f996686f5a15270b4-5fece4458b87ce40-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "6b2be65d-2234-8f09-ed5a-e41355f7bdd4",
+        "x-ms-date": "Wed, 18 Sep 2019 19:49:33 GMT",
+        "x-ms-range": "bytes=0-",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "225",
+        "Content-Type": "application\u002fxml",
+        "Date": "Wed, 18 Sep 2019 19:49:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "6b2be65d-2234-8f09-ed5a-e41355f7bdd4",
+        "x-ms-error-code": "ContainerNotFound",
+        "x-ms-request-id": "77e14405-901e-0070-585a-6e41c4000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": [
+        "\ufeff\u003c?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003e\u003cError\u003e\u003cCode\u003eContainerNotFound\u003c\u002fCode\u003e\u003cMessage\u003eThe specified container does not exist.\n",
+        "RequestId:77e14405-901e-0070-585a-6e41c4000000\n",
+        "Time:2019-09-18T19:49:33.9161596Z\u003c\u002fMessage\u003e\u003c\u002fError\u003e"
+      ]
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-d8caf62e-0230-9a4b-23ff-20ad735f6c2c\u002ftest-blob-e86ece87-88c9-8e62-b840-0499739a8eec",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-450c1f68e443c14f996686f5a15270b4-5fece4458b87ce40-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "6b2be65d-2234-8f09-ed5a-e41355f7bdd4",
+        "x-ms-date": "Wed, 18 Sep 2019 19:49:33 GMT",
+        "x-ms-range": "bytes=0-",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023\u002f1024",
+        "Content-Type": "application\u002foctet-stream",
+        "Date": "Wed, 18 Sep 2019 19:49:34 GMT",
+        "ETag": "\u00220x8D73C7153D42E19\u0022",
+        "Last-Modified": "Wed, 18 Sep 2019 19:49:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-blob-content-md5": "xcOIISVzWGNRfav8oewXlw==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "6b2be65d-2234-8f09-ed5a-e41355f7bdd4",
+        "x-ms-creation-time": "Wed, 18 Sep 2019 19:49:33 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "5e261205-f01e-0068-705a-6e2b9e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-tag-count": "0",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": "gKkU\u002fUsiTQhbz8s6xJgQHtUWZJBIDI8SpbfRyjqmSTR6oDLg8Cy\u002bJ5YPBM4pWoWxHs0fm3PrVXQZAVeUUILNtIWXwCNlLy6pWDz6OQfB6UsxH6tth63Ajku\u002bxu7UKtcTQU9IkpliS\u002b6edUM38RxsWBgMYjHWXy3Y1jHYp2k\u002f1S1l5ve3eFaxz9O9zhFpiJ0vUW3Wx8ilPeIhcLtniaSFX6AV0goltODBW5JdGZEcbk2UqFX7aQ1lv6gVlgiaSUUvN29wU7aTCpyNFGw1SCRRBQFu0\u002bBOivaTsBNhDx7YJhFMLeEhqxuXAZ64bVSgMHaEw5AHLHVk4a153aOjMfp\u002bte5b6BtCL1nl1tJClRyh84Cc3UyN0fmb50w0qM549M\u002bkOrhmREdaQpQ2IVaiIkuQ1\u002bkjBlSu8OT0vwDPDoeLbeIDnVtkO644QZq3VrCj\u002bcUApNDkVO179knUcYVGizQMq7Nzn4TwK5s76sS59pk0UMY7zmm3phn0h6cRkMoo8rZmq6v8MFlAEHg0qWopwv\u002bwoCC\u002fCrzKVQWafhjd3pvREvgNUkruNyBt\u002b77xgvyuy8SnYfCpaef5nFWlYrFAYjHcYpdxG2\u002b1wWgAUg7\u002b2NMJ67NTNX2rKKgRFLX1SdRvLJmMFR9kPa9U8p\u002bHqBfY\u002b8SCnHf\u002b7Sy0MDruYAe6v3iTkSV1ccOzpK4D\u002fkPdJH\u002bQOBnxcq1dcD5s2OTlddyomjIn8xfxY4kAzvfI\u002bu7p1gy6XSftyE3LNiDnCZnfzi7RW2MQtjFon9WP8aO1lHZPggLYKhe0utLlXL33ClnwIQDJ95\u002bL2SDbUb5SXtepFaGpl4aWB6MWHKCRKllzcZR7n8\u002bj7J3XxKji\u002fNhZYlz7PEYcTXPSWRpcstr\u002b\u002ba7GZ\u002bAq1r4HBSkD0tLetArKvblElu4SVyMgqUW1RznD2Mr6G5X3Loyd8zYdGHqh9KUQkfUgumO\u002fsw\u002b9CSx4Ub7vQPkH45h00o4tpqK49T\u002bpf7SgpbZEoh5nOmiGOiVfJKF3LdiAmRAMm75m8xPBB77PE4l42KwIq57boKkw7ZhozYEAQMdnKOajkwn33a4KpjOqtieb50z1b4I5pfhn3K4m\u002fSWSwMb2aOuj1ESjEM3v0Pp1hjdwzOY1C9FFLYLtPLdb0d\u002bJeOVts047\u002bBIHUl60StT\u002b8VV2tTE\u002bXbT0sTpotpiMRz\u002ftZVgUCNLpNdTTLblzkOOu7kpi5BuuShsweAIT0kJ6egoexuR76eiCjX9cai\u002f7gSFXusdNKmMjPxo95JDQ1WORWbKvVMn\u002bMgVh31acUt\u002frNfbguxd6LFCm\u002b4fJPgVYsrccyhF9TC1YWYjC7EsMh\u002b07Ua\u002bZ8BpLFyxiCFhBNPMACS2efw=="
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-d8caf62e-0230-9a4b-23ff-20ad735f6c2c?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-54007986dccf9a4ca3870bc576ad4aa2-1fba9a75e22a6d45-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "768f67c3-7943-8372-fd1a-5c101c9b7ef2",
+        "x-ms-date": "Wed, 18 Sep 2019 19:49:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:49:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "768f67c3-7943-8372-fd1a-5c101c9b7ef2",
+        "x-ms-request-id": "5e261227-f01e-0068-085a-6e2b9e000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "347958568",
+    "Storage_TestConfigSecondary": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttp:\u002f\u002fstorageteglazatesting.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.table.core.windows.net\n\n\n\n\nhttp:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f;QueueEndpoint=http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f;TableEndpoint=http:\u002f\u002fstorageteglazatesting.table.core.windows.net\u002f;FileEndpoint=http:\u002f\u002fstorageteglazatesting.file.core.windows.net\u002f;BlobSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f;QueueSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f;TableSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\u002f;FileSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\u002f;AccountName=storageteglazatesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/DownloadAsync_ReadFromSecondaryStorageShouldNotPut.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/DownloadAsync_ReadFromSecondaryStorageShouldNotPut.json
@@ -1,0 +1,152 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-a067a98c-8d1d-318d-63a4-8d44087c628c?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-7c49871e43dce9458ef1874c64b25e4b-6fa515048db25742-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "17732738-99ff-b0eb-ece6-ce9483e1e954",
+        "x-ms-date": "Wed, 18 Sep 2019 19:49:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:49:15 GMT",
+        "ETag": "\u00220x8D73C7149615710\u0022",
+        "Last-Modified": "Wed, 18 Sep 2019 19:49:15 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "17732738-99ff-b0eb-ece6-ce9483e1e954",
+        "x-ms-request-id": "bb7853b0-c01e-0097-385a-6e1b03000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-a067a98c-8d1d-318d-63a4-8d44087c628c\u002ftest-blob-b8078007-3693-49ae-39b4-be172ffa3ca4",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "traceparent": "00-259dd65b70cbdb4db68db10e99a07324-1c8546b8f0900d42-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "d87ba765-17cd-f3b2-b1fe-511858aacc01",
+        "x-ms-date": "Wed, 18 Sep 2019 19:49:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "4btKHjH\u002fXcBKGtpKilphNOEMC\u002bEIS42pqC79qf3KyuTqr1IT5KRPOcqzzOS\u002boSaShJmydtUHS5UtoHYCArTCgFD2YNoHTlA8vdIXVX\u002bo6wcIaiRkF1MO4mO85UMuTDcV8EuUyEFLijZJdrkD8PYWhbVv\u002bpePXmj85313SmgMDXCbAWUzFCLFvd\u002fuGqGaCvFspWCOv1KfhpHjl\u002bDD00DNPWhJaO\u002bR43CTqTy3oUPHYt2LCqQIfk4d\u002b3vTUHxBAumfId04UKIC28Lv\u002bhYV6ORNGzQDN8mbxb4aK2xzvZPzUaZTGIBmjhE6iC7iGIM3BxOWhTRHPcogBFweHiU1jh0u\u002fKhvwtBk54wjya\u002bauKw64iRZ3ThfqxTcMxMkR3DsBPoQsxzax0RDMZ2nJHQbhUuv5DsA3LHlz1CUko\u002b8QKAcNsS1iQWQXxrfFqyat4efwa3HdGM06yhIK\u002bPLRTW1hvD9i\u002b2vZvtGHoQgIcUEShjI9dHh9Ms850ucbF4hxRrlKY\u002b7nCyZ71uxgVbfFMpiRODLAlBj05IkwaOiE\u002fqdJVlqOvc1Sa7sLwV1L3N1XdOBOSd9VsLJglb9ltuJ99xhE1v8ddnSLPoy39NL7aMfrmTPINnSIM\u002bXoLihOLLSYjcoFBsXeef6rgwtSnbufpSy3ed3udYDj\u002fOMZdQgMPRIX3ybItmHCDV81HHMpdVYqCIk71rKW6hhJYUoihMT2n0Y5er6Uly7KtWy\u002b\u002bVkNuodNLyy\u002b0GZfQTTOvxTX34haPrztL\u002fqXlXFacWFGGDD\u002fO\u002bbClZXYN48fmfmJhhfZ8pXkJLrcIIqM9Zm7JF8FGSkED4NuFUnygcbtzVXBDc9ZQL6LYjN2ItscdeA8HRMwGkDQhbZUq91L8WKz7lM0i6fKYaPgebb1jeyoEZ9p9qTzvfLVMEgYxNThf7CQwjSH5\u002bo4cbtvT6CKGvfJ7Jo94fr9gHBgH1tfsVzPPzoGJMv4ICn1cYTphG5SSxVQTxg6o1310wGEJ8hO2IBeoBBmg\u002fYr0cywCLA2FDvCDdRFz2JElFvcUFGKM\u002fhhppkESuRd64cfJH1Lipqtv77FgdnzyMkeGcu0inNkoZ3UDqIW8YkXpGJNJqsk\u002bQnBLpCSxHHerZ2QJnEYqSFT\u002boKfd3v4ls41rh23puJd\u002bSCBs5uikd1r9aDEhssYPztA\u002bWvoRUGOCFfCnRZUZwb7ci1QVvVFsSjlc4Ha9BAC3a7iNq12dXOfM6sD4DSG146aCRSdx6gGO0gCwxH\u002f8xRH\u002f79ncjBZRPy58WNKAdE0XlvzAOr7ZRXG3Dtlc3Jhn0CW\u002fCB1X2VeAIRX49ZE\u002b\u002fl3DqT1zPIpjFppYJY1NBFKWBIis0Wwvz82lMAmo0E\u002fg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "MSt\u002fT158BHamAhLGtClDkg==",
+        "Date": "Wed, 18 Sep 2019 19:49:15 GMT",
+        "ETag": "\u00220x8D73C714963F4BE\u0022",
+        "Last-Modified": "Wed, 18 Sep 2019 19:49:15 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "d87ba765-17cd-f3b2-b1fe-511858aacc01",
+        "x-ms-content-crc64": "S5Zz\u002bpvVo\u002b4=",
+        "x-ms-request-id": "bb7853b9-c01e-0097-405a-6e1b03000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-a067a98c-8d1d-318d-63a4-8d44087c628c\u002ftest-blob-b8078007-3693-49ae-39b4-be172ffa3ca4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-f85084f93c5b2642a911e9980702cd7e-7647a26bf1af7848-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "87b21ba8-647f-1ad6-1843-7e13370a766f",
+        "x-ms-date": "Wed, 18 Sep 2019 19:49:15 GMT",
+        "x-ms-range": "bytes=0-",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023\u002f1024",
+        "Content-Type": "application\u002foctet-stream",
+        "Date": "Wed, 18 Sep 2019 19:49:15 GMT",
+        "ETag": "\u00220x8D73C714963F4BE\u0022",
+        "Last-Modified": "Wed, 18 Sep 2019 19:49:15 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-blob-content-md5": "MSt\u002fT158BHamAhLGtClDkg==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "87b21ba8-647f-1ad6-1843-7e13370a766f",
+        "x-ms-creation-time": "Wed, 18 Sep 2019 19:49:15 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "bb7853bc-c01e-0097-435a-6e1b03000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-tag-count": "0",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": "4btKHjH\u002fXcBKGtpKilphNOEMC\u002bEIS42pqC79qf3KyuTqr1IT5KRPOcqzzOS\u002boSaShJmydtUHS5UtoHYCArTCgFD2YNoHTlA8vdIXVX\u002bo6wcIaiRkF1MO4mO85UMuTDcV8EuUyEFLijZJdrkD8PYWhbVv\u002bpePXmj85313SmgMDXCbAWUzFCLFvd\u002fuGqGaCvFspWCOv1KfhpHjl\u002bDD00DNPWhJaO\u002bR43CTqTy3oUPHYt2LCqQIfk4d\u002b3vTUHxBAumfId04UKIC28Lv\u002bhYV6ORNGzQDN8mbxb4aK2xzvZPzUaZTGIBmjhE6iC7iGIM3BxOWhTRHPcogBFweHiU1jh0u\u002fKhvwtBk54wjya\u002bauKw64iRZ3ThfqxTcMxMkR3DsBPoQsxzax0RDMZ2nJHQbhUuv5DsA3LHlz1CUko\u002b8QKAcNsS1iQWQXxrfFqyat4efwa3HdGM06yhIK\u002bPLRTW1hvD9i\u002b2vZvtGHoQgIcUEShjI9dHh9Ms850ucbF4hxRrlKY\u002b7nCyZ71uxgVbfFMpiRODLAlBj05IkwaOiE\u002fqdJVlqOvc1Sa7sLwV1L3N1XdOBOSd9VsLJglb9ltuJ99xhE1v8ddnSLPoy39NL7aMfrmTPINnSIM\u002bXoLihOLLSYjcoFBsXeef6rgwtSnbufpSy3ed3udYDj\u002fOMZdQgMPRIX3ybItmHCDV81HHMpdVYqCIk71rKW6hhJYUoihMT2n0Y5er6Uly7KtWy\u002b\u002bVkNuodNLyy\u002b0GZfQTTOvxTX34haPrztL\u002fqXlXFacWFGGDD\u002fO\u002bbClZXYN48fmfmJhhfZ8pXkJLrcIIqM9Zm7JF8FGSkED4NuFUnygcbtzVXBDc9ZQL6LYjN2ItscdeA8HRMwGkDQhbZUq91L8WKz7lM0i6fKYaPgebb1jeyoEZ9p9qTzvfLVMEgYxNThf7CQwjSH5\u002bo4cbtvT6CKGvfJ7Jo94fr9gHBgH1tfsVzPPzoGJMv4ICn1cYTphG5SSxVQTxg6o1310wGEJ8hO2IBeoBBmg\u002fYr0cywCLA2FDvCDdRFz2JElFvcUFGKM\u002fhhppkESuRd64cfJH1Lipqtv77FgdnzyMkeGcu0inNkoZ3UDqIW8YkXpGJNJqsk\u002bQnBLpCSxHHerZ2QJnEYqSFT\u002boKfd3v4ls41rh23puJd\u002bSCBs5uikd1r9aDEhssYPztA\u002bWvoRUGOCFfCnRZUZwb7ci1QVvVFsSjlc4Ha9BAC3a7iNq12dXOfM6sD4DSG146aCRSdx6gGO0gCwxH\u002f8xRH\u002f79ncjBZRPy58WNKAdE0XlvzAOr7ZRXG3Dtlc3Jhn0CW\u002fCB1X2VeAIRX49ZE\u002b\u002fl3DqT1zPIpjFppYJY1NBFKWBIis0Wwvz82lMAmo0E\u002fg=="
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-a067a98c-8d1d-318d-63a4-8d44087c628c?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-86ef106b9e6e17459f9aaa62ef5bc554-b843f967dcc68c4c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "3d70df94-44f7-3982-d8b3-b61457d94653",
+        "x-ms-date": "Wed, 18 Sep 2019 19:49:15 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:49:15 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "3d70df94-44f7-3982-d8b3-b61457d94653",
+        "x-ms-request-id": "bb7853be-c01e-0097-455a-6e1b03000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "296140952",
+    "Storage_TestConfigSecondary": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttp:\u002f\u002fstorageteglazatesting.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.table.core.windows.net\n\n\n\n\nhttp:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f;QueueEndpoint=http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f;TableEndpoint=http:\u002f\u002fstorageteglazatesting.table.core.windows.net\u002f;FileEndpoint=http:\u002f\u002fstorageteglazatesting.file.core.windows.net\u002f;BlobSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f;QueueSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f;TableSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\u002f;FileSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\u002f;AccountName=storageteglazatesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/DownloadAsync_ReadFromSecondaryStorageShouldNotPutAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/DownloadAsync_ReadFromSecondaryStorageShouldNotPutAsync.json
@@ -1,0 +1,152 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-1366ef34-53b9-a0d7-7531-b5cda39b7197?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-ecc5d2ab7690a34085517b60bdd61d52-e14817dd210f2b49-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "87575881-bdf7-5104-3947-938c791cd6eb",
+        "x-ms-date": "Wed, 18 Sep 2019 19:49:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:49:34 GMT",
+        "ETag": "\u00220x8D73C715536B1CA\u0022",
+        "Last-Modified": "Wed, 18 Sep 2019 19:49:35 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "87575881-bdf7-5104-3947-938c791cd6eb",
+        "x-ms-request-id": "5e26133d-f01e-0068-015a-6e2b9e000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-1366ef34-53b9-a0d7-7531-b5cda39b7197\u002ftest-blob-f5be8af0-c2ae-e0b7-6a95-919d0873522b",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "traceparent": "00-ad7eac68e9fcfd4fa7a8214ebc77eb7d-3c3ee67655a5e748-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "b2a921c2-51a0-11ac-231a-4718bec8bd99",
+        "x-ms-date": "Wed, 18 Sep 2019 19:49:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "3y4T28DnOt08XeF8Ho\u002bH1A0mTEtE6Z\u002bnLChyRcMnjxVlSmfqjEnOmh56S5rbhzKpwL9\u002fU9CLp\u002faOa6\u002bXdPQaFc3LF9QonEfDV7IsyZ0Fy6T1yYQEpzxF2qNxXCGZNiUpYDXMEG9egCN3u\u002fseXt1YiJ8KoqpwFm2RhTwxtkAmKiGMAmlnObs1lkhgjOxBJnvFGNOBj5R6uUrIOooyLcrjUZHZklt08E7k1QtiD4mBUF\u002fBa55tpJqMEUkfn\u002f8wAml\u002bfTtbZ5QfUSeEnbqIGKnAR\u002bkrccEsdaz2TYASVFFPs9Oi45FNJunKoRp26QfgBPifXlgVBZCoUgePZBoTDfzWNOnn5jUXcyAAYNCntYylFkiIcvb5Oa5C\u002bpGKvsHPt5MdoLQd\u002bB7Dh\u002bs3FaS\u002fAJx76k3Ri5oG3Ps6pOykjbRfMKk9iRXXhx0pxesLwSMKgvn0DtRz\u002fSz4F8O541QyH\u002fk22OX7gneHo2Iwp8Wv\u002bxvXMCLzr3\u002fg6zJ9RHJSHqTJ96bx1Ok\u002bD\u002f\u002bBbWtxQ1ZmSRyo4rMxP296VeyyfT4FNYS\u002bZrAfvSYxmCEicUITbqfcF\u002ftVqTzxl7g2d378jJHBfDfms9ylRov2dkmSD84sZudE1WZDr4tIzc746UanNQuPYfQKLbvLNtBwXzPyX4jpCRCXt7cqfc2sneUNrV1ETkE\u002bAq3ZIjkreZ6W009XVm5GDt82D31UZeMnXo\u002fVvYlzKxHytFzaEOfXbD0YlKp9VEd3x599Dj7D6ZzKscOpVbwVI6c\u002bZaIRbP34XqM\u002fO9E4qgpHXvbp9R3SLsq\u002fEF8kLRaBA3ACP\u002b6lZluiha\u002bbhK7LkQe4YvfGKy2KazfXUVue0zGMvThgNWsbofiaR3BtNqkc9H5Ya8sfutdDeNO3zhT\u002fA7F9D8Z2a1ubnMD\u002fK\u002bS9HDSNu13cRmdmbANgHL2YZNPjm0O\u002b7yfjpokjvM8LII\u002fyhlueKRK3Ir1JF6LDFU6dAzjsG5Ch\u002fywNqhXUuYmYWkxzbZZh\u002bjrBLHiFdNiFH5A6hbiXHwT\u002bUYcvkH\u002f94mkzsL1VT6e4PAn9Ku8XG4pUh4qEmTPRATtHdRwPMmm7xEkPUcMbL8\u002fpgkmvmfQV5jX82gn0eEk1Yq\u002bBDtqLqAmgQWalCMrHOVi7mxfqIWdGMo7mEldgxksA2e4UmSH1Xdk\u002fD1eOcN5rNaGwOdwxS0BHOttLpJayP3sapC7bsqA3xT49qhIQuMKwe922r41vzo6uzF5FqbhDjc\u002fcdMuvj4IBeXOe9KAuN4IZmym5\u002b5Dtq9WfLeVB8RuF\u002bh1DM0T2AOxatDYZ0Nruf5XbKw6PiZE\u002b78j1D2Kcv4dXGfmD6gM\u002bI5o9Xkda09r7sa1QZsYN9XCLBEN7AQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "HjU21gCq7U6\u002fuE31jW\u002b9PA==",
+        "Date": "Wed, 18 Sep 2019 19:49:34 GMT",
+        "ETag": "\u00220x8D73C7155396C60\u0022",
+        "Last-Modified": "Wed, 18 Sep 2019 19:49:35 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "b2a921c2-51a0-11ac-231a-4718bec8bd99",
+        "x-ms-content-crc64": "Q6KPlif2SjY=",
+        "x-ms-request-id": "5e261342-f01e-0068-055a-6e2b9e000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-1366ef34-53b9-a0d7-7531-b5cda39b7197\u002ftest-blob-f5be8af0-c2ae-e0b7-6a95-919d0873522b",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d2c4919cc019c04bae71f05962cebd47-1b8ae0d315e8364d-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "e6dad1af-9fc9-f88a-380a-cadf169c8e90",
+        "x-ms-date": "Wed, 18 Sep 2019 19:49:35 GMT",
+        "x-ms-range": "bytes=0-",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "1024",
+        "Content-Range": "bytes 0-1023\u002f1024",
+        "Content-Type": "application\u002foctet-stream",
+        "Date": "Wed, 18 Sep 2019 19:49:34 GMT",
+        "ETag": "\u00220x8D73C7155396C60\u0022",
+        "Last-Modified": "Wed, 18 Sep 2019 19:49:35 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-blob-content-md5": "HjU21gCq7U6\u002fuE31jW\u002b9PA==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e6dad1af-9fc9-f88a-380a-cadf169c8e90",
+        "x-ms-creation-time": "Wed, 18 Sep 2019 19:49:35 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "5e261348-f01e-0068-0b5a-6e2b9e000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-tag-count": "0",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": "3y4T28DnOt08XeF8Ho\u002bH1A0mTEtE6Z\u002bnLChyRcMnjxVlSmfqjEnOmh56S5rbhzKpwL9\u002fU9CLp\u002faOa6\u002bXdPQaFc3LF9QonEfDV7IsyZ0Fy6T1yYQEpzxF2qNxXCGZNiUpYDXMEG9egCN3u\u002fseXt1YiJ8KoqpwFm2RhTwxtkAmKiGMAmlnObs1lkhgjOxBJnvFGNOBj5R6uUrIOooyLcrjUZHZklt08E7k1QtiD4mBUF\u002fBa55tpJqMEUkfn\u002f8wAml\u002bfTtbZ5QfUSeEnbqIGKnAR\u002bkrccEsdaz2TYASVFFPs9Oi45FNJunKoRp26QfgBPifXlgVBZCoUgePZBoTDfzWNOnn5jUXcyAAYNCntYylFkiIcvb5Oa5C\u002bpGKvsHPt5MdoLQd\u002bB7Dh\u002bs3FaS\u002fAJx76k3Ri5oG3Ps6pOykjbRfMKk9iRXXhx0pxesLwSMKgvn0DtRz\u002fSz4F8O541QyH\u002fk22OX7gneHo2Iwp8Wv\u002bxvXMCLzr3\u002fg6zJ9RHJSHqTJ96bx1Ok\u002bD\u002f\u002bBbWtxQ1ZmSRyo4rMxP296VeyyfT4FNYS\u002bZrAfvSYxmCEicUITbqfcF\u002ftVqTzxl7g2d378jJHBfDfms9ylRov2dkmSD84sZudE1WZDr4tIzc746UanNQuPYfQKLbvLNtBwXzPyX4jpCRCXt7cqfc2sneUNrV1ETkE\u002bAq3ZIjkreZ6W009XVm5GDt82D31UZeMnXo\u002fVvYlzKxHytFzaEOfXbD0YlKp9VEd3x599Dj7D6ZzKscOpVbwVI6c\u002bZaIRbP34XqM\u002fO9E4qgpHXvbp9R3SLsq\u002fEF8kLRaBA3ACP\u002b6lZluiha\u002bbhK7LkQe4YvfGKy2KazfXUVue0zGMvThgNWsbofiaR3BtNqkc9H5Ya8sfutdDeNO3zhT\u002fA7F9D8Z2a1ubnMD\u002fK\u002bS9HDSNu13cRmdmbANgHL2YZNPjm0O\u002b7yfjpokjvM8LII\u002fyhlueKRK3Ir1JF6LDFU6dAzjsG5Ch\u002fywNqhXUuYmYWkxzbZZh\u002bjrBLHiFdNiFH5A6hbiXHwT\u002bUYcvkH\u002f94mkzsL1VT6e4PAn9Ku8XG4pUh4qEmTPRATtHdRwPMmm7xEkPUcMbL8\u002fpgkmvmfQV5jX82gn0eEk1Yq\u002bBDtqLqAmgQWalCMrHOVi7mxfqIWdGMo7mEldgxksA2e4UmSH1Xdk\u002fD1eOcN5rNaGwOdwxS0BHOttLpJayP3sapC7bsqA3xT49qhIQuMKwe922r41vzo6uzF5FqbhDjc\u002fcdMuvj4IBeXOe9KAuN4IZmym5\u002b5Dtq9WfLeVB8RuF\u002bh1DM0T2AOxatDYZ0Nruf5XbKw6PiZE\u002b78j1D2Kcv4dXGfmD6gM\u002bI5o9Xkda09r7sa1QZsYN9XCLBEN7AQ=="
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-1366ef34-53b9-a0d7-7531-b5cda39b7197?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-8a283f5725dbb5469b7da7f7ea3dd8f6-275e744d470e3847-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "ec68d4c2-d7ee-03cf-bb48-e81dc3277b39",
+        "x-ms-date": "Wed, 18 Sep 2019 19:49:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:49:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "ec68d4c2-d7ee-03cf-bb48-e81dc3277b39",
+        "x-ms-request-id": "5e26134f-f01e-0068-115a-6e2b9e000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1244405175",
+    "Storage_TestConfigSecondary": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttp:\u002f\u002fstorageteglazatesting.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.table.core.windows.net\n\n\n\n\nhttp:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f;QueueEndpoint=http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f;TableEndpoint=http:\u002f\u002fstorageteglazatesting.table.core.windows.net\u002f;FileEndpoint=http:\u002f\u002fstorageteglazatesting.file.core.windows.net\u002f;BlobSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f;QueueSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f;TableSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\u002f;FileSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\u002f;AccountName=storageteglazatesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Ctor_Uri.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Ctor_Uri.json
@@ -1,0 +1,4 @@
+{
+  "Entries": [],
+  "Variables": {}
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Ctor_UriAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Ctor_UriAsync.json
@@ -1,0 +1,4 @@
+{
+  "Entries": [],
+  "Variables": {}
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/ListContainersSegmentAsync_SecondaryStorageFirstRetrySuccessful.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/ListContainersSegmentAsync_SecondaryStorageFirstRetrySuccessful.json
@@ -1,0 +1,146 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-64409c18-915d-6a6f-0255-e8f5ffe6a376?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-1241df5a0118174a9c39425f70599b9f-4199c927dac82044-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "58666ca3-1dfe-4ed9-9daf-bc4a06db2bd9",
+        "x-ms-date": "Wed, 18 Sep 2019 19:50:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:50:32 GMT",
+        "ETag": "\u00220x8D73C7177374F94\u0022",
+        "Last-Modified": "Wed, 18 Sep 2019 19:50:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "58666ca3-1dfe-4ed9-9daf-bc4a06db2bd9",
+        "x-ms-request-id": "512bbf7b-101e-005f-4e5a-6ef932000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002ftest-container-64409c18-915d-6a6f-0255-e8f5ffe6a376?restype=container",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-7f12f911f1c6d94697f356228f030a45-94db8f4293f14b45-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "92529d5a-4a7f-6877-32a2-143621352c3f",
+        "x-ms-date": "Wed, 18 Sep 2019 19:50:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "225",
+        "Content-Type": "application\u002fxml",
+        "Date": "Wed, 18 Sep 2019 19:50:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "92529d5a-4a7f-6877-32a2-143621352c3f",
+        "x-ms-error-code": "ContainerNotFound",
+        "x-ms-request-id": "255860ea-701e-001c-0a5a-6eea17000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": [
+        "\ufeff\u003c?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003e\u003cError\u003e\u003cCode\u003eContainerNotFound\u003c\u002fCode\u003e\u003cMessage\u003eThe specified container does not exist.\n",
+        "RequestId:255860ea-701e-001c-0a5a-6eea17000000\n",
+        "Time:2019-09-18T19:50:33.2281694Z\u003c\u002fMessage\u003e\u003c\u002fError\u003e"
+      ]
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-64409c18-915d-6a6f-0255-e8f5ffe6a376?restype=container",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-7f12f911f1c6d94697f356228f030a45-94db8f4293f14b45-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "92529d5a-4a7f-6877-32a2-143621352c3f",
+        "x-ms-date": "Wed, 18 Sep 2019 19:50:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:50:34 GMT",
+        "ETag": "\u00220x8D73C7177374F94\u0022",
+        "Last-Modified": "Wed, 18 Sep 2019 19:50:32 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "92529d5a-4a7f-6877-32a2-143621352c3f",
+        "x-ms-default-encryption-scope": "$account-encryption-key",
+        "x-ms-deny-encryption-scope-override": "false",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "512bc2f5-101e-005f-615a-6ef932000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-64409c18-915d-6a6f-0255-e8f5ffe6a376?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-6a5481671695b449bbcf3b01a08b4ef1-e81d55766ca91946-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "69f0a61f-9889-fe59-5975-61abb58d1ae7",
+        "x-ms-date": "Wed, 18 Sep 2019 19:50:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:50:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "69f0a61f-9889-fe59-5975-61abb58d1ae7",
+        "x-ms-request-id": "512bc30c-101e-005f-735a-6ef932000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1872160508",
+    "Storage_TestConfigSecondary": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttp:\u002f\u002fstorageteglazatesting.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.table.core.windows.net\n\n\n\n\nhttp:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f;QueueEndpoint=http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f;TableEndpoint=http:\u002f\u002fstorageteglazatesting.table.core.windows.net\u002f;FileEndpoint=http:\u002f\u002fstorageteglazatesting.file.core.windows.net\u002f;BlobSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f;QueueSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f;TableSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\u002f;FileSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\u002f;AccountName=storageteglazatesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/ListContainersSegmentAsync_SecondaryStorageFirstRetrySuccessfulAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/ListContainersSegmentAsync_SecondaryStorageFirstRetrySuccessfulAsync.json
@@ -1,0 +1,146 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-93fd8620-cc18-8531-6158-1670ab368a56?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-ebf6e5d1a7292f49b9b90b30379404b0-f270b8ce5c146f49-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "02638f1e-d9a8-7962-18ee-35b74273dd0f",
+        "x-ms-date": "Wed, 18 Sep 2019 19:50:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:50:52 GMT",
+        "ETag": "\u00220x8D73C71835EBE23\u0022",
+        "Last-Modified": "Wed, 18 Sep 2019 19:50:52 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "02638f1e-d9a8-7962-18ee-35b74273dd0f",
+        "x-ms-request-id": "d397dcc2-b01e-0079-3c5a-6eb12a000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002ftest-container-93fd8620-cc18-8531-6158-1670ab368a56?restype=container",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-7e7afbb682942044bb0da920e1965e9e-50892359574e0043-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "1c516e24-88d3-25ad-a6f7-ac20682137f5",
+        "x-ms-date": "Wed, 18 Sep 2019 19:50:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "225",
+        "Content-Type": "application\u002fxml",
+        "Date": "Wed, 18 Sep 2019 19:50:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "1c516e24-88d3-25ad-a6f7-ac20682137f5",
+        "x-ms-error-code": "ContainerNotFound",
+        "x-ms-request-id": "bfc61a46-201e-0004-795a-6ec782000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": [
+        "\ufeff\u003c?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003e\u003cError\u003e\u003cCode\u003eContainerNotFound\u003c\u002fCode\u003e\u003cMessage\u003eThe specified container does not exist.\n",
+        "RequestId:bfc61a46-201e-0004-795a-6ec782000000\n",
+        "Time:2019-09-18T19:50:53.6336320Z\u003c\u002fMessage\u003e\u003c\u002fError\u003e"
+      ]
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-93fd8620-cc18-8531-6158-1670ab368a56?restype=container",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-7e7afbb682942044bb0da920e1965e9e-50892359574e0043-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "1c516e24-88d3-25ad-a6f7-ac20682137f5",
+        "x-ms-date": "Wed, 18 Sep 2019 19:50:52 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:50:54 GMT",
+        "ETag": "\u00220x8D73C71835EBE23\u0022",
+        "Last-Modified": "Wed, 18 Sep 2019 19:50:52 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-client-request-id": "1c516e24-88d3-25ad-a6f7-ac20682137f5",
+        "x-ms-default-encryption-scope": "$account-encryption-key",
+        "x-ms-deny-encryption-scope-override": "false",
+        "x-ms-has-immutability-policy": "false",
+        "x-ms-has-legal-hold": "false",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "d397dece-b01e-0079-075a-6eb12a000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-93fd8620-cc18-8531-6158-1670ab368a56?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-8be4c8d8c45dec45aa6e0de2ae52c036-f3fad7afb2886b4a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "d393c2bd-c122-223c-99c9-c1124b531a8b",
+        "x-ms-date": "Wed, 18 Sep 2019 19:50:54 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:50:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "d393c2bd-c122-223c-99c9-c1124b531a8b",
+        "x-ms-request-id": "d397ded9-b01e-0079-105a-6eb12a000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1791306867",
+    "Storage_TestConfigSecondary": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttp:\u002f\u002fstorageteglazatesting.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.table.core.windows.net\n\n\n\n\nhttp:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f;QueueEndpoint=http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f;TableEndpoint=http:\u002f\u002fstorageteglazatesting.table.core.windows.net\u002f;FileEndpoint=http:\u002f\u002fstorageteglazatesting.file.core.windows.net\u002f;BlobSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f;QueueSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f;TableSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\u002f;FileSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\u002f;AccountName=storageteglazatesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/Ctor_ConnectionString.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/Ctor_ConnectionString.json
@@ -1,4 +1,6 @@
 {
   "Entries": [],
-  "Variables": {}
+  "Variables": {
+    "RandomSeed": "613186201"
+  }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/Ctor_Uri.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/Ctor_Uri.json
@@ -1,0 +1,4 @@
+{
+  "Entries": [],
+  "Variables": {}
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/Ctor_UriAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/Ctor_UriAsync.json
@@ -1,0 +1,4 @@
+{
+  "Entries": [],
+  "Variables": {}
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/ListContainersSegmentAsync_SecondaryStorage404OnSecondary.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/ListContainersSegmentAsync_SecondaryStorage404OnSecondary.json
@@ -1,0 +1,102 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-ede44248-66b6-92f0-ef82-693789c420ca?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-90e957038072bc4085439a2a93b7b337-27f519cc9fee4449-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "503cfbad-21a0-b36d-5dc6-41ae0934c92c",
+        "x-ms-date": "Wed, 18 Sep 2019 19:47:16 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:47:15 GMT",
+        "ETag": "\u00220x8D73C71022E0194\u0022",
+        "Last-Modified": "Wed, 18 Sep 2019 19:47:16 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "503cfbad-21a0-b36d-5dc6-41ae0934c92c",
+        "x-ms-request-id": "f2b593be-e01e-004b-0359-6eb15d000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f?comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "8e8a33be-d087-6d29-cf2b-164579f00bf1",
+        "x-ms-date": "Wed, 18 Sep 2019 19:47:16 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application\u002fxml",
+        "Date": "Wed, 18 Sep 2019 19:47:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "Vary": "Origin",
+        "x-ms-client-request-id": "8e8a33be-d087-6d29-cf2b-164579f00bf1",
+        "x-ms-request-id": "f2b5a2ea-e01e-004b-1959-6eb15d000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": "\ufeff\u003c?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003e\u003cEnumerationResults ServiceEndpoint=\u0022http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f\u0022\u003e\u003cContainers\u003e\u003cContainer\u003e\u003cName\u003e$web\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eWed, 18 Sep 2019 01:08:39 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D73BD4BDB8E9C1\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-04796654-55fc-2108-cfec-2c3ffd841109\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:46:29 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E3D0816BCE\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-56dc430b-951e-d762-1cec-62339e9411c8\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:37:53 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E29D3B81F6\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-7e8ac229-204e-7b94-7e4b-e54056d71731\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eSun, 15 Sep 2019 01:07:42 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D739791C21D09A\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003eblob\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-91b086e1-d896-90eb-ff7d-1fa317f870e1\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:32:33 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E1DEA388D6\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-b9af7524-ddad-0be9-2bba-fbac6a024f21\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:28:07 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E13FAFC15D\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-c05831a9-959e-77c8-3063-dd59c949f127\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:49:48 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E44713B324\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-d251e8a4-e914-1626-eed3-de32ad2b3dca\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eThu, 12 Sep 2019 23:52:08 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737DC3932BD79\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-d30c350a-d2d4-6c4c-d9c6-83e3b4ad3d1c\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:50:38 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E464DDE024\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-dc1deb55-17d2-faee-f334-59f96cdaf1f6\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eSun, 15 Sep 2019 01:07:53 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D7397922F30B68\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-e0503d21-892f-b5f3-0640-295fac99e4c6\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eSat, 14 Sep 2019 00:47:04 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D738AD1042D7A4\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-ede44248-66b6-92f0-ef82-693789c420ca\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eWed, 18 Sep 2019 19:47:16 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D73C71022E0194\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-eefc5676-447d-121d-4ab8-536a9ea628af\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:51:33 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E485AEEC9A\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003c\u002fContainers\u003e\u003cNextMarker \u002f\u003e\u003c\u002fEnumerationResults\u003e"
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-ede44248-66b6-92f0-ef82-693789c420ca?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-18716661367a6b489e1fcc176f2a648b-b2702538c56d3844-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "d6efe1bc-3aa9-66a5-a862-df8e080012b2",
+        "x-ms-date": "Wed, 18 Sep 2019 19:47:19 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:47:18 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "d6efe1bc-3aa9-66a5-a862-df8e080012b2",
+        "x-ms-request-id": "f2b5a323-e01e-004b-5059-6eb15d000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1457644886",
+    "Storage_TestConfigSecondary": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttp:\u002f\u002fstorageteglazatesting.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.table.core.windows.net\n\n\n\n\nhttp:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f;QueueEndpoint=http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f;TableEndpoint=http:\u002f\u002fstorageteglazatesting.table.core.windows.net\u002f;FileEndpoint=http:\u002f\u002fstorageteglazatesting.file.core.windows.net\u002f;BlobSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f;QueueSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f;TableSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\u002f;FileSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\u002f;AccountName=storageteglazatesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/ListContainersSegmentAsync_SecondaryStorage404OnSecondaryAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/ListContainersSegmentAsync_SecondaryStorage404OnSecondaryAsync.json
@@ -1,0 +1,102 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-0dea3183-8d0c-4800-91d3-62edc9e706d7?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5ea80a7ddb8c174c8c84aa5748002cca-e212d3904c5f7340-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "ae820729-2e11-b812-eb5d-aa9162082b74",
+        "x-ms-date": "Wed, 18 Sep 2019 19:46:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:46:50 GMT",
+        "ETag": "\u00220x8D73C70F3559B49\u0022",
+        "Last-Modified": "Wed, 18 Sep 2019 19:46:51 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "ae820729-2e11-b812-eb5d-aa9162082b74",
+        "x-ms-request-id": "400a89a2-e01e-0039-1359-6eb612000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f?comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "c1c3fedc-5764-37c5-3ef3-9df36ca3402c",
+        "x-ms-date": "Wed, 18 Sep 2019 19:46:51 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application\u002fxml",
+        "Date": "Wed, 18 Sep 2019 19:46:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "Vary": "Origin",
+        "x-ms-client-request-id": "c1c3fedc-5764-37c5-3ef3-9df36ca3402c",
+        "x-ms-request-id": "400a98d8-e01e-0039-5a59-6eb612000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": "\ufeff\u003c?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003e\u003cEnumerationResults ServiceEndpoint=\u0022http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f\u0022\u003e\u003cContainers\u003e\u003cContainer\u003e\u003cName\u003e$web\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eWed, 18 Sep 2019 01:08:39 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D73BD4BDB8E9C1\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-04796654-55fc-2108-cfec-2c3ffd841109\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:46:29 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E3D0816BCE\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-0dea3183-8d0c-4800-91d3-62edc9e706d7\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eWed, 18 Sep 2019 19:46:51 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D73C70F3559B49\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-56dc430b-951e-d762-1cec-62339e9411c8\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:37:53 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E29D3B81F6\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-7e8ac229-204e-7b94-7e4b-e54056d71731\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eSun, 15 Sep 2019 01:07:42 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D739791C21D09A\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003eblob\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-91b086e1-d896-90eb-ff7d-1fa317f870e1\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:32:33 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E1DEA388D6\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-b9af7524-ddad-0be9-2bba-fbac6a024f21\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:28:07 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E13FAFC15D\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-c05831a9-959e-77c8-3063-dd59c949f127\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:49:48 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E44713B324\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-d251e8a4-e914-1626-eed3-de32ad2b3dca\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eThu, 12 Sep 2019 23:52:08 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737DC3932BD79\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-d30c350a-d2d4-6c4c-d9c6-83e3b4ad3d1c\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:50:38 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E464DDE024\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-dc1deb55-17d2-faee-f334-59f96cdaf1f6\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eSun, 15 Sep 2019 01:07:53 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D7397922F30B68\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-e0503d21-892f-b5f3-0640-295fac99e4c6\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eSat, 14 Sep 2019 00:47:04 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D738AD1042D7A4\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-eefc5676-447d-121d-4ab8-536a9ea628af\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:51:33 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E485AEEC9A\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003c\u002fContainers\u003e\u003cNextMarker \u002f\u003e\u003c\u002fEnumerationResults\u003e"
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-0dea3183-8d0c-4800-91d3-62edc9e706d7?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d1918a2c8769a24db589e19eedb38f5f-4c1ca4ff5de8e343-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "64b46e06-6a44-a70f-9b16-61f4b68fff58",
+        "x-ms-date": "Wed, 18 Sep 2019 19:46:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:46:54 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "64b46e06-6a44-a70f-9b16-61f4b68fff58",
+        "x-ms-request-id": "400a9936-e01e-0039-3159-6eb612000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "727853493",
+    "Storage_TestConfigSecondary": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttp:\u002f\u002fstorageteglazatesting.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.table.core.windows.net\n\n\n\n\nhttp:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f;QueueEndpoint=http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f;TableEndpoint=http:\u002f\u002fstorageteglazatesting.table.core.windows.net\u002f;FileEndpoint=http:\u002f\u002fstorageteglazatesting.file.core.windows.net\u002f;BlobSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f;QueueSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f;TableSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\u002f;FileSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\u002f;AccountName=storageteglazatesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/ListContainersSegmentAsync_SecondaryStorageFirstRetrySuccessful.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/ListContainersSegmentAsync_SecondaryStorageFirstRetrySuccessful.json
@@ -1,0 +1,102 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-dbfce049-1691-99ab-58b1-b8e3e8b0b820?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-393a8593e4d0fa45afd961deaff6fdc0-4c0e6ed910f6074a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "ac80c774-ce2d-02bb-fcde-be2327c34522",
+        "x-ms-date": "Wed, 18 Sep 2019 19:47:19 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:47:19 GMT",
+        "ETag": "\u00220x8D73C710472B35A\u0022",
+        "Last-Modified": "Wed, 18 Sep 2019 19:47:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "ac80c774-ce2d-02bb-fcde-be2327c34522",
+        "x-ms-request-id": "f2b5a382-e01e-004b-2b59-6eb15d000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f?comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "216e89f8-0c2f-ecf3-12ac-5d1ddba9d90d",
+        "x-ms-date": "Wed, 18 Sep 2019 19:47:19 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application\u002fxml",
+        "Date": "Wed, 18 Sep 2019 19:47:20 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "Vary": "Origin",
+        "x-ms-client-request-id": "216e89f8-0c2f-ecf3-12ac-5d1ddba9d90d",
+        "x-ms-request-id": "70b1ed10-501e-0000-6659-6e3200000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": "\ufeff\u003c?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003e\u003cEnumerationResults ServiceEndpoint=\u0022http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f\u0022\u003e\u003cContainers\u003e\u003cContainer\u003e\u003cName\u003e$web\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eWed, 18 Sep 2019 01:08:39 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D73BD4BDB8E9C1\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-04796654-55fc-2108-cfec-2c3ffd841109\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:46:29 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E3D0816BCE\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-56dc430b-951e-d762-1cec-62339e9411c8\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:37:53 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E29D3B81F6\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-7e8ac229-204e-7b94-7e4b-e54056d71731\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eSun, 15 Sep 2019 01:07:42 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D739791C21D09A\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003eblob\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-91b086e1-d896-90eb-ff7d-1fa317f870e1\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:32:33 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E1DEA388D6\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-b9af7524-ddad-0be9-2bba-fbac6a024f21\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:28:07 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E13FAFC15D\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-c05831a9-959e-77c8-3063-dd59c949f127\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:49:48 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E44713B324\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-d251e8a4-e914-1626-eed3-de32ad2b3dca\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eThu, 12 Sep 2019 23:52:08 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737DC3932BD79\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-d30c350a-d2d4-6c4c-d9c6-83e3b4ad3d1c\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:50:38 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E464DDE024\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-dc1deb55-17d2-faee-f334-59f96cdaf1f6\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eSun, 15 Sep 2019 01:07:53 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D7397922F30B68\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-e0503d21-892f-b5f3-0640-295fac99e4c6\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eSat, 14 Sep 2019 00:47:04 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D738AD1042D7A4\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-eefc5676-447d-121d-4ab8-536a9ea628af\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:51:33 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E485AEEC9A\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003c\u002fContainers\u003e\u003cNextMarker \u002f\u003e\u003c\u002fEnumerationResults\u003e"
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-dbfce049-1691-99ab-58b1-b8e3e8b0b820?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d68a1c0b8fe6894ea9b3e12076a3088c-02b8b88673120b40-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "9e2b1282-2355-a5f2-f7bd-d6be882ad468",
+        "x-ms-date": "Wed, 18 Sep 2019 19:47:20 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:47:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "9e2b1282-2355-a5f2-f7bd-d6be882ad468",
+        "x-ms-request-id": "f2b5a5f0-e01e-004b-6759-6eb15d000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1125547364",
+    "Storage_TestConfigSecondary": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttp:\u002f\u002fstorageteglazatesting.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.table.core.windows.net\n\n\n\n\nhttp:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f;QueueEndpoint=http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f;TableEndpoint=http:\u002f\u002fstorageteglazatesting.table.core.windows.net\u002f;FileEndpoint=http:\u002f\u002fstorageteglazatesting.file.core.windows.net\u002f;BlobSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f;QueueSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f;TableSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\u002f;FileSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\u002f;AccountName=storageteglazatesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/ListContainersSegmentAsync_SecondaryStorageFirstRetrySuccessfulAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/ListContainersSegmentAsync_SecondaryStorageFirstRetrySuccessfulAsync.json
@@ -1,0 +1,102 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-302c9d69-9d61-44e0-f06d-fa867a31db84?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-1c908c29e582ae46b153cb6d25e360b0-af3fbea55a47964f-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "ba4da5dd-35f2-1ff9-c003-b030abf43e06",
+        "x-ms-date": "Wed, 18 Sep 2019 19:46:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:46:54 GMT",
+        "ETag": "\u00220x8D73C70F5BC5C8D\u0022",
+        "Last-Modified": "Wed, 18 Sep 2019 19:46:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "ba4da5dd-35f2-1ff9-c003-b030abf43e06",
+        "x-ms-request-id": "400a99b6-e01e-0039-2659-6eb612000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f?comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "d4a8354e-20e4-9492-87ad-57885cdbef13",
+        "x-ms-date": "Wed, 18 Sep 2019 19:46:55 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application\u002fxml",
+        "Date": "Wed, 18 Sep 2019 19:46:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "Vary": "Origin",
+        "x-ms-client-request-id": "d4a8354e-20e4-9492-87ad-57885cdbef13",
+        "x-ms-request-id": "15b651b4-b01e-000a-2059-6e2b89000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": "\ufeff\u003c?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003e\u003cEnumerationResults ServiceEndpoint=\u0022http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f\u0022\u003e\u003cContainers\u003e\u003cContainer\u003e\u003cName\u003e$web\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eWed, 18 Sep 2019 01:08:39 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D73BD4BDB8E9C1\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-04796654-55fc-2108-cfec-2c3ffd841109\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:46:29 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E3D0816BCE\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-56dc430b-951e-d762-1cec-62339e9411c8\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:37:53 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E29D3B81F6\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-7e8ac229-204e-7b94-7e4b-e54056d71731\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eSun, 15 Sep 2019 01:07:42 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D739791C21D09A\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003eblob\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-91b086e1-d896-90eb-ff7d-1fa317f870e1\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:32:33 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E1DEA388D6\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-b9af7524-ddad-0be9-2bba-fbac6a024f21\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:28:07 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E13FAFC15D\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-c05831a9-959e-77c8-3063-dd59c949f127\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:49:48 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E44713B324\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-d251e8a4-e914-1626-eed3-de32ad2b3dca\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eThu, 12 Sep 2019 23:52:08 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737DC3932BD79\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-d30c350a-d2d4-6c4c-d9c6-83e3b4ad3d1c\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:50:38 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E464DDE024\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-dc1deb55-17d2-faee-f334-59f96cdaf1f6\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eSun, 15 Sep 2019 01:07:53 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D7397922F30B68\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-e0503d21-892f-b5f3-0640-295fac99e4c6\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eSat, 14 Sep 2019 00:47:04 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D738AD1042D7A4\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-eefc5676-447d-121d-4ab8-536a9ea628af\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:51:33 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E485AEEC9A\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003c\u002fContainers\u003e\u003cNextMarker \u002f\u003e\u003c\u002fEnumerationResults\u003e"
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-302c9d69-9d61-44e0-f06d-fa867a31db84?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-dd3a3f6e9894ea4489ca6be83a4e7880-f0e6c6da37a8fa4e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "76e21981-694c-8e21-ee90-dea9fcd1ffb5",
+        "x-ms-date": "Wed, 18 Sep 2019 19:46:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:46:55 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "76e21981-694c-8e21-ee90-dea9fcd1ffb5",
+        "x-ms-request-id": "400a9c94-e01e-0039-5b59-6eb612000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1247346677",
+    "Storage_TestConfigSecondary": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttp:\u002f\u002fstorageteglazatesting.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.table.core.windows.net\n\n\n\n\nhttp:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f;QueueEndpoint=http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f;TableEndpoint=http:\u002f\u002fstorageteglazatesting.table.core.windows.net\u002f;FileEndpoint=http:\u002f\u002fstorageteglazatesting.file.core.windows.net\u002f;BlobSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f;QueueSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f;TableSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\u002f;FileSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\u002f;AccountName=storageteglazatesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/ListContainersSegmentAsync_SecondaryStorageSecondRetrySuccessful.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/ListContainersSegmentAsync_SecondaryStorageSecondRetrySuccessful.json
@@ -1,0 +1,102 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-ea98ac11-e3c6-14f4-4690-959917c8dc72?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-c0e45a593995994cbaab40fd8a085d6b-9230c594d4055543-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "c7312cca-bdc5-0e4f-8eac-b6f0de9a505d",
+        "x-ms-date": "Wed, 18 Sep 2019 19:47:20 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:47:19 GMT",
+        "ETag": "\u00220x8D73C7104E58E87\u0022",
+        "Last-Modified": "Wed, 18 Sep 2019 19:47:20 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "c7312cca-bdc5-0e4f-8eac-b6f0de9a505d",
+        "x-ms-request-id": "f2b5a605-e01e-004b-7c59-6eb15d000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f?comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "eacfbdb0-1596-daac-71e0-a7174549f331",
+        "x-ms-date": "Wed, 18 Sep 2019 19:47:20 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application\u002fxml",
+        "Date": "Wed, 18 Sep 2019 19:47:21 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "Vary": "Origin",
+        "x-ms-client-request-id": "eacfbdb0-1596-daac-71e0-a7174549f331",
+        "x-ms-request-id": "f2b5abe8-e01e-004b-5d59-6eb15d000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": "\ufeff\u003c?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003e\u003cEnumerationResults ServiceEndpoint=\u0022http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f\u0022\u003e\u003cContainers\u003e\u003cContainer\u003e\u003cName\u003e$web\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eWed, 18 Sep 2019 01:08:39 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D73BD4BDB8E9C1\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-04796654-55fc-2108-cfec-2c3ffd841109\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:46:29 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E3D0816BCE\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-56dc430b-951e-d762-1cec-62339e9411c8\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:37:53 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E29D3B81F6\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-7e8ac229-204e-7b94-7e4b-e54056d71731\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eSun, 15 Sep 2019 01:07:42 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D739791C21D09A\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003eblob\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-91b086e1-d896-90eb-ff7d-1fa317f870e1\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:32:33 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E1DEA388D6\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-b9af7524-ddad-0be9-2bba-fbac6a024f21\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:28:07 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E13FAFC15D\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-c05831a9-959e-77c8-3063-dd59c949f127\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:49:48 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E44713B324\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-d251e8a4-e914-1626-eed3-de32ad2b3dca\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eThu, 12 Sep 2019 23:52:08 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737DC3932BD79\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-d30c350a-d2d4-6c4c-d9c6-83e3b4ad3d1c\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:50:38 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E464DDE024\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-dc1deb55-17d2-faee-f334-59f96cdaf1f6\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eSun, 15 Sep 2019 01:07:53 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D7397922F30B68\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-e0503d21-892f-b5f3-0640-295fac99e4c6\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eSat, 14 Sep 2019 00:47:04 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D738AD1042D7A4\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-ea98ac11-e3c6-14f4-4690-959917c8dc72\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eWed, 18 Sep 2019 19:47:20 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D73C7104E58E87\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-eefc5676-447d-121d-4ab8-536a9ea628af\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:51:33 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E485AEEC9A\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003c\u002fContainers\u003e\u003cNextMarker \u002f\u003e\u003c\u002fEnumerationResults\u003e"
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-ea98ac11-e3c6-14f4-4690-959917c8dc72?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-e006b161270959418b00e5f94cde144a-c8787ae8d5d6e941-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "213f4a4e-66cb-7bc6-8867-62275be0d029",
+        "x-ms-date": "Wed, 18 Sep 2019 19:47:22 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:47:21 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "213f4a4e-66cb-7bc6-8867-62275be0d029",
+        "x-ms-request-id": "f2b5abfe-e01e-004b-7259-6eb15d000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "859333222",
+    "Storage_TestConfigSecondary": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttp:\u002f\u002fstorageteglazatesting.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.table.core.windows.net\n\n\n\n\nhttp:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f;QueueEndpoint=http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f;TableEndpoint=http:\u002f\u002fstorageteglazatesting.table.core.windows.net\u002f;FileEndpoint=http:\u002f\u002fstorageteglazatesting.file.core.windows.net\u002f;BlobSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f;QueueSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f;TableSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\u002f;FileSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\u002f;AccountName=storageteglazatesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/ListContainersSegmentAsync_SecondaryStorageSecondRetrySuccessfulAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/ListContainersSegmentAsync_SecondaryStorageSecondRetrySuccessfulAsync.json
@@ -1,0 +1,102 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-1f2b0920-d198-cf05-0a9e-cbe84fe44455?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-e3e157825b49854691c9d85f9f1c4f44-ae31230c61755746-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "4bc5b81f-480c-adcf-44c7-426ff7f9f7d9",
+        "x-ms-date": "Wed, 18 Sep 2019 19:46:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:46:55 GMT",
+        "ETag": "\u00220x8D73C70F62FFB2B\u0022",
+        "Last-Modified": "Wed, 18 Sep 2019 19:46:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "4bc5b81f-480c-adcf-44c7-426ff7f9f7d9",
+        "x-ms-request-id": "400a9caa-e01e-0039-6e59-6eb612000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f?comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "97c8ea9c-f91f-f749-77b4-e27c19b8b458",
+        "x-ms-date": "Wed, 18 Sep 2019 19:46:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application\u002fxml",
+        "Date": "Wed, 18 Sep 2019 19:46:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "Vary": "Origin",
+        "x-ms-client-request-id": "97c8ea9c-f91f-f749-77b4-e27c19b8b458",
+        "x-ms-request-id": "400aa2cc-e01e-0039-3a59-6eb612000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": "\ufeff\u003c?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003e\u003cEnumerationResults ServiceEndpoint=\u0022http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f\u0022\u003e\u003cContainers\u003e\u003cContainer\u003e\u003cName\u003e$web\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eWed, 18 Sep 2019 01:08:39 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D73BD4BDB8E9C1\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-04796654-55fc-2108-cfec-2c3ffd841109\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:46:29 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E3D0816BCE\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-1f2b0920-d198-cf05-0a9e-cbe84fe44455\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eWed, 18 Sep 2019 19:46:56 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D73C70F62FFB2B\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-56dc430b-951e-d762-1cec-62339e9411c8\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:37:53 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E29D3B81F6\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-7e8ac229-204e-7b94-7e4b-e54056d71731\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eSun, 15 Sep 2019 01:07:42 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D739791C21D09A\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003eblob\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-91b086e1-d896-90eb-ff7d-1fa317f870e1\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:32:33 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E1DEA388D6\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-b9af7524-ddad-0be9-2bba-fbac6a024f21\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:28:07 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E13FAFC15D\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-c05831a9-959e-77c8-3063-dd59c949f127\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:49:48 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E44713B324\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-d251e8a4-e914-1626-eed3-de32ad2b3dca\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eThu, 12 Sep 2019 23:52:08 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737DC3932BD79\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-d30c350a-d2d4-6c4c-d9c6-83e3b4ad3d1c\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:50:38 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E464DDE024\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-dc1deb55-17d2-faee-f334-59f96cdaf1f6\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eSun, 15 Sep 2019 01:07:53 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D7397922F30B68\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-e0503d21-892f-b5f3-0640-295fac99e4c6\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eSat, 14 Sep 2019 00:47:04 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D738AD1042D7A4\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-eefc5676-447d-121d-4ab8-536a9ea628af\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:51:33 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E485AEEC9A\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003c\u002fContainers\u003e\u003cNextMarker \u002f\u003e\u003c\u002fEnumerationResults\u003e"
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-1f2b0920-d198-cf05-0a9e-cbe84fe44455?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-f8efcae53c2cde43b5febd6a7811af9d-e849683703759946-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "0dd203ab-5f31-eeba-6087-d4b9e10eaa28",
+        "x-ms-date": "Wed, 18 Sep 2019 19:46:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:46:56 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "0dd203ab-5f31-eeba-6087-d4b9e10eaa28",
+        "x-ms-request-id": "400aa2e6-e01e-0039-5059-6eb612000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1205661169",
+    "Storage_TestConfigSecondary": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttp:\u002f\u002fstorageteglazatesting.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.table.core.windows.net\n\n\n\n\nhttp:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f;QueueEndpoint=http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f;TableEndpoint=http:\u002f\u002fstorageteglazatesting.table.core.windows.net\u002f;FileEndpoint=http:\u002f\u002fstorageteglazatesting.file.core.windows.net\u002f;BlobSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f;QueueSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f;TableSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\u002f;FileSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\u002f;AccountName=storageteglazatesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/ListContainersSegmentAsync_SecondaryStorageThirdRetrySuccessful.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/ListContainersSegmentAsync_SecondaryStorageThirdRetrySuccessful.json
@@ -1,0 +1,102 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-fba01eb9-d3bd-12b4-4cda-c4a1a4d63782?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-054371f2820b2f4cb533870299b172ed-922d988cbb9bbb43-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "8b9753ac-9e87-5152-0eee-50f77954263a",
+        "x-ms-date": "Wed, 18 Sep 2019 19:47:22 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:47:21 GMT",
+        "ETag": "\u00220x8D73C7105DBC36C\u0022",
+        "Last-Modified": "Wed, 18 Sep 2019 19:47:22 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "8b9753ac-9e87-5152-0eee-50f77954263a",
+        "x-ms-request-id": "f2b5ac1f-e01e-004b-0e59-6eb15d000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f?comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "50f4b53d-ac3e-c7fa-cc55-c76b267b297f",
+        "x-ms-date": "Wed, 18 Sep 2019 19:47:22 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application\u002fxml",
+        "Date": "Wed, 18 Sep 2019 19:47:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "Vary": "Origin",
+        "x-ms-client-request-id": "50f4b53d-ac3e-c7fa-cc55-c76b267b297f",
+        "x-ms-request-id": "70b1ed63-501e-0000-3359-6e3200000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": "\ufeff\u003c?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003e\u003cEnumerationResults ServiceEndpoint=\u0022http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f\u0022\u003e\u003cContainers\u003e\u003cContainer\u003e\u003cName\u003e$web\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eWed, 18 Sep 2019 01:08:39 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D73BD4BDB8E9C1\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-04796654-55fc-2108-cfec-2c3ffd841109\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:46:29 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E3D0816BCE\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-56dc430b-951e-d762-1cec-62339e9411c8\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:37:53 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E29D3B81F6\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-7e8ac229-204e-7b94-7e4b-e54056d71731\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eSun, 15 Sep 2019 01:07:42 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D739791C21D09A\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003eblob\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-91b086e1-d896-90eb-ff7d-1fa317f870e1\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:32:33 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E1DEA388D6\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-b9af7524-ddad-0be9-2bba-fbac6a024f21\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:28:07 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E13FAFC15D\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-c05831a9-959e-77c8-3063-dd59c949f127\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:49:48 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E44713B324\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-d251e8a4-e914-1626-eed3-de32ad2b3dca\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eThu, 12 Sep 2019 23:52:08 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737DC3932BD79\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-d30c350a-d2d4-6c4c-d9c6-83e3b4ad3d1c\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:50:38 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E464DDE024\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-dc1deb55-17d2-faee-f334-59f96cdaf1f6\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eSun, 15 Sep 2019 01:07:53 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D7397922F30B68\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-e0503d21-892f-b5f3-0640-295fac99e4c6\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eSat, 14 Sep 2019 00:47:04 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D738AD1042D7A4\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-eefc5676-447d-121d-4ab8-536a9ea628af\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:51:33 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E485AEEC9A\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003c\u002fContainers\u003e\u003cNextMarker \u002f\u003e\u003c\u002fEnumerationResults\u003e"
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-fba01eb9-d3bd-12b4-4cda-c4a1a4d63782?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-db95b5a38113b04e8f8134ec4b29b408-e66c98e7e7f9cf43-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "c4b94b87-d65f-bcfb-5fec-45f678941c30",
+        "x-ms-date": "Wed, 18 Sep 2019 19:47:25 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:47:25 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "c4b94b87-d65f-bcfb-5fec-45f678941c30",
+        "x-ms-request-id": "f2b5bb22-e01e-004b-6459-6eb15d000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1162815872",
+    "Storage_TestConfigSecondary": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttp:\u002f\u002fstorageteglazatesting.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.table.core.windows.net\n\n\n\n\nhttp:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f;QueueEndpoint=http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f;TableEndpoint=http:\u002f\u002fstorageteglazatesting.table.core.windows.net\u002f;FileEndpoint=http:\u002f\u002fstorageteglazatesting.file.core.windows.net\u002f;BlobSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f;QueueSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f;TableSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\u002f;FileSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\u002f;AccountName=storageteglazatesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/ListContainersSegmentAsync_SecondaryStorageThirdRetrySuccessfulAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/ListContainersSegmentAsync_SecondaryStorageThirdRetrySuccessfulAsync.json
@@ -1,0 +1,102 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-bc48f80b-3d17-70bd-7671-aa8d95a23e1e?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-f0cce261cd4d1a4a88ce48d826d7c945-cf8ca33ff4cd624b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "4d9f723d-0ae5-8c89-8b31-cca1db15a042",
+        "x-ms-date": "Wed, 18 Sep 2019 19:46:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:46:56 GMT",
+        "ETag": "\u00220x8D73C70F71786AB\u0022",
+        "Last-Modified": "Wed, 18 Sep 2019 19:46:57 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "4d9f723d-0ae5-8c89-8b31-cca1db15a042",
+        "x-ms-request-id": "400aa2f9-e01e-0039-6359-6eb612000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f?comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "2350d082-f003-3338-d657-25f20a0a3854",
+        "x-ms-date": "Wed, 18 Sep 2019 19:46:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application\u002fxml",
+        "Date": "Wed, 18 Sep 2019 19:47:01 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "Vary": "Origin",
+        "x-ms-client-request-id": "2350d082-f003-3338-d657-25f20a0a3854",
+        "x-ms-request-id": "15b65240-b01e-000a-2659-6e2b89000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": "\ufeff\u003c?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003e\u003cEnumerationResults ServiceEndpoint=\u0022http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f\u0022\u003e\u003cContainers\u003e\u003cContainer\u003e\u003cName\u003e$web\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eWed, 18 Sep 2019 01:08:39 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D73BD4BDB8E9C1\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-04796654-55fc-2108-cfec-2c3ffd841109\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:46:29 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E3D0816BCE\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-56dc430b-951e-d762-1cec-62339e9411c8\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:37:53 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E29D3B81F6\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-7e8ac229-204e-7b94-7e4b-e54056d71731\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eSun, 15 Sep 2019 01:07:42 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D739791C21D09A\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003eblob\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-91b086e1-d896-90eb-ff7d-1fa317f870e1\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:32:33 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E1DEA388D6\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-b9af7524-ddad-0be9-2bba-fbac6a024f21\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:28:07 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E13FAFC15D\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-c05831a9-959e-77c8-3063-dd59c949f127\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:49:48 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E44713B324\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-d251e8a4-e914-1626-eed3-de32ad2b3dca\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eThu, 12 Sep 2019 23:52:08 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737DC3932BD79\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-d30c350a-d2d4-6c4c-d9c6-83e3b4ad3d1c\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:50:38 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E464DDE024\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-dc1deb55-17d2-faee-f334-59f96cdaf1f6\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eSun, 15 Sep 2019 01:07:53 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D7397922F30B68\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-e0503d21-892f-b5f3-0640-295fac99e4c6\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eSat, 14 Sep 2019 00:47:04 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D738AD1042D7A4\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003cContainer\u003e\u003cName\u003etest-container-eefc5676-447d-121d-4ab8-536a9ea628af\u003c\u002fName\u003e\u003cProperties\u003e\u003cLast-Modified\u003eFri, 13 Sep 2019 00:51:33 GMT\u003c\u002fLast-Modified\u003e\u003cEtag\u003e\u00220x8D737E485AEEC9A\u0022\u003c\u002fEtag\u003e\u003cLeaseStatus\u003eunlocked\u003c\u002fLeaseStatus\u003e\u003cLeaseState\u003eavailable\u003c\u002fLeaseState\u003e\u003cPublicAccess\u003econtainer\u003c\u002fPublicAccess\u003e\u003cDefaultEncryptionScope\u003e$account-encryption-key\u003c\u002fDefaultEncryptionScope\u003e\u003cDenyEncryptionScopeOverride\u003efalse\u003c\u002fDenyEncryptionScopeOverride\u003e\u003cHasImmutabilityPolicy\u003efalse\u003c\u002fHasImmutabilityPolicy\u003e\u003cHasLegalHold\u003efalse\u003c\u002fHasLegalHold\u003e\u003c\u002fProperties\u003e\u003c\u002fContainer\u003e\u003c\u002fContainers\u003e\u003cNextMarker \u002f\u003e\u003c\u002fEnumerationResults\u003e"
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002ftest-container-bc48f80b-3d17-70bd-7671-aa8d95a23e1e?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-8f51aebf35f69e48b6952f6f8d50227c-c16c5b9198db4f4f-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs\u002f12.0.0-dev.20190918.1\u002bc08104d0e7bb34348df76981f57e5bdd5eac0128",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "0a1e1f20-7dc5-5f3e-69c9-5eb8bd502a43",
+        "x-ms-date": "Wed, 18 Sep 2019 19:47:01 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 18 Sep 2019 19:47:00 GMT",
+        "Server": [
+          "Windows-Azure-Blob\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-client-request-id": "0a1e1f20-7dc5-5f3e-69c9-5eb8bd502a43",
+        "x-ms-request-id": "400ab45a-e01e-0039-2959-6eb612000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "314105842",
+    "Storage_TestConfigSecondary": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttp:\u002f\u002fstorageteglazatesting.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.table.core.windows.net\n\n\n\n\nhttp:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f;QueueEndpoint=http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f;TableEndpoint=http:\u002f\u002fstorageteglazatesting.table.core.windows.net\u002f;FileEndpoint=http:\u002f\u002fstorageteglazatesting.file.core.windows.net\u002f;BlobSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f;QueueSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f;TableSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\u002f;FileSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\u002f;AccountName=storageteglazatesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Common/src/Constants.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Constants.cs
@@ -428,5 +428,16 @@ namespace Azure.Storage
             internal const string Code = "Code";
             internal const string Message = "Message";
         }
+
+        internal static class GeoRedundantRead
+        {
+            internal const string AlternateHostKey  = "Azure.Storage.Common.GeoRedundantReadPolicy.AlternateHostKey";
+            internal const string ResourceNotReplicated = "Azure.Storage.Common.GeoRedundantReadPolicy.ResourceNotReplicated";
+        }
+
+        internal static class HttpStatusCode
+        {
+            internal const int NotFound = 404;
+        }
     }
 }

--- a/sdk/storage/Azure.Storage.Common/src/GeoRedundantReadPolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/src/GeoRedundantReadPolicy.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+using System;
+using Azure.Core.Pipeline;
+
+namespace Azure.Storage.Common
+{
+    /// <summary>
+    /// This policy is used if the SecondaryUri property is passed in on the clientOptions. It allows for storage 
+    /// accounts configured with RA-GRS to retry GET or HEAD requests against the secondary storage Uri.
+    /// </summary>
+    internal class GeoRedundantReadPolicy : SynchronousHttpPipelinePolicy
+    {
+        private readonly string _secondaryStorageHost;
+
+        public GeoRedundantReadPolicy(Uri secondaryStorageUri)
+        {
+            if (secondaryStorageUri == null)
+            {
+                throw Errors.ArgumentNull(nameof(secondaryStorageUri));
+            }
+            this._secondaryStorageHost = secondaryStorageUri.Host;
+        }
+
+        public override void OnSendingRequest(HttpPipelineMessage message)
+        {
+            if (message.Request.Method != RequestMethod.Get && message.Request.Method != RequestMethod.Head)
+            {
+                return;
+            }
+
+            // Look up what the alternate host is set to in the message properties. For the initial request, this will
+            // not be set.
+            string alternateHost =
+                message.TryGetProperty(
+                    Constants.GeoRedundantRead.AlternateHostKey,
+                    out var alternateHostObj)
+                ? alternateHostObj as string
+                : null;
+            if (alternateHost == null)
+            {
+                // queue up the secondary host for subsequent retries
+                message.SetProperty(Constants.GeoRedundantRead.AlternateHostKey, this._secondaryStorageHost);
+                return;
+            }
+
+            // Check the flag that indicates whether the resource has not been propagated to the secondary host yet.
+            // If this flag is set, we don't want to retry against the secondary host again for any subsequent retries.
+            // Also, the flag being set implies that the current request must already be set to the primary host, so we
+            // are safe to return without checking if the current host is secondary or primary.
+            var resourceNotReplicated =
+                message.TryGetProperty(Constants.GeoRedundantRead.ResourceNotReplicated, out var value)
+                && (bool)value;
+            if (resourceNotReplicated)
+            {
+                return;
+            }
+
+            // If alternateHost was not null that means the message is being retried. Hence what is stored in the Host 
+            // property of UriBuilder is actually the host from the last try.
+            var lastTriedHost = message.Request.UriBuilder.Host;
+
+            // If necessary, set the flag to indicate that the resource has not yet been propagated to the secondary host.
+            if (message.HasResponse
+                && message.Response.Status == Constants.HttpStatusCode.NotFound
+                && lastTriedHost == this._secondaryStorageHost)
+            {
+                message.SetProperty(Constants.GeoRedundantRead.ResourceNotReplicated, true);
+            }
+
+            // Toggle the host set in the request to use the alternate host for the upcoming attempt, and update the
+            // the property for the AlternateHostKey to be the host used in the last try.
+            message.Request.UriBuilder.Host = alternateHost;
+            message.SetProperty(Constants.GeoRedundantRead.AlternateHostKey, lastTriedHost);
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/src/GeoRedundantReadPolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/src/GeoRedundantReadPolicy.cs
@@ -21,7 +21,7 @@ namespace Azure.Storage.Common
             {
                 throw Errors.ArgumentNull(nameof(secondaryStorageUri));
             }
-            this._secondaryStorageHost = secondaryStorageUri.Host;
+            _secondaryStorageHost = secondaryStorageUri.Host;
         }
 
         public override void OnSendingRequest(HttpPipelineMessage message)
@@ -42,7 +42,7 @@ namespace Azure.Storage.Common
             if (alternateHost == null)
             {
                 // queue up the secondary host for subsequent retries
-                message.SetProperty(Constants.GeoRedundantRead.AlternateHostKey, this._secondaryStorageHost);
+                message.SetProperty(Constants.GeoRedundantRead.AlternateHostKey, _secondaryStorageHost);
                 return;
             }
 
@@ -65,7 +65,7 @@ namespace Azure.Storage.Common
             // If necessary, set the flag to indicate that the resource has not yet been propagated to the secondary host.
             if (message.HasResponse
                 && message.Response.Status == Constants.HttpStatusCode.NotFound
-                && lastTriedHost == this._secondaryStorageHost)
+                && lastTriedHost == _secondaryStorageHost)
             {
                 message.SetProperty(Constants.GeoRedundantRead.ResourceNotReplicated, true);
             }

--- a/sdk/storage/Azure.Storage.Common/src/StorageResponseClassifier.cs
+++ b/sdk/storage/Azure.Storage.Common/src/StorageResponseClassifier.cs
@@ -13,7 +13,7 @@ namespace Azure.Storage.Common
 
         public StorageResponseClassifier(Uri secondaryStorageUri)
         {
-            this.SecondaryStorageUri = secondaryStorageUri;
+            SecondaryStorageUri = secondaryStorageUri;
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Common/src/StorageResponseClassifier.cs
+++ b/sdk/storage/Azure.Storage.Common/src/StorageResponseClassifier.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+using System;
+using Azure.Core.Pipeline;
+
+namespace Azure.Storage.Common
+{
+    internal class StorageResponseClassifier : ResponseClassifier
+    {
+        public Uri SecondaryStorageUri { get; }
+
+        public StorageResponseClassifier(Uri secondaryStorageUri)
+        {
+            this.SecondaryStorageUri = secondaryStorageUri;
+        }
+
+        /// <summary>
+        /// Overridden version of IsRetriableResponse that allows for retrying 404 that occurs against the secondary host.
+        /// </summary>
+        /// <param name="message">The message containing both Response and Request</param>
+        /// <returns></returns>
+        public override bool IsRetriableResponse(HttpPipelineMessage message)
+        {
+            if (message.Request.UriBuilder.Host == SecondaryStorageUri.Host && message.Response.Status == Constants.HttpStatusCode.NotFound)
+            {
+                return true;
+            }
+            return base.IsRetriableResponse(message);
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/tests/CommonTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/CommonTestBase.cs
@@ -49,12 +49,12 @@ namespace Azure.Storage.Common.Test
 
         public BlobServiceClient GetSecondaryStorageReadEnabledServiceClient(TenantConfiguration config, int numberOfReadFailuresToSimulate, bool simulate404 = false)
         {
-            var options = this.GetBlobOptions();
+            BlobClientOptions options = GetBlobOptions();
             options.GeoRedundantSecondaryUri = new Uri(config.BlobServiceSecondaryEndpoint);
             options.Retry.MaxRetries = 4;
             options.AddPolicy(new TestExceptionPolicy(numberOfReadFailuresToSimulate, options.GeoRedundantSecondaryUri, simulate404), HttpPipelinePosition.PerRetry);
 
-            return this.InstrumentClient(
+            return InstrumentClient(
                  new BlobServiceClient(
                     new Uri(config.BlobServiceEndpoint),
                     new StorageSharedKeyCredential(config.AccountName, config.AccountKey),

--- a/sdk/storage/Azure.Storage.Common/tests/CommonTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/CommonTestBase.cs
@@ -46,5 +46,19 @@ namespace Azure.Storage.Common.Test
 
             return Recording.InstrumentClientOptions(options);
         }
+
+        public BlobServiceClient GetSecondaryStorageReadEnabledServiceClient(TenantConfiguration config, int numberOfReadFailuresToSimulate, bool simulate404 = false)
+        {
+            var options = this.GetBlobOptions();
+            options.GeoRedundantSecondaryUri = new Uri(config.BlobServiceSecondaryEndpoint);
+            options.Retry.MaxRetries = 4;
+            options.AddPolicy(new TestExceptionPolicy(numberOfReadFailuresToSimulate, options.GeoRedundantSecondaryUri, simulate404), HttpPipelinePosition.PerRetry);
+
+            return this.InstrumentClient(
+                 new BlobServiceClient(
+                    new Uri(config.BlobServiceEndpoint),
+                    new StorageSharedKeyCredential(config.AccountName, config.AccountKey),
+                    options));
+        }
     }
 }

--- a/sdk/storage/Azure.Storage.Common/tests/GeoRedundantReadPolicyTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/GeoRedundantReadPolicyTests.cs
@@ -1,0 +1,131 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+using System;
+using System.Threading;
+using Azure.Core.Pipeline;
+using Azure.Core.Testing;
+using NUnit.Framework;
+
+namespace Azure.Storage.Common.Tests
+{
+    public class GeoRedundantReadPolicyTests
+    {
+        private static readonly Uri MockPrimaryUri = new Uri("http://dummyaccount.blob.core.windows.net");
+        private static readonly Uri MockSecondaryUri = new Uri("http://dummyaccount-secondary.blob.core.windows.net");
+
+        [Test]
+        public void OnSendingRequest_FirstTry_ShouldUsePrimary_ShouldSetAlternateToSecondary()
+        {
+            var message = new HttpPipelineMessage(
+                this.CreateMockRequest(MockPrimaryUri),
+                new StorageResponseClassifier(MockSecondaryUri),
+                CancellationToken.None);
+            var policy = new GeoRedundantReadPolicy(MockSecondaryUri);
+
+            policy.OnSendingRequest(message);
+
+            Assert.AreEqual(MockPrimaryUri.Host, message.Request.UriBuilder.Host);
+            Assert.IsTrue(message.TryGetProperty(Constants.GeoRedundantRead.AlternateHostKey, out object val)
+                && (string) val == MockSecondaryUri.Host);
+        }
+
+        [Test]
+        public void OnSendingRequest_SecondTry_ShouldUseSecondary_ShouldSetAlternateToPrimary()
+        {
+            var message = new HttpPipelineMessage(
+                this.CreateMockRequest(MockPrimaryUri),
+                new StorageResponseClassifier(MockSecondaryUri),
+                CancellationToken.None);
+            message.SetProperty(Constants.GeoRedundantRead.AlternateHostKey, MockSecondaryUri.Host);
+            var policy = new GeoRedundantReadPolicy(MockSecondaryUri);
+
+            policy.OnSendingRequest(message);
+
+            Assert.AreEqual(MockSecondaryUri.Host, message.Request.UriBuilder.Host);
+            Assert.IsTrue(message.TryGetProperty(Constants.GeoRedundantRead.AlternateHostKey, out object val)
+                && (string)val == MockPrimaryUri.Host);
+        }
+
+        [Test]
+        public void OnSendingRequest_ThirdTry_ShouldUsePrimary_ShouldSetAlternateToSecondary()
+        {
+            var message = new HttpPipelineMessage(
+                this.CreateMockRequest(MockSecondaryUri),
+                new StorageResponseClassifier(MockSecondaryUri),
+                CancellationToken.None);
+            message.SetProperty(Constants.GeoRedundantRead.AlternateHostKey, MockPrimaryUri.Host);
+            var policy = new GeoRedundantReadPolicy(MockSecondaryUri);
+
+            policy.OnSendingRequest(message);
+
+            Assert.AreEqual(MockPrimaryUri.Host, message.Request.UriBuilder.Host);
+            Assert.IsTrue(message.TryGetProperty(Constants.GeoRedundantRead.AlternateHostKey, out object val)
+                && (string)val == MockSecondaryUri.Host);
+        }
+
+        [Test]
+        public void OnSendingRequest_404onSecondary_ShouldSetNotFoundFlag_ShouldUsePrimary()
+        {
+            var message = new HttpPipelineMessage(
+                this.CreateMockRequest(MockSecondaryUri),
+                new StorageResponseClassifier(MockSecondaryUri),
+                CancellationToken.None)
+            {
+                Response = new MockResponse(Constants.HttpStatusCode.NotFound)
+            };
+            message.SetProperty(Constants.GeoRedundantRead.AlternateHostKey, MockSecondaryUri.Host);
+            var policy = new GeoRedundantReadPolicy(MockSecondaryUri);
+
+            policy.OnSendingRequest(message);
+
+            Assert.AreEqual(MockSecondaryUri.Host, message.Request.UriBuilder.Host);
+            Assert.IsTrue(message.TryGetProperty(Constants.GeoRedundantRead.ResourceNotReplicated, out object val)
+                && (bool) val);
+        }
+
+        [Test]
+        public void OnSendingRequest_404FlagSet_ShouldUsePrimary()
+        {
+            var message = new HttpPipelineMessage(
+                this.CreateMockRequest(MockPrimaryUri),
+                new StorageResponseClassifier(MockSecondaryUri),
+                CancellationToken.None);
+            message.SetProperty(Constants.GeoRedundantRead.AlternateHostKey, MockSecondaryUri.Host);
+            message.SetProperty(Constants.GeoRedundantRead.ResourceNotReplicated, true);
+            var policy = new GeoRedundantReadPolicy(MockSecondaryUri);
+
+            policy.OnSendingRequest(message);
+
+            Assert.AreEqual(MockPrimaryUri.Host, message.Request.UriBuilder.Host);
+        }
+
+        [Test]
+        public void OnSendingRequest_PutRequest_ShouldIgnore()
+        {
+            var request = CreateMockRequest(MockPrimaryUri);
+            request.Method = RequestMethod.Put;
+            var message = new HttpPipelineMessage(
+                request,
+                new StorageResponseClassifier(MockSecondaryUri),
+                CancellationToken.None);
+            var policy = new GeoRedundantReadPolicy(MockSecondaryUri);
+
+            policy.OnSendingRequest(message);
+
+            Assert.AreEqual(MockPrimaryUri.Host, message.Request.UriBuilder.Host);
+            Assert.IsFalse(message.TryGetProperty(Constants.GeoRedundantRead.AlternateHostKey, out object val)
+                && (string)val == MockSecondaryUri.Host);
+        }
+
+        private MockRequest CreateMockRequest(Uri uri)
+        {
+            MockRequest mockRequest = new MockRequest();
+            mockRequest.UriBuilder.Uri = uri;
+            mockRequest.Method = RequestMethod.Get;
+            return mockRequest;
+        }
+
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/tests/GeoRedundantReadPolicyTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/GeoRedundantReadPolicyTests.cs
@@ -19,9 +19,9 @@ namespace Azure.Storage.Common.Tests
         public void OnSendingRequest_FirstTry_ShouldUsePrimary_ShouldSetAlternateToSecondary()
         {
             var message = new HttpPipelineMessage(
-                this.CreateMockRequest(MockPrimaryUri),
-                new StorageResponseClassifier(MockSecondaryUri),
-                CancellationToken.None);
+                CreateMockRequest(MockPrimaryUri),
+                new StorageResponseClassifier(MockSecondaryUri));
+
             var policy = new GeoRedundantReadPolicy(MockSecondaryUri);
 
             policy.OnSendingRequest(message);
@@ -35,9 +35,9 @@ namespace Azure.Storage.Common.Tests
         public void OnSendingRequest_SecondTry_ShouldUseSecondary_ShouldSetAlternateToPrimary()
         {
             var message = new HttpPipelineMessage(
-                this.CreateMockRequest(MockPrimaryUri),
-                new StorageResponseClassifier(MockSecondaryUri),
-                CancellationToken.None);
+                CreateMockRequest(MockPrimaryUri),
+                new StorageResponseClassifier(MockSecondaryUri));
+
             message.SetProperty(Constants.GeoRedundantRead.AlternateHostKey, MockSecondaryUri.Host);
             var policy = new GeoRedundantReadPolicy(MockSecondaryUri);
 
@@ -52,9 +52,9 @@ namespace Azure.Storage.Common.Tests
         public void OnSendingRequest_ThirdTry_ShouldUsePrimary_ShouldSetAlternateToSecondary()
         {
             var message = new HttpPipelineMessage(
-                this.CreateMockRequest(MockSecondaryUri),
-                new StorageResponseClassifier(MockSecondaryUri),
-                CancellationToken.None);
+                CreateMockRequest(MockSecondaryUri),
+                new StorageResponseClassifier(MockSecondaryUri));
+
             message.SetProperty(Constants.GeoRedundantRead.AlternateHostKey, MockPrimaryUri.Host);
             var policy = new GeoRedundantReadPolicy(MockSecondaryUri);
 
@@ -69,9 +69,9 @@ namespace Azure.Storage.Common.Tests
         public void OnSendingRequest_404onSecondary_ShouldSetNotFoundFlag_ShouldUsePrimary()
         {
             var message = new HttpPipelineMessage(
-                this.CreateMockRequest(MockSecondaryUri),
-                new StorageResponseClassifier(MockSecondaryUri),
-                CancellationToken.None)
+                CreateMockRequest(MockSecondaryUri),
+                new StorageResponseClassifier(MockSecondaryUri))
+
             {
                 Response = new MockResponse(Constants.HttpStatusCode.NotFound)
             };
@@ -89,9 +89,9 @@ namespace Azure.Storage.Common.Tests
         public void OnSendingRequest_404FlagSet_ShouldUsePrimary()
         {
             var message = new HttpPipelineMessage(
-                this.CreateMockRequest(MockPrimaryUri),
-                new StorageResponseClassifier(MockSecondaryUri),
-                CancellationToken.None);
+                CreateMockRequest(MockPrimaryUri),
+                new StorageResponseClassifier(MockSecondaryUri));
+
             message.SetProperty(Constants.GeoRedundantRead.AlternateHostKey, MockSecondaryUri.Host);
             message.SetProperty(Constants.GeoRedundantRead.ResourceNotReplicated, true);
             var policy = new GeoRedundantReadPolicy(MockSecondaryUri);
@@ -104,12 +104,12 @@ namespace Azure.Storage.Common.Tests
         [Test]
         public void OnSendingRequest_PutRequest_ShouldIgnore()
         {
-            var request = CreateMockRequest(MockPrimaryUri);
+            MockRequest request = CreateMockRequest(MockPrimaryUri);
             request.Method = RequestMethod.Put;
             var message = new HttpPipelineMessage(
                 request,
-                new StorageResponseClassifier(MockSecondaryUri),
-                CancellationToken.None);
+                new StorageResponseClassifier(MockSecondaryUri));
+
             var policy = new GeoRedundantReadPolicy(MockSecondaryUri);
 
             policy.OnSendingRequest(message);

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/TestExceptionPolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/TestExceptionPolicy.cs
@@ -26,16 +26,16 @@ namespace Azure.Storage.Common.Test
 
         public TestExceptionPolicy(int numberOfReadFailuresToSimulate, Uri secondaryUri, bool simulate404 = false, List<RequestMethod> trackedRequestMethods = null)
         {
-            this.NumberOfReadFailuresToSimulate = numberOfReadFailuresToSimulate;
-            this.Simulate404 = simulate404;
-            this.SecondaryUri = secondaryUri;
-            this.HostsSetInRequests = new List<string>();
-            this.TrackedRequestMethods = trackedRequestMethods ?? new List<RequestMethod>(new RequestMethod[] { RequestMethod.Get, RequestMethod.Head });
+            NumberOfReadFailuresToSimulate = numberOfReadFailuresToSimulate;
+            Simulate404 = simulate404;
+            SecondaryUri = secondaryUri;
+            HostsSetInRequests = new List<string>();
+            TrackedRequestMethods = trackedRequestMethods ?? new List<RequestMethod>(new RequestMethod[] { RequestMethod.Get, RequestMethod.Head });
         }
 
         public override void Process(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
-            if (!this.SimulateFailure(message))
+            if (!SimulateFailure(message))
             {
                 ProcessNext(message, pipeline);
             }
@@ -43,7 +43,7 @@ namespace Azure.Storage.Common.Test
 
         public override async ValueTask ProcessAsync(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
-            if (!this.SimulateFailure(message))
+            if (!SimulateFailure(message))
             {
                 await ProcessNextAsync(message, pipeline).ConfigureAwait(false);
             }
@@ -51,13 +51,13 @@ namespace Azure.Storage.Common.Test
 
         private bool SimulateFailure(HttpPipelineMessage message)
         {
-            if (this.TrackedRequestMethods.Contains(message.Request.Method))
+            if (TrackedRequestMethods.Contains(message.Request.Method))
             {
-                this.CurrentInvocationNumber++;
-                this.HostsSetInRequests.Add(message.Request.UriBuilder.Host);
-                if (this.CurrentInvocationNumber <= this.NumberOfReadFailuresToSimulate)
+                CurrentInvocationNumber++;
+                HostsSetInRequests.Add(message.Request.UriBuilder.Host);
+                if (CurrentInvocationNumber <= NumberOfReadFailuresToSimulate)
                 {
-                    message.Response = new MockResponse(this.Simulate404 && message.Request.UriBuilder.Host == this.SecondaryUri.Host ? 404 : 429);
+                    message.Response = new MockResponse(Simulate404 && message.Request.UriBuilder.Host == SecondaryUri.Host ? 404 : 429);
                     return true;
                 }
             }

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/TestExceptionPolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/TestExceptionPolicy.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Azure.Core.Pipeline;
+using Azure.Core.Testing;
+
+namespace Azure.Storage.Common.Test
+{
+    public class TestExceptionPolicy : HttpPipelinePolicy
+    {
+        public List<string> HostsSetInRequests { get; private set; }
+
+        private int CurrentInvocationNumber { get; set; }
+
+        private int NumberOfReadFailuresToSimulate { get; set; }
+
+        private Uri SecondaryUri { get; set; }
+
+        private bool Simulate404 { get; set; }
+
+        private List<RequestMethod> TrackedRequestMethods { get; set; }
+
+        public TestExceptionPolicy(int numberOfReadFailuresToSimulate, Uri secondaryUri, bool simulate404 = false, List<RequestMethod> trackedRequestMethods = null)
+        {
+            this.NumberOfReadFailuresToSimulate = numberOfReadFailuresToSimulate;
+            this.Simulate404 = simulate404;
+            this.SecondaryUri = secondaryUri;
+            this.HostsSetInRequests = new List<string>();
+            this.TrackedRequestMethods = trackedRequestMethods ?? new List<RequestMethod>(new RequestMethod[] { RequestMethod.Get, RequestMethod.Head });
+        }
+
+        public override void Process(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+        {
+            if (!this.SimulateFailure(message))
+            {
+                ProcessNext(message, pipeline);
+            }
+        }
+
+        public override async ValueTask ProcessAsync(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+        {
+            if (!this.SimulateFailure(message))
+            {
+                await ProcessNextAsync(message, pipeline).ConfigureAwait(false);
+            }
+        }
+
+        private bool SimulateFailure(HttpPipelineMessage message)
+        {
+            if (this.TrackedRequestMethods.Contains(message.Request.Method))
+            {
+                this.CurrentInvocationNumber++;
+                this.HostsSetInRequests.Add(message.Request.UriBuilder.Host);
+                if (this.CurrentInvocationNumber <= this.NumberOfReadFailuresToSimulate)
+                {
+                    message.Response = new MockResponse(this.Simulate404 && message.Request.UriBuilder.Host == this.SecondaryUri.Host ? 404 : 429);
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/tests/StorageResponseClassifierTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/StorageResponseClassifierTests.cs
@@ -53,8 +53,7 @@ namespace Azure.Storage.Common.Tests
                 {
                     Method = RequestMethod.Get
                 },
-                new StorageResponseClassifier(MockSecondaryUri),
-                CancellationToken.None)
+                new StorageResponseClassifier(MockSecondaryUri))
             {
                 Response = response
             };

--- a/sdk/storage/Azure.Storage.Common/tests/StorageResponseClassifierTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/StorageResponseClassifierTests.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+using System;
+using System.Threading;
+using Azure.Core.Pipeline;
+using Azure.Core.Testing;
+using NUnit.Framework;
+
+namespace Azure.Storage.Common.Tests
+{
+    public class StorageResponseClassifierTests
+    {
+        private static readonly Uri MockPrimaryUri = new Uri("http://dummyaccount.blob.core.windows.net");
+        private static readonly Uri MockSecondaryUri = new Uri("http://dummyaccount-secondary.blob.core.windows.net");
+        private static readonly StorageResponseClassifier classifier = new StorageResponseClassifier(MockSecondaryUri);
+
+        [Test]
+        public void IsRetriableResponse_404OnSecondary_ShouldBeTrue()
+        {
+            var message = BuildMessage(new MockResponse(Constants.HttpStatusCode.NotFound));
+            message.Request.UriBuilder.Host = MockSecondaryUri.Host;
+
+            Assert.IsTrue(classifier.IsRetriableResponse(message));
+        }
+
+        [Test]
+        [TestCase(500)]
+        [TestCase(429)]
+        [TestCase(503)]
+        public void IsRetriableResponse_OtherStatusCodeOnSecondary_ShouldMatchBase(int statusCode)
+        {
+            var message = BuildMessage(new MockResponse(statusCode));
+            message.Request.UriBuilder.Host = MockSecondaryUri.Host;
+
+            Assert.AreEqual(new ResponseClassifier().IsRetriableResponse(message), classifier.IsRetriableResponse(message));
+        }
+
+        [Test]
+        public void IsRetriableResponse_404OnPrimary_ShouldBeFalse()
+        {
+            var message = BuildMessage(new MockResponse(Constants.HttpStatusCode.NotFound));
+            message.Request.UriBuilder.Host = MockPrimaryUri.Host;
+
+            Assert.IsFalse(classifier.IsRetriableResponse(message));
+        }
+
+        private HttpPipelineMessage BuildMessage(Response response)
+        {
+            return new HttpPipelineMessage(
+                new MockRequest()
+                {
+                    Method = RequestMethod.Get
+                },
+                new StorageResponseClassifier(MockSecondaryUri),
+                CancellationToken.None)
+            {
+                Response = response
+            };
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/tests/StorageResponseClassifierTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/StorageResponseClassifierTests.cs
@@ -19,7 +19,7 @@ namespace Azure.Storage.Common.Tests
         [Test]
         public void IsRetriableResponse_404OnSecondary_ShouldBeTrue()
         {
-            var message = BuildMessage(new MockResponse(Constants.HttpStatusCode.NotFound));
+            HttpPipelineMessage message = BuildMessage(new MockResponse(Constants.HttpStatusCode.NotFound));
             message.Request.UriBuilder.Host = MockSecondaryUri.Host;
 
             Assert.IsTrue(classifier.IsRetriableResponse(message));
@@ -31,7 +31,7 @@ namespace Azure.Storage.Common.Tests
         [TestCase(503)]
         public void IsRetriableResponse_OtherStatusCodeOnSecondary_ShouldMatchBase(int statusCode)
         {
-            var message = BuildMessage(new MockResponse(statusCode));
+            HttpPipelineMessage message = BuildMessage(new MockResponse(statusCode));
             message.Request.UriBuilder.Host = MockSecondaryUri.Host;
 
             Assert.AreEqual(new ResponseClassifier().IsRetriableResponse(message), classifier.IsRetriableResponse(message));
@@ -40,7 +40,7 @@ namespace Azure.Storage.Common.Tests
         [Test]
         public void IsRetriableResponse_404OnPrimary_ShouldBeFalse()
         {
-            var message = BuildMessage(new MockResponse(Constants.HttpStatusCode.NotFound));
+            HttpPipelineMessage message = BuildMessage(new MockResponse(Constants.HttpStatusCode.NotFound));
             message.Request.UriBuilder.Host = MockPrimaryUri.Host;
 
             Assert.IsFalse(classifier.IsRetriableResponse(message));

--- a/sdk/storage/Azure.Storage.Files/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files/tests/ServiceClientTests.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Azure.Core.Testing;
 using Azure.Storage.Common;
 using Azure.Storage.Files.Models;
 using Azure.Storage.Files.Tests;

--- a/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
@@ -117,10 +117,10 @@ namespace Azure.Storage.Queues
                 {
                     QueueName = queueName
                 };
-            this._uri = builder.Uri;
-            this._messagesUri = this._uri.AppendToPath(Constants.Queue.MessagesUri);
+            _uri = builder.Uri;
+            _messagesUri = _uri.AppendToPath(Constants.Queue.MessagesUri);
             options ??= new QueueClientOptions();
-            this._pipeline = options.Build(conn.Credentials);
+            _pipeline = options.Build(conn.Credentials);
         }
 
         /// <summary>
@@ -201,10 +201,10 @@ namespace Azure.Storage.Queues
         /// </param>
         internal QueueClient(Uri queueUri, HttpPipelinePolicy authentication, QueueClientOptions options)
         {
-            this._uri = queueUri;
-            this._messagesUri = queueUri.AppendToPath(Constants.Queue.MessagesUri);
+            _uri = queueUri;
+            _messagesUri = queueUri.AppendToPath(Constants.Queue.MessagesUri);
             options ??= new QueueClientOptions();
-            this._pipeline = options.Build(authentication);
+            _pipeline = options.Build(authentication);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
@@ -117,9 +117,10 @@ namespace Azure.Storage.Queues
                 {
                     QueueName = queueName
                 };
-            _uri = builder.Uri;
-            _messagesUri = _uri.AppendToPath(Constants.Queue.MessagesUri);
-            _pipeline = (options ?? new QueueClientOptions()).Build(conn.Credentials);
+            this._uri = builder.Uri;
+            this._messagesUri = this._uri.AppendToPath(Constants.Queue.messagesUri);
+            options ??= new QueueClientOptions();
+            this._pipeline = options.Build(conn.Credentials);
         }
 
         /// <summary>
@@ -200,9 +201,10 @@ namespace Azure.Storage.Queues
         /// </param>
         internal QueueClient(Uri queueUri, HttpPipelinePolicy authentication, QueueClientOptions options)
         {
-            _uri = queueUri;
-            _messagesUri = queueUri.AppendToPath(Constants.Queue.MessagesUri);
-            _pipeline = (options ?? new QueueClientOptions()).Build(authentication);
+            this._uri = queueUri;
+            this._messagesUri = queueUri.AppendToPath(Constants.Queue.messagesUri);
+            options ??= new QueueClientOptions();
+            this._pipeline = options.Build(authentication);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
@@ -118,7 +118,7 @@ namespace Azure.Storage.Queues
                     QueueName = queueName
                 };
             this._uri = builder.Uri;
-            this._messagesUri = this._uri.AppendToPath(Constants.Queue.messagesUri);
+            this._messagesUri = this._uri.AppendToPath(Constants.Queue.MessagesUri);
             options ??= new QueueClientOptions();
             this._pipeline = options.Build(conn.Credentials);
         }
@@ -202,7 +202,7 @@ namespace Azure.Storage.Queues
         internal QueueClient(Uri queueUri, HttpPipelinePolicy authentication, QueueClientOptions options)
         {
             this._uri = queueUri;
-            this._messagesUri = queueUri.AppendToPath(Constants.Queue.messagesUri);
+            this._messagesUri = queueUri.AppendToPath(Constants.Queue.MessagesUri);
             options ??= new QueueClientOptions();
             this._pipeline = options.Build(authentication);
         }

--- a/sdk/storage/Azure.Storage.Queues/src/QueueClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueClientOptions.cs
@@ -74,7 +74,7 @@ namespace Azure.Storage.Queues
         /// <returns>An HttpPipeline to use for Storage requests.</returns>
         internal HttpPipeline Build(HttpPipelinePolicy authentication = null)
         {
-            return this.Build(authentication, this.GeoRedundantSecondaryUri);
+            return this.Build(authentication, GeoRedundantSecondaryUri);
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace Azure.Storage.Queues
         /// <returns>An HttpPipeline to use for Storage requests.</returns>
         internal HttpPipeline Build(object credentials)
         {
-            return this.Build(credentials, this.GeoRedundantSecondaryUri);
+            return this.Build(credentials, GeoRedundantSecondaryUri);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Queues/src/QueueClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueClientOptions.cs
@@ -3,7 +3,6 @@
 // license information.
 
 using System;
-using Azure.Core;
 using Azure.Core.Pipeline;
 
 namespace Azure.Storage.Queues
@@ -54,6 +53,38 @@ namespace Azure.Storage.Queues
         {
             Version = version;
             this.Initialize();
+        }
+
+        /// <summary>
+        /// Gets or sets the secondary storage <see cref="Uri"/> that can be read from for the storage account if the
+        /// account is enabled for RA-GRS.
+        /// 
+        /// If this property is set, the secondary Uri will be used for GET or HEAD requests during retries.
+        /// If the status of the response from the secondary Uri is a 404, then subsequent retries for 
+        /// the request will not use the secondary Uri again, as this indicates that the resource
+        /// may not have propagated there yet. Otherwise, subsequent retries will alternate back and forth
+        /// between primary and secondary Uri.
+        /// </summary>
+        public Uri GeoRedundantSecondaryUri { get; set; }
+
+        /// <summary>
+        /// Create an HttpPipeline from QueueClientOptions.
+        /// </summary>
+        /// <param name="authentication">Optional authentication policy.</param>
+        /// <returns>An HttpPipeline to use for Storage requests.</returns>
+        internal HttpPipeline Build(HttpPipelinePolicy authentication = null)
+        {
+            return this.Build(authentication, this.GeoRedundantSecondaryUri);
+        }
+
+        /// <summary>
+        /// Create an HttpPipeline from QueueClientOptions.
+        /// </summary>
+        /// <param name="credentials">Optional authentication credentials.</param>
+        /// <returns>An HttpPipeline to use for Storage requests.</returns>
+        internal HttpPipeline Build(object credentials)
+        {
+            return this.Build(credentials, this.GeoRedundantSecondaryUri);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Queues/src/QueueServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueServiceClient.cs
@@ -82,9 +82,9 @@ namespace Azure.Storage.Queues
         public QueueServiceClient(string connectionString, QueueClientOptions options)
         {
             var conn = StorageConnectionString.Parse(connectionString);
-            this._uri = conn.QueueEndpoint;
+            _uri = conn.QueueEndpoint;
             options ??= new QueueClientOptions();
-            this._pipeline = options.Build(conn.Credentials);
+            _pipeline = options.Build(conn.Credentials);
         }
 
         /// <summary>
@@ -161,9 +161,9 @@ namespace Azure.Storage.Queues
         /// </param>
         internal QueueServiceClient(Uri serviceUri, HttpPipelinePolicy authentication, QueueClientOptions options)
         {
-            this._uri = serviceUri;
+            _uri = serviceUri;
             options ??= new QueueClientOptions();
-            this._pipeline = options.Build(authentication);
+            _pipeline = options.Build(authentication);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Queues/src/QueueServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueServiceClient.cs
@@ -82,8 +82,9 @@ namespace Azure.Storage.Queues
         public QueueServiceClient(string connectionString, QueueClientOptions options)
         {
             var conn = StorageConnectionString.Parse(connectionString);
-            _uri = conn.QueueEndpoint;
-            _pipeline = (options ?? new QueueClientOptions()).Build(conn.Credentials);
+            this._uri = conn.QueueEndpoint;
+            options ??= new QueueClientOptions();
+            this._pipeline = options.Build(conn.Credentials);
         }
 
         /// <summary>
@@ -160,8 +161,9 @@ namespace Azure.Storage.Queues
         /// </param>
         internal QueueServiceClient(Uri serviceUri, HttpPipelinePolicy authentication, QueueClientOptions options)
         {
-            _uri = serviceUri;
-            _pipeline = (options ?? new QueueClientOptions()).Build(authentication);
+            this._uri = serviceUri;
+            options ??= new QueueClientOptions();
+            this._pipeline = options.Build(authentication);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueClientTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueClientTests.cs
@@ -37,9 +37,9 @@ namespace Azure.Storage.Queues.Test
 
             var queueName = GetNewQueueName();
 
-            var client1 = this.InstrumentClient(new QueueClient(connectionString.ToString(true), queueName, this.GetOptions()));
+            QueueClient client1 = InstrumentClient(new QueueClient(connectionString.ToString(true), queueName, GetOptions()));
 
-            var client2 = this.InstrumentClient(new QueueClient(connectionString.ToString(true), queueName));
+            QueueClient client2 = InstrumentClient(new QueueClient(connectionString.ToString(true), queueName));
 
             var builder1 = new QueueUriBuilder(client1.Uri);
             var builder2 = new QueueUriBuilder(client2.Uri);
@@ -58,7 +58,7 @@ namespace Azure.Storage.Queues.Test
             var queueEndpoint = new Uri("http://127.0.0.1/" + accountName);
             var credentials = new StorageSharedKeyCredential(accountName, accountKey);
 
-            var queue = this.InstrumentClient(new QueueClient(queueEndpoint, credentials));
+            QueueClient queue = InstrumentClient(new QueueClient(queueEndpoint, credentials));
             var builder = new QueueUriBuilder(queue.Uri);
 
             Assert.AreEqual(accountName, builder.AccountName);
@@ -226,10 +226,9 @@ namespace Azure.Storage.Queues.Test
         [Test]
         public async Task GetPropertiesAsync_SecondaryStorage()
         {
-            TestExceptionPolicy testExceptionPolicy;
-            var queueClient = this.GetQueueClient_SecondaryAccount_ReadEnabledOnRetry(1, out testExceptionPolicy);
+            QueueClient queueClient = GetQueueClient_SecondaryAccount_ReadEnabledOnRetry(1, out TestExceptionPolicy testExceptionPolicy);
             await queueClient.CreateAsync();
-            var properties = await this.EnsurePropagatedAsync(
+            Response<QueueProperties> properties = await EnsurePropagatedAsync(
                 async () => await queueClient.GetPropertiesAsync(),
                 properties => properties.GetRawResponse().Status != 404);
 
@@ -237,7 +236,7 @@ namespace Azure.Storage.Queues.Test
             Assert.AreEqual(200, properties.GetRawResponse().Status);
 
             await queueClient.DeleteAsync();
-            this.AssertSecondaryStorageFirstRetrySuccessful(SecondaryStorageTenantPrimaryHost(), SecondaryStorageTenantSecondaryHost(), testExceptionPolicy);
+            AssertSecondaryStorageFirstRetrySuccessful(SecondaryStorageTenantPrimaryHost(), SecondaryStorageTenantSecondaryHost(), testExceptionPolicy);
         }
         #endregion
 

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueTestBase.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueTestBase.cs
@@ -79,16 +79,16 @@ namespace Azure.Storage.Queues.Tests
             GetServiceClientFromOauthConfig(TestConfigOAuth);
 
         public QueueServiceClient GetServiceClient_SecondaryAccount_ReadEnabledOnRetry(int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false)
-=> this.GetSecondaryReadServiceClient(this.TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404);
+=> GetSecondaryReadServiceClient(TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404);
 
         public QueueClient GetQueueClient_SecondaryAccount_ReadEnabledOnRetry(int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false)
-=> this.GetSecondaryReadQueueClient(this.TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404);
+=> GetSecondaryReadQueueClient(TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404);
 
         private QueueServiceClient GetSecondaryReadServiceClient(TenantConfiguration config, int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
         {
-            var options = this.getSecondaryStorageOptions(config, out testExceptionPolicy, numberOfReadFailuresToSimulate, simulate404, enabledRequestMethods);
+            QueueClientOptions options = getSecondaryStorageOptions(config, out testExceptionPolicy, numberOfReadFailuresToSimulate, simulate404, enabledRequestMethods);
 
-            return this.InstrumentClient(
+            return InstrumentClient(
                  new QueueServiceClient(
                     new Uri(config.QueueServiceEndpoint),
                     new StorageSharedKeyCredential(config.AccountName, config.AccountKey),
@@ -97,18 +97,18 @@ namespace Azure.Storage.Queues.Tests
 
         private QueueClient GetSecondaryReadQueueClient(TenantConfiguration config, int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
         {
-            var options = this.getSecondaryStorageOptions(config, out testExceptionPolicy, numberOfReadFailuresToSimulate, simulate404, enabledRequestMethods);
+            QueueClientOptions options = getSecondaryStorageOptions(config, out testExceptionPolicy, numberOfReadFailuresToSimulate, simulate404, enabledRequestMethods);
             
-            return this.InstrumentClient(
+            return InstrumentClient(
                  new QueueClient(
-                    new Uri(config.QueueServiceEndpoint).AppendToPath(this.GetNewQueueName()),
+                    new Uri(config.QueueServiceEndpoint).AppendToPath(GetNewQueueName()),
                     new StorageSharedKeyCredential(config.AccountName, config.AccountKey),
                     options));
         }
 
         private QueueClientOptions getSecondaryStorageOptions(TenantConfiguration config, out TestExceptionPolicy testExceptionPolicy, int numberOfReadFailuresToSimulate = 1, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
         {
-            var options = this.GetOptions();
+            QueueClientOptions options = GetOptions();
             options.GeoRedundantSecondaryUri = new Uri(config.QueueServiceSecondaryEndpoint);
             options.Retry.MaxRetries = 4;
             testExceptionPolicy = new TestExceptionPolicy(numberOfReadFailuresToSimulate, options.GeoRedundantSecondaryUri, simulate404, enabledRequestMethods);

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueTestBase.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueTestBase.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Net;
 using Azure.Core.Pipeline;
 using Azure.Core.Testing;
+using Azure.Storage.Common.Test;
 using Azure.Storage.Queues.Models;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
@@ -18,6 +19,12 @@ namespace Azure.Storage.Queues.Tests
     {
         public string GetNewQueueName() => $"test-queue-{Recording.Random.NewGuid()}";
         public string GetNewMessageId() => $"test-message-{Recording.Random.NewGuid()}";
+
+        protected string SecondaryStorageTenantPrimaryHost() =>
+            new Uri(TestConfigSecondary.QueueServiceEndpoint).Host;
+
+        protected string SecondaryStorageTenantSecondaryHost() =>
+            new Uri(TestConfigSecondary.QueueServiceSecondaryEndpoint).Host;
 
         public QueueTestBase(bool async) : this(async, null) { }
 
@@ -70,6 +77,44 @@ namespace Azure.Storage.Queues.Tests
 
         public QueueServiceClient GetServiceClient_OauthAccount() =>
             GetServiceClientFromOauthConfig(TestConfigOAuth);
+
+        public QueueServiceClient GetServiceClient_SecondaryAccount_ReadEnabledOnRetry(int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false)
+=> this.GetSecondaryReadServiceClient(this.TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404);
+
+        public QueueClient GetQueueClient_SecondaryAccount_ReadEnabledOnRetry(int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false)
+=> this.GetSecondaryReadQueueClient(this.TestConfigSecondary, numberOfReadFailuresToSimulate, out testExceptionPolicy, simulate404);
+
+        private QueueServiceClient GetSecondaryReadServiceClient(TenantConfiguration config, int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
+        {
+            var options = this.getSecondaryStorageOptions(config, out testExceptionPolicy, numberOfReadFailuresToSimulate, simulate404, enabledRequestMethods);
+
+            return this.InstrumentClient(
+                 new QueueServiceClient(
+                    new Uri(config.QueueServiceEndpoint),
+                    new StorageSharedKeyCredential(config.AccountName, config.AccountKey),
+                    options));
+        }
+
+        private QueueClient GetSecondaryReadQueueClient(TenantConfiguration config, int numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
+        {
+            var options = this.getSecondaryStorageOptions(config, out testExceptionPolicy, numberOfReadFailuresToSimulate, simulate404, enabledRequestMethods);
+            
+            return this.InstrumentClient(
+                 new QueueClient(
+                    new Uri(config.QueueServiceEndpoint).AppendToPath(this.GetNewQueueName()),
+                    new StorageSharedKeyCredential(config.AccountName, config.AccountKey),
+                    options));
+        }
+
+        private QueueClientOptions getSecondaryStorageOptions(TenantConfiguration config, out TestExceptionPolicy testExceptionPolicy, int numberOfReadFailuresToSimulate = 1, bool simulate404 = false, List<RequestMethod> enabledRequestMethods = null)
+        {
+            var options = this.GetOptions();
+            options.GeoRedundantSecondaryUri = new Uri(config.QueueServiceSecondaryEndpoint);
+            options.Retry.MaxRetries = 4;
+            testExceptionPolicy = new TestExceptionPolicy(numberOfReadFailuresToSimulate, options.GeoRedundantSecondaryUri, simulate404, enabledRequestMethods);
+            options.AddPolicy(testExceptionPolicy, HttpPipelinePosition.PerRetry);
+            return options;
+        }
 
         private QueueServiceClient GetServiceClientFromOauthConfig(TenantConfiguration config) =>
             InstrumentClient(

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueClientTests/Ctor_Uri.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueClientTests/Ctor_Uri.json
@@ -1,0 +1,4 @@
+{
+  "Entries": [],
+  "Variables": {}
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueClientTests/Ctor_UriAsync.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueClientTests/Ctor_UriAsync.json
@@ -1,0 +1,4 @@
+{
+  "Entries": [],
+  "Variables": {}
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueClientTests/GetPropertiesAsync_SecondaryStorage.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueClientTests/GetPropertiesAsync_SecondaryStorage.json
@@ -1,0 +1,134 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002ftest-queue-ec4204e8-6a04-18e5-d764-bd3ba96ec4e0",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Request-Id": "|a8343030-40c25a7c64e61204.",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "ab1bd1e74a92233b27b5b694e7c37ad1",
+        "x-ms-date": "Mon, 16 Sep 2019 18:58:41 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 16 Sep 2019 18:58:41 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-request-id": "f033ee38-5003-0071-2cc0-6cab25000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002ftest-queue-ec4204e8-6a04-18e5-d764-bd3ba96ec4e0?comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Request-Id": "|a8343031-40c25a7c64e61204.",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "d3ce94c69b23c67056a0f95440d2f995",
+        "x-ms-date": "Mon, 16 Sep 2019 18:58:41 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Length": "217",
+        "Content-Type": "application\u002fxml",
+        "Date": "Mon, 16 Sep 2019 18:58:41 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-error-code": "QueueNotFound",
+        "x-ms-request-id": "7bf1dea0-5003-0029-79c0-6c4442000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": [
+        "\ufeff\u003c?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003e\u003cError\u003e\u003cCode\u003eQueueNotFound\u003c\u002fCode\u003e\u003cMessage\u003eThe specified queue does not exist.\n",
+        "RequestId:7bf1dea0-5003-0029-79c0-6c4442000000\n",
+        "Time:2019-09-16T18:58:42.0588344Z\u003c\u002fMessage\u003e\u003c\u002fError\u003e"
+      ]
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002ftest-queue-ec4204e8-6a04-18e5-d764-bd3ba96ec4e0?comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Request-Id": "|a8343031-40c25a7c64e61204.",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "d3ce94c69b23c67056a0f95440d2f995",
+        "x-ms-date": "Mon, 16 Sep 2019 18:58:41 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Mon, 16 Sep 2019 18:58:42 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "f033ef5b-5003-0071-27c0-6cab25000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002ftest-queue-ec4204e8-6a04-18e5-d764-bd3ba96ec4e0",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Request-Id": "|a8343032-40c25a7c64e61204.",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "c43da7dba0bc9e50c81ec54eb3513013",
+        "x-ms-date": "Mon, 16 Sep 2019 18:58:43 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 16 Sep 2019 18:58:43 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-request-id": "f033ef60-5003-0071-2cc0-6cab25000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1715375262",
+    "Storage_TestConfigSecondary": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttp:\u002f\u002fstorageteglazatesting.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.table.core.windows.net\n\n\n\n\nhttp:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f;QueueEndpoint=http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f;TableEndpoint=http:\u002f\u002fstorageteglazatesting.table.core.windows.net\u002f;FileEndpoint=http:\u002f\u002fstorageteglazatesting.file.core.windows.net\u002f;BlobSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f;QueueSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f;TableSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\u002f;FileSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\u002f;AccountName=storageteglazatesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueClientTests/GetPropertiesAsync_SecondaryStorageAsync.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueClientTests/GetPropertiesAsync_SecondaryStorageAsync.json
@@ -1,0 +1,134 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002ftest-queue-62e7742d-6588-c1da-7841-54e1187123b5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Request-Id": "|528398c-4e4bbbeae3a6630b.",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "63d108f16cc5a1de29a5b9fcdd4da27e",
+        "x-ms-date": "Mon, 16 Sep 2019 18:58:56 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 16 Sep 2019 18:58:57 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-request-id": "6f67c11b-e003-0064-14c0-6cbc96000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002ftest-queue-62e7742d-6588-c1da-7841-54e1187123b5?comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Request-Id": "|528398d-4e4bbbeae3a6630b.",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "f3dda65f1e372f5b70df52376123a25e",
+        "x-ms-date": "Mon, 16 Sep 2019 18:58:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Length": "217",
+        "Content-Type": "application\u002fxml",
+        "Date": "Mon, 16 Sep 2019 18:58:57 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-error-code": "QueueNotFound",
+        "x-ms-request-id": "1b8f5329-2003-0062-61c0-6c75d8000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": [
+        "\ufeff\u003c?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003e\u003cError\u003e\u003cCode\u003eQueueNotFound\u003c\u002fCode\u003e\u003cMessage\u003eThe specified queue does not exist.\n",
+        "RequestId:1b8f5329-2003-0062-61c0-6c75d8000000\n",
+        "Time:2019-09-16T18:58:58.1233480Z\u003c\u002fMessage\u003e\u003c\u002fError\u003e"
+      ]
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002ftest-queue-62e7742d-6588-c1da-7841-54e1187123b5?comp=metadata",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Request-Id": "|528398d-4e4bbbeae3a6630b.",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "f3dda65f1e372f5b70df52376123a25e",
+        "x-ms-date": "Mon, 16 Sep 2019 18:58:57 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Mon, 16 Sep 2019 18:58:59 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-approximate-messages-count": "0",
+        "x-ms-request-id": "6f67c1a6-e003-0064-07c0-6cbc96000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002ftest-queue-62e7742d-6588-c1da-7841-54e1187123b5",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Request-Id": "|528398e-4e4bbbeae3a6630b.",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "016cc79c424cc0c9954538e3acdde32a",
+        "x-ms-date": "Mon, 16 Sep 2019 18:58:59 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 16 Sep 2019 18:58:59 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-request-id": "6f67c1af-e003-0064-0fc0-6cbc96000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "217401132",
+    "Storage_TestConfigSecondary": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttp:\u002f\u002fstorageteglazatesting.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.table.core.windows.net\n\n\n\n\nhttp:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f;QueueEndpoint=http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f;TableEndpoint=http:\u002f\u002fstorageteglazatesting.table.core.windows.net\u002f;FileEndpoint=http:\u002f\u002fstorageteglazatesting.file.core.windows.net\u002f;BlobSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f;QueueSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f;TableSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\u002f;FileSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\u002f;AccountName=storageteglazatesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/Ctor_ConnectionString.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/Ctor_ConnectionString.json
@@ -1,6 +1,6 @@
 {
   "Entries": [],
   "Variables": {
-    "RandomSeed": "938329009"
+    "RandomSeed": "975635"
   }
 }

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/Ctor_ConnectionStringAsync.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/Ctor_ConnectionStringAsync.json
@@ -1,6 +1,6 @@
 {
   "Entries": [],
   "Variables": {
-    "RandomSeed": "938329009"
+    "RandomSeed": "1981232040"
   }
 }

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/Ctor_Uri.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/Ctor_Uri.json
@@ -1,0 +1,4 @@
+{
+  "Entries": [],
+  "Variables": {}
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/Ctor_UriAsync.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/Ctor_UriAsync.json
@@ -1,0 +1,4 @@
+{
+  "Entries": [],
+  "Variables": {}
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/GetQueuesAsync_SecondaryStorage404OnSecondary.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/GetQueuesAsync_SecondaryStorage404OnSecondary.json
@@ -1,0 +1,97 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002ftest-queue-d5f66aa8-98df-ba21-bd2d-d1f195793349",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Request-Id": "|52dbda8b-4ba0274d4faf14c1.",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "63d1685f5b201de89c1731b71cfa9531",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:07 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 16 Sep 2019 18:57:06 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-request-id": "0199831f-d003-000d-31c0-6c85da000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f?comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "6131a28db6a06f035efec6c9151f1bee",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:07 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "no-cache",
+        "Content-Type": "application\u002fxml",
+        "Date": "Mon, 16 Sep 2019 18:57:09 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-request-id": "0199880d-d003-000d-73c0-6c85da000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": "\ufeff\u003c?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003e\u003cEnumerationResults ServiceEndpoint=\u0022http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f\u0022\u003e\u003cQueues\u003e\u003cQueue\u003e\u003cName\u003etest-queue-d5f66aa8-98df-ba21-bd2d-d1f195793349\u003c\u002fName\u003e\u003c\u002fQueue\u003e\u003c\u002fQueues\u003e\u003cNextMarker \u002f\u003e\u003c\u002fEnumerationResults\u003e"
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002ftest-queue-d5f66aa8-98df-ba21-bd2d-d1f195793349",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Request-Id": "|52dbda8c-4ba0274d4faf14c1.",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "474f1b18a3244cd682d839c866699ec3",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 16 Sep 2019 18:57:09 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-request-id": "01998813-d003-000d-79c0-6c85da000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1293251332",
+    "Storage_TestConfigSecondary": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttp:\u002f\u002fstorageteglazatesting.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.table.core.windows.net\n\n\n\n\nhttp:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f;QueueEndpoint=http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f;TableEndpoint=http:\u002f\u002fstorageteglazatesting.table.core.windows.net\u002f;FileEndpoint=http:\u002f\u002fstorageteglazatesting.file.core.windows.net\u002f;BlobSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f;QueueSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f;TableSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\u002f;FileSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\u002f;AccountName=storageteglazatesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/GetQueuesAsync_SecondaryStorage404OnSecondaryAsync.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/GetQueuesAsync_SecondaryStorage404OnSecondaryAsync.json
@@ -1,0 +1,97 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002ftest-queue-b7983520-9e7f-2805-9f18-c89f79f0994d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Request-Id": "|73c6cd7f-4d1567403453f635.",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "4313f6ddef59429df3a7c959d18f8a7b",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 16 Sep 2019 18:57:32 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-request-id": "bf706a4c-a003-0007-42c0-6c216d000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f?comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "3371cc54a64712014ff09bf7c067f47b",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:32 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "no-cache",
+        "Content-Type": "application\u002fxml",
+        "Date": "Mon, 16 Sep 2019 18:57:35 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-request-id": "bf706e06-a003-0007-22c0-6c216d000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": "\ufeff\u003c?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003e\u003cEnumerationResults ServiceEndpoint=\u0022http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f\u0022\u003e\u003cQueues\u003e\u003cQueue\u003e\u003cName\u003etest-queue-b7983520-9e7f-2805-9f18-c89f79f0994d\u003c\u002fName\u003e\u003c\u002fQueue\u003e\u003c\u002fQueues\u003e\u003cNextMarker \u002f\u003e\u003c\u002fEnumerationResults\u003e"
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002ftest-queue-b7983520-9e7f-2805-9f18-c89f79f0994d",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Request-Id": "|73c6cd80-4d1567403453f635.",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "38c1bc0fb00f31589755c4d8d4ac560f",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 16 Sep 2019 18:57:35 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-request-id": "bf706e09-a003-0007-25c0-6c216d000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "443392961",
+    "Storage_TestConfigSecondary": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttp:\u002f\u002fstorageteglazatesting.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.table.core.windows.net\n\n\n\n\nhttp:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f;QueueEndpoint=http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f;TableEndpoint=http:\u002f\u002fstorageteglazatesting.table.core.windows.net\u002f;FileEndpoint=http:\u002f\u002fstorageteglazatesting.file.core.windows.net\u002f;BlobSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f;QueueSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f;TableSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\u002f;FileSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\u002f;AccountName=storageteglazatesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/GetQueuesAsync_SecondaryStorageFirstRetrySuccessful.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/GetQueuesAsync_SecondaryStorageFirstRetrySuccessful.json
@@ -1,0 +1,128 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002ftest-queue-d7284b33-37c7-2cf0-752d-681d97a3d101",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Request-Id": "|52dbda8d-4ba0274d4faf14c1.",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "aaea09b038bb95f5e1627582788dad54",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 16 Sep 2019 18:57:09 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-request-id": "01998816-d003-000d-7cc0-6c85da000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f?comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "c10a7f2ad0cd4e2124c671b156fe1315",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "no-cache",
+        "Content-Type": "application\u002fxml",
+        "Date": "Mon, 16 Sep 2019 18:57:10 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-request-id": "e74dca20-8003-0009-39c0-6c288e000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": "\ufeff\u003c?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003e\u003cEnumerationResults ServiceEndpoint=\u0022http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f\u0022\u003e\u003cQueues \u002f\u003e\u003cNextMarker \u002f\u003e\u003c\u002fEnumerationResults\u003e"
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f?comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "b815c4e71b6efabf5592f564c26db4e8",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:21 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "no-cache",
+        "Content-Type": "application\u002fxml",
+        "Date": "Mon, 16 Sep 2019 18:57:21 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-request-id": "0199972f-d003-000d-48c0-6c85da000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": "\ufeff\u003c?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003e\u003cEnumerationResults ServiceEndpoint=\u0022http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f\u0022\u003e\u003cQueues\u003e\u003cQueue\u003e\u003cName\u003etest-queue-d7284b33-37c7-2cf0-752d-681d97a3d101\u003c\u002fName\u003e\u003c\u002fQueue\u003e\u003c\u002fQueues\u003e\u003cNextMarker \u002f\u003e\u003c\u002fEnumerationResults\u003e"
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002ftest-queue-d7284b33-37c7-2cf0-752d-681d97a3d101",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Request-Id": "|52dbda8e-4ba0274d4faf14c1.",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "18f3137f0f99e034e79c86f5c7443fe3",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:21 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 16 Sep 2019 18:57:21 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-request-id": "01999737-d003-000d-50c0-6c85da000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "301106385",
+    "Storage_TestConfigSecondary": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttp:\u002f\u002fstorageteglazatesting.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.table.core.windows.net\n\n\n\n\nhttp:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f;QueueEndpoint=http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f;TableEndpoint=http:\u002f\u002fstorageteglazatesting.table.core.windows.net\u002f;FileEndpoint=http:\u002f\u002fstorageteglazatesting.file.core.windows.net\u002f;BlobSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f;QueueSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f;TableSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\u002f;FileSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\u002f;AccountName=storageteglazatesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/GetQueuesAsync_SecondaryStorageFirstRetrySuccessfulAsync.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/GetQueuesAsync_SecondaryStorageFirstRetrySuccessfulAsync.json
@@ -1,0 +1,97 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002ftest-queue-685627fc-2a58-7573-51f0-f7bb506f8e23",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Request-Id": "|73c6cd81-4d1567403453f635.",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "43e9e0f8dcd3d18a0a781fe3fa63e053",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 16 Sep 2019 18:57:35 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-request-id": "bf706e0c-a003-0007-28c0-6c216d000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f?comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "6516f30a8488c4fdbb2b3841b084d94d",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "no-cache",
+        "Content-Type": "application\u002fxml",
+        "Date": "Mon, 16 Sep 2019 18:57:35 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-request-id": "713d8f10-0003-0013-1ac0-6c07e1000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": "\ufeff\u003c?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003e\u003cEnumerationResults ServiceEndpoint=\u0022http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f\u0022\u003e\u003cQueues\u003e\u003cQueue\u003e\u003cName\u003etest-queue-32169db4-1f16-3ebf-1b33-2081c72f7c12\u003c\u002fName\u003e\u003c\u002fQueue\u003e\u003c\u002fQueues\u003e\u003cNextMarker \u002f\u003e\u003c\u002fEnumerationResults\u003e"
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002ftest-queue-685627fc-2a58-7573-51f0-f7bb506f8e23",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Request-Id": "|73c6cd82-4d1567403453f635.",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "ffbd08b7a9271f259c845de00b8f7bed",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 16 Sep 2019 18:57:36 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-request-id": "bf706ef2-a003-0007-77c0-6c216d000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "285161090",
+    "Storage_TestConfigSecondary": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttp:\u002f\u002fstorageteglazatesting.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.table.core.windows.net\n\n\n\n\nhttp:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f;QueueEndpoint=http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f;TableEndpoint=http:\u002f\u002fstorageteglazatesting.table.core.windows.net\u002f;FileEndpoint=http:\u002f\u002fstorageteglazatesting.file.core.windows.net\u002f;BlobSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f;QueueSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f;TableSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\u002f;FileSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\u002f;AccountName=storageteglazatesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/GetQueuesAsync_SecondaryStorageSecondRetrySuccessful.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/GetQueuesAsync_SecondaryStorageSecondRetrySuccessful.json
@@ -1,0 +1,97 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002ftest-queue-a12746e5-0f4b-3418-689b-3dbf18dd82bb",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Request-Id": "|52dbda8f-4ba0274d4faf14c1.",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "3e79428d22db69945e7b4695ec853ae0",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:21 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 16 Sep 2019 18:57:21 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-request-id": "01999746-d003-000d-5dc0-6c85da000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f?comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "d8b37781b798997ab14746cd39b6bb2b",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:21 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "no-cache",
+        "Content-Type": "application\u002fxml",
+        "Date": "Mon, 16 Sep 2019 18:57:22 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-request-id": "01999989-d003-000d-03c0-6c85da000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": "\ufeff\u003c?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003e\u003cEnumerationResults ServiceEndpoint=\u0022http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f\u0022\u003e\u003cQueues\u003e\u003cQueue\u003e\u003cName\u003etest-queue-a12746e5-0f4b-3418-689b-3dbf18dd82bb\u003c\u002fName\u003e\u003c\u002fQueue\u003e\u003c\u002fQueues\u003e\u003cNextMarker \u002f\u003e\u003c\u002fEnumerationResults\u003e"
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002ftest-queue-a12746e5-0f4b-3418-689b-3dbf18dd82bb",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Request-Id": "|52dbda90-4ba0274d4faf14c1.",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "e176212ec81cc304b1bd42cfc98348e3",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:23 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 16 Sep 2019 18:57:22 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-request-id": "0199998e-d003-000d-08c0-6c85da000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1093167725",
+    "Storage_TestConfigSecondary": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttp:\u002f\u002fstorageteglazatesting.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.table.core.windows.net\n\n\n\n\nhttp:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f;QueueEndpoint=http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f;TableEndpoint=http:\u002f\u002fstorageteglazatesting.table.core.windows.net\u002f;FileEndpoint=http:\u002f\u002fstorageteglazatesting.file.core.windows.net\u002f;BlobSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f;QueueSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f;TableSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\u002f;FileSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\u002f;AccountName=storageteglazatesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/GetQueuesAsync_SecondaryStorageSecondRetrySuccessfulAsync.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/GetQueuesAsync_SecondaryStorageSecondRetrySuccessfulAsync.json
@@ -1,0 +1,97 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002ftest-queue-a4fd0840-f2ce-3b43-3783-67e896c703d5",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Request-Id": "|73c6cd83-4d1567403453f635.",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "1aade846e95a243155b4dfbcb4734643",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 16 Sep 2019 18:57:36 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-request-id": "bf706ef7-a003-0007-7cc0-6c216d000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f?comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "8405cabf89bfd36ed56c55067486e140",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "no-cache",
+        "Content-Type": "application\u002fxml",
+        "Date": "Mon, 16 Sep 2019 18:57:38 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-request-id": "bf707080-a003-0007-46c0-6c216d000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": "\ufeff\u003c?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003e\u003cEnumerationResults ServiceEndpoint=\u0022http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f\u0022\u003e\u003cQueues\u003e\u003cQueue\u003e\u003cName\u003etest-queue-a4fd0840-f2ce-3b43-3783-67e896c703d5\u003c\u002fName\u003e\u003c\u002fQueue\u003e\u003c\u002fQueues\u003e\u003cNextMarker \u002f\u003e\u003c\u002fEnumerationResults\u003e"
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002ftest-queue-a4fd0840-f2ce-3b43-3783-67e896c703d5",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Request-Id": "|73c6cd84-4d1567403453f635.",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "ade36823943f563ad6d94e1a138686c4",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 16 Sep 2019 18:57:38 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-request-id": "bf707082-a003-0007-48c0-6c216d000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "278158023",
+    "Storage_TestConfigSecondary": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttp:\u002f\u002fstorageteglazatesting.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.table.core.windows.net\n\n\n\n\nhttp:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f;QueueEndpoint=http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f;TableEndpoint=http:\u002f\u002fstorageteglazatesting.table.core.windows.net\u002f;FileEndpoint=http:\u002f\u002fstorageteglazatesting.file.core.windows.net\u002f;BlobSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f;QueueSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f;TableSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\u002f;FileSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\u002f;AccountName=storageteglazatesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/GetQueuesAsync_SecondaryStorageThirdRetrySuccessful.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/GetQueuesAsync_SecondaryStorageThirdRetrySuccessful.json
@@ -1,0 +1,97 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002ftest-queue-32169db4-1f16-3ebf-1b33-2081c72f7c12",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Request-Id": "|52dbda91-4ba0274d4faf14c1.",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "06ccf41c6b77c108ed211ef8ccdfd9de",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:23 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 16 Sep 2019 18:57:22 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-request-id": "01999994-d003-000d-0ec0-6c85da000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f?comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "b83e0b1e785909043125e86cda5fc8b3",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:23 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "no-cache",
+        "Content-Type": "application\u002fxml",
+        "Date": "Mon, 16 Sep 2019 18:57:26 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-request-id": "e74dca30-8003-0009-3ec0-6c288e000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": "\ufeff\u003c?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003e\u003cEnumerationResults ServiceEndpoint=\u0022http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f\u0022\u003e\u003cQueues\u003e\u003cQueue\u003e\u003cName\u003etest-queue-d5f66aa8-98df-ba21-bd2d-d1f195793349\u003c\u002fName\u003e\u003c\u002fQueue\u003e\u003c\u002fQueues\u003e\u003cNextMarker \u002f\u003e\u003c\u002fEnumerationResults\u003e"
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002ftest-queue-32169db4-1f16-3ebf-1b33-2081c72f7c12",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Request-Id": "|52dbda92-4ba0274d4faf14c1.",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "718e3c32b4d8494f945545f400c6723c",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:26 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 16 Sep 2019 18:57:26 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-request-id": "01999fe5-d003-000d-1ac0-6c85da000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "905383730",
+    "Storage_TestConfigSecondary": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttp:\u002f\u002fstorageteglazatesting.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.table.core.windows.net\n\n\n\n\nhttp:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f;QueueEndpoint=http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f;TableEndpoint=http:\u002f\u002fstorageteglazatesting.table.core.windows.net\u002f;FileEndpoint=http:\u002f\u002fstorageteglazatesting.file.core.windows.net\u002f;BlobSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f;QueueSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f;TableSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\u002f;FileSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\u002f;AccountName=storageteglazatesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/GetQueuesAsync_SecondaryStorageThirdRetrySuccessfulAsync.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/GetQueuesAsync_SecondaryStorageThirdRetrySuccessfulAsync.json
@@ -1,0 +1,97 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002ftest-queue-22bc81a8-b0b0-2c3f-b824-a4d42a3d5596",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Request-Id": "|73c6cd85-4d1567403453f635.",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "0ee026a2ae9468ffbe41514c146729eb",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 16 Sep 2019 18:57:38 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-request-id": "bf707087-a003-0007-4dc0-6c216d000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f?comp=list",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "c86429c512e3ffc6a8f243d7db92d963",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "no-cache",
+        "Content-Type": "application\u002fxml",
+        "Date": "Mon, 16 Sep 2019 18:57:41 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-request-id": "713d8f17-0003-0013-1dc0-6c07e1000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": "\ufeff\u003c?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003e\u003cEnumerationResults ServiceEndpoint=\u0022http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f\u0022\u003e\u003cQueues\u003e\u003cQueue\u003e\u003cName\u003etest-queue-32169db4-1f16-3ebf-1b33-2081c72f7c12\u003c\u002fName\u003e\u003c\u002fQueue\u003e\u003c\u002fQueues\u003e\u003cNextMarker \u002f\u003e\u003c\u002fEnumerationResults\u003e"
+    },
+    {
+      "RequestUri": "http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002ftest-queue-22bc81a8-b0b0-2c3f-b824-a4d42a3d5596",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Request-Id": "|73c6cd86-4d1567403453f635.",
+        "User-Agent": [
+          "azsdk-net-Storage.Queues\u002f12.0.0-dev.20190916.1\u002b6c3a64c57695ba0db6ecd6df57f517870bcbae01",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.18362 )"
+        ],
+        "x-ms-client-request-id": "1a9e6c52d3e0f9978154646e5ff21751",
+        "x-ms-date": "Mon, 16 Sep 2019 18:57:41 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2018-11-09"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 16 Sep 2019 18:57:41 GMT",
+        "Server": [
+          "Windows-Azure-Queue\u002f1.0",
+          "Microsoft-HTTPAPI\u002f2.0"
+        ],
+        "x-ms-request-id": "bf7072e1-a003-0007-56c0-6c216d000000",
+        "x-ms-version": "2018-11-09"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1218947067",
+    "Storage_TestConfigSecondary": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttp:\u002f\u002fstorageteglazatesting.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting.table.core.windows.net\n\n\n\n\nhttp:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\nhttp:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http:\u002f\u002fstorageteglazatesting.blob.core.windows.net\u002f;QueueEndpoint=http:\u002f\u002fstorageteglazatesting.queue.core.windows.net\u002f;TableEndpoint=http:\u002f\u002fstorageteglazatesting.table.core.windows.net\u002f;FileEndpoint=http:\u002f\u002fstorageteglazatesting.file.core.windows.net\u002f;BlobSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.blob.core.windows.net\u002f;QueueSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.queue.core.windows.net\u002f;TableSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.table.core.windows.net\u002f;FileSecondaryEndpoint=http:\u002f\u002fstorageteglazatesting-secondary.file.core.windows.net\u002f;AccountName=storageteglazatesting;AccountKey=Sanitized"
+  }
+}


### PR DESCRIPTION
Fixes #6890 

Adds a settable property on BlobClientOptions and QueueClientOptions where users can specify the GeoRedundantSecondaryUri. This should only be set if the account is configured to have Read-access geo-redundant storage (RA-GRS), i.e. accounts having geo replication without read access would not use this feature. Note Files do not support RA-GRS. If the property is set, in the event of retriable responses or exceptions for either HEAD or GET requests, we will retry against the secondary storage. If that retry fails, we will toggle back to primary storage and continue on in this way for subsequent failures for as many retries are configured in the RetryOptions. 

This is different than the Track 1 C# implementation which has a property called LocationMode with the following options: PrimaryOnly (default), PrimaryThenSecondary, SecondaryOnly, SecondaryThenPrimary. What we are implementing is essentially the same as the PrimaryThenSecondary option from Track 1. SecondaryOnly and SecondaryThenPrimary are not supported in this Track 2 implementation. These two options rely on the client being able to add a custom RetryPolicy in which they add an implementation for the Evaluate method (see https://docs.microsoft.com/en-us/azure/storage/common/storage-designing-ha-apps-with-ragrs?toc=%2fazure%2fstorage%2fblobs%2ftoc.json). In this method, they could determine, based on information within RetryContext and OperationContext whether future retries should only occur against Secondary Storage (SecondaryOnly), or against Secondary and then Primary (SecondaryThenPrimary). For now, we would like to leave this level of configurability out of scope and align with the Java implementations for [Track 1](https://github.com/Azure/azure-sdk-for-java/blob/master/sdk/storage/microsoft-azure-storage-blob/src/main/java/com/microsoft/azure/storage/blob/RequestRetryFactory.java#L106) and [Track 2](https://github.com/Azure/azure-sdk-for-java/blob/master/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/RequestRetryPolicy.java#L45) which do the same toggling between Primary and Secondary storage that we are adding here. In the future, if we have a need for the more advanced configuration, we could expose our GeoRedundantReadPolicy class so that customers can override to have more flexibility in where retries are routed to.
