### PR TITLE
IKeyEncryptionKey::KeyId type Uri => string

### DIFF
--- a/sdk/core/Azure.Core/src/Cryptography/IKeyEncryptionKey.cs
+++ b/sdk/core/Azure.Core/src/Cryptography/IKeyEncryptionKey.cs
@@ -15,7 +15,7 @@ namespace Azure.Core.Cryptography
         /// <summary>
         /// The Id of the key used to perform cryptographic operations for the client.
         /// </summary>
-        Uri KeyId { get; }
+        string KeyId { get; }
 
         /// <summary>
         /// Encrypts the specified key using the specified algorithm

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/CryptographyClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/CryptographyClient.cs
@@ -97,7 +97,12 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
         /// <summary>
         /// The <see cref="Key.Id"/> of the key used to perform cryptographic operations for the client.
         /// </summary>
-        public string KeyId => _keyId.ToString();
+        public Uri KeyId => _keyId;
+
+        /// <summary>
+        /// The Id of the key used to perform cryptographic operations for the client.
+        /// </summary>
+        string IKeyEncryptionKey.KeyId => _keyId.ToString();
 
         /// <summary>
         /// Encrypts the specified plain text.

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/CryptographyClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/CryptographyClient.cs
@@ -97,7 +97,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
         /// <summary>
         /// The <see cref="Key.Id"/> of the key used to perform cryptographic operations for the client.
         /// </summary>
-        public Uri KeyId => _keyId;
+        public string KeyId => _keyId.ToString();
 
         /// <summary>
         /// Encrypts the specified plain text.

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/CryptographyClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/CryptographyClient.cs
@@ -97,12 +97,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
         /// <summary>
         /// The <see cref="Key.Id"/> of the key used to perform cryptographic operations for the client.
         /// </summary>
-        public Uri KeyId => _keyId;
-
-        /// <summary>
-        /// The Id of the key used to perform cryptographic operations for the client.
-        /// </summary>
-        string IKeyEncryptionKey.KeyId => _keyId.ToString();
+        public string KeyId => _keyId.ToString();
 
         /// <summary>
         /// Encrypts the specified plain text.


### PR DESCRIPTION
Storage previously supported providers using any string as a key id. Type must be relaxed from Uri back to string to be compatible with data already in storage.