### PR TITLE
Replace Uri property with ToUri method

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/BreakingChanges.txt
+++ b/sdk/storage/Azure.Storage.Blobs/BreakingChanges.txt
@@ -1,5 +1,8 @@
 Breaking Changes
 ================
+Next Release
+--------------------------
+- Removing Uri property from BlobUriBuilder and replacing with a ToUri method that returns the Uri.
 
 12.0.0-preview.3 (2019-09)
 --------------------------

--- a/sdk/storage/Azure.Storage.Blobs/src/AppendBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/AppendBlobClient.cs
@@ -205,7 +205,7 @@ namespace Azure.Storage.Blobs.Specialized
         public new AppendBlobClient WithSnapshot(string snapshot)
         {
             var builder = new BlobUriBuilder(Uri) { Snapshot = snapshot };
-            return new AppendBlobClient(builder.Uri, Pipeline);
+            return new AppendBlobClient(builder.ToUri(), Pipeline);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -168,7 +168,7 @@ namespace Azure.Storage.Blobs.Specialized
                     ContainerName = containerName,
                     BlobName = blobName
                 };
-            _uri = builder.Uri;
+            _uri = builder.ToUri();
             _pipeline = (options ?? new BlobClientOptions()).Build(conn.Credentials);
             _customerProvidedKey = options?.CustomerProvidedKey;
         }
@@ -309,7 +309,7 @@ namespace Azure.Storage.Blobs.Specialized
         protected virtual BlobBaseClient WithSnapshotImpl(string snapshot)
         {
             var builder = new BlobUriBuilder(Uri) { Snapshot = snapshot };
-            return new BlobBaseClient(builder.Uri, Pipeline);
+            return new BlobBaseClient(builder.ToUri(), Pipeline);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -141,7 +141,7 @@ namespace Azure.Storage.Blobs
         {
             var conn = StorageConnectionString.Parse(connectionString);
             var builder = new BlobUriBuilder(conn.BlobEndpoint) { ContainerName = containerName };
-            _uri = builder.Uri;
+            _uri = builder.ToUri();
             options ??= new BlobClientOptions();
             _pipeline = options.Build(conn.Credentials);
         }

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobUriBuilder.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobUriBuilder.cs
@@ -230,20 +230,17 @@ namespace Azure.Storage.Blobs
         }
 
         /// <summary>
-        /// Gets a <see cref="System.Uri"/> representing the
-        /// <see cref="BlobUriBuilder"/>'s fields.   The <see cref="Uri.Query"/>
-        /// property contains the SAS, snapshot, and additional query parameters.
+        /// Returns the <see cref="System.Uri"/> constructed from the
+        /// <see cref="BlobUriBuilder"/>'s fields. The <see cref="Uri.Query"/>
+        /// property contains the SAS and additional query parameters.
         /// </summary>
