### PR TITLE
Change RequestUriBuilder.Uri property to Assign/ToUri methods

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ApiVersionPolicy.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ApiVersionPolicy.cs
@@ -18,7 +18,7 @@ namespace Azure.Data.AppConfiguration
 
         public override void OnSendingRequest(HttpPipelineMessage message)
         {
-            message.Request.UriBuilder.AppendQuery("api-version", _versionString);
+            message.Request.Uri.AppendQuery("api-version", _versionString);
         }
     }
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/AuthenticationPolicy.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/AuthenticationPolicy.cs
@@ -56,7 +56,7 @@ namespace Azure.Data.AppConfiguration
 
             using (var hmac = new HMACSHA256(_secret))
             {
-                Uri uri = message.Request.UriBuilder.Uri;
+                Uri uri = message.Request.UriBuilder.ToUri();
                 var host = uri.Host;
                 var pathAndQuery = uri.PathAndQuery;
 

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/AuthenticationPolicy.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/AuthenticationPolicy.cs
@@ -56,7 +56,7 @@ namespace Azure.Data.AppConfiguration
 
             using (var hmac = new HMACSHA256(_secret))
             {
-                Uri uri = message.Request.UriBuilder.ToUri();
+                Uri uri = message.Request.Uri.ToUri();
                 var host = uri.Host;
                 var pathAndQuery = uri.PathAndQuery;
 

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
@@ -160,7 +160,7 @@ namespace Azure.Data.AppConfiguration
 
             request.Method = RequestMethod.Put;
 
-            BuildUriForKvRoute(request.UriBuilder, setting);
+            BuildUriForKvRoute(request.Uri, setting);
 
             request.Headers.Add(IfNoneMatch, "*");
             request.Headers.Add(s_mediaTypeKeyValueApplicationHeader);
@@ -270,7 +270,7 @@ namespace Azure.Data.AppConfiguration
             ReadOnlyMemory<byte> content = Serialize(setting);
 
             request.Method = RequestMethod.Put;
-            BuildUriForKvRoute(request.UriBuilder, setting);
+            BuildUriForKvRoute(request.Uri, setting);
             request.Headers.Add(s_mediaTypeKeyValueApplicationHeader);
             request.Headers.Add(HttpHeader.Common.JsonContentType);
 
@@ -362,7 +362,7 @@ namespace Azure.Data.AppConfiguration
 
             Request request = _pipeline.CreateRequest();
             request.Method = RequestMethod.Delete;
-            BuildUriForKvRoute(request.UriBuilder, key, label);
+            BuildUriForKvRoute(request.Uri, key, label);
 
             if (etag != default)
             {
@@ -483,7 +483,7 @@ namespace Azure.Data.AppConfiguration
 
             Request request = _pipeline.CreateRequest();
             request.Method = RequestMethod.Get;
-            BuildUriForKvRoute(request.UriBuilder, key, label);
+            BuildUriForKvRoute(request.Uri, key, label);
             request.Headers.Add(s_mediaTypeKeyValueApplicationHeader);
 
             if (acceptDateTime != default)
@@ -566,7 +566,7 @@ namespace Azure.Data.AppConfiguration
         {
             Request request = _pipeline.CreateRequest();
             request.Method = RequestMethod.Get;
-            BuildUriForGetBatch(request.UriBuilder, selector, pageLink);
+            BuildUriForGetBatch(request.Uri, selector, pageLink);
             request.Headers.Add(s_mediaTypeKeyValueApplicationHeader);
             if (selector.AsOf.HasValue)
             {
@@ -647,7 +647,7 @@ namespace Azure.Data.AppConfiguration
         {
             Request request = _pipeline.CreateRequest();
             request.Method = RequestMethod.Get;
-            BuildUriForRevisions(request.UriBuilder, selector, pageLink);
+            BuildUriForRevisions(request.Uri, selector, pageLink);
             request.Headers.Add(s_mediaTypeKeyValueApplicationHeader);
             if (selector.AsOf.HasValue)
             {
@@ -745,7 +745,7 @@ namespace Azure.Data.AppConfiguration
 
             Request request = _pipeline.CreateRequest();
             request.Method = RequestMethod.Head;
-            BuildUriForKvRoute(request.UriBuilder, key, label);
+            BuildUriForKvRoute(request.Uri, key, label);
             request.Headers.Add(s_mediaTypeKeyValueApplicationHeader);
             request.Headers.Add(HttpHeader.Common.JsonContentType);
             return request;

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient_private.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient_private.cs
@@ -90,7 +90,7 @@ namespace Azure.Data.AppConfiguration
 
         private void BuildUriForKvRoute(RequestUriBuilder builder, string key, string label)
         {
-            builder.Uri = _baseUri;
+            builder.Assign(_baseUri);
             builder.AppendPath(KvRoute);
             builder.AppendPath(key);
 
@@ -169,14 +169,14 @@ namespace Azure.Data.AppConfiguration
 
         private void BuildUriForGetBatch(RequestUriBuilder builder, SettingSelector selector, string pageLink)
         {
-            builder.Uri = _baseUri;
+            builder.Assign(_baseUri);
             builder.AppendPath(KvRoute);
             BuildBatchQuery(builder, selector, pageLink);
         }
 
         private void BuildUriForRevisions(RequestUriBuilder builder, SettingSelector selector, string pageLink)
         {
-            builder.Uri = _baseUri;
+            builder.Assign(_baseUri);
             builder.AppendPath(RevisionsRoute);
             BuildBatchQuery(builder, selector, pageLink);
         }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationMockTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationMockTests.cs
@@ -64,7 +64,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             AssertRequestCommon(request);
             Assert.AreEqual(RequestMethod.Get, request.Method);
-            Assert.AreEqual($"https://contoso.appconfig.io/kv/test_key?api-version={s_version}", request.UriBuilder.ToString());
+            Assert.AreEqual($"https://contoso.appconfig.io/kv/test_key?api-version={s_version}", request.Uri.ToString());
             Assert.AreEqual(s_testSetting, setting);
         }
 
@@ -82,7 +82,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             AssertRequestCommon(request);
             Assert.AreEqual(RequestMethod.Get, request.Method);
-            Assert.AreEqual($"https://contoso.appconfig.io/kv/test_key?label=test_label&api-version={s_version}", request.UriBuilder.ToString());
+            Assert.AreEqual($"https://contoso.appconfig.io/kv/test_key?label=test_label&api-version={s_version}", request.Uri.ToString());
             Assert.AreEqual(s_testSetting, setting);
         }
 
@@ -115,7 +115,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             AssertRequestCommon(request);
             Assert.AreEqual(RequestMethod.Put, request.Method);
-            Assert.AreEqual($"https://contoso.appconfig.io/kv/test_key?label=test_label&api-version={s_version}", request.UriBuilder.ToString());
+            Assert.AreEqual($"https://contoso.appconfig.io/kv/test_key?label=test_label&api-version={s_version}", request.Uri.ToString());
             Assert.True(request.Headers.TryGetValue("If-None-Match", out var ifNoneMatch));
             Assert.AreEqual("*", ifNoneMatch);
             AssertContent(SerializationHelpers.Serialize(s_testSetting, SerializeRequestSetting), request);
@@ -136,7 +136,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             AssertRequestCommon(request);
             Assert.AreEqual(RequestMethod.Put, request.Method);
-            Assert.AreEqual($"https://contoso.appconfig.io/kv/test_key?label=test_label&api-version={s_version}", request.UriBuilder.ToString());
+            Assert.AreEqual($"https://contoso.appconfig.io/kv/test_key?label=test_label&api-version={s_version}", request.Uri.ToString());
             AssertContent(SerializationHelpers.Serialize(s_testSetting, SerializeRequestSetting), request);
             Assert.AreEqual(s_testSetting, setting);
         }
@@ -155,7 +155,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             AssertRequestCommon(request);
             Assert.AreEqual(RequestMethod.Delete, request.Method);
-            Assert.AreEqual($"https://contoso.appconfig.io/kv/test_key?api-version={s_version}", request.UriBuilder.ToString());
+            Assert.AreEqual($"https://contoso.appconfig.io/kv/test_key?api-version={s_version}", request.Uri.ToString());
         }
 
         [Test]
@@ -172,7 +172,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             AssertRequestCommon(request);
             Assert.AreEqual(RequestMethod.Delete, request.Method);
-            Assert.AreEqual($"https://contoso.appconfig.io/kv/test_key?label=test_label&api-version={s_version}", request.UriBuilder.ToString());
+            Assert.AreEqual($"https://contoso.appconfig.io/kv/test_key?label=test_label&api-version={s_version}", request.Uri.ToString());
         }
 
         [Test]
@@ -225,12 +225,12 @@ namespace Azure.Data.AppConfiguration.Tests
 
             MockRequest request1 = mockTransport.Requests[0];
             Assert.AreEqual(RequestMethod.Get, request1.Method);
-            Assert.AreEqual($"https://contoso.appconfig.io/kv/?key=*&label=*&api-version={s_version}", request1.UriBuilder.ToString());
+            Assert.AreEqual($"https://contoso.appconfig.io/kv/?key=*&label=*&api-version={s_version}", request1.Uri.ToString());
             AssertRequestCommon(request1);
 
             MockRequest request2 = mockTransport.Requests[1];
             Assert.AreEqual(RequestMethod.Get, request2.Method);
-            Assert.AreEqual($"https://contoso.appconfig.io/kv/?key=*&label=*&after=5&api-version={s_version}", request2.UriBuilder.ToString());
+            Assert.AreEqual($"https://contoso.appconfig.io/kv/?key=*&label=*&after=5&api-version={s_version}", request2.Uri.ToString());
             AssertRequestCommon(request1);
         }
 
@@ -265,7 +265,7 @@ namespace Azure.Data.AppConfiguration.Tests
             ConfigurationSetting setting = await service.AddAsync(s_testSetting);
             MockRequest request = mockTransport.SingleRequest;
 
-            StringAssert.Contains("api-version", request.UriBuilder.ToUri().ToString());
+            StringAssert.Contains("api-version", request.Uri.ToUri().ToString());
         }
 
         [Test]
@@ -284,7 +284,7 @@ namespace Azure.Data.AppConfiguration.Tests
             ConfigurationSetting setting = await client.AddAsync(s_testSetting);
             MockRequest request = mockTransport.SingleRequest;
 
-            StringAssert.Contains("api-version=1.0", request.UriBuilder.ToUri().ToString());
+            StringAssert.Contains("api-version=1.0", request.Uri.ToUri().ToString());
         }
 
         [Test]
@@ -321,7 +321,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             AssertRequestCommon(request);
             Assert.AreEqual(RequestMethod.Head, request.Method);
-            Assert.AreEqual($"https://contoso.appconfig.io/kv/test_key?label=test_label&api-version={s_version}", request.UriBuilder.ToString());
+            Assert.AreEqual($"https://contoso.appconfig.io/kv/test_key?label=test_label&api-version={s_version}", request.Uri.ToString());
             Assert.IsFalse(response.Headers.TryGetValue("ETag", out string etag));
             Assert.IsFalse(hasChanged);
         }
@@ -348,7 +348,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             AssertRequestCommon(request);
             Assert.AreEqual(RequestMethod.Head, request.Method);
-            Assert.AreEqual($"https://contoso.appconfig.io/kv/test_key?label=test_label&api-version={s_version}", request.UriBuilder.ToString());
+            Assert.AreEqual($"https://contoso.appconfig.io/kv/test_key?label=test_label&api-version={s_version}", request.Uri.ToString());
             Assert.IsTrue(response.Headers.TryGetValue("ETag", out string etag));
             Assert.AreEqual(version, etag);
             Assert.IsTrue(hasChanged);
@@ -374,7 +374,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             AssertRequestCommon(request);
             Assert.AreEqual(RequestMethod.Head, request.Method);
-            Assert.AreEqual($"https://contoso.appconfig.io/kv/test_key?label=test_label&api-version={s_version}", request.UriBuilder.ToString());
+            Assert.AreEqual($"https://contoso.appconfig.io/kv/test_key?label=test_label&api-version={s_version}", request.Uri.ToString());
             Assert.IsTrue(response.Headers.TryGetValue("ETag", out string etag));
             Assert.AreEqual(version, etag);
             Assert.IsFalse(hasChanged);
@@ -404,7 +404,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             AssertRequestCommon(request);
             Assert.AreEqual(RequestMethod.Head, request.Method);
-            Assert.AreEqual($"https://contoso.appconfig.io/kv/test_key?label=test_label&api-version={s_version}", request.UriBuilder.ToString());
+            Assert.AreEqual($"https://contoso.appconfig.io/kv/test_key?label=test_label&api-version={s_version}", request.Uri.ToString());
             Assert.IsTrue(response.Headers.TryGetValue("ETag", out string etag));
             Assert.AreEqual(version2, etag);
             Assert.IsTrue(hasChanged);
@@ -428,7 +428,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             AssertRequestCommon(request);
             Assert.AreEqual(RequestMethod.Head, request.Method);
-            Assert.AreEqual($"https://contoso.appconfig.io/kv/test_key?label=test_label&api-version={s_version}", request.UriBuilder.ToString());
+            Assert.AreEqual($"https://contoso.appconfig.io/kv/test_key?label=test_label&api-version={s_version}", request.Uri.ToString());
             Assert.IsTrue(hasChanged);
         }
 

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationMockTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationMockTests.cs
@@ -265,7 +265,7 @@ namespace Azure.Data.AppConfiguration.Tests
             ConfigurationSetting setting = await service.AddAsync(s_testSetting);
             MockRequest request = mockTransport.SingleRequest;
 
-            StringAssert.Contains("api-version", request.UriBuilder.Uri.ToString());
+            StringAssert.Contains("api-version", request.UriBuilder.ToUri().ToString());
         }
 
         [Test]
@@ -284,7 +284,7 @@ namespace Azure.Data.AppConfiguration.Tests
             ConfigurationSetting setting = await client.AddAsync(s_testSetting);
             MockRequest request = mockTransport.SingleRequest;
 
-            StringAssert.Contains("api-version=1.0", request.UriBuilder.Uri.ToString());
+            StringAssert.Contains("api-version=1.0", request.UriBuilder.ToUri().ToString());
         }
 
         [Test]

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationSettingTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationSettingTests.cs
@@ -34,13 +34,12 @@ namespace Azure.Data.AppConfiguration.Tests
                 Labels = new List<string>() { "my_label", "label,label" },
             };
 
-            var builder = new RequestUriBuilder
-            {
-                Uri = new Uri("http://localhost/")
-            };
+            var builder = new RequestUriBuilder();
+            builder.Assign(new Uri("http://localhost/"));
+
             ConfigurationClient.BuildBatchQuery(builder, selector, null);
 
-            Assert.AreEqual(@"http://localhost/?key=my_key,key%5C,key&label=my_label,label%5C,label", builder.Uri.AbsoluteUri);
+            Assert.AreEqual(@"http://localhost/?key=my_key,key%5C,key&label=my_label,label%5C,label", builder.ToUri().AbsoluteUri);
 
         }
 
@@ -53,13 +52,12 @@ namespace Azure.Data.AppConfiguration.Tests
                 Labels = new List<string>() { "*label*" },
             };
 
-            var builder = new RequestUriBuilder
-            {
-                Uri = new Uri("http://localhost/")
-            };
+            var builder = new RequestUriBuilder();
+            builder.Assign(new Uri("http://localhost/"));
+
             ConfigurationClient.BuildBatchQuery(builder, selector, null);
 
-            Assert.AreEqual("http://localhost/?key=*key*&label=*label*", builder.Uri.AbsoluteUri);
+            Assert.AreEqual("http://localhost/?key=*key*&label=*label*", builder.ToUri().AbsoluteUri);
         }
 
         [Test]
@@ -70,13 +68,12 @@ namespace Azure.Data.AppConfiguration.Tests
                 Labels = new List<string>() { "" },
             };
 
-            var builder = new RequestUriBuilder
-            {
-                Uri = new Uri("http://localhost/")
-            };
+            var builder = new RequestUriBuilder();
+            builder.Assign(new Uri("http://localhost/"));
+
             ConfigurationClient.BuildBatchQuery(builder, selector, null);
 
-            Assert.AreEqual("http://localhost/?key=*&label=%00", builder.Uri.AbsoluteUri);
+            Assert.AreEqual("http://localhost/?key=*&label=%00", builder.ToUri().AbsoluteUri);
         }
 
         [Test]
@@ -85,13 +82,13 @@ namespace Azure.Data.AppConfiguration.Tests
             var key = "my-key";
             var selector = new SettingSelector(key);
 
-            var builder = new RequestUriBuilder
-            {
-                Uri = new Uri("http://localhost/")
-            };
+
+            var builder = new RequestUriBuilder();
+            builder.Assign(new Uri("http://localhost/"));
+
             ConfigurationClient.BuildBatchQuery(builder, selector, null);
 
