### PR TITLE
[Azure Search] V10.0.1 Re-enable XML docs

### DIFF
--- a/sdk/search/Directory.Build.props
+++ b/sdk/search/Directory.Build.props
@@ -3,7 +3,8 @@
   <Choose>
     <When Condition="'$(IsDataPlaneProject)' == 'true'">
       <PropertyGroup>
-        <VersionPrefix>10.0.0</VersionPrefix>
+        <VersionPrefix>10.0.1</VersionPrefix>
+        <DocumentationFile>$(IntermediateOutputPath)$(TargetFramework)\$(MSBuildProjectName).xml</DocumentationFile>
       </PropertyGroup>
     </When>
   </Choose>

--- a/sdk/search/Microsoft.Azure.Search.Data/src/Microsoft.Azure.Search.Data.csproj
+++ b/sdk/search/Microsoft.Azure.Search.Data/src/Microsoft.Azure.Search.Data.csproj
@@ -5,6 +5,9 @@
     <AssemblyTitle>Microsoft Azure Search Data Library</AssemblyTitle>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <PackageReleaseNotes>See the Microsoft.Azure.Search package for detailed release notes on the entire Azure Search .NET SDK.</PackageReleaseNotes>
+
+    <!-- Disable warning for missing xml doc comments until we can add all the missing ones -->
+    <NoWarn>$(NoWarn);1573;1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Spatial" />

--- a/sdk/search/Microsoft.Azure.Search.Service/src/Microsoft.Azure.Search.Service.csproj
+++ b/sdk/search/Microsoft.Azure.Search.Service/src/Microsoft.Azure.Search.Service.csproj
@@ -5,6 +5,9 @@
     <AssemblyTitle>Microsoft Azure Search Service Library</AssemblyTitle>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <PackageReleaseNotes>See the Microsoft.Azure.Search package for detailed release notes on the entire Azure Search .NET SDK.</PackageReleaseNotes>
+
+    <!-- Disable warning for missing xml doc comments until we can add all the missing ones -->
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Spatial" />

--- a/sdk/search/Microsoft.Azure.Search/changelog.md
+++ b/sdk/search/Microsoft.Azure.Search/changelog.md
@@ -1,8 +1,22 @@
 # GA SDK Releases
 
-Every minor version release targets the same (GA) REST API version as that of the corresponding major version release. The REST API version targeted by the major version releases are listed when appropriate.
+Every minor version release targets the same (GA) REST API version as that of the corresponding major version release. The REST API version targeted by the major version releases are listed where appropriate.
 
 Features and improvements in a GA SDK are considered generally available.
+
+# 10.0.1
+
+# Breaking Changes
+
+None
+
+# Improvements
+
+None
+
+# Bug fixes
+
+- Fixed missing Intellisense and reference documentation. This was caused by missing XML doc files in the NuGet packages. [PR 6298](https://github.com/Azure/azure-sdk-for-net/pull/7786).
 
 <a name="10.0.0"></a>
 

--- a/sdk/search/Microsoft.Azure.Search/src/IndexesGetClientExtensions.cs
+++ b/sdk/search/Microsoft.Azure.Search/src/IndexesGetClientExtensions.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Search
         /// <summary>
         /// Creates a new index client for querying and managing documents in a given index.
         /// </summary>
+        /// <param name="operations">The operation group for indexes of the Search service.</param>
         /// <param name="indexName">The name of the index.</param>
         /// <returns>A new <c cref="Microsoft.Azure.Search.SearchIndexClient">SearchIndexClient</c> instance.</returns>
         /// <remarks>

--- a/sdk/search/Microsoft.Azure.Search/tests/Microsoft.Azure.Search.Tests.csproj
+++ b/sdk/search/Microsoft.Azure.Search/tests/Microsoft.Azure.Search.Tests.csproj
@@ -5,6 +5,9 @@
     <VersionPrefix>1.0.0</VersionPrefix>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+    <!-- Disable warning for missing xml doc comments for test projects -->
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
XML docs were accidentally disabled after we shipped version 9.0.1, probably when upgrading to the new engineering system. This is probably why all the content from our .NET API reference went missing. This should hopefully restore it.