### PR TITLE
Add support for nested polymorphic objects in Firewall Policy

### DIFF
--- a/sdk/network/Microsoft.Azure.Management.Network/src/Customizations/NetworkManagementClientCustomizations.cs
+++ b/sdk/network/Microsoft.Azure.Management.Network/src/Customizations/NetworkManagementClientCustomizations.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+namespace Microsoft.Azure.Management.Network
+{
+    using Microsoft.Azure.Management.Network.Models;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Azure;
+    using Microsoft.Rest.Serialization;
+    using System.Linq;
+
+    public partial class NetworkManagementClient : ServiceClient<NetworkManagementClient>, INetworkManagementClient, IAzureClient
+    {
+        partial void CustomInitialize()
+        {
+            // first remove the converters added by generated code for the FirewallPolicyRule and RuleCondition
+            DeserializationSettings.Converters.Remove(DeserializationSettings.Converters.FirstOrDefault(c => c.GetType() == typeof(PolymorphicDeserializeJsonConverter<FirewallPolicyRule>)));
+            DeserializationSettings.Converters.Remove(DeserializationSettings.Converters.FirstOrDefault(c => c.GetType() == typeof(PolymorphicDeserializeJsonConverter<FirewallPolicyRuleCondition>)));
+            SerializationSettings.Converters.Remove(DeserializationSettings.Converters.FirstOrDefault(c => c.GetType() == typeof(PolymorphicDeserializeJsonConverter<FirewallPolicyRule>)));
+            SerializationSettings.Converters.Remove(DeserializationSettings.Converters.FirstOrDefault(c => c.GetType() == typeof(PolymorphicDeserializeJsonConverter<FirewallPolicyRuleCondition>)));
+
+            // now add the correct converters
+            DeserializationSettings.Converters.Add(new PolymorphicJsonCustomConverter<FirewallPolicyRule, FirewallPolicyRuleCondition>("ruleType", "ruleConditionType"));
+            SerializationSettings.Converters.Add(new PolymorphicJsonCustomConverter<FirewallPolicyRule, FirewallPolicyRuleCondition>("ruleType", "ruleConditionType"));
+        }
+    }
+}

--- a/sdk/network/Microsoft.Azure.Management.Network/src/Customizations/NetworkManagementClientCustomizations.cs
+++ b/sdk/network/Microsoft.Azure.Management.Network/src/Customizations/NetworkManagementClientCustomizations.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Azure.Management.Network
             // first remove the converters added by generated code for the FirewallPolicyRule and RuleCondition
             DeserializationSettings.Converters.Remove(DeserializationSettings.Converters.FirstOrDefault(c => c.GetType() == typeof(PolymorphicDeserializeJsonConverter<FirewallPolicyRule>)));
             DeserializationSettings.Converters.Remove(DeserializationSettings.Converters.FirstOrDefault(c => c.GetType() == typeof(PolymorphicDeserializeJsonConverter<FirewallPolicyRuleCondition>)));
-            SerializationSettings.Converters.Remove(DeserializationSettings.Converters.FirstOrDefault(c => c.GetType() == typeof(PolymorphicDeserializeJsonConverter<FirewallPolicyRule>)));
-            SerializationSettings.Converters.Remove(DeserializationSettings.Converters.FirstOrDefault(c => c.GetType() == typeof(PolymorphicDeserializeJsonConverter<FirewallPolicyRuleCondition>)));
+            SerializationSettings.Converters.Remove(SerializationSettings.Converters.FirstOrDefault(c => c.GetType() == typeof(PolymorphicSerializeJsonConverter<FirewallPolicyRule>)));
+            SerializationSettings.Converters.Remove(SerializationSettings.Converters.FirstOrDefault(c => c.GetType() == typeof(PolymorphicSerializeJsonConverter<FirewallPolicyRuleCondition>)));
 
             // now add the correct converters
             DeserializationSettings.Converters.Add(new PolymorphicJsonCustomConverter<FirewallPolicyRule, FirewallPolicyRuleCondition>("ruleType", "ruleConditionType"));