-            Assert.AreEqual($"http://localhost/?key={key}", builder.Uri.AbsoluteUri);
+            Assert.AreEqual($"http://localhost/?key={key}", builder.ToUri().AbsoluteUri);
         }
 
         [Test]
@@ -100,13 +97,13 @@ namespace Azure.Data.AppConfiguration.Tests
             var label = "my-label";
             var selector = new SettingSelector(null, label);
 
-            var builder = new RequestUriBuilder
-            {
-                Uri = new Uri("http://localhost/")
-            };
+
+            var builder = new RequestUriBuilder();
+            builder.Assign(new Uri("http://localhost/"));
+
             ConfigurationClient.BuildBatchQuery(builder, selector, null);
 
-            Assert.AreEqual($"http://localhost/?key=*&label={label}", builder.Uri.AbsoluteUri);
+            Assert.AreEqual($"http://localhost/?key=*&label={label}", builder.ToUri().AbsoluteUri);
         }
 
         [Test]
@@ -117,13 +114,12 @@ namespace Azure.Data.AppConfiguration.Tests
                 Fields = SettingFields.Key | SettingFields.Value
             };
 
-            var builder = new RequestUriBuilder
-            {
-                Uri = new Uri("http://localhost/")
-            };
+            var builder = new RequestUriBuilder();
+            builder.Assign(new Uri("http://localhost/"));
+
             ConfigurationClient.BuildBatchQuery(builder, selector, null);
 
-            Assert.AreEqual($"http://localhost/?key=key&$select=key,%20value", builder.Uri.AbsoluteUri);
+            Assert.AreEqual($"http://localhost/?key=key&$select=key,%20value", builder.ToUri().AbsoluteUri);
         }
 
         [Test]
@@ -134,13 +130,12 @@ namespace Azure.Data.AppConfiguration.Tests
                 Fields = SettingFields.All
             };
 
-            var builder = new RequestUriBuilder
-            {
-                Uri = new Uri("http://localhost/")
-            };
+            var builder = new RequestUriBuilder();
+            builder.Assign(new Uri("http://localhost/"));
+
             ConfigurationClient.BuildBatchQuery(builder, selector, null);
 
-            Assert.AreEqual($"http://localhost/?key=key", builder.Uri.AbsoluteUri);
+            Assert.AreEqual($"http://localhost/?key=key", builder.ToUri().AbsoluteUri);
         }
 
         [Test]

--- a/sdk/core/Azure.Core/src/Diagnostics/HttpPipelineEventSource.cs
+++ b/sdk/core/Azure.Core/src/Diagnostics/HttpPipelineEventSource.cs
@@ -51,7 +51,7 @@ namespace Azure.Core.Diagnostics
         {
             if (IsEnabled(EventLevel.Informational, EventKeywords.None))
             {
-                Request(request.ClientRequestId, request.Method.ToString().ToUpperInvariant(), request.UriBuilder.ToString(), FormatHeaders(request.Headers));
+                Request(request.ClientRequestId, request.Method.ToString().ToUpperInvariant(), request.Uri.ToString(), FormatHeaders(request.Headers));
             }
         }
 

--- a/sdk/core/Azure.Core/src/Http/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Http/HttpClientTransport.cs
@@ -203,7 +203,7 @@ namespace Azure.Core.Pipeline
                 {
                     // A copy of a message needs to be made because HttpClient does not allow sending the same message twice,
                     // and so the retry logic fails.
-                    currentRequest = new HttpRequestMessage(_requestMessage.Method, UriBuilder.ToUri());
+                    currentRequest = new HttpRequestMessage(_requestMessage.Method, Uri.ToUri());
                     CopyHeaders(_requestMessage.Headers, currentRequest.Headers);
                 }
                 else
@@ -211,7 +211,7 @@ namespace Azure.Core.Pipeline
                     currentRequest = _requestMessage;
                 }
 
-                currentRequest.RequestUri = UriBuilder.ToUri();
+                currentRequest.RequestUri = Uri.ToUri();
 
 
                 if (Content != null)

--- a/sdk/core/Azure.Core/src/Http/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Http/HttpClientTransport.cs
@@ -203,7 +203,7 @@ namespace Azure.Core.Pipeline
                 {
                     // A copy of a message needs to be made because HttpClient does not allow sending the same message twice,
                     // and so the retry logic fails.
-                    currentRequest = new HttpRequestMessage(_requestMessage.Method, UriBuilder.Uri);
+                    currentRequest = new HttpRequestMessage(_requestMessage.Method, UriBuilder.ToUri());
                     CopyHeaders(_requestMessage.Headers, currentRequest.Headers);
                 }
                 else
@@ -211,7 +211,7 @@ namespace Azure.Core.Pipeline
                     currentRequest = _requestMessage;
                 }
 
-                currentRequest.RequestUri = UriBuilder.Uri;
+                currentRequest.RequestUri = UriBuilder.ToUri();
 
 
                 if (Content != null)

--- a/sdk/core/Azure.Core/src/Http/RequestUriBuilder.cs
+++ b/sdk/core/Azure.Core/src/Http/RequestUriBuilder.cs
@@ -105,25 +105,24 @@ namespace Azure.Core.Http
 
         public string PathAndQuery => _pathAndQuery.ToString();
 
-        public Uri Uri
+        public void Assign(Uri value)
         {
-            get
+            Scheme = value.Scheme;
+            Host = value.Host;
+            Port = value.Port;
+            Path = value.AbsolutePath;
+            Query = value.Query;
+            _uri = value;
+        }
+
+        public Uri ToUri()
+        {
+            if (_uri == null)
             {
-                if (_uri == null)
-                {
-                    _uri = new Uri(ToString());
-                }
-                return _uri;
+                _uri = new Uri(ToString());
             }
-            set
-            {
-                Scheme = value.Scheme;
-                Host = value.Host;
-                Port = value.Port;
-                Path = value.AbsolutePath;
-                Query = value.Query;
-                _uri = value;
-            }
+
+            return _uri;
         }
 
         public void AppendQuery(string name, string value)

--- a/sdk/core/Azure.Core/src/Pipeline/RequestActivityPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/RequestActivityPolicy.cs
@@ -58,7 +58,7 @@ namespace Azure.Core.Pipeline
 
             var activity = new Activity("Azure.Core.Http.Request");
             activity.AddTag("http.method", message.Request.Method.Method);
-            activity.AddTag("http.url", message.Request.UriBuilder.ToString());
+            activity.AddTag("http.url", message.Request.Uri.ToString());
             activity.AddTag("requestId", message.Request.ClientRequestId);
 
             if (message.Request.Headers.TryGetValue("User-Agent", out string? userAgent))

