### PR TITLE
[Event Hubs Client] Track Two: Fourth Preview (DateTimeOffset Parsing)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubConsumer.cs
@@ -127,8 +127,8 @@ namespace Azure.Messaging.EventHubs.Compatibility
                     LastEnqueuedEventInformation.UpdateMetrics(
                         TrackOneReceiver.RuntimeInfo.LastSequenceNumber,
                         ((parsedOffset >= 0) ? parsedOffset : default(long?)),
-                        TrackOneReceiver.RuntimeInfo.LastEnqueuedTimeUtc,
-                        TrackOneReceiver.RuntimeInfo.RetrievalTime);
+                        ((TrackOneReceiver.RuntimeInfo.LastEnqueuedTimeUtc == DateTime.MinValue) ? default(DateTimeOffset?) : new DateTimeOffset(TrackOneReceiver.RuntimeInfo.LastEnqueuedTimeUtc)),
+                        ((TrackOneReceiver.RuntimeInfo.RetrievalTime == DateTime.MinValue) ? default(DateTimeOffset?) : new DateTimeOffset(TrackOneReceiver.RuntimeInfo.RetrievalTime)));
                 }
 
                 return events;


### PR DESCRIPTION
# Summary

The intent of these changes is to fix a parsing error in translation for the last tracked event data in which  `DateTime.MinValue` was not being properly translated to `null` and was causing an error for some time zones.

# Last Upstream Rebase

Monday, September 30, 2019 11:48am (EDT)

# Related and Follow-Up Issues

- [Consumer EventData does not work if system time isn't UTC](https://github.com/Azure/azure-sdk-for-net/issues/7708) (#7708)  