-        public Uri Uri
+        public Uri ToUri()
         {
-            get
+            if (_uri == null)
             {
-                if (_uri == null)
-                {
-                    _uri = BuildUri().ToUri();
-                }
-                return _uri;
+                _uri = BuildUri().ToUri();
             }
+            return _uri;
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
@@ -268,7 +268,7 @@ namespace Azure.Storage.Blobs.Specialized
         protected sealed override BlobBaseClient WithSnapshotImpl(string snapshot)
         {
             var builder = new BlobUriBuilder(Uri) { Snapshot = snapshot };
-            return new BlockBlobClient(builder.Uri, Pipeline);
+            return new BlockBlobClient(builder.ToUri(), Pipeline);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/src/PageBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/PageBlobClient.cs
@@ -213,7 +213,7 @@ namespace Azure.Storage.Blobs.Specialized
         protected sealed override BlobBaseClient WithSnapshotImpl(string snapshot)
         {
             var builder = new BlobUriBuilder(Uri) { Snapshot = snapshot };
-            return new PageBlobClient(builder.Uri, Pipeline);
+            return new PageBlobClient(builder.ToUri(), Pipeline);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobUriBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobUriBuilderTests.cs
@@ -22,7 +22,7 @@ namespace Azure.Storage.Blobs.Test
             BlobServiceClient service = GetServiceClient_AccountSas();
             var blobUriBuilder = new BlobUriBuilder(service.Uri);
 
-            Uri blobUri = blobUriBuilder.Uri;
+            Uri blobUri = blobUriBuilder.ToUri();
 
             var expectedUri = WebUtility.UrlDecode(service.Uri.AbsoluteUri);
             var actualUri = WebUtility.UrlDecode(blobUri.AbsoluteUri);
@@ -39,7 +39,7 @@ namespace Azure.Storage.Blobs.Test
 
             // Act
             var blobUriBuilder = new BlobUriBuilder(originalUri.Uri);
-            Uri newUri = blobUriBuilder.Uri;
+            Uri newUri = blobUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", blobUriBuilder.Scheme);
@@ -63,7 +63,7 @@ namespace Azure.Storage.Blobs.Test
 
             // Act
             var blobUriBuilder = new BlobUriBuilder(originalUri.Uri);
-            Uri newUri = blobUriBuilder.Uri;
+            Uri newUri = blobUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", blobUriBuilder.Scheme);
@@ -87,7 +87,7 @@ namespace Azure.Storage.Blobs.Test
 
             // Act
             var blobUriBuilder = new BlobUriBuilder(originalUri.Uri);
-            Uri newUri = blobUriBuilder.Uri;
+            Uri newUri = blobUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", blobUriBuilder.Scheme);
@@ -111,7 +111,7 @@ namespace Azure.Storage.Blobs.Test
 
             // Act
             var blobUriBuilder = new BlobUriBuilder(originalUri.Uri);
-            Uri newUri = blobUriBuilder.Uri;
+            Uri newUri = blobUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", blobUriBuilder.Scheme);
@@ -135,7 +135,7 @@ namespace Azure.Storage.Blobs.Test
 
             // Act
             var blobUriBuilder = new BlobUriBuilder(originalUri.Uri);
-            Uri newUri = blobUriBuilder.Uri;
+            Uri newUri = blobUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", blobUriBuilder.Scheme);
@@ -159,7 +159,7 @@ namespace Azure.Storage.Blobs.Test
 
             // Act
             var blobUriBuilder = new BlobUriBuilder(originalUri.Uri);
-            Uri newUri = blobUriBuilder.Uri;
+            Uri newUri = blobUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", blobUriBuilder.Scheme);
@@ -195,7 +195,7 @@ namespace Azure.Storage.Blobs.Test
 
             // Act
             var blobUriBuilder = new BlobUriBuilder(originalUri.Uri);
-            Uri newUri = blobUriBuilder.Uri;
+            Uri newUri = blobUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", blobUriBuilder.Scheme);
@@ -220,7 +220,7 @@ namespace Azure.Storage.Blobs.Test
 
             // Act
             var blobUriBuilder = new BlobUriBuilder(originalUri.Uri);
-            Uri newUri = blobUriBuilder.Uri;
+            Uri newUri = blobUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", blobUriBuilder.Scheme);
@@ -245,7 +245,7 @@ namespace Azure.Storage.Blobs.Test
 
             // Act
             var blobUriBuilder = new BlobUriBuilder(originalUri.Uri);
-            Uri newUri = blobUriBuilder.Uri;
+            Uri newUri = blobUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", blobUriBuilder.Scheme);
@@ -270,7 +270,7 @@ namespace Azure.Storage.Blobs.Test
 
             // Act
             var blobUriBuilder = new BlobUriBuilder(originalUri.Uri);
-            Uri newUri = blobUriBuilder.Uri;
+            Uri newUri = blobUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", blobUriBuilder.Scheme);
@@ -295,7 +295,7 @@ namespace Azure.Storage.Blobs.Test
 
             // Act
             var blobUriBuilder = new BlobUriBuilder(originalUri.Uri);
-            Uri newUri = blobUriBuilder.Uri;
+            Uri newUri = blobUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", blobUriBuilder.Scheme);
@@ -320,7 +320,7 @@ namespace Azure.Storage.Blobs.Test
 
             // Act
             var blobUriBuilder = new BlobUriBuilder(originalUri.Uri);
-            Uri newUri = blobUriBuilder.Uri;
+            Uri newUri = blobUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", blobUriBuilder.Scheme);

--- a/sdk/storage/Azure.Storage.Files/BreakingChanges.txt
+++ b/sdk/storage/Azure.Storage.Files/BreakingChanges.txt
@@ -1,5 +1,8 @@
 Breaking Changes
 ================
+Next Release
+--------------------------
+- Removing Uri property from FileUriBuilder and replacing with a ToUri method that returns the Uri.
 
 12.0.0-preview.1 (2019-07)
 --------------------------

--- a/sdk/storage/Azure.Storage.Files/src/DirectoryClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/DirectoryClient.cs
@@ -151,7 +151,7 @@ namespace Azure.Storage.Files
                     ShareName = shareName,
                     DirectoryOrFilePath = directoryPath
                 };
-            _uri = builder.Uri;
+            _uri = builder.ToUri();
             _pipeline = (options ?? new FileClientOptions()).Build(conn.Credentials);
         }
 

--- a/sdk/storage/Azure.Storage.Files/src/FileClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/FileClient.cs
@@ -165,7 +165,7 @@ namespace Azure.Storage.Files
                     ShareName = shareName,
                     DirectoryOrFilePath = filePath
                 };
