### PR TITLE
Include response header override params in SasQueryParameters

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasBuilder.cs
@@ -188,13 +188,18 @@ namespace Azure.Storage.Sas
                 identifier: Identifier,
                 resource: Resource,
                 permissions: Permissions,
-                signature: signature);
+                signature: signature,
+                cacheControl: CacheControl,
+                contentDisposition: ContentDisposition,
+                contentEncoding: ContentEncoding,
+                contentLanguage: ContentLanguage,
+                contentType: ContentType);
             return p;
         }
 
         /// <summary>
         /// Use an account's <see cref="UserDelegationKey"/> to sign this
-        /// shared access signature values to produce the propery SAS query
+        /// shared access signature values to produce the proper SAS query
         /// parameters for authenticating requests.
         /// </summary>
         /// <param name="userDelegationKey">
@@ -258,7 +263,12 @@ namespace Azure.Storage.Sas
                 keyExpiry: userDelegationKey.SignedExpiry,
                 keyService: userDelegationKey.SignedService,
                 keyVersion: userDelegationKey.SignedVersion,
-                signature: signature);
+                signature: signature,
+                cacheControl: CacheControl,
+                contentDisposition: ContentDisposition,
+                contentEncoding: ContentEncoding,
+                contentLanguage: ContentLanguage,
+                contentType: ContentType);
             return p;
         }
 

--- a/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasQueryParameters.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasQueryParameters.cs
@@ -19,32 +19,32 @@ namespace Azure.Storage.Sas
         /// <summary>
         /// Gets the Azure Active Directory object ID in GUID format.
         /// </summary>
-        public string KeyObjectId => keyObjectId;
+        public string KeyObjectId => _keyObjectId;
 
         /// <summary>
         /// Gets the Azure Active Directory tenant ID in GUID format
         /// </summary>
-        public string KeyTenantId => keyTenantId;
+        public string KeyTenantId => _keyTenantId;
 
         /// <summary>
         /// Gets the time at which the key becomes valid.
         /// </summary>
-        public DateTimeOffset KeyStart => keyStart;
+        public DateTimeOffset KeyStart => _keyStart;
 
         /// <summary>
         /// Gets the time at which the key becomes expires.
         /// </summary>
-        public DateTimeOffset KeyExpiry => keyExpiry;
+        public DateTimeOffset KeyExpiry => _keyExpiry;
 
         /// <summary>
         /// Gets the Storage service that accepts the key.
         /// </summary>
-        public string KeyService => keyService;
+        public string KeyService => _keyService;
 
         /// <summary>
         /// Gets the Storage service version that created the key.
         /// </summary>
-        public string KeyVersion => keyVersion;
+        public string KeyVersion => _keyVersion;
 
         /// <summary>
         /// Gets empty shared access signature query parameters.
@@ -79,7 +79,12 @@ namespace Azure.Storage.Sas
             DateTimeOffset keyStart = default,
             DateTimeOffset keyExpiry = default,
             string keyService = default,
-            string keyVersion = default)
+            string keyVersion = default,
+            string cacheControl = default,
+            string contentDisposition = default,
+            string contentEncoding = default,
+            string contentLanguage = default,
+            string contentType = default)
             : base(
                 version,
                 services,
@@ -97,7 +102,12 @@ namespace Azure.Storage.Sas
                 keyStart,
                 keyExpiry,
                 keyService,
-                keyVersion)
+                keyVersion,
+                cacheControl,
+                contentDisposition,
+                contentEncoding,
+                contentLanguage,
+                contentType)
         {
         }
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
@@ -60,6 +60,8 @@ namespace Azure.Storage.Blobs.Test
             Assert.AreEqual(Constants.Sas.Resource.Container, sasQueryParameters.Resource);
             Assert.AreEqual(Permissions, sasQueryParameters.Permissions);
             Assert.AreEqual(signature, sasQueryParameters.Signature);
+            AssertResponseHeaders(constants, sasQueryParameters);
+
         }
 
         [Test]
@@ -93,6 +95,8 @@ namespace Azure.Storage.Blobs.Test
             Assert.AreEqual(Constants.Sas.Resource.Container, sasQueryParameters.Resource);
             Assert.AreEqual(Permissions, sasQueryParameters.Permissions);
             Assert.AreEqual(signature, sasQueryParameters.Signature);
