### PR TITLE
Manually include the CentralPackageVersion files

### DIFF
--- a/eng/Directory.Build.Data.props
+++ b/eng/Directory.Build.Data.props
@@ -34,11 +34,6 @@
     <AddDotnetfeedProjectSource>false</AddDotnetfeedProjectSource>
   </PropertyGroup>
 
-  <!-- CentralPackageVersions properties -->
-  <PropertyGroup>
-    <CentralPackagesFile>$(MSBuildThisFileDirectory)Packages.Data.props</CentralPackagesFile>
-  </PropertyGroup>
-
   <PropertyGroup>
     <IsTestProject Condition="$(MSBuildProjectName.EndsWith('.Tests'))">true</IsTestProject>
     <IsSamplesProject Condition="$(MSBuildProjectName.EndsWith('.Samples'))">true</IsSamplesProject>

--- a/eng/Directory.Build.Data.targets
+++ b/eng/Directory.Build.Data.targets
@@ -1,6 +1,4 @@
 ﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Sdk Name="microsoft.build.centralpackageversions" Version="2.0.36" />
-
   <Target Name="ValidateTargetFrameworks" BeforeTargets="Build">
     <ItemGroup>
       <RequiredTargetFrameworks Include="$(RequiredTargetFrameworks)" />
@@ -68,4 +66,13 @@
   <Import Project="$(DefaultReferenceTargets)" Condition="Exists('$(DefaultReferenceTargets)') And '$(ImportDefaultReferences)'=='true'" />
 
   <Import Project="Versioning.targets" />
+
+
+  <!-- CentralPackageVersions properties -->
+  <PropertyGroup>
+    <CentralPackagesFile>$(MSBuildThisFileDirectory)Packages.Data.props</CentralPackagesFile>
+    <CentralPackageVersionPackagePath>$(MSBuildThisFileDirectory)Microsoft.Build.CentralPackageVersions\2.0.46\Sdk</CentralPackageVersionPackagePath>
+  </PropertyGroup>
+
+  <Import Project="$(CentralPackageVersionPackagePath)\Sdk.targets" />
 </Project>

--- a/eng/Microsoft.Build.CentralPackageVersions/2.0.46/Sdk/Sdk.props
+++ b/eng/Microsoft.Build.CentralPackageVersions/2.0.46/Sdk/Sdk.props
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  
+  Licensed under the MIT license.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(CustomBeforeCentralPackageVersionsProps)" Condition=" '$(CustomBeforeCentralPackageVersionsProps)' != '' And Exists('$(CustomBeforeCentralPackageVersionsProps)') " />
+
+  <PropertyGroup>
+    <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition=" '$(MicrosoftCommonPropsHasBeenImported)' != 'true' And Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props') "/>
+
+  <Import Project="$(CustomAfterCentralPackageVersionsProps)" Condition=" '$(CustomAfterCentralPackageVersionsProps)' != '' And Exists('$(CustomAfterCentralPackageVersionsProps)') " />
+</Project>

