### PR TITLE
Make publicAccessType required in ContainerProperties

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
@@ -16109,7 +16109,7 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// PublicAccess
         /// </summary>
-        public Azure.Storage.Blobs.Models.PublicAccessType? PublicAccess { get; internal set; }
+        public Azure.Storage.Blobs.Models.PublicAccessType PublicAccess { get; internal set; }
 
         /// <summary>
         /// HasImmutabilityPolicy
@@ -16158,11 +16158,7 @@ namespace Azure.Storage.Blobs.Models
             {
                 _value.LeaseDuration = Azure.Storage.Blobs.BlobRestClient.Serialization.ParseLeaseDurationType(_child.Value);
             }
-            _child = element.Element(System.Xml.Linq.XName.Get("PublicAccess", ""));
-            if (_child != null && !string.IsNullOrEmpty(_child.Value))
-            {
-                _value.PublicAccess = Azure.Storage.Blobs.BlobRestClient.Serialization.ParsePublicAccessType(_child.Value);
-            }
+            _value.PublicAccess = Azure.Storage.Blobs.BlobRestClient.Serialization.ParsePublicAccessType(element.Element(System.Xml.Linq.XName.Get("PublicAccess", ""))?.Value);
             _child = element.Element(System.Xml.Linq.XName.Get("HasImmutabilityPolicy", ""));
             if (_child != null)
             {
@@ -16191,22 +16187,22 @@ namespace Azure.Storage.Blobs.Models
         /// </summary>
         public static ContainerProperties ContainerProperties(
             System.DateTimeOffset lastModified,
+            Azure.Storage.Blobs.Models.PublicAccessType publicAccess,
             Azure.Core.Http.ETag eTag,
             Azure.Storage.Blobs.Models.LeaseStatus? leaseStatus = default,
             Azure.Storage.Blobs.Models.LeaseState? leaseState = default,
             Azure.Storage.Blobs.Models.LeaseDurationType? leaseDuration = default,
-            Azure.Storage.Blobs.Models.PublicAccessType? publicAccess = default,
             bool? hasImmutabilityPolicy = default,
             bool? hasLegalHold = default)
         {
             return new ContainerProperties()
             {
                 LastModified = lastModified,
+                PublicAccess = publicAccess,
                 ETag = eTag,
                 LeaseStatus = leaseStatus,
                 LeaseState = leaseState,
                 LeaseDuration = leaseDuration,
-                PublicAccess = publicAccess,
                 HasImmutabilityPolicy = hasImmutabilityPolicy,
                 HasLegalHold = hasLegalHold,
             };

--- a/sdk/storage/Azure.Storage.Blobs/swagger/readme.md
+++ b/sdk/storage/Azure.Storage.Blobs/swagger/readme.md
@@ -1048,7 +1048,10 @@ directive:
 - from: swagger-document
   where: $.parameters.BlobPublicAccess
   transform: $.required = true;
-```
+- from: swagger-document
+  where: $.definitions.ContainerProperties
+  transform: $.required.push("PublicAccess");
+  ```
 
 ### Make lease duration a long
 Lease Duration is represented as a TimeSpan in the .NET client libraries, but TimeSpan.MaxValue would overflow an int. Because of this, we are changing the 

--- a/sdk/storage/Azure.Storage.Common/swagger/Generator/src/generator.ts
+++ b/sdk/storage/Azure.Storage.Common/swagger/Generator/src/generator.ts
@@ -1132,7 +1132,13 @@ function generateDeserialize(w: IndentWriter, service: IService, type: IObjectTy
                     // Change fromName if it ever stops being universal to the format
                     return `${types.getName(model)}.${fromName}(${text})`;
                 } else {
-                    return types.convertFromString(`${text}.Value`, model, service);
+                    if (isEnumType(model) && model.skipValue) { 
+                        // If skipValue is set on the enum, that means that the service would return a null for that value.
+                        // Hence, we add the null conditional for this case. 
+                        return types.convertFromString(`${text}?.Value`, model, service);
+                    } else {
+                        return types.convertFromString(`${text}.Value`, model, service);
+                    }
                 }
             };
 


### PR DESCRIPTION
Marking the parameter required made it necessary to update the generator to add a null conditional for the case when skipValue is set on an Enum.