### PR TITLE
Update transforms to make data lake models internal rather than public

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
@@ -12953,7 +12953,7 @@ namespace Azure.Storage.Blobs.Models
     /// <summary>
     /// Blob GetAccessControlResult
     /// </summary>
-    public partial class BlobGetAccessControlResult
+    internal partial class BlobGetAccessControlResult
     {
         /// <summary>
         /// An HTTP entity tag associated with the file or directory.
@@ -12991,34 +12991,6 @@ namespace Azure.Storage.Blobs.Models
         /// </summary>
         internal BlobGetAccessControlResult() { }
     }
-
-    /// <summary>
-    /// BlobsModelFactory provides utilities for mocking.
-    /// </summary>
-    public static partial class BlobsModelFactory
-    {
-        /// <summary>
-        /// Creates a new BlobGetAccessControlResult instance for mocking.
-        /// </summary>
-        public static BlobGetAccessControlResult BlobGetAccessControlResult(
-            Azure.Core.Http.ETag eTag,
-            System.DateTimeOffset lastModified,
-            string xMSOwner,
-            string xMSGroup,
-            string xMSPermissions,
-            string xMSAcl)
-        {
-            return new BlobGetAccessControlResult()
-            {
-                ETag = eTag,
-                LastModified = lastModified,
-                XMSOwner = xMSOwner,
-                XMSGroup = xMSGroup,
-                XMSPermissions = xMSPermissions,
-                XMSAcl = xMSAcl,
-            };
-        }
-    }
 }
 #endregion class BlobGetAccessControlResult
 
@@ -13028,7 +13000,7 @@ namespace Azure.Storage.Blobs.Models
     /// <summary>
     /// Blob RenameResult
     /// </summary>
-    public partial class BlobRenameResult
+    internal partial class BlobRenameResult
     {
         /// <summary>
         /// An HTTP entity tag associated with the file or directory.
@@ -13051,28 +13023,6 @@ namespace Azure.Storage.Blobs.Models
         /// </summary>
         internal BlobRenameResult() { }
     }
-
-    /// <summary>
-    /// BlobsModelFactory provides utilities for mocking.
-    /// </summary>
-    public static partial class BlobsModelFactory
-    {
-        /// <summary>
-        /// Creates a new BlobRenameResult instance for mocking.
-        /// </summary>
-        public static BlobRenameResult BlobRenameResult(
-            Azure.Core.Http.ETag eTag,
-            System.DateTimeOffset lastModified,
-            long contentLength)
-        {
-            return new BlobRenameResult()
-            {
-                ETag = eTag,
-                LastModified = lastModified,
-                ContentLength = contentLength,
-            };
-        }
-    }
 }
 #endregion class BlobRenameResult
 
@@ -13082,7 +13032,7 @@ namespace Azure.Storage.Blobs.Models
     /// <summary>
     /// Blob SetAccessControlResult
     /// </summary>
-    public partial class BlobSetAccessControlResult
+    internal partial class BlobSetAccessControlResult
     {
         /// <summary>
         /// An HTTP entity tag associated with the file or directory.
@@ -13099,26 +13049,6 @@ namespace Azure.Storage.Blobs.Models
         /// You can use BlobsModelFactory.BlobSetAccessControlResult instead.
         /// </summary>
         internal BlobSetAccessControlResult() { }
-    }
-
-    /// <summary>
-    /// BlobsModelFactory provides utilities for mocking.
-    /// </summary>
-    public static partial class BlobsModelFactory
-    {
-        /// <summary>
-        /// Creates a new BlobSetAccessControlResult instance for mocking.
-        /// </summary>
-        public static BlobSetAccessControlResult BlobSetAccessControlResult(
-            Azure.Core.Http.ETag eTag,
-            System.DateTimeOffset lastModified)
-        {
-            return new BlobSetAccessControlResult()
-            {
-                ETag = eTag,
-                LastModified = lastModified,
-            };
-        }
     }
 }
 #endregion class BlobSetAccessControlResult
@@ -16661,7 +16591,7 @@ namespace Azure.Storage.Blobs.Models
     /// <summary>
     /// Directory CreateResult
     /// </summary>
-    public partial class DirectoryCreateResult
+    internal partial class DirectoryCreateResult
     {
         /// <summary>
         /// An HTTP entity tag associated with the file or directory.
@@ -16684,28 +16614,6 @@ namespace Azure.Storage.Blobs.Models
         /// </summary>
         internal DirectoryCreateResult() { }
     }