--- a/eng/Microsoft.Build.CentralPackageVersions/2.0.46/Sdk/Sdk.targets
+++ b/eng/Microsoft.Build.CentralPackageVersions/2.0.46/Sdk/Sdk.targets
@@ -1,0 +1,183 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  
+  Licensed under the MIT license.
+-->
+<Project InitialTargets="CheckPackageReferences" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!--
+    Import a user extension if specified.
+  -->
+  <Import Project="$(CustomBeforeCentralPackageVersionsTargets)"
+          Condition=" '$(EnableCentralPackageVersions)' != 'false' And '$(CustomBeforeCentralPackageVersionsTargets)' != '' And Exists('$(CustomBeforeCentralPackageVersionsTargets)') " />
+
+  <PropertyGroup Condition=" '$(EnableCentralPackageVersions)' != 'false' ">
+    <!--
+      Walk up the directory tree looking for a Packages.props, unless a user has already specified a path.
+    -->
+    <CentralPackagesFile Condition=" '$(CentralPackagesFile)' == '' ">$([MSBuild]::GetPathOfFileAbove('Packages.props', $(MSBuildProjectDirectory)))</CentralPackagesFile>
+
+    <!--
+      Disable all functionality if:
+      * The central package management file does not exist.
+      * The project is using packages.config.  Visual Studio project systems will get confused if there are any PackageReference
+        items and it won't show the packages in the packages.config.  NuGet does not support using both and so packages.config has to win.
+      * The project is a type that doesn't not support PackageReference in Visual Studio (like vcxproj, ccproj, or nuproj).
+    -->
+    <EnableCentralPackageVersions
+      Condition="'$(EnableCentralPackageVersions)' == '' And (!Exists('$(CentralPackagesFile)') Or Exists('$(MSBuildProjectDirectory)\packages.config') Or '$(MSBuildProjectExtension)' == '.vcxproj' Or '$(MSBuildProjectExtension)' == '.ccproj' Or '$(MSBuildProjectExtension)' == '.nuproj')">false</EnableCentralPackageVersions>
+
+    <!--
+      Include this file and the Packages.props file (if necessary) in MSBuildAllProjects so that rebuilds happen if the Packages.props changes.
+    -->
+    <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
+    <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current' And '$(EnableCentralPackageVersions)' != 'false'">$(CentralPackagesFile);$(MSBuildAllProjects)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup Condition=" '$(EnableCentralPackageVersions)' != 'false' ">
+    <GlobalPackageReference Condition=" $([MSBuild]::ValueOrDefault('$(EnableGlobalPackageReferencePrivateAssetsAll)', 'true')) ">
+      <!--
+        Default global package references to only consume the Analyzers and Build logic in a package.
+        This helps ensure that the package assets are not passed to the compiler or copied to the
+        output directory.  Having a compile-time reference to a package for all projects in a tree
+        is not recommended.  You should only have "global" references to packages that are used for
+        build.
+      -->
+      <IncludeAssets>Analyzers;Build</IncludeAssets>
+      <!--
+        Default global package references to have all assets private.  This is because global package
+        references are generally stuff like versioning, signing, etc and should not flow to downstream
+        dependencies.  Also, global package references are already referenced by every project in the
+        tree so we don't need them to be transitive.
+      -->
+      <PrivateAssets>All</PrivateAssets>
+    </GlobalPackageReference>
+  </ItemDefinitionGroup>
+
+  <ItemGroup Condition=" '$(EnableCentralPackageVersions)' != 'false' ">
+    <!--
+      Workaround the issue where FSharp SDK adds implicit PackageReference items but doesn't mark them as such
+      https://github.com/microsoft/MSBuildSdks/issues/90
+    -->
+    <PackageReference Update="FSharp.Core"
+                      Condition="'$(MSBuildProjectExtension)' == '.fsproj' And '$(DisableImplicitFSharpCoreReference)' != 'true' And '$(UpdateImplicitFSharpCoreReference)' != 'false'"
+                      IsImplicitlyDefined="true" />
+
+    <PackageReference Update="System.ValueTuple"
+                      Condition="'$(MSBuildProjectExtension)' == '.fsproj' And '$(DisableImplicitSystemValueTupleReference)' != 'true' And '$(UpdateImplicitSystemValueTupleReference)' != 'false' And '$(TargetFrameworkIdentifier)' == '.NETFramework' And '$(_TargetFrameworkVersionWithoutV)' &gt;= '4.0' And '$(_TargetFrameworkVersionWithoutV)' &lt;= '4.7'"
+                      IsImplicitlyDefined="true" />
+
+    <!--
+      Workaround the issue where Microsoft.AspNet.App and Microsoft.AspNet.All are not marked as implicitly defined
+    -->
+    <PackageReference Update="Microsoft.AspNetCore.App"
+                      Condition="'$(UsingMicrosoftNETSdkWeb)' == 'true'"
+                      IsImplicitlyDefined="true" />
+
+    <PackageReference Update="Microsoft.AspNetCore.All"
+                      Condition="'$(UsingMicrosoftNETSdkWeb)' == 'true'"
+                      IsImplicitlyDefined="true" />
+
+    <!--
+      Store a list of <PackageReference /> items that specified a Version so that an error can be displayed.
+    -->
+    <_PackageReferenceWithVersion Include="@(PackageReference->HasMetadata('Version'))" />
+
+    <!--
+      Store a list of the original <PackageReference /> items so later they can be checked for duplicates in
+      the <GlobalPackageReference /> items.  Clear the metadata to save some memory.
+    -->
+    <_OriginalPackageReference Include="@(PackageReference->ClearMetadata())" />
+  </ItemGroup>
+
+  <Import Project="$(CentralPackagesFile)"
+          Condition=" '$(EnableCentralPackageVersions)' != 'false' " />
+
+  <ItemGroup Condition=" '$(EnableCentralPackageVersions)' != 'false' ">
+    <!--
+      Copy <GlobalPackageReference /> items to the list of <PackageReference /> items.
+    -->
+    <PackageReference Include="@(GlobalPackageReference)"
+                      Condition=" '$(EnableGlobalPackageReferences)' != 'false' " />
+
+    <!--
+      Get a list of <PackageReference /> items that specify the VersionOverride metadata and copy the value
+      to the Version metadata.  All other metadata is also copied.
+      
+      VersionOverride is important because it forces the user to opt-in to overriding a version at the project
+      level.
+    -->
+    <_PackageReferenceWithVersionOverride Include="@(PackageReference->HasMetadata('VersionOverride'))"
+                                          Version="%(VersionOverride)"
+                                          Condition=" '$(EnablePackageVersionOverride)' != 'false' "
+                                          />
+
+    <!--
+      Remove items in the original <PackageReference /> list that have a version override so that they can be
+      added back. The items being added have their Version set to the original VersionOverride.
+    -->
+    <PackageReference Remove="@(_PackageReferenceWithVersionOverride)"
+                      Condition=" '$(EnablePackageVersionOverride)' != 'false' "/>
+
+    <PackageReference Include="@(_PackageReferenceWithVersionOverride)"
+                      Condition=" '$(EnablePackageVersionOverride)' != 'false' "/>
+
+    <!--
+      Clear the temporary list of package references with VersionOverride to free up some memory.
+    -->
+    <_PackageReferenceWithVersionOverride Remove="@(_PackageReferenceWithVersionOverride)" />
+  </ItemGroup>
+
+  <Target Name="CheckPackageReferences"
+          Condition=" '$(EnableCentralPackageVersions)' != 'false' And '$(DesignTimeBuild)' != 'true' And @(PackageReference->Count()) > 0 ">
+
+    <!--
+      Get a list of duplicate <PackageReference /> and <GlobalPackageReference /> items.  Users must be made aware
+      that this could cause strange behavior and they should not include a PackageReference if there's already a 
+      global PackageReference.
+    -->
+    <ItemGroup Condition=" '$(EnableGlobalPackageReferences)' != 'false' ">
+      <_DuplicateGlobalPackageReference Include="@(_OriginalPackageReference)"
+                                        Condition=" '@(GlobalPackageReference)' == '@(_OriginalPackageReference)' and '%(Identity)' != '' " />
+    </ItemGroup>
+
+    <!--
+      Log an error if there are any duplicate <PackageReference /> items where a <GlobalPackageReference /> is already defined.
+    -->
+    <Error
+      Text="The package reference '%(_DuplicateGlobalPackageReference.Identity)' is already defined as a GlobalPackageReference in '$(CentralPackagesFile)'.  Individual projects do not need to include a PackageReference if a GlobalPackageReference is declared."
+      Condition=" '$(EnableGlobalPackageReferences)' != 'false' And @(_DuplicateGlobalPackageReference->Count()) > 0"
+      File="$(MSBuildProjectFullPath)" />
+
+    <!--
+      Generate an error if any explicit PackageReference has a version specified in a project.  Users must specify a version in
+      the central pacakge management file or use VersionOverride.
+    -->
+    <Error
+      Text="The package reference '%(_PackageReferenceWithVersion.Identity)' should not specify a version.  Please specify the version in '$(CentralPackagesFile)' or set VersionOverride to override the centrally defined version."
+      Condition=" @(_PackageReferenceWithVersion->Count()) > 0 And '%(_PackageReferenceWithVersion.IsImplicitlyDefined)' != 'true' And '$(EnablePackageVersionOverride)' != 'false' "
+      File="$(MSBuildProjectFullPath) "/>
+
+    <Error
+      Text="The package reference '%(_PackageReferenceWithVersion.Identity)' should not specify a version.  Please specify the version in '$(CentralPackagesFile)'."
+      Condition=" @(_PackageReferenceWithVersion->Count()) > 0 And '%(_PackageReferenceWithVersion.IsImplicitlyDefined)' != 'true' And '$(EnablePackageVersionOverride)' == 'false'"
+      File="$(MSBuildProjectFullPath) "/>
+
+    <!--
+      Generate an error if any explicit PackageReference did not have Version specified in the central package management file.
+    -->
+    <Error
+      Text="The package reference '%(PackageReference.Identity)' must have a version defined in '$(CentralPackagesFile)'."
+      Condition=" '%(PackageReference.IsImplicitlyDefined)' != 'true' And '%(PackageReference.Version)' == '' "
+      File="$(MSBuildProjectFullPath)" />
+  </Target>
+
+  <!--
+    Import a user extension if specified.
+  -->
+  <Import Project="$(CustomAfterCentralPackageVersionsTargets)"
+          Condition=" '$(EnableCentralPackageVersions)' != 'false' And '$(CustomAfterCentralPackageVersionsTargets)' != '' And Exists('$(CustomAfterCentralPackageVersionsTargets)') " />
+
+
+</Project>

--- a/eng/Microsoft.Build.CentralPackageVersions/Readme.md
+++ b/eng/Microsoft.Build.CentralPackageVersions/Readme.md
@@ -1,0 +1,9 @@
+To workaround an issue with https://github.com/Azure/azure-sdk-for-net/issues/7490 we are simply going to
+include the contents of the package in the repo itself, given that it is just a props and targets file.
+
+If this needs to be updated go and download the latest package from
+https://www.nuget.org/packages/Microsoft.Build.CentralPackageVersions and extract the sdk.props/targets
+file from the package and put them under a folder matching the version of the package. Then update
+the places we are importing those files to include the updated version number. Currently only
+the CentralPackageVersionPackagePath property in Directory.Build.Data.targets. Be sure to cleam up
+the old version as well.


### PR DESCRIPTION
To workaround https://github.com/Azure/azure-sdk-for-net/issues/7490
we are going to simply extract and include the props and targets
file from the package directly into our repo.

This should eliminate the issue in #7490 and if the nuget team ever fixes the resolve issue we can consider switching back to using an SDK reference instead. 

cc @chidozieononiwu @pakrym 