--- a/sdk/core/Azure.Core/src/Request.cs
+++ b/sdk/core/Azure.Core/src/Request.cs
@@ -10,7 +10,7 @@ namespace Azure.Core.Http
 {
     public abstract class Request : IDisposable
     {
-        public virtual RequestUriBuilder UriBuilder { get; set; } = new RequestUriBuilder();
+        public virtual RequestUriBuilder Uri { get; set; } = new RequestUriBuilder();
 
         public virtual RequestMethod Method { get; set; }
 

--- a/sdk/core/Azure.Core/tests/EventSourceTests.cs
+++ b/sdk/core/Azure.Core/tests/EventSourceTests.cs
@@ -81,7 +81,7 @@ namespace Azure.Core.Tests
             using (Request request = pipeline.CreateRequest())
             {
                 request.Method = RequestMethod.Get;
-                request.UriBuilder.Assign(new Uri("https://contoso.a.io"));
+                request.Uri.Assign(new Uri("https://contoso.a.io"));
                 request.Headers.Add("Date", "3/26/2019");
                 request.Headers.Add("Custom-Header", "Value");
                 request.Content = HttpPipelineRequestContent.Create(new byte[] { 1, 2, 3, 4, 5 });
@@ -144,7 +144,7 @@ namespace Azure.Core.Tests
             using (Request request = pipeline.CreateRequest())
             {
                 request.Method = RequestMethod.Get;
-                request.UriBuilder.Assign(new Uri("https://contoso.a.io"));
+                request.Uri.Assign(new Uri("https://contoso.a.io"));
                 request.Content = HttpPipelineRequestContent.Create(Encoding.UTF8.GetBytes("Hello world"));
                 request.Headers.Add("Content-Type", "text/json");
                 requestId = request.ClientRequestId;
@@ -175,7 +175,7 @@ namespace Azure.Core.Tests
             using (Request request = pipeline.CreateRequest())
             {
                 request.Method = RequestMethod.Get;
-                request.UriBuilder.Assign(new Uri("https://contoso.a.io"));
+                request.Uri.Assign(new Uri("https://contoso.a.io"));
                 request.Content = HttpPipelineRequestContent.Create(Encoding.UTF8.GetBytes("Hello world"));
                 request.Headers.Add("Content-Type", "text/json");
 
@@ -198,7 +198,7 @@ namespace Azure.Core.Tests
             using (Request request = pipeline.CreateRequest())
             {
                 request.Method = RequestMethod.Get;
-                request.UriBuilder.Assign(new Uri("https://contoso.a.io"));
+                request.Uri.Assign(new Uri("https://contoso.a.io"));
                 request.Content = HttpPipelineRequestContent.Create(Encoding.UTF8.GetBytes("Hello world"));
 
                 await SendRequestAsync(pipeline, request);
@@ -221,7 +221,7 @@ namespace Azure.Core.Tests
             using (Request request = pipeline.CreateRequest())
             {
                 request.Method = RequestMethod.Get;
-                request.UriBuilder.Assign(new Uri("https://contoso.a.io"));
+                request.Uri.Assign(new Uri("https://contoso.a.io"));
                 request.Content = HttpPipelineRequestContent.Create(Encoding.UTF8.GetBytes("Hello world"));
 
                 await SendRequestAsync(pipeline, request);
@@ -398,7 +398,7 @@ namespace Azure.Core.Tests
             using (Request request = pipeline.CreateRequest())
             {
                 request.Method = RequestMethod.Get;
-                request.UriBuilder.Assign(new Uri("https://contoso.a.io"));
+                request.Uri.Assign(new Uri("https://contoso.a.io"));
 
                 Response response = await SendRequestAsync(pipeline, request);
 

--- a/sdk/core/Azure.Core/tests/EventSourceTests.cs
+++ b/sdk/core/Azure.Core/tests/EventSourceTests.cs
@@ -81,7 +81,7 @@ namespace Azure.Core.Tests
             using (Request request = pipeline.CreateRequest())
             {
                 request.Method = RequestMethod.Get;
-                request.UriBuilder.Uri = new Uri("https://contoso.a.io");
+                request.UriBuilder.Assign(new Uri("https://contoso.a.io"));
                 request.Headers.Add("Date", "3/26/2019");
                 request.Headers.Add("Custom-Header", "Value");
                 request.Content = HttpPipelineRequestContent.Create(new byte[] { 1, 2, 3, 4, 5 });
@@ -144,7 +144,7 @@ namespace Azure.Core.Tests
             using (Request request = pipeline.CreateRequest())
             {
                 request.Method = RequestMethod.Get;
-                request.UriBuilder.Uri = new Uri("https://contoso.a.io");
+                request.UriBuilder.Assign(new Uri("https://contoso.a.io"));
                 request.Content = HttpPipelineRequestContent.Create(Encoding.UTF8.GetBytes("Hello world"));
                 request.Headers.Add("Content-Type", "text/json");
                 requestId = request.ClientRequestId;
@@ -175,7 +175,7 @@ namespace Azure.Core.Tests
             using (Request request = pipeline.CreateRequest())
             {
                 request.Method = RequestMethod.Get;
-                request.UriBuilder.Uri = new Uri("https://contoso.a.io");
+                request.UriBuilder.Assign(new Uri("https://contoso.a.io"));
                 request.Content = HttpPipelineRequestContent.Create(Encoding.UTF8.GetBytes("Hello world"));
                 request.Headers.Add("Content-Type", "text/json");
 
@@ -198,7 +198,7 @@ namespace Azure.Core.Tests
             using (Request request = pipeline.CreateRequest())
             {
                 request.Method = RequestMethod.Get;
-                request.UriBuilder.Uri = new Uri("https://contoso.a.io");
+                request.UriBuilder.Assign(new Uri("https://contoso.a.io"));
                 request.Content = HttpPipelineRequestContent.Create(Encoding.UTF8.GetBytes("Hello world"));
 
                 await SendRequestAsync(pipeline, request);
@@ -221,7 +221,7 @@ namespace Azure.Core.Tests
             using (Request request = pipeline.CreateRequest())
             {
                 request.Method = RequestMethod.Get;
-                request.UriBuilder.Uri = new Uri("https://contoso.a.io");
+                request.UriBuilder.Assign(new Uri("https://contoso.a.io"));
                 request.Content = HttpPipelineRequestContent.Create(Encoding.UTF8.GetBytes("Hello world"));
 
                 await SendRequestAsync(pipeline, request);
@@ -398,7 +398,7 @@ namespace Azure.Core.Tests
             using (Request request = pipeline.CreateRequest())
             {
                 request.Method = RequestMethod.Get;
-                request.UriBuilder.Uri = new Uri("https://contoso.a.io");
+                request.UriBuilder.Assign(new Uri("https://contoso.a.io"));
 
                 Response response = await SendRequestAsync(pipeline, request);
 

--- a/sdk/core/Azure.Core/tests/HttpClientTransportFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpClientTransportFunctionalTests.cs
@@ -34,7 +34,7 @@ namespace Azure.Core.Tests
 
                     var transport = new HttpClientTransport();
                     Request request = transport.CreateRequest();
-                    request.UriBuilder.Uri = new Uri(url);
+                    request.UriBuilder.Assign(new Uri(url));
                     Response response = await ExecuteRequest(request, transport);
                     Assert.True(response.Headers.TryGetValue("Via", out var via));
                     Assert.AreEqual("Test-Proxy", via);
@@ -59,7 +59,7 @@ namespace Azure.Core.Tests
             {
                 var transport = new HttpClientTransport();
                 Request request = transport.CreateRequest();
-                request.UriBuilder.Uri = testServer.Address;
+                request.UriBuilder.Assign(testServer.Address);
                 Response response = await ExecuteRequest(request, transport);
                 Assert.True(response.Headers.TryGetValues("Sync-Token", out System.Collections.Generic.IEnumerable<string> tokens));
                 Assert.AreEqual(2, tokens.Count());
@@ -80,7 +80,7 @@ namespace Azure.Core.Tests
             {
                 var transport = new HttpClientTransport();
                 Request request = transport.CreateRequest();
-                request.UriBuilder.Uri = testServer.Address;
+                request.UriBuilder.Assign(testServer.Address);
                 Response response = await ExecuteRequest(request, transport);
                 Assert.True(response.Headers.TryGetValues("Sync-Token", out System.Collections.Generic.IEnumerable<string> tokens));
                 Assert.AreEqual(1, tokens.Count());
@@ -100,7 +100,7 @@ namespace Azure.Core.Tests
             {
                 var transport = new HttpClientTransport();
                 Request request = transport.CreateRequest();
-                request.UriBuilder.Uri = testServer.Address;
+                request.UriBuilder.Assign(testServer.Address);
                 RequestFailedException exception = Assert.ThrowsAsync<RequestFailedException>(async () => await ExecuteRequest(request, transport));
                 Assert.AreEqual("An error occurred while sending the request.", exception.Message);
             }
@@ -122,7 +122,7 @@ namespace Azure.Core.Tests
             {
                 var transport = new HttpClientTransport();
                 Request request = transport.CreateRequest();
-                request.UriBuilder.Uri = testServer.Address;
+                request.UriBuilder.Assign(testServer.Address);
                 Response response = await ExecuteRequest(request, transport);
 
                 tcs.SetResult(null);

--- a/sdk/core/Azure.Core/tests/HttpClientTransportFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpClientTransportFunctionalTests.cs
@@ -34,7 +34,7 @@ namespace Azure.Core.Tests
 
                     var transport = new HttpClientTransport();
                     Request request = transport.CreateRequest();
-                    request.UriBuilder.Assign(new Uri(url));
+                    request.Uri.Assign(new Uri(url));
                     Response response = await ExecuteRequest(request, transport);
                     Assert.True(response.Headers.TryGetValue("Via", out var via));
                     Assert.AreEqual("Test-Proxy", via);
@@ -59,7 +59,7 @@ namespace Azure.Core.Tests
             {
                 var transport = new HttpClientTransport();
                 Request request = transport.CreateRequest();
-                request.UriBuilder.Assign(testServer.Address);
+                request.Uri.Assign(testServer.Address);
                 Response response = await ExecuteRequest(request, transport);
                 Assert.True(response.Headers.TryGetValues("Sync-Token", out System.Collections.Generic.IEnumerable<string> tokens));
                 Assert.AreEqual(2, tokens.Count());
@@ -80,7 +80,7 @@ namespace Azure.Core.Tests
             {
                 var transport = new HttpClientTransport();
                 Request request = transport.CreateRequest();
-                request.UriBuilder.Assign(testServer.Address);
+                request.Uri.Assign(testServer.Address);
                 Response response = await ExecuteRequest(request, transport);
                 Assert.True(response.Headers.TryGetValues("Sync-Token", out System.Collections.Generic.IEnumerable<string> tokens));
                 Assert.AreEqual(1, tokens.Count());
@@ -100,7 +100,7 @@ namespace Azure.Core.Tests
             {
                 var transport = new HttpClientTransport();
                 Request request = transport.CreateRequest();
-                request.UriBuilder.Assign(testServer.Address);
+                request.Uri.Assign(testServer.Address);
                 RequestFailedException exception = Assert.ThrowsAsync<RequestFailedException>(async () => await ExecuteRequest(request, transport));
                 Assert.AreEqual("An error occurred while sending the request.", exception.Message);
             }
@@ -122,7 +122,7 @@ namespace Azure.Core.Tests
             {
                 var transport = new HttpClientTransport();
                 Request request = transport.CreateRequest();
-                request.UriBuilder.Assign(testServer.Address);
+                request.Uri.Assign(testServer.Address);
                 Response response = await ExecuteRequest(request, transport);
 
                 tcs.SetResult(null);

--- a/sdk/core/Azure.Core/tests/HttpClientTransportTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpClientTransportTests.cs
@@ -39,7 +39,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = new Uri("https://example.com");
+            request.UriBuilder.Assign(new Uri("https://example.com"));
             request.Content = content;
 
             await ExecuteRequest(request, transport);
@@ -57,7 +57,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = new Uri("https://example.com");
+            request.UriBuilder.Assign(new Uri("https://example.com"));
             request.Content = HttpPipelineRequestContent.Create(new byte[10]);
             request.Headers.Add("Content-Length", "50");
 
@@ -81,7 +81,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = new Uri("http://example.com:340");
+            request.UriBuilder.Assign(new Uri("http://example.com:340"));
 
             await ExecuteRequest(request, transport);
 
@@ -103,7 +103,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = new Uri("https://example.com:340");
+            request.UriBuilder.Assign(new Uri("https://example.com:340"));
             request.Headers.Add("Host", "example.org");
 
             await ExecuteRequest(request, transport);
@@ -128,7 +128,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = new Uri("https://example.com:340");
+            request.UriBuilder.Assign(new Uri("https://example.com:340"));
 
             Response response = await ExecuteRequest(request, transport);
 
@@ -163,7 +163,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = method;
-            request.UriBuilder.Uri = new Uri("https://example.com:340");
+            request.UriBuilder.Assign(new Uri("https://example.com:340"));
 
             Assert.AreEqual(method, request.Method);
 
@@ -186,7 +186,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = expectedUri;
+            request.UriBuilder.Assign(expectedUri);
 
             Assert.AreEqual(expectedUri.ToString(), request.UriBuilder.ToString());
 
@@ -210,7 +210,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = new Uri("https://example.com:340");
+            request.UriBuilder.Assign(new Uri("https://example.com:340"));
             request.Content = content;
 
             Assert.AreEqual(content, request.Content);
@@ -356,7 +356,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = new Uri("https://example.com:340");
+            request.UriBuilder.Assign(new Uri("https://example.com:340"));
 
             Response response = await ExecuteRequest(request, transport);
 
@@ -378,7 +378,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = new Uri("https://example.com:340");
+            request.UriBuilder.Assign(new Uri("https://example.com:340"));
             request.Headers.Add(headerName, headerValue);
 
             await ExecuteRequest(request, transport);
@@ -455,7 +455,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = new Uri("https://example.com:340");
+            request.UriBuilder.Assign(new Uri("https://example.com:340"));
 
             Response response = await ExecuteRequest(request, transport);
 
@@ -494,7 +494,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = new Uri("https://example.com:340");
+            request.UriBuilder.Assign(new Uri("https://example.com:340"));
 
             Response response = await ExecuteRequest(request, transport);
             response.ContentStream = new MemoryStream();
@@ -515,7 +515,7 @@ namespace Azure.Core.Tests
         {
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = new Uri("https://example.com:340");
+            request.UriBuilder.Assign(new Uri("https://example.com:340"));
             request.Content = HttpPipelineRequestContent.Create(bytes ?? Array.Empty<byte>());
             return request;
         }
@@ -530,7 +530,7 @@ namespace Azure.Core.Tests
             Assert.IsNotEmpty(request.ClientRequestId);
             Assert.True(Guid.TryParse(request.ClientRequestId, out _));
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = new Uri("https://example.com:340");
+            request.UriBuilder.Assign(new Uri("https://example.com:340"));
 
             Response response = await ExecuteRequest(request, transport);
             Assert.AreEqual(request.ClientRequestId, response.ClientRequestId);
@@ -546,7 +546,7 @@ namespace Azure.Core.Tests
 
             request.ClientRequestId = "123";
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = new Uri("https://example.com:340");
+            request.UriBuilder.Assign(new Uri("https://example.com:340"));
 
             Response response = await ExecuteRequest(request, transport);
             Assert.AreEqual(request.ClientRequestId, response.ClientRequestId);
@@ -568,7 +568,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = new Uri("https://example.com:340");
+            request.UriBuilder.Assign(new Uri("https://example.com:340"));
 
             Response response = await ExecuteRequest(request, transport);
 
@@ -610,7 +610,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = new Uri("https://example.com:340");
+            request.UriBuilder.Assign(new Uri("https://example.com:340"));
 
             Response response = await ExecuteRequest(request, transport);
 
@@ -632,7 +632,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = new Uri("https://example.com:340");
+            request.UriBuilder.Assign(new Uri("https://example.com:340"));
 
             Response response = await ExecuteRequest(request, transport);
 
@@ -655,7 +655,7 @@ namespace Azure.Core.Tests
             Request request = transport.CreateRequest();
             request.Content = HttpPipelineRequestContent.Create(new MemoryStream(new byte[] { 1, 2, 3 }));
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = new Uri("https://example.com:340");
+            request.UriBuilder.Assign(new Uri("https://example.com:340"));
 
             await ExecuteRequest(request, transport);
             await ExecuteRequest(request, transport);
@@ -682,7 +682,7 @@ namespace Azure.Core.Tests
             {
                 request.Content = disposeTrackingContent;
                 request.Method = RequestMethod.Get;
-                request.UriBuilder.Uri = new Uri("https://example.com:340");
+                request.UriBuilder.Assign(new Uri("https://example.com:340"));
 
                 await ExecuteRequest(request, transport);
                 Assert.False(disposeTrackingContent.IsDisposed);

--- a/sdk/core/Azure.Core/tests/HttpClientTransportTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpClientTransportTests.cs
@@ -39,7 +39,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(new Uri("https://example.com"));
+            request.Uri.Assign(new Uri("https://example.com"));
             request.Content = content;
 
             await ExecuteRequest(request, transport);
@@ -57,7 +57,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(new Uri("https://example.com"));
+            request.Uri.Assign(new Uri("https://example.com"));
             request.Content = HttpPipelineRequestContent.Create(new byte[10]);
             request.Headers.Add("Content-Length", "50");
 
@@ -81,7 +81,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(new Uri("http://example.com:340"));
+            request.Uri.Assign(new Uri("http://example.com:340"));
 
             await ExecuteRequest(request, transport);
 
@@ -103,7 +103,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(new Uri("https://example.com:340"));
+            request.Uri.Assign(new Uri("https://example.com:340"));
             request.Headers.Add("Host", "example.org");
 
             await ExecuteRequest(request, transport);
@@ -128,7 +128,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(new Uri("https://example.com:340"));
+            request.Uri.Assign(new Uri("https://example.com:340"));
 
             Response response = await ExecuteRequest(request, transport);
 
@@ -163,7 +163,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = method;
-            request.UriBuilder.Assign(new Uri("https://example.com:340"));
+            request.Uri.Assign(new Uri("https://example.com:340"));
 
             Assert.AreEqual(method, request.Method);
 
@@ -186,9 +186,9 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(expectedUri);
+            request.Uri.Assign(expectedUri);
 
-            Assert.AreEqual(expectedUri.ToString(), request.UriBuilder.ToString());
+            Assert.AreEqual(expectedUri.ToString(), request.Uri.ToString());
 
             await ExecuteRequest(request, transport);
 
@@ -210,7 +210,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(new Uri("https://example.com:340"));
+            request.Uri.Assign(new Uri("https://example.com:340"));
             request.Content = content;
 
             Assert.AreEqual(content, request.Content);
@@ -356,7 +356,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(new Uri("https://example.com:340"));
+            request.Uri.Assign(new Uri("https://example.com:340"));
 
             Response response = await ExecuteRequest(request, transport);
 
@@ -378,7 +378,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(new Uri("https://example.com:340"));
+            request.Uri.Assign(new Uri("https://example.com:340"));
             request.Headers.Add(headerName, headerValue);
 
             await ExecuteRequest(request, transport);
@@ -455,7 +455,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(new Uri("https://example.com:340"));
+            request.Uri.Assign(new Uri("https://example.com:340"));
 
             Response response = await ExecuteRequest(request, transport);
 
@@ -494,7 +494,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(new Uri("https://example.com:340"));
+            request.Uri.Assign(new Uri("https://example.com:340"));
 
             Response response = await ExecuteRequest(request, transport);
             response.ContentStream = new MemoryStream();
@@ -515,7 +515,7 @@ namespace Azure.Core.Tests
         {
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(new Uri("https://example.com:340"));
+            request.Uri.Assign(new Uri("https://example.com:340"));
             request.Content = HttpPipelineRequestContent.Create(bytes ?? Array.Empty<byte>());
             return request;
         }
@@ -530,7 +530,7 @@ namespace Azure.Core.Tests
             Assert.IsNotEmpty(request.ClientRequestId);
             Assert.True(Guid.TryParse(request.ClientRequestId, out _));
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(new Uri("https://example.com:340"));
+            request.Uri.Assign(new Uri("https://example.com:340"));
 
             Response response = await ExecuteRequest(request, transport);
             Assert.AreEqual(request.ClientRequestId, response.ClientRequestId);
@@ -546,7 +546,7 @@ namespace Azure.Core.Tests
 
             request.ClientRequestId = "123";
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(new Uri("https://example.com:340"));
+            request.Uri.Assign(new Uri("https://example.com:340"));
 
             Response response = await ExecuteRequest(request, transport);
             Assert.AreEqual(request.ClientRequestId, response.ClientRequestId);
@@ -568,7 +568,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(new Uri("https://example.com:340"));
+            request.Uri.Assign(new Uri("https://example.com:340"));
 
             Response response = await ExecuteRequest(request, transport);
 
@@ -610,7 +610,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(new Uri("https://example.com:340"));
+            request.Uri.Assign(new Uri("https://example.com:340"));
 
             Response response = await ExecuteRequest(request, transport);
 
@@ -632,7 +632,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(new Uri("https://example.com:340"));
+            request.Uri.Assign(new Uri("https://example.com:340"));
 
             Response response = await ExecuteRequest(request, transport);
 
@@ -655,7 +655,7 @@ namespace Azure.Core.Tests
             Request request = transport.CreateRequest();
             request.Content = HttpPipelineRequestContent.Create(new MemoryStream(new byte[] { 1, 2, 3 }));
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(new Uri("https://example.com:340"));
+            request.Uri.Assign(new Uri("https://example.com:340"));
 
             await ExecuteRequest(request, transport);
             await ExecuteRequest(request, transport);
@@ -682,7 +682,7 @@ namespace Azure.Core.Tests
             {
                 request.Content = disposeTrackingContent;
                 request.Method = RequestMethod.Get;
-                request.UriBuilder.Assign(new Uri("https://example.com:340"));
+                request.Uri.Assign(new Uri("https://example.com:340"));
 
                 await ExecuteRequest(request, transport);
                 Assert.False(disposeTrackingContent.IsDisposed);

--- a/sdk/core/Azure.Core/tests/HttpPipelineBuilderTest.cs
+++ b/sdk/core/Azure.Core/tests/HttpPipelineBuilderTest.cs
@@ -30,7 +30,7 @@ namespace Azure.Core.Tests
 
             using Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = new Uri("http://example.com");
+            request.UriBuilder.Assign(new Uri("http://example.com"));
 
             Response response = await pipeline.SendRequestAsync(request, CancellationToken.None);
 
@@ -51,7 +51,7 @@ namespace Azure.Core.Tests
 
             using Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = new Uri("http://example.com");
+            request.UriBuilder.Assign(new Uri("http://example.com"));
 
             await pipeline.SendRequestAsync(request, CancellationToken.None);
 

--- a/sdk/core/Azure.Core/tests/HttpPipelineBuilderTest.cs
+++ b/sdk/core/Azure.Core/tests/HttpPipelineBuilderTest.cs
@@ -30,7 +30,7 @@ namespace Azure.Core.Tests
 
             using Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(new Uri("http://example.com"));
+            request.Uri.Assign(new Uri("http://example.com"));
 
             Response response = await pipeline.SendRequestAsync(request, CancellationToken.None);
 
@@ -51,7 +51,7 @@ namespace Azure.Core.Tests
 
             using Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(new Uri("http://example.com"));
+            request.Uri.Assign(new Uri("http://example.com"));
 
             await pipeline.SendRequestAsync(request, CancellationToken.None);
 

--- a/sdk/core/Azure.Core/tests/HttpPipelineFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpPipelineFunctionalTests.cs
@@ -31,7 +31,7 @@ namespace Azure.Core.Tests
             for (int i = 0; i < 100; i++)
             {
                 using Request request = httpPipeline.CreateRequest();
-                request.UriBuilder.Uri = testServer.Address;
+                request.UriBuilder.Assign(testServer.Address);
 
                 using Response response = await httpPipeline.SendRequestAsync(request, CancellationToken.None);
 
@@ -61,7 +61,7 @@ namespace Azure.Core.Tests
                 Stream extractedStream;
                 using (HttpPipelineMessage message = httpPipeline.CreateMessage())
                 {
-                    message.Request.UriBuilder.Uri = testServer.Address;
+                    message.Request.UriBuilder.Assign(testServer.Address);
                     message.BufferResponse = false;
 
                     await httpPipeline.SendAsync(message, CancellationToken.None);

--- a/sdk/core/Azure.Core/tests/HttpPipelineFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpPipelineFunctionalTests.cs
@@ -31,7 +31,7 @@ namespace Azure.Core.Tests
             for (int i = 0; i < 100; i++)
             {
                 using Request request = httpPipeline.CreateRequest();
-                request.UriBuilder.Assign(testServer.Address);
+                request.Uri.Assign(testServer.Address);
 
                 using Response response = await httpPipeline.SendRequestAsync(request, CancellationToken.None);
 
@@ -61,7 +61,7 @@ namespace Azure.Core.Tests
                 Stream extractedStream;
                 using (HttpPipelineMessage message = httpPipeline.CreateMessage())
                 {
-                    message.Request.UriBuilder.Assign(testServer.Address);
+                    message.Request.Uri.Assign(testServer.Address);
                     message.BufferResponse = false;
 
                     await httpPipeline.SendAsync(message, CancellationToken.None);

--- a/sdk/core/Azure.Core/tests/PipelineTests.cs
+++ b/sdk/core/Azure.Core/tests/PipelineTests.cs
@@ -25,7 +25,7 @@ namespace Azure.Core.Tests
 
             Http.Request request = pipeline.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(new Uri("https://contoso.a.io"));
+            request.Uri.Assign(new Uri("https://contoso.a.io"));
             Response response = await pipeline.SendRequestAsync(request, CancellationToken.None);
 
             Assert.AreEqual(1, response.Status);

--- a/sdk/core/Azure.Core/tests/PipelineTests.cs
+++ b/sdk/core/Azure.Core/tests/PipelineTests.cs
@@ -25,7 +25,7 @@ namespace Azure.Core.Tests
 
             Http.Request request = pipeline.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = new Uri("https://contoso.a.io");
+            request.UriBuilder.Assign(new Uri("https://contoso.a.io"));
             Response response = await pipeline.SendRequestAsync(request, CancellationToken.None);
 
             Assert.AreEqual(1, response.Status);

--- a/sdk/core/Azure.Core/tests/PolicyTestBase.cs
+++ b/sdk/core/Azure.Core/tests/PolicyTestBase.cs
@@ -19,7 +19,7 @@ namespace Azure.Core.Tests
             using (Request request = transport.CreateRequest())
             {
                 request.Method = RequestMethod.Get;
-                request.UriBuilder.Assign(new Uri("http://example.com"));
+                request.Uri.Assign(new Uri("http://example.com"));
                 var pipeline = new HttpPipeline(transport, new[] { policy }, responseClassifier);
                 return await pipeline.SendRequestAsync(request, CancellationToken.None);
             }

--- a/sdk/core/Azure.Core/tests/PolicyTestBase.cs
+++ b/sdk/core/Azure.Core/tests/PolicyTestBase.cs
@@ -19,7 +19,7 @@ namespace Azure.Core.Tests
             using (Request request = transport.CreateRequest())
             {
                 request.Method = RequestMethod.Get;
-                request.UriBuilder.Uri = new Uri("http://example.com");
+                request.UriBuilder.Assign(new Uri("http://example.com"));
                 var pipeline = new HttpPipeline(transport, new[] { policy }, responseClassifier);
                 return await pipeline.SendRequestAsync(request, CancellationToken.None);
             }

--- a/sdk/core/Azure.Core/tests/RecordSessionTests.cs
+++ b/sdk/core/Azure.Core/tests/RecordSessionTests.cs
@@ -81,7 +81,7 @@ namespace Azure.Core.Tests
             {
                 Method = RequestMethod.Head
             };
-            mockRequest.UriBuilder.Assign(new Uri("http://localhost"));
+            mockRequest.Uri.Assign(new Uri("http://localhost"));
             mockRequest.Headers.Add("Some-Header", "Random value");
             mockRequest.Headers.Add("Some-Other-Header", "V");
 
@@ -122,7 +122,7 @@ namespace Azure.Core.Tests
             {
                 Method = RequestMethod.Put
             };
-            mockRequest.UriBuilder.Assign(new Uri("http://localhost"));
+            mockRequest.Uri.Assign(new Uri("http://localhost"));
 
             RecordEntry[] entries = new[]
             {
@@ -149,7 +149,7 @@ namespace Azure.Core.Tests
             {
                 Method = RequestMethod.Head
             };
-            mockRequest.UriBuilder.Assign(new Uri("http://localhost"));
+            mockRequest.Uri.Assign(new Uri("http://localhost"));
             mockRequest.Headers.Add("Some-Header", "Random value");
             mockRequest.Headers.Add("Some-Other-Header", "V");
 

--- a/sdk/core/Azure.Core/tests/RecordSessionTests.cs
+++ b/sdk/core/Azure.Core/tests/RecordSessionTests.cs
@@ -81,7 +81,7 @@ namespace Azure.Core.Tests
             {
                 Method = RequestMethod.Head
             };
-            mockRequest.UriBuilder.Uri = new Uri("http://localhost");
+            mockRequest.UriBuilder.Assign(new Uri("http://localhost"));
             mockRequest.Headers.Add("Some-Header", "Random value");
             mockRequest.Headers.Add("Some-Other-Header", "V");
 
@@ -122,7 +122,7 @@ namespace Azure.Core.Tests
             {
                 Method = RequestMethod.Put
             };
-            mockRequest.UriBuilder.Uri = new Uri("http://localhost");
+            mockRequest.UriBuilder.Assign(new Uri("http://localhost"));
 
             RecordEntry[] entries = new[]
             {
@@ -149,7 +149,7 @@ namespace Azure.Core.Tests
             {
                 Method = RequestMethod.Head
             };
-            mockRequest.UriBuilder.Uri = new Uri("http://localhost");
+            mockRequest.UriBuilder.Assign(new Uri("http://localhost"));
             mockRequest.Headers.Add("Some-Header", "Random value");
             mockRequest.Headers.Add("Some-Other-Header", "V");
 

--- a/sdk/core/Azure.Core/tests/RequestActivityPolicyTests.cs
+++ b/sdk/core/Azure.Core/tests/RequestActivityPolicyTests.cs
@@ -39,7 +39,7 @@ namespace Azure.Core.Tests
 
             using Request request = mockTransport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = new Uri("http://example.com");
+            request.UriBuilder.Assign(new Uri("http://example.com"));
             request.Headers.Add("User-Agent", "agent");
 
             Task<Response> requestTask = SendRequestAsync(mockTransport, request, s_enabledPolicy);
@@ -82,7 +82,7 @@ namespace Azure.Core.Tests
 
                 using Request request = mockTransport.CreateRequest();
                 request.Method = RequestMethod.Get;
-                request.UriBuilder.Uri = new Uri("http://example.com");
+                request.UriBuilder.Assign(new Uri("http://example.com"));
 
                 Task<Response> requestTask = SendRequestAsync(mockTransport, request, s_enabledPolicy);
 

--- a/sdk/core/Azure.Core/tests/RequestActivityPolicyTests.cs
+++ b/sdk/core/Azure.Core/tests/RequestActivityPolicyTests.cs
@@ -39,7 +39,7 @@ namespace Azure.Core.Tests
 
             using Request request = mockTransport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(new Uri("http://example.com"));
+            request.Uri.Assign(new Uri("http://example.com"));
             request.Headers.Add("User-Agent", "agent");
 
             Task<Response> requestTask = SendRequestAsync(mockTransport, request, s_enabledPolicy);
@@ -82,7 +82,7 @@ namespace Azure.Core.Tests
 
                 using Request request = mockTransport.CreateRequest();
                 request.Method = RequestMethod.Get;
-                request.UriBuilder.Assign(new Uri("http://example.com"));
+                request.Uri.Assign(new Uri("http://example.com"));
 
                 Task<Response> requestTask = SendRequestAsync(mockTransport, request, s_enabledPolicy);
 

--- a/sdk/core/Azure.Core/tests/RequestUriBuilderTest.cs
+++ b/sdk/core/Azure.Core/tests/RequestUriBuilderTest.cs
@@ -22,18 +22,16 @@ namespace Azure.Core.Tests
         [TestCaseSource(nameof(Uris))]
         public void RoundtripWithUri(Uri uri)
         {
-            var uriBuilder = new RequestUriBuilder
-            {
-                Uri = uri
-            };
+            var uriBuilder = new RequestUriBuilder();
+            uriBuilder.Assign(uri);
 
             Assert.AreEqual(uri.Scheme, uriBuilder.Scheme);
             Assert.AreEqual(uri.Host, uriBuilder.Host);
             Assert.AreEqual(uri.Port, uriBuilder.Port);
             Assert.AreEqual(uri.AbsolutePath, uriBuilder.Path);
             Assert.AreEqual(uri.Query, uriBuilder.Query);
-            Assert.AreEqual(uri, uriBuilder.Uri);
-            Assert.AreSame(uri, uriBuilder.Uri);
+            Assert.AreEqual(uri, uriBuilder.ToUri());
+            Assert.AreSame(uri, uriBuilder.ToUri());
         }
 
         [TestCase("", "http://localhost/")]
@@ -50,7 +48,7 @@ namespace Azure.Core.Tests
                 Path = path
             };
 
-            Assert.AreEqual(expected, uriBuilder.Uri.ToString());
+            Assert.AreEqual(expected, uriBuilder.ToUri().ToString());
         }
 
         [TestCase("", "http://localhost/")]
@@ -67,7 +65,7 @@ namespace Azure.Core.Tests
                 Query = query
             };
 
-            Assert.AreEqual(expected, uriBuilder.Uri.ToString());
+            Assert.AreEqual(expected, uriBuilder.ToUri().ToString());
         }
 
         [TestCase(null)]
@@ -82,11 +80,11 @@ namespace Azure.Core.Tests
                 Query = "a"
             };
 
-            Assert.AreEqual("http://localhost/?a", uriBuilder.Uri.ToString());
+            Assert.AreEqual("http://localhost/?a", uriBuilder.ToUri().ToString());
 
             uriBuilder.Query = query;
 
-            Assert.AreEqual("http://localhost/", uriBuilder.Uri.ToString());
+            Assert.AreEqual("http://localhost/", uriBuilder.ToUri().ToString());
         }
 
         [TestCase("\u1234\u2345", "%E1%88%B4%E2%8D%85")]
@@ -104,7 +102,7 @@ namespace Azure.Core.Tests
                 Path = path
             };
 
-            Assert.AreEqual("http://localhost/" + expectedPath, uriBuilder.Uri.OriginalString);
+            Assert.AreEqual("http://localhost/" + expectedPath, uriBuilder.ToUri().OriginalString);
         }
 
         [Test]
@@ -118,7 +116,7 @@ namespace Azure.Core.Tests
                 Query = "\u1234"
             };
 
-            Assert.AreEqual("http://localhost/?\u1234", uriBuilder.Uri.ToString());
+            Assert.AreEqual("http://localhost/?\u1234", uriBuilder.ToUri().ToString());
         }
 
         [Test]
@@ -132,7 +130,7 @@ namespace Azure.Core.Tests
             };
             uriBuilder.AppendQuery("a", null);
 
-            Assert.AreEqual("http://localhost/?a=", uriBuilder.Uri.ToString());
+            Assert.AreEqual("http://localhost/?a=", uriBuilder.ToUri().ToString());
         }
 
         [TestCase(null, "http://localhost/?a=b&c=d")]
@@ -152,7 +150,7 @@ namespace Azure.Core.Tests
             uriBuilder.AppendQuery("a", "b");
             uriBuilder.AppendQuery("c", "d");
 
-            Assert.AreEqual(expectedResult, uriBuilder.Uri.ToString());
+            Assert.AreEqual(expectedResult, uriBuilder.ToUri().ToString());
         }
 
         [TestCase(null, "", "http://localhost/")]
@@ -172,46 +170,40 @@ namespace Azure.Core.Tests
             };
             uriBuilder.AppendPath(append);
 
-            Assert.AreEqual(expectedResult, uriBuilder.Uri.OriginalString);
+            Assert.AreEqual(expectedResult, uriBuilder.ToUri().OriginalString);
         }
 
         [Test]
         public void AppendingQueryResetsUri()
         {
-            var uriBuilder = new RequestUriBuilder
-            {
-                Uri = new Uri("http://localhost/")
-            };
+            var uriBuilder = new RequestUriBuilder();
+            uriBuilder.Assign(new Uri("http://localhost/"));
             uriBuilder.AppendQuery("a", "b");
 
-            Assert.AreEqual("http://localhost/?a=b", uriBuilder.Uri.ToString());
+            Assert.AreEqual("http://localhost/?a=b", uriBuilder.ToUri().ToString());
         }
 
         [Test]
         public void AppendingPathResetsUri()
         {
-            var uriBuilder = new RequestUriBuilder
-            {
-                Uri = new Uri("http://localhost/")
-            };
+            var uriBuilder = new RequestUriBuilder();
+            uriBuilder.Assign(new Uri("http://localhost/"));
             uriBuilder.AppendPath("a");
 
-            Assert.AreEqual("http://localhost/a", uriBuilder.Uri.ToString());
+            Assert.AreEqual("http://localhost/a", uriBuilder.ToUri().ToString());
         }
 
         [Test]
         public void AppendingPathAfterQueryAndSettingTheUriWorks()
         {
-            var uriBuilder = new RequestUriBuilder
-            {
-                Uri = new Uri("http://localhost/")
-            };
+            var uriBuilder = new RequestUriBuilder();
+            uriBuilder.Assign(new Uri("http://localhost/"));
             uriBuilder.AppendQuery("query", "value");
             uriBuilder.AppendPath("a");
             uriBuilder.AppendPath("b");
             uriBuilder.AppendQuery("c", "d");
 
-            Assert.AreEqual("http://localhost/ab?query=value&c=d", uriBuilder.Uri.ToString());
+            Assert.AreEqual("http://localhost/ab?query=value&c=d", uriBuilder.ToUri().ToString());
         }
     }
 }

--- a/sdk/core/Azure.Core/tests/RetriableStreamTests.cs
+++ b/sdk/core/Azure.Core/tests/RetriableStreamTests.cs
@@ -259,7 +259,7 @@ namespace Azure.Core.Tests
         {
             Request request = pipeline.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = new Uri("https://example.com");
+            request.UriBuilder.Assign(new Uri("https://example.com"));
             request.Headers.Add("Range", "bytes=" + offset);
             return request;
         }

--- a/sdk/core/Azure.Core/tests/RetriableStreamTests.cs
+++ b/sdk/core/Azure.Core/tests/RetriableStreamTests.cs
@@ -259,7 +259,7 @@ namespace Azure.Core.Tests
         {
             Request request = pipeline.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(new Uri("https://example.com"));
+            request.Uri.Assign(new Uri("https://example.com"));
             request.Headers.Add("Range", "bytes=" + offset);
             return request;
         }

--- a/sdk/core/Azure.Core/tests/TestFramework/MockRequest.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/MockRequest.cs
@@ -105,7 +105,7 @@ namespace Azure.Core.Testing
 
         public override string ClientRequestId { get; set; }
 
-        public override string ToString() => $"{Method} {UriBuilder}";
+        public override string ToString() => $"{Method} {Uri}";
 
         public override void Dispose()
         {

--- a/sdk/core/Azure.Core/tests/TestFramework/RecordMatcher.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/RecordMatcher.cs
@@ -67,7 +67,7 @@ namespace Azure.Core.Testing
 
             _sanitizer.SanitizeHeaders(headers);
 
-            string uri = _sanitizer.SanitizeUri(request.UriBuilder.ToString());
+            string uri = _sanitizer.SanitizeUri(request.Uri.ToString());
 
             int bestScore = int.MaxValue;
             RecordEntry bestScoreEntry = null;

--- a/sdk/core/Azure.Core/tests/TestFramework/RecordTransport.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/RecordTransport.cs
@@ -70,7 +70,7 @@ namespace Azure.Core.Testing
         {
             var entry = new RecordEntry
             {
-                RequestUri = request.UriBuilder.ToString(),
+                RequestUri = request.Uri.ToString(),
                 RequestMethod = request.Method,
                 RequestHeaders = new SortedDictionary<string, string[]>(StringComparer.OrdinalIgnoreCase),
                 ResponseHeaders = new SortedDictionary<string, string[]>(StringComparer.OrdinalIgnoreCase),

--- a/sdk/core/Azure.Core/tests/TestFramework/SyncAsyncPolicyTestBase.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/SyncAsyncPolicyTestBase.cs
@@ -48,7 +48,7 @@ namespace Azure.Core.Testing
         {
             using Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(new Uri("http://example.com"));
+            request.Uri.Assign(new Uri("http://example.com"));
             return await SendRequestAsync(transport, request, policy, responseClassifier, bufferResponse);
         }
     }

--- a/sdk/core/Azure.Core/tests/TestFramework/SyncAsyncPolicyTestBase.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/SyncAsyncPolicyTestBase.cs
@@ -48,7 +48,7 @@ namespace Azure.Core.Testing
         {
             using Request request = transport.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = new Uri("http://example.com");
+            request.UriBuilder.Assign(new Uri("http://example.com"));
             return await SendRequestAsync(transport, request, policy, responseClassifier, bufferResponse);
         }
     }

--- a/sdk/core/Azure.Core/tests/samples/Sample1_HelloWorld.cs
+++ b/sdk/core/Azure.Core/tests/samples/Sample1_HelloWorld.cs
@@ -22,7 +22,7 @@ namespace Azure.Core.Samples
 
             var uri = new Uri(@"https://raw.githubusercontent.com/Azure/azure-sdk-for-net/master/README.md");
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Assign(uri);
+            request.Uri.Assign(uri);
             request.Headers.Add("Host", uri.Host);
 
             Response response = await pipeline.SendRequestAsync(request, cancellationToken: default).ConfigureAwait(false);

--- a/sdk/core/Azure.Core/tests/samples/Sample1_HelloWorld.cs
+++ b/sdk/core/Azure.Core/tests/samples/Sample1_HelloWorld.cs
@@ -22,7 +22,7 @@ namespace Azure.Core.Samples
 
             var uri = new Uri(@"https://raw.githubusercontent.com/Azure/azure-sdk-for-net/master/README.md");
             request.Method = RequestMethod.Get;
-            request.UriBuilder.Uri = uri;
+            request.UriBuilder.Assign(uri);
             request.Headers.Add("Host", uri.Host);
 
             Response response = await pipeline.SendRequestAsync(request, cancellationToken: default).ConfigureAwait(false);

--- a/sdk/identity/Azure.Identity/src/AadIdentityClient.cs
+++ b/sdk/identity/Azure.Identity/src/AadIdentityClient.cs
@@ -176,7 +176,7 @@ namespace Azure.Identity
 
             request.Headers.Add(HttpHeader.Common.FormUrlEncodedContentType);
 
-            request.UriBuilder.Uri = _options.AuthorityHost;
+            request.UriBuilder.Assign(_options.AuthorityHost);
 
             request.UriBuilder.AppendPath(tenantId);
 
@@ -199,7 +199,7 @@ namespace Azure.Identity
 
             request.Headers.Add(HttpHeader.Common.FormUrlEncodedContentType);
 
-            request.UriBuilder.Uri = _options.AuthorityHost;
+            request.UriBuilder.Assign(_options.AuthorityHost);
 
             request.UriBuilder.AppendPath(tenantId);
 

--- a/sdk/identity/Azure.Identity/src/AadIdentityClient.cs
+++ b/sdk/identity/Azure.Identity/src/AadIdentityClient.cs
@@ -176,11 +176,11 @@ namespace Azure.Identity
 
             request.Headers.Add(HttpHeader.Common.FormUrlEncodedContentType);
 
-            request.UriBuilder.Assign(_options.AuthorityHost);
+            request.Uri.Assign(_options.AuthorityHost);
 
-            request.UriBuilder.AppendPath(tenantId);
+            request.Uri.AppendPath(tenantId);
 
-            request.UriBuilder.AppendPath("/oauth2/v2.0/token");
+            request.Uri.AppendPath("/oauth2/v2.0/token");
 
             var bodyStr = $"response_type=token&grant_type=client_credentials&client_id={Uri.EscapeDataString(clientId)}&client_secret={Uri.EscapeDataString(clientSecret)}&scope={Uri.EscapeDataString(string.Join(" ", scopes))}";
 
@@ -199,13 +199,13 @@ namespace Azure.Identity
 
             request.Headers.Add(HttpHeader.Common.FormUrlEncodedContentType);
 
-            request.UriBuilder.Assign(_options.AuthorityHost);
+            request.Uri.Assign(_options.AuthorityHost);
 
-            request.UriBuilder.AppendPath(tenantId);
+            request.Uri.AppendPath(tenantId);
 
-            request.UriBuilder.AppendPath("/oauth2/v2.0/token");
+            request.Uri.AppendPath("/oauth2/v2.0/token");
 
-            string clientAssertion = CreateClientAssertionJWT(clientId, request.UriBuilder.ToString(), clientCertficate);
+            string clientAssertion = CreateClientAssertionJWT(clientId, request.Uri.ToString(), clientCertficate);
 
             var bodyStr = $"response_type=token&grant_type=client_credentials&client_id={Uri.EscapeDataString(clientId)}&client_assertion_type={Uri.EscapeDataString(ClientAssertionType)}&client_assertion={Uri.EscapeDataString(clientAssertion)}&scope={Uri.EscapeDataString(string.Join(" ", scopes))}";
 

--- a/sdk/identity/Azure.Identity/src/HttpExtensions.cs
+++ b/sdk/identity/Azure.Identity/src/HttpExtensions.cs
@@ -20,7 +20,7 @@ namespace Azure.Identity
 
             pipelineRequest.Method = RequestMethod.Parse(request.Method.Method);
 
-            pipelineRequest.UriBuilder.Uri = request.RequestUri;
+            pipelineRequest.UriBuilder.Assign(request.RequestUri);
 
             pipelineRequest.Content = await request.Content.ToPipelineRequestContentAsync().ConfigureAwait(false);
 

--- a/sdk/identity/Azure.Identity/src/HttpExtensions.cs
+++ b/sdk/identity/Azure.Identity/src/HttpExtensions.cs
@@ -20,7 +20,7 @@ namespace Azure.Identity
 
             pipelineRequest.Method = RequestMethod.Parse(request.Method.Method);
 
-            pipelineRequest.UriBuilder.Assign(request.RequestUri);
+            pipelineRequest.Uri.Assign(request.RequestUri);
 
             pipelineRequest.Content = await request.Content.ToPipelineRequestContentAsync().ConfigureAwait(false);
 

--- a/sdk/identity/Azure.Identity/src/ManagedIdentityClient.cs
+++ b/sdk/identity/Azure.Identity/src/ManagedIdentityClient.cs
@@ -301,7 +301,7 @@ namespace Azure.Identity
             {
                 request.Method = RequestMethod.Get;
 
-                request.UriBuilder.Uri = s_imdsEndpoint;
+                request.UriBuilder.Assign(s_imdsEndpoint);
 
                 request.UriBuilder.AppendQuery("api-version", ImdsApiVersion);
 
@@ -333,7 +333,7 @@ namespace Azure.Identity
             {
                 request.Method = RequestMethod.Get;
 
-                request.UriBuilder.Uri = s_imdsEndpoint;
+                request.UriBuilder.Assign(s_imdsEndpoint);
 
                 request.UriBuilder.AppendQuery("api-version", ImdsApiVersion);
 
@@ -367,7 +367,7 @@ namespace Azure.Identity
 
             request.Headers.Add("Metadata", "true");
 
-            request.UriBuilder.Uri = s_endpoint;
+            request.UriBuilder.Assign(s_endpoint);
 
             request.UriBuilder.AppendQuery("api-version", ImdsApiVersion);
 
@@ -392,7 +392,7 @@ namespace Azure.Identity
 
             request.Headers.Add("secret", Environment.GetEnvironmentVariable(MsiSecretEnvironemntVariable));
 
-            request.UriBuilder.Uri = s_endpoint;
+            request.UriBuilder.Assign(s_endpoint);
 
             request.UriBuilder.AppendQuery("api-version", AppServiceMsiApiVersion);
 
@@ -417,7 +417,7 @@ namespace Azure.Identity
 
             request.Headers.Add(HttpHeader.Common.FormUrlEncodedContentType);
 
-            request.UriBuilder.Uri = s_endpoint;
+            request.UriBuilder.Assign(s_endpoint);
 
             request.Headers.Add("Metadata", "true");
 

--- a/sdk/identity/Azure.Identity/src/ManagedIdentityClient.cs
+++ b/sdk/identity/Azure.Identity/src/ManagedIdentityClient.cs
@@ -301,9 +301,9 @@ namespace Azure.Identity
             {
                 request.Method = RequestMethod.Get;
 
-                request.UriBuilder.Assign(s_imdsEndpoint);
+                request.Uri.Assign(s_imdsEndpoint);
 
-                request.UriBuilder.AppendQuery("api-version", ImdsApiVersion);
+                request.Uri.AppendQuery("api-version", ImdsApiVersion);
 
                 CancellationToken imdsTimeout = new CancellationTokenSource(ImdsAvailableTimeoutMs).Token;
 
@@ -333,9 +333,9 @@ namespace Azure.Identity
             {
                 request.Method = RequestMethod.Get;
 
-                request.UriBuilder.Assign(s_imdsEndpoint);
+                request.Uri.Assign(s_imdsEndpoint);
 
-                request.UriBuilder.AppendQuery("api-version", ImdsApiVersion);
+                request.Uri.AppendQuery("api-version", ImdsApiVersion);
 
                 CancellationToken imdsTimeout = new CancellationTokenSource(ImdsAvailableTimeoutMs).Token;
 
@@ -367,15 +367,15 @@ namespace Azure.Identity
 
             request.Headers.Add("Metadata", "true");
 
-            request.UriBuilder.Assign(s_endpoint);
+            request.Uri.Assign(s_endpoint);
 
-            request.UriBuilder.AppendQuery("api-version", ImdsApiVersion);
+            request.Uri.AppendQuery("api-version", ImdsApiVersion);
 
-            request.UriBuilder.AppendQuery("resource", Uri.EscapeDataString(resource));
+            request.Uri.AppendQuery("resource", Uri.EscapeDataString(resource));
 
             if (!string.IsNullOrEmpty(clientId))
             {
-                request.UriBuilder.AppendQuery("client_id", Uri.EscapeDataString(clientId));
+                request.Uri.AppendQuery("client_id", Uri.EscapeDataString(clientId));
             }
 
             return request;
@@ -392,15 +392,15 @@ namespace Azure.Identity
 
             request.Headers.Add("secret", Environment.GetEnvironmentVariable(MsiSecretEnvironemntVariable));
 
-            request.UriBuilder.Assign(s_endpoint);
+            request.Uri.Assign(s_endpoint);
 
-            request.UriBuilder.AppendQuery("api-version", AppServiceMsiApiVersion);
+            request.Uri.AppendQuery("api-version", AppServiceMsiApiVersion);
 
-            request.UriBuilder.AppendQuery("resource", Uri.EscapeDataString(resource));
+            request.Uri.AppendQuery("resource", Uri.EscapeDataString(resource));
 
             if (!string.IsNullOrEmpty(clientId))
             {
-                request.UriBuilder.AppendQuery("client_id", Uri.EscapeDataString(clientId));
+                request.Uri.AppendQuery("client_id", Uri.EscapeDataString(clientId));
             }
 
             return request;
@@ -417,7 +417,7 @@ namespace Azure.Identity
 
             request.Headers.Add(HttpHeader.Common.FormUrlEncodedContentType);
 
-            request.UriBuilder.Assign(s_endpoint);
+            request.Uri.Assign(s_endpoint);
 
             request.Headers.Add("Metadata", "true");
 

--- a/sdk/identity/Azure.Identity/tests/DeviceCodeCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DeviceCodeCredentialTests.cs
@@ -161,7 +161,7 @@ namespace Azure.Identity.Tests
 
         private MockResponse ProcessMockRequest(MockRequest mockRequest, string code, string token)
         {
-            string requestUrl = mockRequest.UriBuilder.Uri.AbsoluteUri;
+            string requestUrl = mockRequest.UriBuilder.ToUri().AbsoluteUri;
 
             if (requestUrl.StartsWith("https://login.microsoftonline.com/common/discovery/instance"))
             {

--- a/sdk/identity/Azure.Identity/tests/DeviceCodeCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DeviceCodeCredentialTests.cs
@@ -161,7 +161,7 @@ namespace Azure.Identity.Tests
 
         private MockResponse ProcessMockRequest(MockRequest mockRequest, string code, string token)
         {
-            string requestUrl = mockRequest.UriBuilder.ToUri().AbsoluteUri;
+            string requestUrl = mockRequest.Uri.ToUri().AbsoluteUri;
 
             if (requestUrl.StartsWith("https://login.microsoftonline.com/common/discovery/instance"))
             {

--- a/sdk/identity/Azure.Identity/tests/ManagedIdentityClientTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ManagedIdentityClientTests.cs
@@ -51,7 +51,7 @@ namespace Azure.Identity.Tests
 
                 MockRequest request = mockTransport.Requests[mockTransport.Requests.Count - 1];
 
-                string query = request.UriBuilder.Query;
+                string query = request.Uri.Query;
 
                 Assert.IsTrue(query.Contains("api-version=2018-02-01"));
 
@@ -88,7 +88,7 @@ namespace Azure.Identity.Tests
 
                 MockRequest request = mockTransport.Requests[mockTransport.Requests.Count - 1];
 
-                string query = request.UriBuilder.Query;
+                string query = request.Uri.Query;
 
                 Assert.IsTrue(query.Contains("api-version=2018-02-01"));
 
@@ -127,9 +127,9 @@ namespace Azure.Identity.Tests
 
                 MockRequest request = mockTransport.Requests[0];
 
-                Assert.IsTrue(request.UriBuilder.ToString().StartsWith("https://mock.msi.endpoint/"));
+                Assert.IsTrue(request.Uri.ToString().StartsWith("https://mock.msi.endpoint/"));
 
-                string query = request.UriBuilder.Query;
+                string query = request.Uri.Query;
 
                 Assert.IsTrue(query.Contains("api-version=2017-09-01"));
 
@@ -166,9 +166,9 @@ namespace Azure.Identity.Tests
 
                 MockRequest request = mockTransport.Requests[0];
 
-                Assert.IsTrue(request.UriBuilder.ToString().StartsWith("https://mock.msi.endpoint/"));
+                Assert.IsTrue(request.Uri.ToString().StartsWith("https://mock.msi.endpoint/"));
 
-                string query = request.UriBuilder.Query;
+                string query = request.Uri.Query;
 
                 Assert.IsTrue(query.Contains("api-version=2017-09-01"));
 
@@ -207,7 +207,7 @@ namespace Azure.Identity.Tests
 
                 MockRequest request = mockTransport.Requests[0];
 
-                Assert.IsTrue(request.UriBuilder.ToString().StartsWith("https://mock.msi.endpoint/"));
+                Assert.IsTrue(request.Uri.ToString().StartsWith("https://mock.msi.endpoint/"));
 
                 Assert.IsTrue(request.Content.TryComputeLength(out long contentLen));
 
@@ -252,7 +252,7 @@ namespace Azure.Identity.Tests
 
                 MockRequest request = mockTransport.Requests[0];
 
-                Assert.IsTrue(request.UriBuilder.ToString().StartsWith("https://mock.msi.endpoint/"));
+                Assert.IsTrue(request.Uri.ToString().StartsWith("https://mock.msi.endpoint/"));
 
                 Assert.IsTrue(request.Content.TryComputeLength(out long contentLen));
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/ChallengeBasedAuthenticationPolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/ChallengeBasedAuthenticationPolicy.cs
@@ -243,7 +243,7 @@ namespace Azure.Security.KeyVault
 
             private static string GetRequestAuthority(Request request)
             {
-                Uri uri = request.UriBuilder.Uri;
+                Uri uri = request.UriBuilder.ToUri();
 
                 string authority = uri.Authority;
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/ChallengeBasedAuthenticationPolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/ChallengeBasedAuthenticationPolicy.cs
@@ -243,7 +243,7 @@ namespace Azure.Security.KeyVault
 
             private static string GetRequestAuthority(Request request)
             {
-                Uri uri = request.UriBuilder.ToUri();
+                Uri uri = request.Uri.ToUri();
 
                 string authority = uri.Authority;
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/KeyVaultPipeline.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/KeyVaultPipeline.cs
@@ -59,7 +59,7 @@ namespace Azure.Security.KeyVault
             request.Headers.Add(HttpHeader.Common.JsonContentType);
             request.Headers.Add(HttpHeader.Common.JsonAccept);
             request.Method = method;
-            request.UriBuilder.Assign(uri);
+            request.Uri.Assign(uri);
 
             return request;
         }
@@ -71,14 +71,14 @@ namespace Azure.Security.KeyVault
             request.Headers.Add(HttpHeader.Common.JsonContentType);
             request.Headers.Add(HttpHeader.Common.JsonAccept);
             request.Method = method;
-            request.UriBuilder.Assign(_vaultUri);
+            request.Uri.Assign(_vaultUri);
 
             foreach (var p in path)
             {
-                request.UriBuilder.AppendPath(p);
+                request.Uri.AppendPath(p);
             }
 
-            request.UriBuilder.AppendQuery("api-version", ApiVersion);
+            request.Uri.AppendQuery("api-version", ApiVersion);
 
             return request;
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/KeyVaultPipeline.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/KeyVaultPipeline.cs
@@ -27,23 +27,19 @@ namespace Azure.Security.KeyVault
 
         public Uri CreateFirstPageUri(string path)
         {
-            var firstPage = new RequestUriBuilder
-            {
-                Uri = _vaultUri,
-            };
+            var firstPage = new RequestUriBuilder();
+            firstPage.Assign(_vaultUri);
 
             firstPage.AppendPath(path);
             firstPage.AppendQuery("api-version", ApiVersion);
 
-            return firstPage.Uri;
+            return firstPage.ToUri();
         }
 
         public Uri CreateFirstPageUri(string path, params ValueTuple<string, string>[] queryParams)
         {
-            var firstPage = new RequestUriBuilder
-            {
-                Uri = _vaultUri,
-            };
+            var firstPage = new RequestUriBuilder();
+            firstPage.Assign(_vaultUri);
 
             firstPage.AppendPath(path);
             firstPage.AppendQuery("api-version", ApiVersion);
@@ -53,7 +49,7 @@ namespace Azure.Security.KeyVault
                 firstPage.AppendQuery(tuple.Item1, tuple.Item2);
             }
 
-            return firstPage.Uri;
+            return firstPage.ToUri();
         }
 
         public Request CreateRequest(RequestMethod method, Uri uri)
@@ -63,7 +59,7 @@ namespace Azure.Security.KeyVault
             request.Headers.Add(HttpHeader.Common.JsonContentType);
             request.Headers.Add(HttpHeader.Common.JsonAccept);
             request.Method = method;
-            request.UriBuilder.Uri = uri;
+            request.UriBuilder.Assign(uri);
 
             return request;
         }
@@ -75,7 +71,7 @@ namespace Azure.Security.KeyVault
             request.Headers.Add(HttpHeader.Common.JsonContentType);
             request.Headers.Add(HttpHeader.Common.JsonAccept);
             request.Method = method;
-            request.UriBuilder.Uri = _vaultUri;
+            request.UriBuilder.Assign(_vaultUri);
 
             foreach (var p in path)
             {

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobUriBuilder.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobUriBuilder.cs
@@ -241,7 +241,7 @@ namespace Azure.Storage.Blobs
             {
                 if (_uri == null)
                 {
-                    _uri = BuildUri().Uri;
+                    _uri = BuildUri().ToUri();
                 }
                 return _uri;
             }

--- a/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
@@ -117,10 +117,10 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "service");
-                _request.UriBuilder.AppendQuery("comp", "properties");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "service");
+                _request.Uri.AppendQuery("comp", "properties");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -248,10 +248,10 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "service");
-                _request.UriBuilder.AppendQuery("comp", "properties");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "service");
+                _request.Uri.AppendQuery("comp", "properties");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -382,10 +382,10 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "service");
-                _request.UriBuilder.AppendQuery("comp", "stats");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "service");
+                _request.Uri.AppendQuery("comp", "stats");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -536,13 +536,13 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "list");
-                if (prefix != null) { _request.UriBuilder.AppendQuery("prefix", System.Uri.EscapeDataString(prefix)); }
-                if (marker != null) { _request.UriBuilder.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
-                if (maxresults != null) { _request.UriBuilder.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (include != null) { _request.UriBuilder.AppendQuery("include", System.Uri.EscapeDataString(Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(include.Value))); }
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "list");
+                if (prefix != null) { _request.Uri.AppendQuery("prefix", System.Uri.EscapeDataString(prefix)); }
+                if (marker != null) { _request.Uri.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
+                if (maxresults != null) { _request.Uri.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (include != null) { _request.Uri.AppendQuery("include", System.Uri.EscapeDataString(Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(include.Value))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -682,10 +682,10 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Post;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "service");
-                _request.UriBuilder.AppendQuery("comp", "userdelegationkey");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "service");
+                _request.Uri.AppendQuery("comp", "userdelegationkey");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -813,9 +813,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "account");
-                _request.UriBuilder.AppendQuery("comp", "properties");
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "account");
+                _request.Uri.AppendQuery("comp", "properties");
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -978,9 +978,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Post;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "batch");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "batch");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("Content-Length", contentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
@@ -1141,9 +1141,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "container");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "container");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 if (access != Azure.Storage.Blobs.Models.PublicAccessType.None) { _request.Headers.SetValue("x-ms-blob-public-access", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(access)); }
@@ -1296,9 +1296,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "container");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "container");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -1487,9 +1487,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Delete;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "container");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "container");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -1628,10 +1628,10 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "container");
-                _request.UriBuilder.AppendQuery("comp", "metadata");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "container");
+                _request.Uri.AppendQuery("comp", "metadata");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -1785,10 +1785,10 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "container");
-                _request.UriBuilder.AppendQuery("comp", "acl");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "container");
+                _request.Uri.AppendQuery("comp", "acl");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -1965,10 +1965,10 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "container");
-                _request.UriBuilder.AppendQuery("comp", "acl");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "container");
+                _request.Uri.AppendQuery("comp", "acl");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 if (access != Azure.Storage.Blobs.Models.PublicAccessType.None) { _request.Headers.SetValue("x-ms-blob-public-access", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(access)); }
@@ -2147,10 +2147,10 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "lease");
-                _request.UriBuilder.AppendQuery("restype", "container");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "lease");
+                _request.Uri.AppendQuery("restype", "container");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-lease-action", "acquire");
@@ -2319,10 +2319,10 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "lease");
-                _request.UriBuilder.AppendQuery("restype", "container");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "lease");
+                _request.Uri.AppendQuery("restype", "container");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-lease-action", "release");
@@ -2486,10 +2486,10 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "lease");
-                _request.UriBuilder.AppendQuery("restype", "container");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "lease");
+                _request.Uri.AppendQuery("restype", "container");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-lease-action", "renew");
@@ -2653,10 +2653,10 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "lease");
-                _request.UriBuilder.AppendQuery("restype", "container");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "lease");
+                _request.Uri.AppendQuery("restype", "container");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-lease-action", "break");
@@ -2833,10 +2833,10 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "lease");
-                _request.UriBuilder.AppendQuery("restype", "container");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "lease");
+                _request.Uri.AppendQuery("restype", "container");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-lease-action", "change");
@@ -3006,14 +3006,14 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "container");
-                _request.UriBuilder.AppendQuery("comp", "list");
-                if (prefix != null) { _request.UriBuilder.AppendQuery("prefix", System.Uri.EscapeDataString(prefix)); }
-                if (marker != null) { _request.UriBuilder.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
-                if (maxresults != null) { _request.UriBuilder.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (include != null) { _request.UriBuilder.AppendQuery("include", System.Uri.EscapeDataString(string.Join(",", System.Linq.Enumerable.Select(include, item => Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(item))))); }
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "container");
+                _request.Uri.AppendQuery("comp", "list");
+                if (prefix != null) { _request.Uri.AppendQuery("prefix", System.Uri.EscapeDataString(prefix)); }
+                if (marker != null) { _request.Uri.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
+                if (maxresults != null) { _request.Uri.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (include != null) { _request.Uri.AppendQuery("include", System.Uri.EscapeDataString(string.Join(",", System.Linq.Enumerable.Select(include, item => Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(item))))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -3169,15 +3169,15 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "container");
-                _request.UriBuilder.AppendQuery("comp", "list");
-                if (prefix != null) { _request.UriBuilder.AppendQuery("prefix", System.Uri.EscapeDataString(prefix)); }
-                if (delimiter != null) { _request.UriBuilder.AppendQuery("delimiter", System.Uri.EscapeDataString(delimiter)); }
-                if (marker != null) { _request.UriBuilder.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
-                if (maxresults != null) { _request.UriBuilder.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (include != null) { _request.UriBuilder.AppendQuery("include", System.Uri.EscapeDataString(string.Join(",", System.Linq.Enumerable.Select(include, item => Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(item))))); }
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "container");
+                _request.Uri.AppendQuery("comp", "list");
+                if (prefix != null) { _request.Uri.AppendQuery("prefix", System.Uri.EscapeDataString(prefix)); }
+                if (delimiter != null) { _request.Uri.AppendQuery("delimiter", System.Uri.EscapeDataString(delimiter)); }
+                if (marker != null) { _request.Uri.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
+                if (maxresults != null) { _request.Uri.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (include != null) { _request.Uri.AppendQuery("include", System.Uri.EscapeDataString(string.Join(",", System.Linq.Enumerable.Select(include, item => Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(item))))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -3378,9 +3378,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                if (snapshot != null) { _request.UriBuilder.AppendQuery("snapshot", System.Uri.EscapeDataString(snapshot)); }
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                if (snapshot != null) { _request.Uri.AppendQuery("snapshot", System.Uri.EscapeDataString(snapshot)); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -3837,9 +3837,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Head;
-                _request.UriBuilder.Assign(resourceUri);
-                if (snapshot != null) { _request.UriBuilder.AppendQuery("snapshot", System.Uri.EscapeDataString(snapshot)); }
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                if (snapshot != null) { _request.Uri.AppendQuery("snapshot", System.Uri.EscapeDataString(snapshot)); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -4167,9 +4167,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Delete;
-                _request.UriBuilder.Assign(resourceUri);
-                if (snapshot != null) { _request.UriBuilder.AppendQuery("snapshot", System.Uri.EscapeDataString(snapshot)); }
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                if (snapshot != null) { _request.Uri.AppendQuery("snapshot", System.Uri.EscapeDataString(snapshot)); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -4341,9 +4341,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Patch;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("action", "setAccessControl");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("action", "setAccessControl");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -4523,12 +4523,12 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Head;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("action", "getAccessControl");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("action", "getAccessControl");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
                 if (upn != null) {
                 #pragma warning disable CA1308 // Normalize strings to uppercase
-                _request.UriBuilder.AppendQuery("upn", System.Uri.EscapeDataString(upn.Value.ToString(System.Globalization.CultureInfo.InvariantCulture).ToLowerInvariant()));
+                _request.Uri.AppendQuery("upn", System.Uri.EscapeDataString(upn.Value.ToString(System.Globalization.CultureInfo.InvariantCulture).ToLowerInvariant()));
                 #pragma warning restore CA1308 // Normalize strings to uppercase
                 }
 
@@ -4796,9 +4796,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (pathRenameMode != null) { _request.UriBuilder.AppendQuery("mode", System.Uri.EscapeDataString(Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(pathRenameMode.Value))); }
+                _request.Uri.Assign(resourceUri);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (pathRenameMode != null) { _request.Uri.AppendQuery("mode", System.Uri.EscapeDataString(Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(pathRenameMode.Value))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-rename-source", renameSource);
@@ -4962,9 +4962,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "undelete");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "undelete");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -5140,9 +5140,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "properties");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "properties");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -5353,9 +5353,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "metadata");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "metadata");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -5548,9 +5548,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "lease");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "lease");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-lease-action", "acquire");
@@ -5731,9 +5731,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "lease");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "lease");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-lease-action", "release");
@@ -5909,9 +5909,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "lease");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "lease");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-lease-action", "renew");
@@ -6100,9 +6100,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "lease");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "lease");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-lease-action", "change");
@@ -6279,9 +6279,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "lease");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "lease");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-lease-action", "break");
@@ -6477,9 +6477,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "snapshot");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "snapshot");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -6711,8 +6711,8 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-copy-source", copySource.ToString());
@@ -6943,8 +6943,8 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-requires-sync", "true");
@@ -7125,10 +7125,10 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "copy");
-                _request.UriBuilder.AppendQuery("copyid", System.Uri.EscapeDataString(copyId));
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "copy");
+                _request.Uri.AppendQuery("copyid", System.Uri.EscapeDataString(copyId));
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-copy-action", "abort");
@@ -7266,9 +7266,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "tier");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "tier");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-access-tier", tier);
@@ -7494,8 +7494,8 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-blob-type", "PageBlob");
@@ -7766,9 +7766,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "page");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "page");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-page-write", "update");
@@ -8009,9 +8009,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "page");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "page");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-page-write", "clear");
@@ -8295,9 +8295,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "page");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "page");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-page-write", "update");
@@ -8521,10 +8521,10 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "pagelist");
-                if (snapshot != null) { _request.UriBuilder.AppendQuery("snapshot", System.Uri.EscapeDataString(snapshot)); }
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "pagelist");
+                if (snapshot != null) { _request.Uri.AppendQuery("snapshot", System.Uri.EscapeDataString(snapshot)); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -8731,11 +8731,11 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "pagelist");
-                if (snapshot != null) { _request.UriBuilder.AppendQuery("snapshot", System.Uri.EscapeDataString(snapshot)); }
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (prevsnapshot != null) { _request.UriBuilder.AppendQuery("prevsnapshot", System.Uri.EscapeDataString(prevsnapshot)); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "pagelist");
+                if (snapshot != null) { _request.Uri.AppendQuery("snapshot", System.Uri.EscapeDataString(snapshot)); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (prevsnapshot != null) { _request.Uri.AppendQuery("prevsnapshot", System.Uri.EscapeDataString(prevsnapshot)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -8947,9 +8947,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "properties");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "properties");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-blob-content-length", blobContentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
@@ -9138,9 +9138,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "properties");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "properties");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-sequence-number-action", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(sequenceNumberAction));
@@ -9321,9 +9321,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "incrementalcopy");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "incrementalcopy");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-copy-source", copySource.ToString());
@@ -9565,8 +9565,8 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-blob-type", "AppendBlob");
@@ -9825,9 +9825,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "appendblock");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "appendblock");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("Content-Length", contentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
@@ -10112,9 +10112,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "appendblock");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "appendblock");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-copy-source", sourceUri.ToString());
@@ -10415,8 +10415,8 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-blob-type", "BlockBlob");
@@ -10658,10 +10658,10 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "block");
-                _request.UriBuilder.AppendQuery("blockid", System.Uri.EscapeDataString(blockId));
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "block");
+                _request.Uri.AppendQuery("blockid", System.Uri.EscapeDataString(blockId));
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("Content-Length", contentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
@@ -10894,10 +10894,10 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "block");
-                _request.UriBuilder.AppendQuery("blockid", System.Uri.EscapeDataString(blockId));
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "block");
+                _request.Uri.AppendQuery("blockid", System.Uri.EscapeDataString(blockId));
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("Content-Length", contentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
@@ -11168,9 +11168,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "blocklist");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "blocklist");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -11378,11 +11378,11 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "blocklist");
-                _request.UriBuilder.AppendQuery("blocklisttype", System.Uri.EscapeDataString(Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(listType)));
-                if (snapshot != null) { _request.UriBuilder.AppendQuery("snapshot", System.Uri.EscapeDataString(snapshot)); }
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "blocklist");
+                _request.Uri.AppendQuery("blocklisttype", System.Uri.EscapeDataString(Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(listType)));
+                if (snapshot != null) { _request.Uri.AppendQuery("snapshot", System.Uri.EscapeDataString(snapshot)); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -11607,9 +11607,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("resource", "directory");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("resource", "directory");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -11876,10 +11876,10 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (marker != null) { _request.UriBuilder.AppendQuery("continuation", System.Uri.EscapeDataString(marker)); }
-                if (pathRenameMode != null) { _request.UriBuilder.AppendQuery("mode", System.Uri.EscapeDataString(Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(pathRenameMode.Value))); }
+                _request.Uri.Assign(resourceUri);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (marker != null) { _request.Uri.AppendQuery("continuation", System.Uri.EscapeDataString(marker)); }
+                if (pathRenameMode != null) { _request.Uri.AppendQuery("mode", System.Uri.EscapeDataString(Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(pathRenameMode.Value))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-rename-source", renameSource);
@@ -12082,14 +12082,14 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Delete;
-                _request.UriBuilder.Assign(resourceUri);
+                _request.Uri.Assign(resourceUri);
 
                 #pragma warning disable CA1308 // Normalize strings to uppercase
-                _request.UriBuilder.AppendQuery("recursive", System.Uri.EscapeDataString(recursiveDirectoryDelete.ToString(System.Globalization.CultureInfo.InvariantCulture).ToLowerInvariant()));
+                _request.Uri.AppendQuery("recursive", System.Uri.EscapeDataString(recursiveDirectoryDelete.ToString(System.Globalization.CultureInfo.InvariantCulture).ToLowerInvariant()));
                 #pragma warning restore CA1308 // Normalize strings to uppercase
 
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (marker != null) { _request.UriBuilder.AppendQuery("continuation", System.Uri.EscapeDataString(marker)); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (marker != null) { _request.Uri.AppendQuery("continuation", System.Uri.EscapeDataString(marker)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -12276,9 +12276,9 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Patch;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("action", "setAccessControl");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("action", "setAccessControl");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -12458,12 +12458,12 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Head;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("action", "getAccessControl");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("action", "getAccessControl");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
                 if (upn != null) {
                 #pragma warning disable CA1308 // Normalize strings to uppercase
-                _request.UriBuilder.AppendQuery("upn", System.Uri.EscapeDataString(upn.Value.ToString(System.Globalization.CultureInfo.InvariantCulture).ToLowerInvariant()));
+                _request.Uri.AppendQuery("upn", System.Uri.EscapeDataString(upn.Value.ToString(System.Globalization.CultureInfo.InvariantCulture).ToLowerInvariant()));
                 #pragma warning restore CA1308 // Normalize strings to uppercase
                 }
 

--- a/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
@@ -117,7 +117,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "service");
                 _request.UriBuilder.AppendQuery("comp", "properties");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -248,7 +248,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "service");
                 _request.UriBuilder.AppendQuery("comp", "properties");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -382,7 +382,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "service");
                 _request.UriBuilder.AppendQuery("comp", "stats");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -536,7 +536,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "list");
                 if (prefix != null) { _request.UriBuilder.AppendQuery("prefix", System.Uri.EscapeDataString(prefix)); }
                 if (marker != null) { _request.UriBuilder.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
@@ -682,7 +682,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Post;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "service");
                 _request.UriBuilder.AppendQuery("comp", "userdelegationkey");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -813,7 +813,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "account");
                 _request.UriBuilder.AppendQuery("comp", "properties");
 
@@ -978,7 +978,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Post;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "batch");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -1141,7 +1141,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "container");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -1296,7 +1296,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "container");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -1487,7 +1487,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Delete;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "container");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -1628,7 +1628,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "container");
                 _request.UriBuilder.AppendQuery("comp", "metadata");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -1785,7 +1785,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "container");
                 _request.UriBuilder.AppendQuery("comp", "acl");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -1965,7 +1965,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "container");
                 _request.UriBuilder.AppendQuery("comp", "acl");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -2147,7 +2147,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "lease");
                 _request.UriBuilder.AppendQuery("restype", "container");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -2319,7 +2319,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "lease");
                 _request.UriBuilder.AppendQuery("restype", "container");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -2486,7 +2486,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "lease");
                 _request.UriBuilder.AppendQuery("restype", "container");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -2653,7 +2653,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "lease");
                 _request.UriBuilder.AppendQuery("restype", "container");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -2833,7 +2833,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "lease");
                 _request.UriBuilder.AppendQuery("restype", "container");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -3006,7 +3006,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "container");
                 _request.UriBuilder.AppendQuery("comp", "list");
                 if (prefix != null) { _request.UriBuilder.AppendQuery("prefix", System.Uri.EscapeDataString(prefix)); }
