### PR TITLE
Prompt to install net47 MTP

### DIFF
--- a/sdk/keyvault/.vsconfig
+++ b/sdk/keyvault/.vsconfig
@@ -1,0 +1,6 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.Net.Component.4.7.TargetingPack"
+  ]
+}


### PR DESCRIPTION
This only prompts for the .NET Framework 4.7 targeting pack, which is needed in addition to the standard configuration mentioned elsewhere in the repo, that we need for Key Vault since we can't compile against netstandard20 using `ECParameters` et. al. This has caught a few people by surprise, and by default is not easy to diagnose how to resolve the issue without this change.