-
-    /// <summary>
-    /// BlobsModelFactory provides utilities for mocking.
-    /// </summary>
-    public static partial class BlobsModelFactory
-    {
-        /// <summary>
-        /// Creates a new DirectoryCreateResult instance for mocking.
-        /// </summary>
-        public static DirectoryCreateResult DirectoryCreateResult(
-            Azure.Core.Http.ETag eTag,
-            System.DateTimeOffset lastModified,
-            long contentLength)
-        {
-            return new DirectoryCreateResult()
-            {
-                ETag = eTag,
-                LastModified = lastModified,
-                ContentLength = contentLength,
-            };
-        }
-    }
 }
 #endregion class DirectoryCreateResult
 
@@ -16715,7 +16623,7 @@ namespace Azure.Storage.Blobs.Models
     /// <summary>
     /// Directory DeleteResult
     /// </summary>
-    public partial class DirectoryDeleteResult
+    internal partial class DirectoryDeleteResult
     {
         /// <summary>
         /// When renaming a directory, the number of paths that are renamed with each invocation is limited. If the number of paths to be renamed exceeds this limit, a continuation token is returned in this response header. When a continuation token is returned in the response, it must be specified in a subsequent invocation of the rename operation to continue renaming the directory.
@@ -16728,24 +16636,6 @@ namespace Azure.Storage.Blobs.Models
         /// </summary>
         internal DirectoryDeleteResult() { }
     }
-
-    /// <summary>
-    /// BlobsModelFactory provides utilities for mocking.
-    /// </summary>
-    public static partial class BlobsModelFactory
-    {
-        /// <summary>
-        /// Creates a new DirectoryDeleteResult instance for mocking.
-        /// </summary>
-        public static DirectoryDeleteResult DirectoryDeleteResult(
-            string marker)
-        {
-            return new DirectoryDeleteResult()
-            {
-                Marker = marker,
-            };
-        }
-    }
 }
 #endregion class DirectoryDeleteResult
 
@@ -16755,7 +16645,7 @@ namespace Azure.Storage.Blobs.Models
     /// <summary>
     /// Directory GetAccessControlResult
     /// </summary>
-    public partial class DirectoryGetAccessControlResult
+    internal partial class DirectoryGetAccessControlResult
     {
         /// <summary>
         /// An HTTP entity tag associated with the file or directory.
@@ -16793,34 +16683,6 @@ namespace Azure.Storage.Blobs.Models
         /// </summary>
         internal DirectoryGetAccessControlResult() { }
     }
-
-    /// <summary>
-    /// BlobsModelFactory provides utilities for mocking.
-    /// </summary>
-    public static partial class BlobsModelFactory
-    {
-        /// <summary>
-        /// Creates a new DirectoryGetAccessControlResult instance for mocking.
-        /// </summary>
-        public static DirectoryGetAccessControlResult DirectoryGetAccessControlResult(
-            Azure.Core.Http.ETag eTag,
-            System.DateTimeOffset lastModified,
-            string xMSOwner,
-            string xMSGroup,
-            string xMSPermissions,
-            string xMSAcl)
-        {
-            return new DirectoryGetAccessControlResult()
-            {
-                ETag = eTag,
-                LastModified = lastModified,
-                XMSOwner = xMSOwner,
-                XMSGroup = xMSGroup,
-                XMSPermissions = xMSPermissions,
-                XMSAcl = xMSAcl,
-            };
-        }
-    }
 }
 #endregion class DirectoryGetAccessControlResult
 
@@ -16830,7 +16692,7 @@ namespace Azure.Storage.Blobs.Models
     /// <summary>
     /// Directory RenameResult
     /// </summary>
-    public partial class DirectoryRenameResult
+    internal partial class DirectoryRenameResult
     {
         /// <summary>
         /// When renaming a directory, the number of paths that are renamed with each invocation is limited. If the number of paths to be renamed exceeds this limit, a continuation token is returned in this response header. When a continuation token is returned in the response, it must be specified in a subsequent invocation of the rename operation to continue renaming the directory.
@@ -16858,30 +16720,6 @@ namespace Azure.Storage.Blobs.Models
         /// </summary>
         internal DirectoryRenameResult() { }
     }