@@ -3169,7 +3169,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "container");
                 _request.UriBuilder.AppendQuery("comp", "list");
                 if (prefix != null) { _request.UriBuilder.AppendQuery("prefix", System.Uri.EscapeDataString(prefix)); }
@@ -3378,7 +3378,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 if (snapshot != null) { _request.UriBuilder.AppendQuery("snapshot", System.Uri.EscapeDataString(snapshot)); }
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -3837,7 +3837,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Head;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 if (snapshot != null) { _request.UriBuilder.AppendQuery("snapshot", System.Uri.EscapeDataString(snapshot)); }
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -4167,7 +4167,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Delete;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 if (snapshot != null) { _request.UriBuilder.AppendQuery("snapshot", System.Uri.EscapeDataString(snapshot)); }
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -4341,7 +4341,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Patch;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("action", "setAccessControl");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -4523,7 +4523,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Head;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("action", "getAccessControl");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
                 if (upn != null) {
@@ -4796,7 +4796,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
                 if (pathRenameMode != null) { _request.UriBuilder.AppendQuery("mode", System.Uri.EscapeDataString(Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(pathRenameMode.Value))); }
 
@@ -4962,7 +4962,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "undelete");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -5140,7 +5140,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "properties");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -5353,7 +5353,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "metadata");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -5548,7 +5548,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "lease");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -5731,7 +5731,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "lease");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -5909,7 +5909,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "lease");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -6100,7 +6100,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "lease");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -6279,7 +6279,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "lease");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -6477,7 +6477,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "snapshot");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -6711,7 +6711,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
@@ -6943,7 +6943,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
@@ -7125,7 +7125,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "copy");
                 _request.UriBuilder.AppendQuery("copyid", System.Uri.EscapeDataString(copyId));
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -7266,7 +7266,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "tier");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -7494,7 +7494,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
@@ -7766,7 +7766,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "page");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -8009,7 +8009,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "page");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -8295,7 +8295,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "page");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -8521,7 +8521,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "pagelist");
                 if (snapshot != null) { _request.UriBuilder.AppendQuery("snapshot", System.Uri.EscapeDataString(snapshot)); }
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -8731,7 +8731,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "pagelist");
                 if (snapshot != null) { _request.UriBuilder.AppendQuery("snapshot", System.Uri.EscapeDataString(snapshot)); }
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -8947,7 +8947,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "properties");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -9138,7 +9138,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "properties");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -9321,7 +9321,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "incrementalcopy");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -9565,7 +9565,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
@@ -9825,7 +9825,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "appendblock");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -10112,7 +10112,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "appendblock");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -10415,7 +10415,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
@@ -10658,7 +10658,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "block");
                 _request.UriBuilder.AppendQuery("blockid", System.Uri.EscapeDataString(blockId));
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -10894,7 +10894,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "block");
                 _request.UriBuilder.AppendQuery("blockid", System.Uri.EscapeDataString(blockId));
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -11168,7 +11168,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "blocklist");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -11378,7 +11378,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "blocklist");
                 _request.UriBuilder.AppendQuery("blocklisttype", System.Uri.EscapeDataString(Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(listType)));
                 if (snapshot != null) { _request.UriBuilder.AppendQuery("snapshot", System.Uri.EscapeDataString(snapshot)); }
