### PR TITLE
Update to .NET Core 3.0 GA toolset

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,9 @@
 # Prerequisites:
 
 - Install VS 2019 (Community or higher) and make sure you have the latest updates (https://www.visualstudio.com/).
+  - Need at least .NET Framework 4.6.1 and 4.7 development tools
 - Install the **.NET Core cross-platform development** workloads in VisualStudio
-- Install **.NET Core 3 preview 7** or higher for your specific platform. (https://dotnet.microsoft.com/download/dotnet-core/3.0)
+- Install **.NET Core 3.0.100 SDK ** or higher for your specific platform. (https://dotnet.microsoft.com/download/dotnet-core/3.0)
 - Install the latest version of git (https://git-scm.com/downloads)
 
 ## GENERAL THINGS TO KNOW:

--- a/eng/Directory.Build.Data.props
+++ b/eng/Directory.Build.Data.props
@@ -3,10 +3,13 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <!--
-      Disable NuGet Pack warning that the version is SemVer 2.0.
+      Disable NU5105 NuGet Pack warning that the version is SemVer 2.0.
       SemVer 2.0 is supported by NuGet since 3.0.0 (July 2015) in some capacity, and fully since 3.5.0 (October 2016).
+
+      Disable NU5048 warning which is complaining about using a url for our package icon. Currently most packages still use
+      url's instead of embedded icons so sticking with that approach until there becomes a real reason not to.
     -->
-    <NoWarn>$(NoWarn);NU5105</NoWarn>
+    <NoWarn>$(NoWarn);NU5105;NU5048</NoWarn>
     <!--
       Disable some FxCop rules
      -->

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -24,7 +24,7 @@ jobs:
           DOTNET_CLI_TELEMETRY_OPTOUT: 1
           DOTNET_MULTILEVEL_LOOKUP: 0
       - task: PublishPipelineArtifact@1
-        condition: succeededOrFailed()
+        condition: succeeded()
         inputs:
           artifactName: packages
           path: $(Build.ArtifactStagingDirectory)
@@ -71,7 +71,7 @@ jobs:
           ignoreDirectories: "sdk/storage/Azure.Storage.Common/swagger/Generator"
         condition: and(succeededOrFailed(), ne(variables['Build.Reason'],'PullRequest'))
       - task: PublishPipelineArtifact@1
-        condition: succeededOrFailed()
+        condition: succeeded()
         displayName: "Publish Report Artifacts"
         inputs:
           artifactName: reports
@@ -117,7 +117,7 @@ jobs:
           packageType: sdk
           version: "$(DotNetCoreSDKVersion)"
       - script: >-
-          dotnet test eng/service.proj --filter TestCategory!=Live --framework $(TestTargetFramework) --logger "trx;LogFileName=$(TestTargetFramework).trx" 
+          dotnet test eng/service.proj --filter TestCategory!=Live --framework $(TestTargetFramework) --logger "trx;LogFileName=$(TestTargetFramework).trx"
           /p:ServiceDirectory=${{ parameters.ServiceDirectory }} /p:IncludeSrc=false /p:IncludeSamples=false /p:Configuration=$(BuildConfiguration)
         displayName: "Build & Test ($(TestTargetFramework))"
         env:

--- a/eng/pipelines/templates/jobs/archetype-sdk-mgmt.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-mgmt.yml
@@ -23,7 +23,7 @@ jobs:
           pathtoPublish: $(msBuildLogDir)
           artifactName: MsBuildLogs
       - task: PublishPipelineArtifact@0
-        condition: succeededOrFailed()
+        condition: succeeded()
         inputs:
           artifactName: packages
           targetPath: $(Build.ArtifactStagingDirectory)

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,5 +1,5 @@
 variables:
-  DotNetCoreSDKVersion: '3.0.100-preview7-012821'
+  DotNetCoreSDKVersion: '3.0.100'
   DotNetCoreRuntimeVersion: '2.1.10'
   OfficialBuildId: $(Build.BuildNumber)
   skipComponentGovernanceDetection: true

--- a/sdk/batch/Microsoft.Azure.Batch/src/Microsoft.Azure.Batch.csproj
+++ b/sdk/batch/Microsoft.Azure.Batch/src/Microsoft.Azure.Batch.csproj
@@ -8,7 +8,7 @@
     <PackageTags>Microsoft;Azure;Batch;windowsazureofficial</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <SignAssembly>true</SignAssembly>
-    <NoWarn>1591;NU5105;CA1308;CA1825;CA2237</NoWarn>  <!-- Remove CA1825 supression here when we deprecate net452 -->
+    <NoWarn>$(NoWarn);1591;NU5105;CA1308;CA1825;CA2237</NoWarn>  <!-- Remove CA1825 supression here when we deprecate net452 -->
   </PropertyGroup>
 
   <PropertyGroup>
@@ -22,7 +22,7 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(IsTargetingNetStandard)' == 'true'">
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" />
     <!--
@@ -34,7 +34,7 @@
     <Analyzer Include="..\..\Tools\ConfigureAwaitAnalyzer\ConfigureAwaitAnalyzer\bin\Debug\netstandard1.4\ConfigureAwaitAnalyzer.dll" />
     -->
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
As part of updating a new nuget warning about package icon url's showed
up so disabled that warning as we want to stay with urls instead of
embedding icons in our packages. At least until we can discover a good
reason we need to embed them.

@chidozieononiwu @pakrym 

@heaths as I was updating I noticed I didn't have the 4.7 targeting pack installed and thus got a build error so I added a note about that in the contributing docs as well. 