--- a/sdk/network/Microsoft.Azure.Management.Network/src/Customizations/PolymorphicJsonCustomConverter.cs
+++ b/sdk/network/Microsoft.Azure.Management.Network/src/Customizations/PolymorphicJsonCustomConverter.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+namespace Microsoft.Azure.Management.Network
+{
+    using System;
+    using System.Reflection;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
+
+    public class PolymorphicJsonCustomConverter<T1, T2> : JsonConverter
+        where T1 : class
+        where T2 : class
+    {
+        private PolymorphicDeserializeJsonConverter<T1> firstDeserializeConverter;
+
+        private PolymorphicDeserializeJsonConverter<T2> secondDeserializeConverter;
+
+        private PolymorphicSerializeJsonConverter<T1> firstSerializeConverter;
+
+        private PolymorphicSerializeJsonConverter<T2> secondSerializeConverter;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PolymorphicJsonCustomConverter{T1, T2}"/> class.
+        /// </summary>
+        /// <param name="firstDiscriminatorField">The field on which to choose first child type.</param>
+        /// <param name="secondDiscriminatorField">The field on which to choose second child type.</param>
+        public PolymorphicJsonCustomConverter(string firstDiscriminatorField, string secondDiscriminatorField)
+        {
+            this.firstSerializeConverter = new PolymorphicSerializeJsonConverter<T1>(firstDiscriminatorField);
+
+            this.secondSerializeConverter = new PolymorphicSerializeJsonConverter<T2>(secondDiscriminatorField);
+
+            this.firstDeserializeConverter = new PolymorphicDeserializeJsonConverter<T1>(firstDiscriminatorField);
+
+            this.secondDeserializeConverter = new PolymorphicDeserializeJsonConverter<T2>(secondDiscriminatorField);
+        }
+
+        /// <summary>
+        /// Writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="T:Newtonsoft.Json.JsonWriter" /> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var objectType = value.GetType();
+            if (typeof(T1).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo()))
+            {
+                this.firstSerializeConverter.WriteJson(writer, value, serializer);
+            }
+            else
+            {
+                this.secondSerializeConverter.WriteJson(writer, value, serializer);
+            }
+        }
+
+        /// <summary>
+        /// Reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="T:Newtonsoft.Json.JsonReader" /> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <returns>
+        /// The object value.
+        /// </returns>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (typeof(T1).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo()))
+            {
+                return this.firstDeserializeConverter.ReadJson(reader, objectType, existingValue, serializer);
+            }
+
+            if (typeof(T2).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo()))
+            {
+                return this.secondDeserializeConverter.ReadJson(reader, objectType, existingValue, serializer);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Determines whether this instance can convert the specified object type.
+        /// </summary>
+        /// <param name="objectType">Type of the object.</param>
+        /// <returns>
+        /// <c>true</c> if this instance can convert the specified object type; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool CanConvert(Type objectType)
+        {
+            bool isFirstCanConvert = this.firstDeserializeConverter.CanConvert(objectType);
+            bool isSecondCanConvert = this.secondDeserializeConverter.CanConvert(objectType);
+            return isFirstCanConvert || isSecondCanConvert;
+        }
+    }
+}

--- a/sdk/network/Microsoft.Azure.Management.Network/tests/Helpers/MockServiceClientCredentials.cs
+++ b/sdk/network/Microsoft.Azure.Management.Network/tests/Helpers/MockServiceClientCredentials.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Networks.Tests
+{
+    using Microsoft.Rest;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class MockServiceClientCredentials : ServiceClientCredentials
+    {
+        public override void InitializeServiceClient<T>(ServiceClient<T> client)
+        {
+            base.InitializeServiceClient(client);
+        }
+
+        public override Task ProcessHttpRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(0);
+        }
+    }
+}

