### PR TITLE
Make Response<T> a class

### DIFF
--- a/sdk/core/Azure.Core/src/Response{T}.cs
+++ b/sdk/core/Azure.Core/src/Response{T}.cs
@@ -15,9 +15,9 @@ namespace Azure
             Value = parsed;
         }
 
-        public Response GetRawResponse() => _rawResponse;
+        public virtual Response GetRawResponse() => _rawResponse;
 
-        public T Value { get; }
+        public virtual T Value { get; }
 
         public static implicit operator T(Response<T> response) => response.Value;
 

--- a/sdk/core/Azure.Core/src/Response{T}.cs
+++ b/sdk/core/Azure.Core/src/Response{T}.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.ComponentModel;
 
 namespace Azure
 {
-    public readonly struct Response<T>
+    public class Response<T>
     {
         private readonly Response _rawResponse;
 


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/7740

Technically counts for the breaking change but usages do not change.