### PR TITLE
[Event Hubs Blob Checkpoint Store] Restore Project Reference

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/Directory.Build.props
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/Directory.Build.props
@@ -33,6 +33,6 @@
     <EnableClientSdkAnalyzers>false</EnableClientSdkAnalyzers>
 
     <!-- If there was no override specified, set the type of reference to use for Azure.Messaging.EventHubs -->
-    <UseProjectReferenceToAzureEventHubs Condition="'$(UseProjectReferenceToAzureEventHubs)' == ''">false</UseProjectReferenceToAzureEventHubs>
+    <UseProjectReferenceToAzureEventHubs Condition="'$(UseProjectReferenceToAzureEventHubs)' == ''">true</UseProjectReferenceToAzureEventHubs>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
# Summary

The intent of these changes is to restore the relationship between the blobs checkpoint store and Event Hubs client library by restoring the project referenced used for local development.

# Last Upstream Rebase

Tuesday, September 17, 2019 8:30am (PDT)