### PR TITLE
Added a default setting for handling case sensitivity and set this to…

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/AzureStorageCheckpointLeaseManager.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/AzureStorageCheckpointLeaseManager.cs
@@ -96,7 +96,19 @@ namespace Microsoft.Azure.EventHubs.Processor
             };
 
             this.eventHubContainer = storageClient.GetContainerReference(this.leaseContainerName);
-            this.consumerGroupDirectory = this.eventHubContainer.GetDirectoryReference(this.storageBlobPrefix + this.host.ConsumerGroupName);
+            this.consumerGroupDirectory = GetConsumerGroupDirectory(this.host.ConsumerGroupNameInStorageCaseSensitive, this.storageBlobPrefix, this.host.ConsumerGroupName);
+        }
+
+        private CloudBlobDirectory GetConsumerGroupDirectory(bool consumerGroupNameInStorageCaseSensitive, string storageBlobPrefix, string consumerGroupName)
+        {
+            if (consumerGroupNameInStorageCaseSensitive)
+            {
+                return this.eventHubContainer.GetDirectoryReference(storageBlobPrefix + consumerGroupName);
+            }
+            else
+            {
+                return this.eventHubContainer.GetDirectoryReference(storageBlobPrefix + consumerGroupName.ToLower());
+            }
         }
 
         //
@@ -139,7 +151,7 @@ namespace Microsoft.Azure.EventHubs.Processor
 
         public async Task UpdateCheckpointAsync(Lease lease, Checkpoint checkpoint)
         {
-            AzureBlobLease newLease = new AzureBlobLease((AzureBlobLease) lease)
+            AzureBlobLease newLease = new AzureBlobLease((AzureBlobLease)lease)
             {
                 Offset = checkpoint.Offset,
                 SequenceNumber = checkpoint.SequenceNumber

--- a/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/EventProcessorHost.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/EventProcessorHost.cs
@@ -88,17 +88,19 @@ namespace Microsoft.Azure.EventHubs.Processor
         /// </summary>
         /// <param name="hostName">Name of the processor host. MUST BE UNIQUE. Strongly recommend including a Guid to ensure uniqueness.</param>
         /// <param name="eventHubPath">The name of the EventHub.</param>
-        /// <param name="consumerGroupName">The name of the consumer group within the Event Hub.</param>
+        /// <param name="consumerGroupName">The name of the consumer group within the Event Hub.</param>        
         /// <param name="eventHubConnectionString">Connection string for the Event Hub to receive from.</param>
         /// <param name="checkpointManager">Object implementing ICheckpointManager which handles partition checkpointing.</param>
         /// <param name="leaseManager">Object implementing ILeaseManager which handles leases for partitions.</param>
+        /// <param name="consumerGroupNameInStorageCaseSensitive">Flag for setting case sensitivity og storage for lease manager.</param>
         public EventProcessorHost(
              string hostName,
              string eventHubPath,
              string consumerGroupName,
              string eventHubConnectionString,
              ICheckpointManager checkpointManager,
-             ILeaseManager leaseManager)
+             ILeaseManager leaseManager,
+             bool consumerGroupNameInStorageCaseSensitive = true)
         {
             Guard.ArgumentNotNullOrWhiteSpace(nameof(hostName), hostName);
             Guard.ArgumentNotNullOrWhiteSpace(nameof(consumerGroupName), consumerGroupName);
@@ -138,6 +140,7 @@ namespace Microsoft.Azure.EventHubs.Processor
             this.OperationTimeout = csb.OperationTimeout;
             this.EndpointAddress = csb.Endpoint;
             this.PartitionManager = new PartitionManager(this);
+            this.ConsumerGroupNameInStorageCaseSensitive = consumerGroupNameInStorageCaseSensitive;
             ProcessorEventSource.Log.EventProcessorHostCreated(this.HostName, this.EventHubPath);
         }
 
@@ -336,6 +339,11 @@ namespace Microsoft.Azure.EventHubs.Processor
         /// Gets the consumer group name.
         /// </summary>
         public string ConsumerGroupName { get; }
+
+        /// <summary>
+        /// Get the case insenitivite settings of the storage for storing 
+        /// </summary>
+        public bool ConsumerGroupNameInStorageCaseSensitive { get; }
 
         /// <summary>
         /// Gets the event endpoint URI.


### PR DESCRIPTION
… true.

Used this setting in LeaseManager to make sure this bubles through, and if false then using .ToLower().

This will fix #7783, but is also backwards compatible and no breaking change given the eventhub is initiated and kept running with same flag. Default behaviour is as now.