+            AssertResponseHeaders(constants, sasQueryParameters);
+
         }
 
         [Test]
@@ -120,6 +124,8 @@ namespace Azure.Storage.Blobs.Test
             Assert.AreEqual(Constants.Sas.Resource.Blob, sasQueryParameters.Resource);
             Assert.AreEqual(Permissions, sasQueryParameters.Permissions);
             Assert.AreEqual(signature, sasQueryParameters.Signature);
+            AssertResponseHeaders(constants, sasQueryParameters);
+
         }
 
         [Test]
@@ -153,6 +159,8 @@ namespace Azure.Storage.Blobs.Test
             Assert.AreEqual(Constants.Sas.Resource.Blob, sasQueryParameters.Resource);
             Assert.AreEqual(Permissions, sasQueryParameters.Permissions);
             Assert.AreEqual(signature, sasQueryParameters.Signature);
+            AssertResponseHeaders(constants, sasQueryParameters);
+
         }
 
         [Test]
@@ -180,6 +188,8 @@ namespace Azure.Storage.Blobs.Test
             Assert.AreEqual(Constants.Sas.Resource.BlobSnapshot, sasQueryParameters.Resource);
             Assert.AreEqual(Permissions, sasQueryParameters.Permissions);
             Assert.AreEqual(signature, sasQueryParameters.Signature);
+            AssertResponseHeaders(constants, sasQueryParameters);
+
         }
 
         [Test]
@@ -213,6 +223,8 @@ namespace Azure.Storage.Blobs.Test
             Assert.AreEqual(Constants.Sas.Resource.BlobSnapshot, sasQueryParameters.Resource);
             Assert.AreEqual(Permissions, sasQueryParameters.Permissions);
             Assert.AreEqual(signature, sasQueryParameters.Signature);
+            AssertResponseHeaders(constants, sasQueryParameters);
+
         }
 
         [Test]
@@ -330,5 +342,8 @@ namespace Azure.Storage.Blobs.Test
                 new HMACSHA256(
                     Convert.FromBase64String(userDelegationKeyValue))
                 .ComputeHash(Encoding.UTF8.GetBytes(message)));
+
     }
+
+    
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
@@ -61,7 +61,6 @@ namespace Azure.Storage.Blobs.Test
             Assert.AreEqual(Permissions, sasQueryParameters.Permissions);
             Assert.AreEqual(signature, sasQueryParameters.Signature);
             AssertResponseHeaders(constants, sasQueryParameters);
-
         }
 
         [Test]
@@ -96,7 +95,6 @@ namespace Azure.Storage.Blobs.Test
             Assert.AreEqual(Permissions, sasQueryParameters.Permissions);
             Assert.AreEqual(signature, sasQueryParameters.Signature);
             AssertResponseHeaders(constants, sasQueryParameters);
-
         }
 
         [Test]
@@ -125,7 +123,6 @@ namespace Azure.Storage.Blobs.Test
             Assert.AreEqual(Permissions, sasQueryParameters.Permissions);
             Assert.AreEqual(signature, sasQueryParameters.Signature);
             AssertResponseHeaders(constants, sasQueryParameters);
-
         }
 
         [Test]
@@ -160,7 +157,6 @@ namespace Azure.Storage.Blobs.Test
             Assert.AreEqual(Permissions, sasQueryParameters.Permissions);
             Assert.AreEqual(signature, sasQueryParameters.Signature);
             AssertResponseHeaders(constants, sasQueryParameters);
-
         }
 
         [Test]
@@ -189,7 +185,6 @@ namespace Azure.Storage.Blobs.Test
             Assert.AreEqual(Permissions, sasQueryParameters.Permissions);
             Assert.AreEqual(signature, sasQueryParameters.Signature);
             AssertResponseHeaders(constants, sasQueryParameters);
-
         }
 
         [Test]
@@ -224,7 +219,6 @@ namespace Azure.Storage.Blobs.Test
             Assert.AreEqual(Permissions, sasQueryParameters.Permissions);
             Assert.AreEqual(signature, sasQueryParameters.Signature);
             AssertResponseHeaders(constants, sasQueryParameters);
