### PR TITLE
Fix ExtractResponseContent, disposal and buffering

### DIFF
--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipelineMessage.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipelineMessage.cs
@@ -47,6 +47,9 @@ namespace Azure.Core.Pipeline
 
         public ResponseClassifier ResponseClassifier { get; }
 
+        /// <summary>
+        /// Gets or sets the value indicating if response would be buffered as part of the pipeline. Defaults to true.
+        /// </summary>
         public bool BufferResponse { get; set; }
 
         public bool TryGetProperty(string name, out object? value)

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipelineMessage.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipelineMessage.cs
@@ -21,6 +21,7 @@ namespace Azure.Core.Pipeline
         {
             Request = request;
             ResponseClassifier = responseClassifier;
+            BufferResponse = true;
         }
 
         public Request Request { get; set; }

--- a/sdk/core/Azure.Core/tests/HttpPipelineFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpPipelineFunctionalTests.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core.Http;
+using Azure.Core.Pipeline;
+using NUnit.Framework;
+
+namespace Azure.Core.Tests
+{
+    public class HttpPipelineFunctionalTests
+    {
+        [Test]
+        public async Task SendRequestBuffersResponse()
+        {
+            byte[] buffer = { 0 };
+
+            HttpPipeline httpPipeline = HttpPipelineBuilder.Build(new TestOptions());
+
+            using TestServer testServer = new TestServer(
+                async context =>
+                {
+                    for (int i = 0; i < 1000; i++)
+                    {
+                        await context.Response.Body.WriteAsync(buffer, 0, 1);
+                    }
+                });
+            // Make sure we dispose things correctly and not exhaust the connection pool
+            for (int i = 0; i < 100; i++)
+            {
+                using Request request = httpPipeline.CreateRequest();
+                request.UriBuilder.Uri = testServer.Address;
+
+                using Response response = await httpPipeline.SendRequestAsync(request, CancellationToken.None);
+
+                Assert.AreEqual(response.ContentStream.Length, 1000);
+            }
+        }
+
+        [Test]
+        public async Task NonBufferedExtractedStreamReadableAfterMessageDisposed()
+        {
+            byte[] buffer = { 0 };
+
+            HttpPipeline httpPipeline = HttpPipelineBuilder.Build(new TestOptions());
+
+            using TestServer testServer = new TestServer(
+                async context =>
+                {
+                    for (int i = 0; i < 1000; i++)
+                    {
+                        await context.Response.Body.WriteAsync(buffer, 0, 1);
+                    }
+                });
+
+            // Make sure we dispose things correctly and not exhaust the connection pool
+            for (int i = 0; i < 100; i++)
+            {
+                Stream extractedStream;
+                using (HttpPipelineMessage message = httpPipeline.CreateMessage())
+                {
+                    message.Request.UriBuilder.Uri = testServer.Address;
+                    message.BufferResponse = false;
+
+                    await httpPipeline.SendAsync(message, CancellationToken.None);
+
+                    Assert.AreEqual(message.Response.ContentStream.CanSeek, false);
+
+                    extractedStream = message.ExtractResponseContent();
+                }
+
+                var memoryStream = new MemoryStream();
+                await extractedStream.CopyToAsync(memoryStream);
+                Assert.AreEqual(memoryStream.Length, 1000);
+                extractedStream.Dispose();
+            }
+        }
+
+        private class TestOptions : ClientOptions
+        {
+        }
+    }
+}

--- a/sdk/core/Azure.Core/tests/HttpPipelineTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpPipelineTests.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Azure.Core.Pipeline;
+using Azure.Core.Testing;
+using NUnit.Framework;
+
+namespace Azure.Core.Tests
+{
+    public class HttpPipelineTests
+    {
+        [Test]
+        public async Task DoesntDisposeRequestInSendRequestAsync()
+        {
+            HttpPipeline httpPipeline = HttpPipelineBuilder.Build(new TestOptions()
+            {
+                Transport = new MockTransport(new MockResponse(200))
+            });
+
+            using MockRequest request = (MockRequest)httpPipeline.CreateRequest();
+
+            MockResponse response = (MockResponse)await httpPipeline.SendRequestAsync(request, default);
+
+            Assert.False(request.IsDisposed);
+            Assert.False(response.IsDisposed);
+        }
+
+        private class TestOptions : ClientOptions
+        {
+        }
+    }
+}

--- a/sdk/core/Azure.Core/tests/TestFramework/MockRequest.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/MockRequest.cs
@@ -18,6 +18,8 @@ namespace Azure.Core.Testing
 
         private readonly Dictionary<string, List<string>> _headers = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
 
+        public bool IsDisposed { get; private set; }
+
         public override HttpPipelineRequestContent Content
         {
             get { return base.Content; }
@@ -107,6 +109,7 @@ namespace Azure.Core.Testing
 
         public override void Dispose()
         {
+            IsDisposed = true;
         }
     }
 }

--- a/sdk/core/Azure.Core/tests/TestFramework/MockResponse.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/MockResponse.cs
@@ -29,6 +29,8 @@ namespace Azure.Core.Testing
 
         public override string ClientRequestId { get; set; }
 
+        public bool IsDisposed { get; private set; }
+
         public override string ToString() => $"{Status}";
 
         public void SetContent(byte[] content)
@@ -96,6 +98,7 @@ namespace Azure.Core.Testing
 
         public override void Dispose()
         {
+            IsDisposed = true;
         }
     }
 }


### PR DESCRIPTION
Fixing couple bugs here:
1. Reenable buffering in SendRequest by default
2. ExtractResponseContent would clear the content headers in HttpClientTransport response
3. Disposing message after ExtractResponseContent still disposed the extracted content stream