@@ -11607,7 +11607,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("resource", "directory");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -11876,7 +11876,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
                 if (marker != null) { _request.UriBuilder.AppendQuery("continuation", System.Uri.EscapeDataString(marker)); }
                 if (pathRenameMode != null) { _request.UriBuilder.AppendQuery("mode", System.Uri.EscapeDataString(Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(pathRenameMode.Value))); }
@@ -12082,7 +12082,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Delete;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
 
                 #pragma warning disable CA1308 // Normalize strings to uppercase
                 _request.UriBuilder.AppendQuery("recursive", System.Uri.EscapeDataString(recursiveDirectoryDelete.ToString(System.Globalization.CultureInfo.InvariantCulture).ToLowerInvariant()));
@@ -12276,7 +12276,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Patch;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("action", "setAccessControl");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -12458,7 +12458,7 @@ namespace Azure.Storage.Blobs
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Head;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("action", "getAccessControl");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
                 if (upn != null) {

--- a/sdk/storage/Azure.Storage.Common/src/GeoRedundantReadPolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/src/GeoRedundantReadPolicy.cs
@@ -60,7 +60,7 @@ namespace Azure.Storage.Common
 
             // If alternateHost was not null that means the message is being retried. Hence what is stored in the Host 
             // property of UriBuilder is actually the host from the last try.
-            var lastTriedHost = message.Request.UriBuilder.Host;
+            var lastTriedHost = message.Request.Uri.Host;
 
             // If necessary, set the flag to indicate that the resource has not yet been propagated to the secondary host.
             if (message.HasResponse
@@ -72,7 +72,7 @@ namespace Azure.Storage.Common
 
             // Toggle the host set in the request to use the alternate host for the upcoming attempt, and update the
             // the property for the AlternateHostKey to be the host used in the last try.
-            message.Request.UriBuilder.Host = alternateHost;
+            message.Request.Uri.Host = alternateHost;
             message.SetProperty(Constants.GeoRedundantRead.AlternateHostKey, lastTriedHost);
         }
     }