-
         }
 
         [Test]
@@ -342,8 +336,5 @@ namespace Azure.Storage.Blobs.Test
                 new HMACSHA256(
                     Convert.FromBase64String(userDelegationKeyValue))
                 .ComputeHash(Encoding.UTF8.GetBytes(message)));
-
     }
-
-    
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SasQueryParametersTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SasQueryParametersTests.cs
@@ -31,6 +31,11 @@ namespace Azure.Storage.Blobs.Test
             var resource = "bar";
             var permissions = "rw";
             var signature = "a+b=";
+            var cacheControl = "no-store";
+            var contentDisposition = "inline";
+            var contentEncoding = "identity";
+            var contentLanguage = "en-US";
+            var contentType = "text/html";
 
             var sasQueryParameters = new SasQueryParameters(
                 version,
@@ -43,7 +48,12 @@ namespace Azure.Storage.Blobs.Test
                 identifier,
                 resource,
                 permissions,
-                signature
+                signature,
+                cacheControl: cacheControl,
+                contentDisposition: contentDisposition,
+                contentEncoding: contentEncoding,
+                contentLanguage: contentLanguage,
+                contentType: contentType
                 );
 
             Assert.AreEqual(signature, sasQueryParameters.Signature);

--- a/sdk/storage/Azure.Storage.Common/src/Constants.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Constants.cs
@@ -394,6 +394,16 @@ namespace Azure.Storage
                 public const string KeyServiceUpper = "SKS";
                 public const string KeyVersion = "skv";
                 public const string KeyVersionUpper = "SKV";
+                public const string CacheControl = "rscc";
+                public const string CacheControlUpper = "RSCC";
+                public const string ContentDisposition = "rscd";
+                public const string ContentDispositionUpper = "RSCD";
+                public const string ContentEncoding = "rsce";
+                public const string ContentEncodingUpper = "RSCE";
+                public const string ContentLanguage = "rscl";
+                public const string ContentLanguageUpper = "RSCL";
+                public const string ContentType = "rsct";
+                public const string ContentTypeUpper = "RSCT";
             }
 
             internal static class Resource

--- a/sdk/storage/Azure.Storage.Common/src/Sas/SasQueryParameters.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Sas/SasQueryParameters.cs
@@ -153,31 +153,32 @@ namespace Azure.Storage.Sas
         public string Permissions => _permissions ?? string.Empty;
 
         /// <summary>
-        /// Gets the cache control to be used in the Cache-Control response header.
+        /// Gets the Cache-Control response header, which allows for 
+        /// specifying the client-side caching to be used for blob and file downloads.
         /// </summary>
         public string CacheControl => _cacheControl ?? string.Empty;
 
         /// <summary>
-        /// Gets the content disposition to be used in the Content-Disposition
-        /// response header.
+        /// Gets the Content-Disposition response header, which allows for 
+        /// specifying the way that the blob or file content can be displayed in the browser.
         /// </summary>
         public string ContentDisposition => _contentDisposition ?? string.Empty;
 
         /// <summary>
-        /// Gets the content encoding to be used in the Content-Encoding
-        /// response header.
+        /// Gets the Content-Encoding response header, which allows for specifying
+        /// the type of encoding used for blob and file downloads.
         /// </summary>
         public string ContentEncoding => _contentEncoding ?? string.Empty;
 
         /// <summary>
-        /// Gets the content language to be used in the Content-Language
-        /// response header.
+        /// Gets the Content-Language response header, which allows for specifying the 
+        /// language of the downloaded blob or file content.
         /// </summary>
         public string ContentLanguage => _contentLanguage ?? string.Empty;
 
         /// <summary>
-        /// Gets the content type to be used in the Content-Type response
-        /// header.
+        /// Gets the Content-Type response header, which allows for specifying the 
+        /// type of the downloaded blob or file content.
         /// </summary>
         public string ContentType => _contentType ?? string.Empty;
 

--- a/sdk/storage/Azure.Storage.Common/src/Sas/SasQueryParameters.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Sas/SasQueryParameters.cs
@@ -40,61 +40,76 @@ namespace Azure.Storage.Sas
         // All members are immutable or values so copies of this struct are thread safe.
 
         // sv
