### PR TITLE
Remove == default comparisons that produce error in latest VS

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerTests.cs
@@ -760,7 +760,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     firstSubcriberReceiving = true;
                     StartPublishingIfReady();
 
-                    if (eventData != default)
+                    if (eventData == default)
                     {
                         firstSubscriberEvents.Add(eventData);
                     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerTests.cs
@@ -642,7 +642,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     firstSubcriberReceiving = true;
                     StartPublishingIfReady();
 
-                    if (eventData != default)
+                    if (eventData is object)
                     {
                         firstSubscriberEvents.Add(eventData);
                     }
@@ -664,7 +664,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     secondSubscriberReceiving = true;
                     StartPublishingIfReady();
 
-                    if (eventData != default)
+                    if (eventData is object)
                     {
                         secondSubscriberEvents.Add(eventData);
                     }
@@ -760,7 +760,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     firstSubcriberReceiving = true;
                     StartPublishingIfReady();
 
-                    if (eventData == default)
+                    if (eventData is object)
                     {
                         firstSubscriberEvents.Add(eventData);
                     }
@@ -782,7 +782,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     secondSubscriberReceiving = true;
                     StartPublishingIfReady();
 
-                    if (eventData != default)
+                    if (eventData is object)
                     {
                         secondSubscriberEvents.Add(eventData);
                     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerTests.cs
@@ -642,7 +642,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     firstSubcriberReceiving = true;
                     StartPublishingIfReady();
 
-                    if (eventData is object)
+                    if (eventData != null)
                     {
                         firstSubscriberEvents.Add(eventData);
                     }
@@ -664,7 +664,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     secondSubscriberReceiving = true;
                     StartPublishingIfReady();
 
-                    if (eventData is object)
+                    if (eventData != null)
                     {
                         secondSubscriberEvents.Add(eventData);
                     }
@@ -760,7 +760,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     firstSubcriberReceiving = true;
                     StartPublishingIfReady();
 
-                    if (eventData is object)
+                    if (eventData != null)
                     {
                         firstSubscriberEvents.Add(eventData);
                     }
@@ -782,7 +782,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     secondSubscriberReceiving = true;
                     StartPublishingIfReady();
 
-                    if (eventData is object)
+                    if (eventData != null)
                     {
                         secondSubscriberEvents.Add(eventData);
                     }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyImportOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyImportOptions.cs
@@ -42,10 +42,8 @@ namespace Azure.Security.KeyVault.Keys
 
         internal override void WriteProperties(Utf8JsonWriter json)
         {
-            if (KeyMaterial != default)
-            {
-                KeyMaterial.WriteProperties(json);
-            }
+            KeyMaterial?.WriteProperties(json);
+
             if (Enabled.HasValue || NotBefore.HasValue || Expires.HasValue)
             {
                 json.WriteStartObject(AttributesPropertyNameBytes);

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyRequestParameters.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyRequestParameters.cs
@@ -49,7 +49,7 @@ namespace Azure.Security.KeyVault.Keys
         internal KeyRequestParameters(KeyType type, KeyCreateOptions options = default)
         {
             KeyType = type;
-            if (options != default)
+            if (options != null)
             {
                 if (options.Enabled.HasValue)
                 {

--- a/sdk/storage/Azure.Storage.Common/src/StorageConnectionString.cs
+++ b/sdk/storage/Azure.Storage.Common/src/StorageConnectionString.cs
@@ -175,7 +175,7 @@ namespace Azure.Storage.Common
         /// <remarks>Using HTTPS to connect to the storage services is recommended.</remarks>
         public StorageConnectionString(object storageCredentials, string accountName, string endpointSuffix, bool useHttps)
         {
-            if (storageCredentials == default)
+            if (storageCredentials == null)
             {
                 throw Errors.ArgumentNull(nameof(storageCredentials));
             }


### PR DESCRIPTION
It's not allowed by 16.4preview2 compiler. See 

https://github.com/jcouv/roslyn/blob/5d7d0bb91e84d0587139a5da12ecde66ecc7d85a/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20post%20VS2019.md#this-document-lists-known-breaking-changes-in-roslyn-in-visual-studio-2019-update-1-and-beyond-compared-to-visual-studio-2019

for details