### PR TITLE
[Storage] API feedback - Change IEnumerable<T> to T[]

### DIFF
--- a/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
@@ -987,9 +987,9 @@ namespace Azure.Storage.Queues
         /// Optional <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Response{T}"/> of <see cref="IEnumerable{DequeuedMessage}"/>
+        /// <see cref="Response{T}"/> where T is an array of <see cref="DequeuedMessage"/>
         /// </returns>
-        public virtual Response<IEnumerable<DequeuedMessage>> DequeueMessages(
+        public virtual Response<DequeuedMessage[]> DequeueMessages(
             int? maxMessages = default,
             TimeSpan? visibilityTimeout = default,
             CancellationToken cancellationToken = default) =>
@@ -1015,9 +1015,9 @@ namespace Azure.Storage.Queues
         /// Optional <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Response{T}"/> of <see cref="IEnumerable{DequeuedMessage}"/>
+        /// <see cref="Response{T}"/> where T is an array of <see cref="DequeuedMessage"/>
         /// </returns>
-        public virtual async Task<Response<IEnumerable<DequeuedMessage>>> DequeueMessagesAsync(
+        public virtual async Task<Response<DequeuedMessage[]>> DequeueMessagesAsync(
             int? maxMessages = default,
             TimeSpan? visibilityTimeout = default,
             CancellationToken cancellationToken = default) =>
@@ -1046,9 +1046,9 @@ namespace Azure.Storage.Queues
         /// Optional <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Response{T}"/> of <see cref="IEnumerable{DequeuedMessage}"/>
+        /// <see cref="Response{T}"/> where T is an array of <see cref="DequeuedMessage"/>
         /// </returns>
-        private async Task<Response<IEnumerable<DequeuedMessage>>> DequeueMessagesInternal(
+        private async Task<Response<DequeuedMessage[]>> DequeueMessagesInternal(
             int? maxMessages,
             TimeSpan? visibilityTimeout,
             bool async,
@@ -1064,7 +1064,7 @@ namespace Azure.Storage.Queues
                     $"{nameof(visibilityTimeout)}: {visibilityTimeout}");
                 try
                 {
-                    return await QueueRestClient.Messages.DequeueAsync(
+                    var dequeuedMessage = await QueueRestClient.Messages.DequeueAsync(
                         Pipeline,
                         MessagesUri,
                         numberOfMessages: maxMessages,
@@ -1073,6 +1073,7 @@ namespace Azure.Storage.Queues
                         operationName: Constants.Queue.DequeueMessageOperationName,
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
+                    return new Response<DequeuedMessage[]>(dequeuedMessage.GetRawResponse(), dequeuedMessage.Value.ToArray());
                 }
                 catch (Exception ex)
                 {
@@ -1100,9 +1101,9 @@ namespace Azure.Storage.Queues
         /// Optional <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Response{T}"/> of <see cref="IEnumerable{PeekedMessage}"/>
+        /// <see cref="Response{T}"/> where T is an array of <see cref="PeekedMessage"/>
         /// </returns>
-        public virtual Response<IEnumerable<PeekedMessage>> PeekMessages(
+        public virtual Response<PeekedMessage[]> PeekMessages(
             int? maxMessages = default,
             CancellationToken cancellationToken = default) =>
             PeekMessagesInternal(
@@ -1123,9 +1124,9 @@ namespace Azure.Storage.Queues
         /// Optional <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Response{T}"/> of <see cref="IEnumerable{PeekedMessage}"/>
+        /// <see cref="Response{T}"/> where T is an array of <see cref="PeekedMessage"/>
         /// </returns>
-        public virtual async Task<Response<IEnumerable<PeekedMessage>>> PeekMessagesAsync(
+        public virtual async Task<Response<PeekedMessage[]>> PeekMessagesAsync(
             int? maxMessages = default,
             CancellationToken cancellationToken = default) =>
             await PeekMessagesInternal(
@@ -1149,9 +1150,9 @@ namespace Azure.Storage.Queues
         /// Optional <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Response{T}"/> of <see cref="IEnumerable{PeekedMessage}"/>
+        /// <see cref="Response{T}"/> where T is an array of <see cref="PeekedMessage"/>
         /// </returns>
-        private async Task<Response<IEnumerable<PeekedMessage>>> PeekMessagesInternal(
+        private async Task<Response<PeekedMessage[]>> PeekMessagesInternal(
             int? maxMessages,
             bool async,
             CancellationToken cancellationToken)
@@ -1165,7 +1166,7 @@ namespace Azure.Storage.Queues
                     $"{nameof(maxMessages)}: {maxMessages}");
                 try
                 {
-                    return await QueueRestClient.Messages.PeekAsync(
+                    var peekedMessages = await QueueRestClient.Messages.PeekAsync(
                         Pipeline,
                         MessagesUri,
                         numberOfMessages: maxMessages,
@@ -1173,6 +1174,7 @@ namespace Azure.Storage.Queues
                         operationName: Constants.Queue.PeekMessagesOperationName,
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
+                    return new Response<PeekedMessage[]>(peekedMessages.GetRawResponse(), peekedMessages.Value.ToArray());
                 }
                 catch (Exception ex)
                 {

--- a/sdk/storage/Azure.Storage.Queues/tests/MessageClientTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/MessageClientTests.cs
@@ -76,7 +76,7 @@ namespace Azure.Storage.Queues.Test
                 await queue.EnqueueMessageAsync(GetNewString());
 
                 // Act
-                Response<System.Collections.Generic.IEnumerable<Models.DequeuedMessage>> response = await queue.DequeueMessagesAsync(
+                Response<Models.DequeuedMessage[]> response = await queue.DequeueMessagesAsync(
                     maxMessages: 2,
                     visibilityTimeout: new TimeSpan(1, 0, 0));
 
@@ -96,7 +96,7 @@ namespace Azure.Storage.Queues.Test
                 await queue.EnqueueMessageAsync(GetNewString());
 
                 // Act
-                Response<System.Collections.Generic.IEnumerable<Models.DequeuedMessage>> response = await queue.DequeueMessagesAsync();
+                Response<Models.DequeuedMessage[]> response = await queue.DequeueMessagesAsync();
 
                 // Assert
                 Assert.AreEqual(1, response.Value.Count());
@@ -129,7 +129,7 @@ namespace Azure.Storage.Queues.Test
                 await queue.EnqueueMessageAsync(GetNewString());
 
                 // Act
-                Response<System.Collections.Generic.IEnumerable<Models.PeekedMessage>> response = await queue.PeekMessagesAsync(maxMessages: 2);
+                Response<Models.PeekedMessage[]> response = await queue.PeekMessagesAsync(maxMessages: 2);
 
                 // Assert
                 Assert.AreEqual(2, response.Value.Count());
@@ -147,7 +147,7 @@ namespace Azure.Storage.Queues.Test
                 await queue.EnqueueMessageAsync(GetNewString());
 
                 // Act
-                Response<System.Collections.Generic.IEnumerable<Models.PeekedMessage>> response = await queue.PeekMessagesAsync();
+                Response<Models.PeekedMessage[]> response = await queue.PeekMessagesAsync();
 
                 // Assert
                 Assert.AreEqual(1, response.Value.Count());

--- a/sdk/storage/Azure.Storage.Queues/tests/MessageIdClientTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/MessageIdClientTests.cs
@@ -157,7 +157,7 @@ namespace Azure.Storage.Queues.Test
                 await queue.UpdateMessageAsync(message1, enqueuedMessage.MessageId, enqueuedMessage.PopReceipt);
 
                 // Assert
-                Response<System.Collections.Generic.IEnumerable<Models.PeekedMessage>> peekedMessages = await queue.PeekMessagesAsync(1);
+                Response<Models.PeekedMessage[]> peekedMessages = await queue.PeekMessagesAsync(1);
                 Models.PeekedMessage peekedMessage = peekedMessages.Value.First();
 
                 Assert.AreEqual(1, peekedMessages.Value.Count());


### PR DESCRIPTION
This PR updates the Queue response types to return arrays instead of `IEnumerable<T>`.