-        private readonly string version;
+        private readonly string _version;
 
         // ss
-        private readonly string services;
+        private readonly string _services;
 
         // srt
-        private readonly string resourceTypes;
+        private readonly string _resourceTypes;
 
         // spr
-        private readonly SasProtocol protocol;
+        private readonly SasProtocol _protocol;
 
         // st
-        private readonly DateTimeOffset startTime;
+        private readonly DateTimeOffset _startTime;
 
         // se
-        private readonly DateTimeOffset expiryTime;
+        private readonly DateTimeOffset _expiryTime;
 
         // sip
-        private readonly IPRange ipRange;
+        private readonly IPRange _ipRange;
 
         // si
-        private readonly string identifier;
+        private readonly string _identifier;
 
         // sr
-        private readonly string resource;
+        private readonly string _resource;
 
         // sp
-        private readonly string permissions;
+        private readonly string _permissions;
 
         // sig
-        private readonly string signature;
+        private readonly string _signature;
+
+        // rscc
+        private readonly string _cacheControl;
+
+        // rscd
+        private readonly string _contentDisposition;
+
+        // rsce
+        private readonly string _contentEncoding;
+
+        // rscl
+        private readonly string _contentLanguage;
+
+        // rsct
+        private readonly string _contentType;
 
         /// <summary>
         /// Gets the storage service version to use to authenticate requests
         /// made with this shared access signature, and the service version to
         /// use when handling requests made with this shared access signature.
         /// </summary>
-        public string Version => version ?? DefaultSasVersion;
+        public string Version => _version ?? DefaultSasVersion;
 
         /// <summary>
         /// Gets the signed services accessible with an account level shared
         /// access signature. 
         /// </summary>
-        public string Services => services ?? string.Empty;
+        public string Services => _services ?? string.Empty;
 
         /// <summary>
         /// Gets which resources are accessible via the shared access signature.
         /// </summary>
-        public string ResourceTypes => resourceTypes ?? string.Empty;
+        public string ResourceTypes => _resourceTypes ?? string.Empty;
 
         /// <summary>
         /// Optional. Specifies the protocol permitted for a request made with
         /// the shared access signature.
         /// </summary>
-        public SasProtocol Protocol => protocol;
+        public SasProtocol Protocol => _protocol;
 
         /// <summary>
         /// Gets the optional time at which the shared access signature becomes
@@ -102,32 +117,32 @@ namespace Azure.Storage.Sas
         /// time when the storage service receives the request.
         /// <see cref="DateTimeOffset.MinValue"/> means not set.
         /// </summary>
-        public DateTimeOffset StartTime => startTime;
+        public DateTimeOffset StartTime => _startTime;
 
         /// <summary>
         /// Gets the time at which the shared access signature becomes invalid.
         /// <see cref="DateTimeOffset.MinValue"/> means not set.
         /// </summary>
-        public DateTimeOffset ExpiryTime => expiryTime;
+        public DateTimeOffset ExpiryTime => _expiryTime;
 
         /// <summary>
         /// Gets the optional IP address or a range of IP addresses from which
         /// to accept requests.  When specifying a range, note that the range
         /// is inclusive.
         /// </summary>
-        public IPRange IPRange => ipRange;
+        public IPRange IPRange => _ipRange;
 
         /// <summary>
         /// Gets the optional unique value up to 64 characters in length that
         /// correlates to an access policy specified for the container, queue,
         /// or share.
         /// </summary>
-        public string Identifier => identifier ?? string.Empty;
+        public string Identifier => _identifier ?? string.Empty;
 
         /// <summary>
         /// Gets the resources are accessible via the shared access signature.
         /// </summary>
-        public string Resource => resource ?? string.Empty;
+        public string Resource => _resource ?? string.Empty;
 
         /// <summary>
         /// Gets the permissions associated with the shared access signature.
@@ -135,7 +150,36 @@ namespace Azure.Storage.Sas
         /// This field must be omitted if it has been specified in an
         /// associated stored access policy.
         /// </summary>