--- a/sdk/storage/Azure.Storage.Common/src/StorageResponseClassifier.cs
+++ b/sdk/storage/Azure.Storage.Common/src/StorageResponseClassifier.cs
@@ -23,7 +23,7 @@ namespace Azure.Storage.Common
         /// <returns></returns>
         public override bool IsRetriableResponse(HttpPipelineMessage message)
         {
-            if (message.Request.UriBuilder.Host == SecondaryStorageUri.Host && message.Response.Status == Constants.HttpStatusCode.NotFound)
+            if (message.Request.Uri.Host == SecondaryStorageUri.Host && message.Response.Status == Constants.HttpStatusCode.NotFound)
             {
                 return true;
             }

--- a/sdk/storage/Azure.Storage.Common/src/StorageSharedKeyPipelinePolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/src/StorageSharedKeyPipelinePolicy.cs
@@ -84,7 +84,7 @@ namespace Azure.Storage.Common
                 ifUnmodifiedSince ?? "",
                 range ?? "",
                 BuildCanonicalizedHeaders(message),
-                BuildCanonicalizedResource(message.Request.UriBuilder.Uri));
+                BuildCanonicalizedResource(message.Request.UriBuilder.ToUri()));
             return stringToSign;
         }
 

--- a/sdk/storage/Azure.Storage.Common/src/StorageSharedKeyPipelinePolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/src/StorageSharedKeyPipelinePolicy.cs
@@ -84,7 +84,7 @@ namespace Azure.Storage.Common
                 ifUnmodifiedSince ?? "",
                 range ?? "",
                 BuildCanonicalizedHeaders(message),