-            _uri = builder.Uri;
+            _uri = builder.ToUri();
             _pipeline = (options ?? new FileClientOptions()).Build(conn.Credentials);
         }
 
@@ -267,7 +267,7 @@ namespace Azure.Storage.Files
         public virtual FileClient WithSnapshot(string shareSnapshot)
         {
             var builder = new FileUriBuilder(Uri) { Snapshot = shareSnapshot };
-            return new FileClient(builder.Uri, Pipeline);
+            return new FileClient(builder.ToUri(), Pipeline);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Files/src/FileUriBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files/src/FileUriBuilder.cs
@@ -221,20 +221,17 @@ namespace Azure.Storage.Files
         }
 
         /// <summary>
-        /// Gets a <see cref="System.Uri"/> representing the
-        /// <see cref="FileUriBuilder"/>'s fields.   The <see cref="Uri.Query"/>
-        /// property contains the SAS, snapshot, and additional query parameters.
+        /// Returns the <see cref="System.Uri"/> constructed from the
+        /// <see cref="FileUriBuilder"/>'s fields. The <see cref="Uri.Query"/>
+        /// property contains the SAS and additional query parameters.
         /// </summary>
-        public Uri Uri
+        public Uri ToUri()
         {
-            get
+            if (_uri == null)
             {
-                if (_uri == null)
-                {
-                    _uri = BuildUri().ToUri();
-                }
-                return _uri;
+                _uri = BuildUri().ToUri();
             }
+            return _uri;
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Files/src/ShareClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/ShareClient.cs
@@ -129,7 +129,7 @@ namespace Azure.Storage.Files
         {
             var conn = StorageConnectionString.Parse(connectionString);
             var builder = new FileUriBuilder(conn.FileEndpoint) { ShareName = shareName };
-            _uri = builder.Uri;
+            _uri = builder.ToUri();
             _pipeline = (options ?? new FileClientOptions()).Build(conn.Credentials);
         }
 
@@ -231,7 +231,7 @@ namespace Azure.Storage.Files
         public virtual ShareClient WithSnapshot(string snapshot)
         {
             var p = new FileUriBuilder(Uri) { Snapshot = snapshot };
-            return new ShareClient(p.Uri, Pipeline);
+            return new ShareClient(p.ToUri(), Pipeline);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Files/tests/FileUriBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files/tests/FileUriBuilderTests.cs
@@ -24,7 +24,7 @@ namespace Azure.Storage.Files.Test
             FileServiceClient serviceUri = GetServiceClient_AccountSas();
             var blobUriBuilder = new FileUriBuilder(serviceUri.Uri);
 
-            Uri blobUri = blobUriBuilder.Uri;
+            Uri blobUri = blobUriBuilder.ToUri();
 
             var expectedUri = WebUtility.UrlDecode(serviceUri.Uri.AbsoluteUri);
             var actualUri = WebUtility.UrlDecode(blobUri.AbsoluteUri);
@@ -41,7 +41,7 @@ namespace Azure.Storage.Files.Test
 
             // Act
             var fileUriBuilder = new FileUriBuilder(originalUri.Uri);
-            Uri newUri = fileUriBuilder.Uri;
+            Uri newUri = fileUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", fileUriBuilder.Scheme);
@@ -64,7 +64,7 @@ namespace Azure.Storage.Files.Test
 
             // Act
             var fileUriBuilder = new FileUriBuilder(originalUri.Uri);
-            Uri newUri = fileUriBuilder.Uri;
+            Uri newUri = fileUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", fileUriBuilder.Scheme);
@@ -88,7 +88,7 @@ namespace Azure.Storage.Files.Test
 
             // Act
             var fileUriBuilder = new FileUriBuilder(originalUri.Uri);
-            Uri newUri = fileUriBuilder.Uri;
+            Uri newUri = fileUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", fileUriBuilder.Scheme);
@@ -125,7 +125,7 @@ namespace Azure.Storage.Files.Test
 
             // Act
             var fileUriBuilder = new FileUriBuilder(originalUri.Uri);
-            Uri newUri = fileUriBuilder.Uri;
+            Uri newUri = fileUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", fileUriBuilder.Scheme);
@@ -148,7 +148,7 @@ namespace Azure.Storage.Files.Test
 
             // Act
             var fileUriBuilder = new FileUriBuilder(originalUri.Uri);
-            Uri newUri = fileUriBuilder.Uri;
+            Uri newUri = fileUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", fileUriBuilder.Scheme);

--- a/sdk/storage/Azure.Storage.Queues/BreakingChanges.txt
+++ b/sdk/storage/Azure.Storage.Queues/BreakingChanges.txt
@@ -1,5 +1,8 @@
 Breaking Changes
 ================
+Next Release
+--------------------------
+- Removing Uri property from QueueUriBuilder and replacing with a ToUri method that returns the Uri.
 
 12.0.0-preview.1 (2019-07)
 --------------------------

--- a/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
@@ -150,7 +150,7 @@ namespace Azure.Storage.Queues
                 {
                     QueueName = queueName
                 };
-            _uri = builder.Uri;
+            _uri = builder.ToUri();
             _messagesUri = _uri.AppendToPath(Constants.Queue.MessagesUri);
             options ??= new QueueClientOptions();
             _pipeline = options.Build(conn.Credentials);

--- a/sdk/storage/Azure.Storage.Queues/src/QueueUriBuilder.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueUriBuilder.cs
@@ -207,20 +207,17 @@ namespace Azure.Storage.Queues
         }
 
         /// <summary>
-        /// Gets a <see cref="System.Uri"/> representing the
+        /// Returns the <see cref="System.Uri"/> constructed from the
         /// <see cref="QueueUriBuilder"/>'s fields. The <see cref="Uri.Query"/>
         /// property contains the SAS and additional query parameters.
         /// </summary>
-        public Uri Uri
+        public Uri ToUri()
         {
-            get
+            if (_uri == null)
             {
-                if (_uri == null)
-                {
-                    _uri = BuildUri().ToUri();
-                }
-                return _uri;
+                _uri = BuildUri().ToUri();
             }
+            return _uri;
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueUriBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueUriBuilderTests.cs
@@ -24,7 +24,7 @@ namespace Azure.Storage.Queues.Test
 
             // Act
             var queueUriBuilder = new QueueUriBuilder(originalUri.Uri);
-            Uri newUri = queueUriBuilder.Uri;
+            Uri newUri = queueUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", queueUriBuilder.Scheme);
@@ -49,7 +49,7 @@ namespace Azure.Storage.Queues.Test
 
             // Act
             var queueUriBuilder = new QueueUriBuilder(originalUri.Uri);
-            Uri newUri = queueUriBuilder.Uri;
+            Uri newUri = queueUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", queueUriBuilder.Scheme);
@@ -74,7 +74,7 @@ namespace Azure.Storage.Queues.Test
 
             // Act
             var queueUriBuilder = new QueueUriBuilder(originalUri.Uri);
-            Uri newUri = queueUriBuilder.Uri;
+            Uri newUri = queueUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", queueUriBuilder.Scheme);
@@ -99,7 +99,7 @@ namespace Azure.Storage.Queues.Test
 
             // Act
             var queueUriBuilder = new QueueUriBuilder(originalUri.Uri);
-            Uri newUri = queueUriBuilder.Uri;
+            Uri newUri = queueUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", queueUriBuilder.Scheme);
@@ -124,7 +124,7 @@ namespace Azure.Storage.Queues.Test
 
             // Act
             var queueUriBuilder = new QueueUriBuilder(originalUri.Uri);
-            Uri newUri = queueUriBuilder.Uri;
+            Uri newUri = queueUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", queueUriBuilder.Scheme);
@@ -149,7 +149,7 @@ namespace Azure.Storage.Queues.Test
 
             // Act
             var queueUriBuilder = new QueueUriBuilder(originalUri.Uri);
-            Uri newUri = queueUriBuilder.Uri;
+            Uri newUri = queueUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", queueUriBuilder.Scheme);
@@ -186,7 +186,7 @@ namespace Azure.Storage.Queues.Test
 
             // Act
             var queueUriBuilder = new QueueUriBuilder(originalUri.Uri);
-            Uri newUri = queueUriBuilder.Uri;
+            Uri newUri = queueUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", queueUriBuilder.Scheme);
@@ -211,7 +211,7 @@ namespace Azure.Storage.Queues.Test
 
             // Act
             var queueUriBuilder = new QueueUriBuilder(originalUri.Uri);
-            Uri newUri = queueUriBuilder.Uri;
+            Uri newUri = queueUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", queueUriBuilder.Scheme);
@@ -236,7 +236,7 @@ namespace Azure.Storage.Queues.Test
 
             // Act
             var queueUriBuilder = new QueueUriBuilder(originalUri.Uri);
-            Uri newUri = queueUriBuilder.Uri;
+            Uri newUri = queueUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", queueUriBuilder.Scheme);
@@ -261,7 +261,7 @@ namespace Azure.Storage.Queues.Test
 
             // Act
             var queueUriBuilder = new QueueUriBuilder(originalUri.Uri);
-            Uri newUri = queueUriBuilder.Uri;
+            Uri newUri = queueUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", queueUriBuilder.Scheme);
@@ -286,7 +286,7 @@ namespace Azure.Storage.Queues.Test
 
             // Act
             var queueUriBuilder = new QueueUriBuilder(originalUri.Uri);
-            Uri newUri = queueUriBuilder.Uri;
+            Uri newUri = queueUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", queueUriBuilder.Scheme);
@@ -311,7 +311,7 @@ namespace Azure.Storage.Queues.Test
 
             // Act
             var queueUriBuilder = new QueueUriBuilder(originalUri.Uri);
-            Uri newUri = queueUriBuilder.Uri;
+            Uri newUri = queueUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", queueUriBuilder.Scheme);
@@ -336,7 +336,7 @@ namespace Azure.Storage.Queues.Test
 
             // Act
             var queueUriBuilder = new QueueUriBuilder(originalUri.Uri);
-            Uri newUri = queueUriBuilder.Uri;
+            Uri newUri = queueUriBuilder.ToUri();
 
             // Assert
             Assert.AreEqual("https", queueUriBuilder.Scheme);


### PR DESCRIPTION
This mirrors the changes being made to RequestUriBuilder in https://github.com/Azure/azure-sdk-for-net/pull/7747#event-2659698079

We are not doing the Assign method and will continue to have the Uri passed in in the ctors.