-        public string Permissions => permissions ?? string.Empty;
+        public string Permissions => _permissions ?? string.Empty;
+
+        /// <summary>
+        /// Gets the cache control to be used in the Cache-Control response header.
+        /// </summary>
+        public string CacheControl => _cacheControl ?? string.Empty;
+
+        /// <summary>
+        /// Gets the content disposition to be used in the Content-Disposition
+        /// response header.
+        /// </summary>
+        public string ContentDisposition => _contentDisposition ?? string.Empty;
+
+        /// <summary>
+        /// Gets the content encoding to be used in the Content-Encoding
+        /// response header.
+        /// </summary>
+        public string ContentEncoding => _contentEncoding ?? string.Empty;
+
+        /// <summary>
+        /// Gets the content language to be used in the Content-Language
+        /// response header.
+        /// </summary>
+        public string ContentLanguage => _contentLanguage ?? string.Empty;
+
+        /// <summary>
+        /// Gets the content type to be used in the Content-Type response
+        /// header.
+        /// </summary>
+        public string ContentType => _contentType ?? string.Empty;
 
         /// <summary>
         /// Gets the string-to-sign, a unique string constructed from the
@@ -143,26 +187,26 @@ namespace Azure.Storage.Sas
         /// The signature is an HMAC computed over the string-to-sign and key
         /// using the SHA256 algorithm, and then encoded using Base64 encoding.
         /// </summary>
-        public string Signature => signature ?? string.Empty;
+        public string Signature => _signature ?? string.Empty;
 
         #region Blob Only Parameters
         // skoid
-        internal readonly string keyObjectId;
+        internal readonly string _keyObjectId;
 
         // sktid
-        internal readonly string keyTenantId;
+        internal readonly string _keyTenantId;
 
         // skt
-        internal readonly DateTimeOffset keyStart;
+        internal readonly DateTimeOffset _keyStart;
 
         // ske
-        internal readonly DateTimeOffset keyExpiry;
+        internal readonly DateTimeOffset _keyExpiry;
 
         // sks
-        internal readonly string keyService;
+        internal readonly string _keyService;
 
         // skv
-        internal readonly string keyVersion;
+        internal readonly string _keyVersion;
         #endregion Blob Only Parameters
 
         /// <summary>
@@ -195,26 +239,36 @@ namespace Azure.Storage.Sas
             DateTimeOffset keyStart = default,
             DateTimeOffset keyExpiry = default,
             string keyService = default,
-            string keyVersion = default)
+            string keyVersion = default,
+            string cacheControl = default,
+            string contentDisposition = default,
+            string contentEncoding = default,
+            string contentLanguage = default,
+            string contentType = default)
         {
             // Assume URL-decoded
-            this.version = version ?? DefaultSasVersion;
-            this.services = services ?? string.Empty;
-            this.resourceTypes = resourceTypes ?? string.Empty;
-            this.protocol = protocol;
-            this.startTime = startTime;
-            this.expiryTime = expiryTime;
-            this.ipRange = ipRange;
-            this.identifier = identifier ?? string.Empty;
-            this.resource = resource ?? string.Empty;
-            this.permissions = permissions ?? string.Empty;
-            this.signature = signature ?? string.Empty;  // Should never be null
-            keyObjectId = keyOid;
-            keyTenantId = keyTid;
-            this.keyStart = keyStart;
-            this.keyExpiry = keyExpiry;
-            this.keyService = keyService;
-            this.keyVersion = keyVersion;
+            _version = version ?? DefaultSasVersion;
+            _services = services ?? string.Empty;
+            _resourceTypes = resourceTypes ?? string.Empty;
+            _protocol = protocol;
+            _startTime = startTime;
+            _expiryTime = expiryTime;
+            _ipRange = ipRange;
+            _identifier = identifier ?? string.Empty;
+            _resource = resource ?? string.Empty;
+            _permissions = permissions ?? string.Empty;
+            _signature = signature ?? string.Empty;  // Should never be null
+            _keyObjectId = keyOid;
+            _keyTenantId = keyTid;
+            _keyStart = keyStart;
+            _keyExpiry = keyExpiry;
+            _keyService = keyService;
+            _keyVersion = keyVersion;
+            _cacheControl = cacheControl;
+            _contentDisposition = contentDisposition;
+            _contentEncoding = contentEncoding;
+            _contentLanguage = contentLanguage;
+            _contentType = contentType;
         }
 
         /// <summary>