-                BuildCanonicalizedResource(message.Request.UriBuilder.ToUri()));
+                BuildCanonicalizedResource(message.Request.Uri.ToUri()));
             return stringToSign;
         }
 

--- a/sdk/storage/Azure.Storage.Common/swagger/Generator/src/generator.ts
+++ b/sdk/storage/Azure.Storage.Common/swagger/Generator/src/generator.ts
@@ -350,7 +350,7 @@ function generateOperation(w: IndentWriter, serviceModel: IServiceModel, group: 
         const httpMethod = naming.pascalCase(operation.method);
         w.line(`${requestName}.Method = Azure.Core.Pipeline.RequestMethod.${httpMethod};`);
         const uri = naming.parameter(operation.request.all[1].clientName);
-        w.line(`${requestName}.UriBuilder.Uri = ${uri};`);
+        w.line(`${requestName}.UriBuilder.Assign(${uri});`);
         if (operation.request.queries.length > 0) {
             for (const query of operation.request.queries) {
                 const constant = isEnumType(query.model) && query.model.constant;

--- a/sdk/storage/Azure.Storage.Common/swagger/Generator/src/generator.ts
+++ b/sdk/storage/Azure.Storage.Common/swagger/Generator/src/generator.ts
@@ -350,7 +350,7 @@ function generateOperation(w: IndentWriter, serviceModel: IServiceModel, group: 
         const httpMethod = naming.pascalCase(operation.method);
         w.line(`${requestName}.Method = Azure.Core.Pipeline.RequestMethod.${httpMethod};`);
         const uri = naming.parameter(operation.request.all[1].clientName);
-        w.line(`${requestName}.UriBuilder.Assign(${uri});`);
+        w.line(`${requestName}.Uri.Assign(${uri});`);
         if (operation.request.queries.length > 0) {
             for (const query of operation.request.queries) {
                 const constant = isEnumType(query.model) && query.model.constant;
@@ -358,7 +358,7 @@ function generateOperation(w: IndentWriter, serviceModel: IServiceModel, group: 
                     if (!query.skipUrlEncoding && !constant) {
                         value = `System.Uri.EscapeDataString(${value})`
                     }
-                    w.write(`${requestName}.UriBuilder.AppendQuery("${query.name}", ${value});`);
+                    w.write(`${requestName}.Uri.AppendQuery("${query.name}", ${value});`);
                 });
             }
         }

--- a/sdk/storage/Azure.Storage.Common/tests/GeoRedundantReadPolicyTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/GeoRedundantReadPolicyTests.cs
@@ -26,7 +26,7 @@ namespace Azure.Storage.Common.Tests
 
             policy.OnSendingRequest(message);
 
-            Assert.AreEqual(MockPrimaryUri.Host, message.Request.UriBuilder.Host);
+            Assert.AreEqual(MockPrimaryUri.Host, message.Request.Uri.Host);
             Assert.IsTrue(message.TryGetProperty(Constants.GeoRedundantRead.AlternateHostKey, out object val)
                 && (string) val == MockSecondaryUri.Host);
         }
@@ -43,7 +43,7 @@ namespace Azure.Storage.Common.Tests
 
             policy.OnSendingRequest(message);
 
-            Assert.AreEqual(MockSecondaryUri.Host, message.Request.UriBuilder.Host);
+            Assert.AreEqual(MockSecondaryUri.Host, message.Request.Uri.Host);
             Assert.IsTrue(message.TryGetProperty(Constants.GeoRedundantRead.AlternateHostKey, out object val)
                 && (string)val == MockPrimaryUri.Host);
         }
@@ -60,7 +60,7 @@ namespace Azure.Storage.Common.Tests
 
             policy.OnSendingRequest(message);
 
-            Assert.AreEqual(MockPrimaryUri.Host, message.Request.UriBuilder.Host);
+            Assert.AreEqual(MockPrimaryUri.Host, message.Request.Uri.Host);
             Assert.IsTrue(message.TryGetProperty(Constants.GeoRedundantRead.AlternateHostKey, out object val)
                 && (string)val == MockSecondaryUri.Host);
         }
@@ -80,7 +80,7 @@ namespace Azure.Storage.Common.Tests
 
             policy.OnSendingRequest(message);
 
-            Assert.AreEqual(MockSecondaryUri.Host, message.Request.UriBuilder.Host);
+            Assert.AreEqual(MockSecondaryUri.Host, message.Request.Uri.Host);
             Assert.IsTrue(message.TryGetProperty(Constants.GeoRedundantRead.ResourceNotReplicated, out object val)
                 && (bool) val);
         }
@@ -98,7 +98,7 @@ namespace Azure.Storage.Common.Tests
 
             policy.OnSendingRequest(message);
 
-            Assert.AreEqual(MockPrimaryUri.Host, message.Request.UriBuilder.Host);
+            Assert.AreEqual(MockPrimaryUri.Host, message.Request.Uri.Host);
         }
 
         [Test]
@@ -114,7 +114,7 @@ namespace Azure.Storage.Common.Tests
 
             policy.OnSendingRequest(message);
 
-            Assert.AreEqual(MockPrimaryUri.Host, message.Request.UriBuilder.Host);
+            Assert.AreEqual(MockPrimaryUri.Host, message.Request.Uri.Host);
             Assert.IsFalse(message.TryGetProperty(Constants.GeoRedundantRead.AlternateHostKey, out object val)
                 && (string)val == MockSecondaryUri.Host);
         }
@@ -122,7 +122,7 @@ namespace Azure.Storage.Common.Tests
         private MockRequest CreateMockRequest(Uri uri)
         {
             MockRequest mockRequest = new MockRequest();
-            mockRequest.UriBuilder.Assign(uri);
+            mockRequest.Uri.Assign(uri);
             mockRequest.Method = RequestMethod.Get;
             return mockRequest;
         }

