### PR TITLE
Reverse AddPolicy parameters

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample7_ConfiguringPipeline.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample7_ConfiguringPipeline.cs
@@ -35,10 +35,10 @@ namespace Azure.Data.AppConfiguration.Samples
             options.Retry.Delay = TimeSpan.FromSeconds(1);
 
             // add a policy (custom behavior) that executes once per client call
-            options.AddPolicy(HttpPipelinePosition.PerCall, new AddHeaderPolicy());
+            options.AddPolicy(new AddHeaderPolicy(), HttpPipelinePosition.PerCall);
 
             // add a policy that executes once per retry
-            options.AddPolicy(HttpPipelinePosition.PerRetry, new CustomLogPolicy());
+            options.AddPolicy(new CustomLogPolicy(), HttpPipelinePosition.PerRetry);
 
             var connectionString = Environment.GetEnvironmentVariable("APPCONFIGURATION_CONNECTION_STRING");
             // pass the policy options to the client

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipelineOptions.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipelineOptions.cs
@@ -27,7 +27,7 @@ namespace Azure.Core.Pipeline
 
         public RetryOptions Retry { get; }
 
-        public void AddPolicy(HttpPipelinePosition position, HttpPipelinePolicy policy)
+        public void AddPolicy(HttpPipelinePolicy policy, HttpPipelinePosition position)
         {
             switch (position)
             {

--- a/sdk/core/Azure.Core/tests/HttpPipelineBuilderTest.cs
+++ b/sdk/core/Azure.Core/tests/HttpPipelineBuilderTest.cs
@@ -23,7 +23,7 @@ namespace Azure.Core.Tests
             var transport = new MockTransport(new MockResponse(503), new MockResponse(200));
 
             var options = new TestOptions();
-            options.AddPolicy(position, policy);
+            options.AddPolicy(policy, position);
             options.Transport = transport;
 
             HttpPipeline pipeline = HttpPipelineBuilder.Build(options);

--- a/sdk/core/Microsoft.Extensions.Azure/samples/Startup.cs
+++ b/sdk/core/Microsoft.Extensions.Azure/samples/Startup.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Extensions.Azure.Samples
                 builder.ConfigureDefaults(options => options.Retry.Mode = RetryMode.Exponential);
 
                 // Advanced configure global defaults
-                builder.ConfigureDefaults((options, provider) =>  options.AddPolicy(HttpPipelinePosition.PerCall, provider.GetService<DependencyInjectionEnabledPolicy>()));
+                builder.ConfigureDefaults((options, provider) =>  options.AddPolicy(provider.GetService<DependencyInjectionEnabledPolicy>(), HttpPipelinePosition.PerCall));
 
                 builder.AddBlobServiceClient(Configuration.GetSection("Storage"))
                         .WithVersion(BlobClientOptions.ServiceVersion.V2018_11_09);

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -57,7 +57,7 @@ namespace Azure.Storage.Test.Shared
         {
             raise = raise ?? new Exception("Simulated connection fault");
             var options = this.GetOptions();
-            options.AddPolicy(HttpPipelinePosition.PerCall, new FaultyDownloadPipelinePolicy(raiseAt, raise));
+            options.AddPolicy(new FaultyDownloadPipelinePolicy(raiseAt, raise), HttpPipelinePosition.PerCall);
             return options;
         }
 

--- a/sdk/storage/Azure.Storage.Files/tests/FileTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files/tests/FileTestBase.cs
@@ -72,7 +72,7 @@ namespace Azure.Storage.Files.Tests
         {
             raise = raise ?? new IOException("Simulated connection fault");
             var options = this.GetOptions();
-            options.AddPolicy(HttpPipelinePosition.PerCall, new FaultyDownloadPipelinePolicy(raiseAt, raise));
+            options.AddPolicy(new FaultyDownloadPipelinePolicy(raiseAt, raise), HttpPipelinePosition.PerCall);
             return options;
         }
 


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/7652

# Breaking change

Before
``` C#
options.AddPolicy(HttpPipelinePosition.PerCall, new AddHeaderPolicy());
```
After:
``` C#
options.AddPolicy(new AddHeaderPolicy(), HttpPipelinePosition.PerCall);
```