@@ -241,62 +295,77 @@ namespace Azure.Storage.Sas
                 switch (kv.Key.ToUpperInvariant())
                 {
                     case Constants.Sas.Parameters.VersionUpper:
-                        version = kv.Value;
+                        _version = kv.Value;
                         break;
                     case Constants.Sas.Parameters.ServicesUpper:
-                        services = kv.Value;
+                        _services = kv.Value;
                         break;
                     case Constants.Sas.Parameters.ResourceTypesUpper:
-                        resourceTypes = kv.Value;
+                        _resourceTypes = kv.Value;
                         break;
                     case Constants.Sas.Parameters.ProtocolUpper:
-                        protocol = SasProtocol.Parse(kv.Value);
+                        _protocol = SasProtocol.Parse(kv.Value);
                         break;
                     case Constants.Sas.Parameters.StartTimeUpper:
-                        startTime = DateTimeOffset.ParseExact(kv.Value, Constants.SasTimeFormat, CultureInfo.InvariantCulture);
+                        _startTime = DateTimeOffset.ParseExact(kv.Value, Constants.SasTimeFormat, CultureInfo.InvariantCulture);
                         break;
                     case Constants.Sas.Parameters.ExpiryTimeUpper:
-                        expiryTime = DateTimeOffset.ParseExact(kv.Value, Constants.SasTimeFormat, CultureInfo.InvariantCulture);
+                        _expiryTime = DateTimeOffset.ParseExact(kv.Value, Constants.SasTimeFormat, CultureInfo.InvariantCulture);
                         break;
                     case Constants.Sas.Parameters.IPRangeUpper:
-                        ipRange = IPRange.Parse(kv.Value);
+                        _ipRange = IPRange.Parse(kv.Value);
                         break;
                     case Constants.Sas.Parameters.IdentifierUpper:
-                        identifier = kv.Value;
+                        _identifier = kv.Value;
                         break;
                     case Constants.Sas.Parameters.ResourceUpper:
-                        resource = kv.Value;
+                        _resource = kv.Value;
                         break;
                     case Constants.Sas.Parameters.PermissionsUpper:
-                        permissions = kv.Value;
+                        _permissions = kv.Value;
                         break;
                     case Constants.Sas.Parameters.SignatureUpper:
-                        signature = kv.Value;
+                        _signature = kv.Value;
+                        break;
+                    case Constants.Sas.Parameters.CacheControlUpper:
+                        _cacheControl = kv.Value;
+                        break;
+                    case Constants.Sas.Parameters.ContentDispositionUpper:
+                        _contentDisposition = kv.Value;
+                        break;
+                    case Constants.Sas.Parameters.ContentEncodingUpper:
+                        _contentEncoding = kv.Value;
+                        break;
+                    case Constants.Sas.Parameters.ContentLanguageUpper:
+                        _contentLanguage = kv.Value;
+                        break;
+                    case Constants.Sas.Parameters.ContentTypeUpper:
+                        _contentType = kv.Value;
                         break;
 
                     // Optionally include Blob parameters
                     case Constants.Sas.Parameters.KeyOidUpper:
-                        if (includeBlobParameters) { keyObjectId = kv.Value; }
+                        if (includeBlobParameters) { _keyObjectId = kv.Value; }
                         else { isSasKey = false; }
                         break;
                     case Constants.Sas.Parameters.KeyTidUpper:
-                        if (includeBlobParameters) { keyTenantId = kv.Value; }
+                        if (includeBlobParameters) { _keyTenantId = kv.Value; }
                         else { isSasKey = false; }
                         break;
                     case Constants.Sas.Parameters.KeyStartUpper:
-                        if (includeBlobParameters) { keyStart = DateTimeOffset.ParseExact(kv.Value, Constants.SasTimeFormat, CultureInfo.InvariantCulture); }
+                        if (includeBlobParameters) { _keyStart = DateTimeOffset.ParseExact(kv.Value, Constants.SasTimeFormat, CultureInfo.InvariantCulture); }
                         else { isSasKey = false; }
                         break;
                     case Constants.Sas.Parameters.KeyExpiryUpper:
-                        if (includeBlobParameters) { keyExpiry = DateTimeOffset.ParseExact(kv.Value, Constants.SasTimeFormat, CultureInfo.InvariantCulture); }
+                        if (includeBlobParameters) { _keyExpiry = DateTimeOffset.ParseExact(kv.Value, Constants.SasTimeFormat, CultureInfo.InvariantCulture); }
                         else { isSasKey = false; }
                         break;
                     case Constants.Sas.Parameters.KeyServiceUpper:
-                        if (includeBlobParameters) { keyService = kv.Value; }
+                        if (includeBlobParameters) { _keyService = kv.Value; }
                         else { isSasKey = false; }
                         break;
                     case Constants.Sas.Parameters.KeyVersionUpper:
-                        if (includeBlobParameters) { keyVersion = kv.Value; }
+                        if (includeBlobParameters) { _keyVersion = kv.Value; }
                         else { isSasKey = false; }
                         break;
 
@@ -396,36 +465,61 @@ namespace Azure.Storage.Sas
                 AddToBuilder(Constants.Sas.Parameters.Permissions, Permissions);
             }
 
