### PR TITLE
Added default value for EventHub LastSequenceNumber

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/ReceiverRuntimeInfo.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/ReceiverRuntimeInfo.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.EventHubs
 
         /// <summary>Gets the last sequence number of the event within the partition stream of the Event Hub.</summary>
         /// <value>The logical sequence number of the event.</value>
-        public long LastSequenceNumber { get; internal set; }
+        public long LastSequenceNumber { get; internal set; } = -1L;
 
         /// <summary>Gets the enqueued UTC time of the last event.</summary>
         /// <value>The enqueued time of the last event.</value>

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/OptionsTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/OptionsTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
 
             // EnableReceiverRuntimeMetric is false by default. This case is a convenient opportunity to
             // verify that RuntimeInformation was not updated when the option is false.
-            Assert.True(state.Processor.LatestContext.RuntimeInformation.LastSequenceNumber == 0L,
+            Assert.True(state.Processor.LatestContext.RuntimeInformation.LastSequenceNumber == -1L,
                 $"RuntimeInformation.LastSequenceNumber is {state.Processor.LatestContext.RuntimeInformation.LastSequenceNumber}");
 
             state.DoNormalShutdown(10);


### PR DESCRIPTION
If no event was received, LastSequenceNumber defaults to 0, which does not have special meaning in EventHub, but actually means that the last received message had sequence number '0'. This can lead to the loss of the first message or a thrown exception if there was no first message and we are trying to read next messages.