### PR TITLE
Make Error model internal

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
@@ -18980,7 +18980,7 @@ namespace Azure.Storage.Blobs.Models
     /// <summary>
     /// The service error response object.
     /// </summary>
-    public partial class Error
+    internal partial class Error
     {
         /// <summary>
         /// The service error code.
@@ -19023,26 +19023,6 @@ namespace Azure.Storage.Blobs.Models
         }
 
         static partial void CustomizeFromXml(System.Xml.Linq.XElement element, Azure.Storage.Blobs.Models.Error value);
-    }
-
-    /// <summary>
-    /// BlobsModelFactory provides utilities for mocking.
-    /// </summary>
-    public static partial class BlobsModelFactory
-    {
-        /// <summary>
-        /// Creates a new Error instance for mocking.
-        /// </summary>
-        public static Error Error(
-            string code = default,
-            string message = default)
-        {
-            return new Error()
-            {
-                Code = code,
-                Message = message,
-            };
-        }
     }
 }
 #endregion class Error

--- a/sdk/storage/Azure.Storage.Blobs/swagger/readme.md
+++ b/sdk/storage/Azure.Storage.Blobs/swagger/readme.md
@@ -989,7 +989,7 @@ directive:
     $["x-az-disable-warnings"] = "CA1724";
 ```
 
-### Hide StorageError
+### Hide Error models
 ``` yaml
 directive:
 - from: swagger-document
@@ -999,6 +999,10 @@ directive:
     $.properties.Code = { "type": "string" };
 - from: swagger-document
   where: $.definitions.DataLakeStorageError
+  transform: >
+    $["x-az-public"] = false;
+- from: swagger-document
+  where: $.definitions.DataLakeStorageError.properties["error"]
   transform: >
     $["x-az-public"] = false;
 ```


### PR DESCRIPTION
Error type is only used within DatalakeStorageError which is already marked as internal. However, the generated code still makes Error public which exposes it in our API and causes the creation of the factory method, which we don't want.