+            if (!string.IsNullOrWhiteSpace(CacheControl))
+            {
+                AddToBuilder(Constants.Sas.Parameters.CacheControl, CacheControl);
+            }
+
+            if (!string.IsNullOrWhiteSpace(ContentDisposition))
+            {
+                AddToBuilder(Constants.Sas.Parameters.ContentDisposition, ContentDisposition);
+            }
+
+            if (!string.IsNullOrWhiteSpace(ContentEncoding))
+            {
+                AddToBuilder(Constants.Sas.Parameters.ContentEncoding, ContentEncoding);
+            }
+
+            if (!string.IsNullOrWhiteSpace(ContentLanguage))
+            {
+                AddToBuilder(Constants.Sas.Parameters.ContentLanguage, ContentLanguage);
+            }
+
+            if (!string.IsNullOrWhiteSpace(ContentType))
+            {
+                AddToBuilder(Constants.Sas.Parameters.ContentType, ContentType);
+            }
+
             if (includeBlobParameters)
             {
-                if (!string.IsNullOrWhiteSpace(keyObjectId))
+                if (!string.IsNullOrWhiteSpace(_keyObjectId))
                 {
-                    AddToBuilder(Constants.Sas.Parameters.KeyOid, keyObjectId);
+                    AddToBuilder(Constants.Sas.Parameters.KeyOid, _keyObjectId);
                 }
 
-                if (!string.IsNullOrWhiteSpace(keyTenantId))
+                if (!string.IsNullOrWhiteSpace(_keyTenantId))
                 {
-                    AddToBuilder(Constants.Sas.Parameters.KeyTid, keyTenantId);
+                    AddToBuilder(Constants.Sas.Parameters.KeyTid, _keyTenantId);
                 }
 
-                if (keyStart != DateTimeOffset.MinValue)
+                if (_keyStart != DateTimeOffset.MinValue)
                 {
-                    AddToBuilder(Constants.Sas.Parameters.KeyStart, WebUtility.UrlEncode(keyStart.ToString(Constants.SasTimeFormat, CultureInfo.InvariantCulture)));
+                    AddToBuilder(Constants.Sas.Parameters.KeyStart, WebUtility.UrlEncode(_keyStart.ToString(Constants.SasTimeFormat, CultureInfo.InvariantCulture)));
                 }
 
-                if (keyExpiry != DateTimeOffset.MinValue)
+                if (_keyExpiry != DateTimeOffset.MinValue)
                 {
-                    AddToBuilder(Constants.Sas.Parameters.KeyExpiry, WebUtility.UrlEncode(keyExpiry.ToString(Constants.SasTimeFormat, CultureInfo.InvariantCulture)));
+                    AddToBuilder(Constants.Sas.Parameters.KeyExpiry, WebUtility.UrlEncode(_keyExpiry.ToString(Constants.SasTimeFormat, CultureInfo.InvariantCulture)));
                 }
 
-                if (!string.IsNullOrWhiteSpace(keyService))
+                if (!string.IsNullOrWhiteSpace(_keyService))
                 {
-                    AddToBuilder(Constants.Sas.Parameters.KeyService, keyService);
+                    AddToBuilder(Constants.Sas.Parameters.KeyService, _keyService);
                 }
 
-                if (!string.IsNullOrWhiteSpace(keyVersion))
+                if (!string.IsNullOrWhiteSpace(_keyVersion))
                 {
-                    AddToBuilder(Constants.Sas.Parameters.KeyVersion, keyVersion);
+                    AddToBuilder(Constants.Sas.Parameters.KeyVersion, _keyVersion);
                 }
             }
 

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
@@ -12,7 +12,10 @@ using Azure.Core.Testing;
 using Azure.Identity;
 using Azure.Storage.Common;
 using Azure.Storage.Common.Test;
