### PR TITLE
Adding KeyId property to the IKeyEncryptionKey interface

### DIFF
--- a/sdk/core/Azure.Core/src/Cryptography/IKeyEncryptionKey.cs
+++ b/sdk/core/Azure.Core/src/Cryptography/IKeyEncryptionKey.cs
@@ -13,6 +13,11 @@ namespace Azure.Core.Cryptography
     public interface IKeyEncryptionKey
     {
         /// <summary>
+        /// The Id of the key used to perform cryptographic operations for the client.
+        /// </summary>
+        Uri KeyId { get; }
+
+        /// <summary>
         /// Encrypts the specified key using the specified algorithm
         /// </summary>
         /// <param name="algorithm">The key wrap algorithm used to encrypt the specified key</param>

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/CryptographyClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/CryptographyClient.cs
@@ -94,6 +94,11 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
         internal ICryptographyProvider RemoteClient => _remoteProvider;
 
         /// <summary>
+        /// The <see cref="Key.Id"/> of the key used to perform cryptographic operations for the client.
+        /// </summary>
+        public Uri KeyId => _keyId;
+
+        /// <summary>
         /// Encrypts the specified plain text.
         /// </summary>
         /// <param name="algorithm">The <see cref="EncryptionAlgorithm"/> to use.</param>


### PR DESCRIPTION
This property is needed to maintain compatibility with the Storage client side encryption flow.