--- a/sdk/storage/Azure.Storage.Common/tests/GeoRedundantReadPolicyTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/GeoRedundantReadPolicyTests.cs
@@ -122,7 +122,7 @@ namespace Azure.Storage.Common.Tests
         private MockRequest CreateMockRequest(Uri uri)
         {
             MockRequest mockRequest = new MockRequest();
-            mockRequest.UriBuilder.Uri = uri;
+            mockRequest.UriBuilder.Assign(uri);
             mockRequest.Method = RequestMethod.Get;
             return mockRequest;
         }

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/RecordedClientRequestIdPolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/RecordedClientRequestIdPolicy.cs
@@ -48,9 +48,9 @@ namespace Azure.Storage.Test.Shared
                 message.Request.ClientRequestId = _parallelRangePrefix + range;
             }
             else if(_parallelRangePrefix != null &&
-                message.Request.UriBuilder.Query.Contains("blockid="))
+                message.Request.Uri.Query.Contains("blockid="))
             {
-                var queryParameters = message.Request.UriBuilder.Query.Split('&');
+                var queryParameters = message.Request.Uri.Query.Split('&');
                 var blockIdParameter = queryParameters.Where(s => s.Contains("blockid=")).First();
                 var blockIdValue = blockIdParameter.Split('=')[1];
 

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/TestExceptionPolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/TestExceptionPolicy.cs
@@ -54,10 +54,10 @@ namespace Azure.Storage.Common.Test
             if (TrackedRequestMethods.Contains(message.Request.Method))
             {
                 CurrentInvocationNumber++;
-                HostsSetInRequests.Add(message.Request.UriBuilder.Host);
+                HostsSetInRequests.Add(message.Request.Uri.Host);
                 if (CurrentInvocationNumber <= NumberOfReadFailuresToSimulate)
                 {
-                    message.Response = new MockResponse(Simulate404 && message.Request.UriBuilder.Host == SecondaryUri.Host ? 404 : 429);
+                    message.Response = new MockResponse(Simulate404 && message.Request.Uri.Host == SecondaryUri.Host ? 404 : 429);
                     return true;
                 }
             }

--- a/sdk/storage/Azure.Storage.Common/tests/StorageResponseClassifierTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/StorageResponseClassifierTests.cs
@@ -20,7 +20,7 @@ namespace Azure.Storage.Common.Tests
         public void IsRetriableResponse_404OnSecondary_ShouldBeTrue()
         {
             HttpPipelineMessage message = BuildMessage(new MockResponse(Constants.HttpStatusCode.NotFound));
-            message.Request.UriBuilder.Host = MockSecondaryUri.Host;
+            message.Request.Uri.Host = MockSecondaryUri.Host;
 
             Assert.IsTrue(classifier.IsRetriableResponse(message));
         }
@@ -32,7 +32,7 @@ namespace Azure.Storage.Common.Tests
         public void IsRetriableResponse_OtherStatusCodeOnSecondary_ShouldMatchBase(int statusCode)
         {
             HttpPipelineMessage message = BuildMessage(new MockResponse(statusCode));
-            message.Request.UriBuilder.Host = MockSecondaryUri.Host;
+            message.Request.Uri.Host = MockSecondaryUri.Host;
 
             Assert.AreEqual(new ResponseClassifier().IsRetriableResponse(message), classifier.IsRetriableResponse(message));
         }
@@ -41,7 +41,7 @@ namespace Azure.Storage.Common.Tests
         public void IsRetriableResponse_404OnPrimary_ShouldBeFalse()
         {
             HttpPipelineMessage message = BuildMessage(new MockResponse(Constants.HttpStatusCode.NotFound));
-            message.Request.UriBuilder.Host = MockPrimaryUri.Host;
+            message.Request.Uri.Host = MockPrimaryUri.Host;
 
             Assert.IsFalse(classifier.IsRetriableResponse(message));
         }

--- a/sdk/storage/Azure.Storage.Files/src/FileUriBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files/src/FileUriBuilder.cs
@@ -224,7 +224,7 @@ namespace Azure.Storage.Files
             {
                 if (_uri == null)
                 {
-                    _uri = BuildUri().Uri;
+                    _uri = BuildUri().ToUri();
                 }
                 return _uri;
             }

--- a/sdk/storage/Azure.Storage.Files/src/Generated/FileRestClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Generated/FileRestClient.cs
@@ -112,10 +112,10 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "service");
-                _request.UriBuilder.AppendQuery("comp", "properties");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "service");
+                _request.Uri.AppendQuery("comp", "properties");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -237,10 +237,10 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "service");
-                _request.UriBuilder.AppendQuery("comp", "properties");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "service");
+                _request.Uri.AppendQuery("comp", "properties");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -385,13 +385,13 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "list");
-                if (prefix != null) { _request.UriBuilder.AppendQuery("prefix", System.Uri.EscapeDataString(prefix)); }
-                if (marker != null) { _request.UriBuilder.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
-                if (maxresults != null) { _request.UriBuilder.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (include != null) { _request.UriBuilder.AppendQuery("include", System.Uri.EscapeDataString(string.Join(",", System.Linq.Enumerable.Select(include, item => Azure.Storage.Files.FileRestClient.Serialization.ToString(item))))); }
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "list");
+                if (prefix != null) { _request.Uri.AppendQuery("prefix", System.Uri.EscapeDataString(prefix)); }
+                if (marker != null) { _request.Uri.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
+                if (maxresults != null) { _request.Uri.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (include != null) { _request.Uri.AppendQuery("include", System.Uri.EscapeDataString(string.Join(",", System.Linq.Enumerable.Select(include, item => Azure.Storage.Files.FileRestClient.Serialization.ToString(item))))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -534,9 +534,9 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "share");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "share");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -683,10 +683,10 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "share");
-                if (sharesnapshot != null) { _request.UriBuilder.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "share");
+                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -843,10 +843,10 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Delete;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "share");
-                if (sharesnapshot != null) { _request.UriBuilder.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "share");
+                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -967,10 +967,10 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "share");
-                _request.UriBuilder.AppendQuery("comp", "snapshot");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "share");
+                _request.Uri.AppendQuery("comp", "snapshot");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -1124,10 +1124,10 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "share");
-                _request.UriBuilder.AppendQuery("comp", "filepermission");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "share");
+                _request.Uri.AppendQuery("comp", "filepermission");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -1269,10 +1269,10 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "share");
-                _request.UriBuilder.AppendQuery("comp", "filepermission");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "share");
+                _request.Uri.AppendQuery("comp", "filepermission");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -1406,10 +1406,10 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "share");
-                _request.UriBuilder.AppendQuery("comp", "properties");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "share");
+                _request.Uri.AppendQuery("comp", "properties");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -1550,10 +1550,10 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "share");
-                _request.UriBuilder.AppendQuery("comp", "metadata");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "share");
+                _request.Uri.AppendQuery("comp", "metadata");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -1694,10 +1694,10 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "share");
-                _request.UriBuilder.AppendQuery("comp", "acl");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "share");
+                _request.Uri.AppendQuery("comp", "acl");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -1831,10 +1831,10 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "share");
-                _request.UriBuilder.AppendQuery("comp", "acl");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "share");
+                _request.Uri.AppendQuery("comp", "acl");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -1983,10 +1983,10 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "share");
-                _request.UriBuilder.AppendQuery("comp", "stats");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "share");
+                _request.Uri.AppendQuery("comp", "stats");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -2161,9 +2161,9 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "directory");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "directory");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -2342,10 +2342,10 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "directory");
-                if (sharesnapshot != null) { _request.UriBuilder.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "directory");
+                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -2520,9 +2520,9 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Delete;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "directory");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "directory");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -2674,10 +2674,10 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "directory");
-                _request.UriBuilder.AppendQuery("comp", "properties");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "directory");
+                _request.Uri.AppendQuery("comp", "properties");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -2850,10 +2850,10 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "directory");
-                _request.UriBuilder.AppendQuery("comp", "metadata");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "directory");
+                _request.Uri.AppendQuery("comp", "metadata");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -3014,14 +3014,14 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "directory");
-                _request.UriBuilder.AppendQuery("comp", "list");
-                if (prefix != null) { _request.UriBuilder.AppendQuery("prefix", System.Uri.EscapeDataString(prefix)); }
-                if (sharesnapshot != null) { _request.UriBuilder.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
-                if (marker != null) { _request.UriBuilder.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
-                if (maxresults != null) { _request.UriBuilder.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "directory");
+                _request.Uri.AppendQuery("comp", "list");
+                if (prefix != null) { _request.Uri.AppendQuery("prefix", System.Uri.EscapeDataString(prefix)); }
+                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
+                if (marker != null) { _request.Uri.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
+                if (maxresults != null) { _request.Uri.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -3166,12 +3166,12 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "listhandles");
-                if (marker != null) { _request.UriBuilder.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
-                if (maxresults != null) { _request.UriBuilder.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (sharesnapshot != null) { _request.UriBuilder.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "listhandles");
+                if (marker != null) { _request.Uri.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
+                if (maxresults != null) { _request.Uri.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -3325,11 +3325,11 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "forceclosehandles");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (marker != null) { _request.UriBuilder.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
-                if (sharesnapshot != null) { _request.UriBuilder.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "forceclosehandles");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (marker != null) { _request.Uri.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
+                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-handle-id", handleId);
@@ -3555,8 +3555,8 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -3764,8 +3764,8 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -4145,9 +4145,9 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Head;
-                _request.UriBuilder.Assign(resourceUri);
-                if (sharesnapshot != null) { _request.UriBuilder.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -4384,8 +4384,8 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Delete;
-                _request.UriBuilder.Assign(resourceUri);
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -4572,9 +4572,9 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "properties");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "properties");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -4768,9 +4768,9 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "metadata");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "metadata");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -4944,9 +4944,9 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "range");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "range");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-range", range);
@@ -5139,9 +5139,9 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "range");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "range");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-range", range);
@@ -5302,10 +5302,10 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "rangelist");
-                if (sharesnapshot != null) { _request.UriBuilder.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "rangelist");
+                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -5465,8 +5465,8 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -5625,10 +5625,10 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "copy");
-                _request.UriBuilder.AppendQuery("copyid", System.Uri.EscapeDataString(copyId));
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "copy");
+                _request.Uri.AppendQuery("copyid", System.Uri.EscapeDataString(copyId));
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-copy-action", "abort");
@@ -5759,12 +5759,12 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "listhandles");
-                if (marker != null) { _request.UriBuilder.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
-                if (maxresults != null) { _request.UriBuilder.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (sharesnapshot != null) { _request.UriBuilder.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "listhandles");
+                if (marker != null) { _request.Uri.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
+                if (maxresults != null) { _request.Uri.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -5908,11 +5908,11 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "forceclosehandles");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (marker != null) { _request.UriBuilder.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
-                if (sharesnapshot != null) { _request.UriBuilder.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "forceclosehandles");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (marker != null) { _request.Uri.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
+                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-handle-id", handleId);

--- a/sdk/storage/Azure.Storage.Files/src/Generated/FileRestClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Generated/FileRestClient.cs
@@ -112,7 +112,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "service");
                 _request.UriBuilder.AppendQuery("comp", "properties");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -237,7 +237,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "service");
                 _request.UriBuilder.AppendQuery("comp", "properties");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -385,7 +385,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "list");
                 if (prefix != null) { _request.UriBuilder.AppendQuery("prefix", System.Uri.EscapeDataString(prefix)); }
                 if (marker != null) { _request.UriBuilder.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
@@ -534,7 +534,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "share");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -683,7 +683,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "share");
                 if (sharesnapshot != null) { _request.UriBuilder.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -843,7 +843,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Delete;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "share");
                 if (sharesnapshot != null) { _request.UriBuilder.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -967,7 +967,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "share");
                 _request.UriBuilder.AppendQuery("comp", "snapshot");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -1124,7 +1124,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "share");
                 _request.UriBuilder.AppendQuery("comp", "filepermission");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -1269,7 +1269,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "share");
                 _request.UriBuilder.AppendQuery("comp", "filepermission");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -1406,7 +1406,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "share");
                 _request.UriBuilder.AppendQuery("comp", "properties");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -1550,7 +1550,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "share");
                 _request.UriBuilder.AppendQuery("comp", "metadata");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -1694,7 +1694,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "share");
                 _request.UriBuilder.AppendQuery("comp", "acl");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -1831,7 +1831,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "share");
                 _request.UriBuilder.AppendQuery("comp", "acl");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -1983,7 +1983,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "share");
                 _request.UriBuilder.AppendQuery("comp", "stats");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -2161,7 +2161,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "directory");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -2342,7 +2342,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "directory");
                 if (sharesnapshot != null) { _request.UriBuilder.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -2520,7 +2520,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Delete;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "directory");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -2674,7 +2674,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "directory");
                 _request.UriBuilder.AppendQuery("comp", "properties");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -2850,7 +2850,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "directory");
                 _request.UriBuilder.AppendQuery("comp", "metadata");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -3014,7 +3014,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "directory");
                 _request.UriBuilder.AppendQuery("comp", "list");
                 if (prefix != null) { _request.UriBuilder.AppendQuery("prefix", System.Uri.EscapeDataString(prefix)); }
@@ -3166,7 +3166,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "listhandles");
                 if (marker != null) { _request.UriBuilder.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
                 if (maxresults != null) { _request.UriBuilder.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -3325,7 +3325,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "forceclosehandles");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
                 if (marker != null) { _request.UriBuilder.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
@@ -3555,7 +3555,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
@@ -3764,7 +3764,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
@@ -4145,7 +4145,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Head;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 if (sharesnapshot != null) { _request.UriBuilder.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -4384,7 +4384,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Delete;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
@@ -4572,7 +4572,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "properties");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -4768,7 +4768,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "metadata");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -4944,7 +4944,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "range");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -5139,7 +5139,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "range");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -5302,7 +5302,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "rangelist");
                 if (sharesnapshot != null) { _request.UriBuilder.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -5465,7 +5465,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
@@ -5625,7 +5625,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "copy");
                 _request.UriBuilder.AppendQuery("copyid", System.Uri.EscapeDataString(copyId));
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -5759,7 +5759,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "listhandles");
                 if (marker != null) { _request.UriBuilder.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
                 if (maxresults != null) { _request.UriBuilder.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -5908,7 +5908,7 @@ namespace Azure.Storage.Files
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "forceclosehandles");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
                 if (marker != null) { _request.UriBuilder.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }

--- a/sdk/storage/Azure.Storage.Queues/src/Generated/QueueRestClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Generated/QueueRestClient.cs
@@ -117,10 +117,10 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "service");
-                _request.UriBuilder.AppendQuery("comp", "properties");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "service");
+                _request.Uri.AppendQuery("comp", "properties");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -248,10 +248,10 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "service");
-                _request.UriBuilder.AppendQuery("comp", "properties");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "service");
+                _request.Uri.AppendQuery("comp", "properties");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -382,10 +382,10 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("restype", "service");
-                _request.UriBuilder.AppendQuery("comp", "stats");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("restype", "service");
+                _request.Uri.AppendQuery("comp", "stats");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -536,13 +536,13 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "list");
-                if (prefix != null) { _request.UriBuilder.AppendQuery("prefix", System.Uri.EscapeDataString(prefix)); }
-                if (marker != null) { _request.UriBuilder.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
-                if (maxresults != null) { _request.UriBuilder.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (include != null) { _request.UriBuilder.AppendQuery("include", System.Uri.EscapeDataString(string.Join(",", System.Linq.Enumerable.Select(include, item => Azure.Storage.Queues.QueueRestClient.Serialization.ToString(item))))); }
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "list");
+                if (prefix != null) { _request.Uri.AppendQuery("prefix", System.Uri.EscapeDataString(prefix)); }
+                if (marker != null) { _request.Uri.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
+                if (maxresults != null) { _request.Uri.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (include != null) { _request.Uri.AppendQuery("include", System.Uri.EscapeDataString(string.Join(",", System.Linq.Enumerable.Select(include, item => Azure.Storage.Queues.QueueRestClient.Serialization.ToString(item))))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -686,8 +686,8 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -818,8 +818,8 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Delete;
-                _request.UriBuilder.Assign(resourceUri);
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -940,9 +940,9 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "metadata");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "metadata");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -1092,9 +1092,9 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "metadata");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "metadata");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -1221,9 +1221,9 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "acl");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "acl");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -1363,9 +1363,9 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("comp", "acl");
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("comp", "acl");
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -1518,10 +1518,10 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                if (numberOfMessages != null) { _request.UriBuilder.AppendQuery("numofmessages", System.Uri.EscapeDataString(numberOfMessages.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (visibilitytimeout != null) { _request.UriBuilder.AppendQuery("visibilitytimeout", System.Uri.EscapeDataString(visibilitytimeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                if (numberOfMessages != null) { _request.Uri.AppendQuery("numofmessages", System.Uri.EscapeDataString(numberOfMessages.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (visibilitytimeout != null) { _request.Uri.AppendQuery("visibilitytimeout", System.Uri.EscapeDataString(visibilitytimeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -1656,8 +1656,8 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Delete;
-                _request.UriBuilder.Assign(resourceUri);
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -1797,10 +1797,10 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Post;
-                _request.UriBuilder.Assign(resourceUri);
-                if (visibilitytimeout != null) { _request.UriBuilder.AppendQuery("visibilitytimeout", System.Uri.EscapeDataString(visibilitytimeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (messageTimeToLive != null) { _request.UriBuilder.AppendQuery("messagettl", System.Uri.EscapeDataString(messageTimeToLive.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                if (visibilitytimeout != null) { _request.Uri.AppendQuery("visibilitytimeout", System.Uri.EscapeDataString(visibilitytimeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (messageTimeToLive != null) { _request.Uri.AppendQuery("messagettl", System.Uri.EscapeDataString(messageTimeToLive.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -1947,10 +1947,10 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("peekonly", "true");
-                if (numberOfMessages != null) { _request.UriBuilder.AppendQuery("numofmessages", System.Uri.EscapeDataString(numberOfMessages.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("peekonly", "true");
+                if (numberOfMessages != null) { _request.Uri.AppendQuery("numofmessages", System.Uri.EscapeDataString(numberOfMessages.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -2116,10 +2116,10 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("popreceipt", System.Uri.EscapeDataString(popReceipt));
-                _request.UriBuilder.AppendQuery("visibilitytimeout", System.Uri.EscapeDataString(visibilitytimeout.ToString(System.Globalization.CultureInfo.InvariantCulture)));
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("popreceipt", System.Uri.EscapeDataString(popReceipt));
+                _request.Uri.AppendQuery("visibilitytimeout", System.Uri.EscapeDataString(visibilitytimeout.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -2276,9 +2276,9 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Delete;
-                _request.UriBuilder.Assign(resourceUri);
-                _request.UriBuilder.AppendQuery("popreceipt", System.Uri.EscapeDataString(popReceipt));
-                if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.Assign(resourceUri);
+                _request.Uri.AppendQuery("popreceipt", System.Uri.EscapeDataString(popReceipt));
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");

--- a/sdk/storage/Azure.Storage.Queues/src/Generated/QueueRestClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Generated/QueueRestClient.cs
@@ -117,7 +117,7 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "service");
                 _request.UriBuilder.AppendQuery("comp", "properties");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -248,7 +248,7 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "service");
                 _request.UriBuilder.AppendQuery("comp", "properties");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -382,7 +382,7 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("restype", "service");
                 _request.UriBuilder.AppendQuery("comp", "stats");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -536,7 +536,7 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "list");
                 if (prefix != null) { _request.UriBuilder.AppendQuery("prefix", System.Uri.EscapeDataString(prefix)); }
                 if (marker != null) { _request.UriBuilder.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
@@ -686,7 +686,7 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
@@ -818,7 +818,7 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Delete;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
@@ -940,7 +940,7 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "metadata");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -1092,7 +1092,7 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "metadata");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -1221,7 +1221,7 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "acl");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -1363,7 +1363,7 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("comp", "acl");
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
@@ -1518,7 +1518,7 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 if (numberOfMessages != null) { _request.UriBuilder.AppendQuery("numofmessages", System.Uri.EscapeDataString(numberOfMessages.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
                 if (visibilitytimeout != null) { _request.UriBuilder.AppendQuery("visibilitytimeout", System.Uri.EscapeDataString(visibilitytimeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -1656,7 +1656,7 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Delete;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
@@ -1797,7 +1797,7 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Post;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 if (visibilitytimeout != null) { _request.UriBuilder.AppendQuery("visibilitytimeout", System.Uri.EscapeDataString(visibilitytimeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
                 if (messageTimeToLive != null) { _request.UriBuilder.AppendQuery("messagettl", System.Uri.EscapeDataString(messageTimeToLive.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -1947,7 +1947,7 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Get;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("peekonly", "true");
                 if (numberOfMessages != null) { _request.UriBuilder.AppendQuery("numofmessages", System.Uri.EscapeDataString(numberOfMessages.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -2116,7 +2116,7 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Put;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("popreceipt", System.Uri.EscapeDataString(popReceipt));
                 _request.UriBuilder.AppendQuery("visibilitytimeout", System.Uri.EscapeDataString(visibilitytimeout.ToString(System.Globalization.CultureInfo.InvariantCulture)));
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
@@ -2276,7 +2276,7 @@ namespace Azure.Storage.Queues
 
                 // Set the endpoint
                 _request.Method = Azure.Core.Pipeline.RequestMethod.Delete;
-                _request.UriBuilder.Uri = resourceUri;
+                _request.UriBuilder.Assign(resourceUri);
                 _request.UriBuilder.AppendQuery("popreceipt", System.Uri.EscapeDataString(popReceipt));
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 

--- a/sdk/storage/Azure.Storage.Queues/src/QueueUriBuilder.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueUriBuilder.cs
@@ -218,7 +218,7 @@ namespace Azure.Storage.Queues
             {
                 if (_uri == null)
                 {
-                    _uri = BuildUri().Uri;
+                    _uri = BuildUri().ToUri();
                 }
                 return _uri;
             }


### PR DESCRIPTION
Fix https://github.com/Azure/azure-sdk-for-net/issues/7745
Also, `Request.UriBuilder` to `Request.Uri`

# Breaking change

Before:
![image](https://user-images.githubusercontent.com/1697911/65554474-8eb76380-dede-11e9-88dc-77e32bd61d86.png)


After:
![image](https://user-images.githubusercontent.com/1697911/65554502-a0007000-dede-11e9-9b57-f8671e4e05cf.png)