+using Azure.Storage.Sas;
 using NUnit.Framework;
+using TestConstants = Azure.Storage.Test.Constants;
+
 
 namespace Azure.Storage.Test.Shared
 {
@@ -321,6 +324,15 @@ namespace Azure.Storage.Test.Shared
                 }
             }
             return response;
+        }
+
+        internal void AssertResponseHeaders(TestConstants constants, SasQueryParameters sasQueryParameters)
+        {
+            Assert.AreEqual(constants.Sas.CacheControl, sasQueryParameters.CacheControl);
+            Assert.AreEqual(constants.Sas.ContentDisposition, sasQueryParameters.ContentDisposition);
+            Assert.AreEqual(constants.Sas.ContentEncoding, sasQueryParameters.ContentEncoding);
+            Assert.AreEqual(constants.Sas.ContentLanguage, sasQueryParameters.ContentLanguage);
+            Assert.AreEqual(constants.Sas.ContentType, sasQueryParameters.ContentType);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
@@ -16,7 +16,6 @@ using Azure.Storage.Sas;
 using NUnit.Framework;
 using TestConstants = Azure.Storage.Test.Constants;
 
-
 namespace Azure.Storage.Test.Shared
 {
     public abstract class StorageTestBase : RecordedTestBase

--- a/sdk/storage/Azure.Storage.Files/src/Sas/FileSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Sas/FileSasBuilder.cs
@@ -175,7 +175,12 @@ namespace Azure.Storage.Sas
                 identifier: Identifier,
                 resource: resource,
                 permissions: Permissions,
-                signature: signature);
+                signature: signature,
+                cacheControl: CacheControl,
+                contentDisposition: ContentDisposition,
+                contentEncoding: ContentEncoding,
+                contentLanguage: ContentLanguage,
+                contentType: ContentType);
             return p;
         }
 

--- a/sdk/storage/Azure.Storage.Files/tests/FileSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files/tests/FileSasBuilderTests.cs
@@ -44,6 +44,7 @@ namespace Azure.Storage.Files.Test
             Assert.AreEqual(Constants.Sas.Resource.File, sasQueryParameters.Resource);
             Assert.AreEqual(Permissions, sasQueryParameters.Permissions);
             Assert.AreEqual(signature, sasQueryParameters.Signature);
+            AssertResponseHeaders(constants, sasQueryParameters);
         }
 
         [Test]
@@ -71,6 +72,7 @@ namespace Azure.Storage.Files.Test
             Assert.AreEqual(Constants.Sas.Resource.Share, sasQueryParameters.Resource);
             Assert.AreEqual(Permissions, sasQueryParameters.Permissions);
             Assert.AreEqual(signature, sasQueryParameters.Signature);
+            AssertResponseHeaders(constants, sasQueryParameters);
         }
 
         [Test]


### PR DESCRIPTION
These query parameters were missing SasQueryParameters. They were included in the signature that was generated from calling ToSasQueryParameters, but not included as query params within the Uri:


Response header name | Corresponding SAS query parameter
-- | --
Cache-Control | rscc
Content-Disposition | rscd
Content-Encoding | rsce
Content-Language | rscl
Content-Type | rsct

Note the response header overrides can only be specified for Files and Blobs (see https://docs.microsoft.com/en-us/rest/api/storageservices/create-service-sas)