--- a/sdk/network/Microsoft.Azure.Management.Network/tests/TestData/FirewallPolicyRuleGroupSampleResource.json
+++ b/sdk/network/Microsoft.Azure.Management.Network/tests/TestData/FirewallPolicyRuleGroupSampleResource.json
@@ -1,0 +1,37 @@
+{
+  "location": "westus",
+  "properties": {
+    "priority": 110,
+    "name": "SampleRuleGroup",
+    "provisioningState":  "Succeeded",
+    "rules": [
+      {
+        "ruleType": "FirewallPolicyNatRule",
+        "name": "Example-Nat-Rule",
+        "priority": 230,
+        "TranslatedPort": "55001",
+        "TranslatedAddress": "10.1.22.12",
+        "Action": {
+          "type": "Dnat"
+        },
+        "ruleCondition": {
+          "ruleConditionType": "NetworkRuleCondition",
+          "name": "network-condition1",
+          "description":  "Rule condition to test nested polymorphism in Firewall Policy Rule Group Resource",
+          "sourceAddresses": [
+            "10.1.25.0/24"
+          ],
+          "destinationAddresses": [
+            "13.22.11.44"
+          ],
+          "ipProtocols": [
+            "TCP"
+          ],
+          "destinationPorts": [
+            "55001"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/sdk/network/Microsoft.Azure.Management.Network/tests/Tests/FirewallPolicyRuleGroupTestResource.cs
+++ b/sdk/network/Microsoft.Azure.Management.Network/tests/Tests/FirewallPolicyRuleGroupTestResource.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Networks.Tests
+{
+    using System.IO;
+    using Newtonsoft.Json.Linq;
+
+    internal static class FirewallPolicyRuleGroupTestResource
+    {
+        internal static JObject GetSampleResource()
+        {
+            var sampleResourceJson = File.ReadAllText("TestData/FirewallPolicyRuleGroupSampleResource.json");
+            var json = sampleResourceJson.Replace("'", "\"");
+            var resource = JObject.Parse(json).ToObject<JObject>();
+
+            return resource;
+        }
+    }
+}

--- a/sdk/network/Microsoft.Azure.Management.Network/tests/Tests/FirewallPolicyTests.cs
+++ b/sdk/network/Microsoft.Azure.Management.Network/tests/Tests/FirewallPolicyTests.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Networks.Tests
+{
+    using System;
+    using Microsoft.Azure.Management.Network;
+    using Microsoft.Azure.Management.Network.Models;
+    using Xunit;
+
+    using Microsoft.Rest;
+
+    public class FirewallPolicyTests
+    {
+        [Fact()]
+        public void FirewallPolicyRuleGroupDeserializationTest()
+        {
+            ServiceClientCredentials creds = new MockServiceClientCredentials();
+            var networkManagementClient = new NetworkManagementClient(new Uri("https://management.azure.com"), creds); 
+            var responseContent = FirewallPolicyRuleGroupTestResource.GetSampleResource().ToString();
+            var ruleGroup = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<FirewallPolicyRuleGroup>(responseContent, networkManagementClient.DeserializationSettings);
+
+            Assert.True(ruleGroup != null);
+            Assert.Equal(1, ruleGroup.Rules.Count);
+
+            FirewallPolicyNatRule policyRule = ruleGroup.Rules[0] as FirewallPolicyNatRule;
+            Assert.Equal(typeof(NetworkRuleCondition), policyRule.RuleCondition.GetType());          
+            
+        }
+    }
+}


### PR DESCRIPTION
The autogenerated code for Firewall Policy is incorrect since the
PolymorphicJsonConverter used does not support nested polymorphism

We have FirewallPolicyRule with Derived Types: FirewallPolicyFilterRule
and FirewallPolicyNatRule.

These derived types have one/more FirewallPolicyRuleCondition(s), with
Derived Types: NetworkRuleCondition and ApplicationRuleCondition.

We need to customize the initialization of the NetworkManagementClient
to add a polymorphicJsonConverter that accepts the two class types and
discriminator fields. Also, the PolyMorphicJsonConverter<T1, T2> is a wrapper over the PolymorphicJsonConverter<T1> available in the Microsoft.Rest.Serialization assembly.