-
-    /// <summary>
-    /// BlobsModelFactory provides utilities for mocking.
-    /// </summary>
-    public static partial class BlobsModelFactory
-    {
-        /// <summary>
-        /// Creates a new DirectoryRenameResult instance for mocking.
-        /// </summary>
-        public static DirectoryRenameResult DirectoryRenameResult(
-            string marker,
-            Azure.Core.Http.ETag eTag,
-            System.DateTimeOffset lastModified,
-            long contentLength)
-        {
-            return new DirectoryRenameResult()
-            {
-                Marker = marker,
-                ETag = eTag,
-                LastModified = lastModified,
-                ContentLength = contentLength,
-            };
-        }
-    }
 }
 #endregion class DirectoryRenameResult
 
@@ -16891,7 +16729,7 @@ namespace Azure.Storage.Blobs.Models
     /// <summary>
     /// Directory SetAccessControlResult
     /// </summary>
-    public partial class DirectorySetAccessControlResult
+    internal partial class DirectorySetAccessControlResult
     {
         /// <summary>
         /// An HTTP entity tag associated with the file or directory.
@@ -16908,26 +16746,6 @@ namespace Azure.Storage.Blobs.Models
         /// You can use BlobsModelFactory.DirectorySetAccessControlResult instead.
         /// </summary>
         internal DirectorySetAccessControlResult() { }
-    }
-
-    /// <summary>
-    /// BlobsModelFactory provides utilities for mocking.
-    /// </summary>
-    public static partial class BlobsModelFactory
-    {
-        /// <summary>
-        /// Creates a new DirectorySetAccessControlResult instance for mocking.
-        /// </summary>
-        public static DirectorySetAccessControlResult DirectorySetAccessControlResult(
-            Azure.Core.Http.ETag eTag,
-            System.DateTimeOffset lastModified)
-        {
-            return new DirectorySetAccessControlResult()
-            {
-                ETag = eTag,
-                LastModified = lastModified,
-            };
-        }
     }
 }
 #endregion class DirectorySetAccessControlResult

--- a/sdk/storage/Azure.Storage.Blobs/swagger/readme.md
+++ b/sdk/storage/Azure.Storage.Blobs/swagger/readme.md
@@ -1057,7 +1057,6 @@ directive:
     $.format = "int64";
 ```
 
-
 ### Merge the PageBlob AccessTier type
 ``` yaml
 directive:
@@ -1065,4 +1064,41 @@ directive:
   where: $.parameters.PremiumPageBlobAccessTierOptional
   transform: >
     $["x-ms-enum"].name = "AccessTier";
+```
+
+### Hide Result models relating to data lake
+``` yaml
+directive:
+- from: swagger-document
+  where: $["x-ms-paths"]["/{filesystem}/{path}?action=getAccessControl&directory"]
+  transform: >
+    $.head.responses["200"]["x-az-public"] = false;
+- from: swagger-document
+  where: $["x-ms-paths"]["/{filesystem}/{path}?action=getAccessControl&blob"]
+  transform: >
+    $.head.responses["200"]["x-az-public"] = false;
+- from: swagger-document
+  where: $["x-ms-paths"]["/{filesystem}/{path}?action=setAccessControl&directory"]
+  transform: >
+    $.patch.responses["200"]["x-az-public"] = false;
+- from: swagger-document
+  where: $["x-ms-paths"]["/{filesystem}/{path}?action=setAccessControl&blob"]
+  transform: >
+    $.patch.responses["200"]["x-az-public"] = false;
+- from: swagger-document
+  where: $["x-ms-paths"]["/{filesystem}/{path}?DirectoryRename"]
+  transform: >
+    $.put.responses["201"]["x-az-public"] = false;
+- from: swagger-document
+  where: $["x-ms-paths"]["/{filesystem}/{path}?FileRename"]
+  transform: >
+    $.put.responses["201"]["x-az-public"] = false;
+- from: swagger-document
+  where: $["x-ms-paths"]["/{filesystem}/{path}?resource=directory&Create"]
+  transform: >
+    $.put.responses["201"]["x-az-public"] = false;
+- from: swagger-document
+  where: $["x-ms-paths"]["/{filesystem}/{path}?DirectoryDelete"]
+  transform: >
+    $.delete.responses["200"]["x-az-public"] = false;
 ```


### PR DESCRIPTION
Hide the following types related to data lake as these should not be exposed to consumers of the library:

- BlobGetAccessControlResult
- BlobRenameResult
- BlobSetAccessControlResult
- DirectoryCreateResult
- DirectoryDeleteResult
- DirectoryGetAccessControlResult
- DirectoryRenameResult
- DirectorySetAccessControlResult

