### PR TITLE
Move BlobDownloadProperties back into a namespace

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/Models/BlobInfo.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/BlobInfo.cs
@@ -79,7 +79,6 @@ namespace Azure.Storage.Blobs.Models
             GC.SuppressFinalize(this);
         }
     }
-}
 
     /// <summary>
     /// Properties returned when downloading a Blob
@@ -214,78 +213,79 @@ namespace Azure.Storage.Blobs.Models
 #pragma warning restore CA1819 // Properties should not return arrays
     }
 
-/// <summary>
-/// BlobsModelFactory provides utilities for mocking.
-/// </summary>
-public static partial class BlobsModelFactory
-{
     /// <summary>
-    /// Creates a new BlobDownloadInfo instance for mocking.
+    /// BlobsModelFactory provides utilities for mocking.
     /// </summary>
-    public static BlobDownloadInfo BlobDownloadInfo(
-        System.DateTimeOffset lastModified = default,
-        long blobSequenceNumber = default,
-        Azure.Storage.Blobs.Models.BlobType blobType = default,
-        byte[] contentCrc64 = default,
-        string contentLanguage = default,
-        string copyStatusDescription = default,
-        string copyId = default,
-        string copyProgress = default,
-        System.Uri copySource = default,
-        Azure.Storage.Blobs.Models.CopyStatus copyStatus = default,
-        string contentDisposition = default,
-        Azure.Storage.Blobs.Models.LeaseDurationType leaseDuration = default,
-        string cacheControl = default,
-        Azure.Storage.Blobs.Models.LeaseState leaseState = default,
-        string contentEncoding = default,
-        Azure.Storage.Blobs.Models.LeaseStatus leaseStatus = default,
-        byte[] contentHash = default,
-        string acceptRanges = default,
-        Azure.Core.Http.ETag eTag = default,
-        int blobCommittedBlockCount = default,
-        string contentRange = default,
-        bool isServerEncrypted = default,
-        string contentType = default,
-        string encryptionKeySha256 = default,
-        long contentLength = default,
-        byte[] blobContentHash = default,
-        System.Collections.Generic.IDictionary<string, string> metadata = default,
-        System.IO.Stream content = default,
-        System.DateTimeOffset copyCompletionTime = default)
+    public static partial class BlobsModelFactory
     {
-        return new BlobDownloadInfo(
-            new FlattenedDownloadProperties()
-            {
-                LastModified = lastModified,
-                BlobSequenceNumber = blobSequenceNumber,
-                BlobType = blobType,
-                ContentCrc64 = contentCrc64,
-                ContentLanguage = contentLanguage,
-                CopyStatusDescription = copyStatusDescription,
-                CopyId = copyId,
-                CopyProgress = copyProgress,
-                CopySource = copySource,
-                CopyStatus = copyStatus,
-                ContentDisposition = contentDisposition,
-                LeaseDuration = leaseDuration,
-                CacheControl = cacheControl,
-                LeaseState = leaseState,
-                ContentEncoding = contentEncoding,
-                LeaseStatus = leaseStatus,
-                ContentHash = contentHash,
-                AcceptRanges = acceptRanges,
-                ETag = eTag,
-                BlobCommittedBlockCount = blobCommittedBlockCount,
-                ContentRange = contentRange,
-                IsServerEncrypted = isServerEncrypted,
-                ContentType = contentType,
-                EncryptionKeySha256 = encryptionKeySha256,
-                ContentLength = contentLength,
-                BlobContentHash = blobContentHash,
-                Metadata = metadata,
-                Content = content,
-                CopyCompletionTime = copyCompletionTime
-            }
-        );
+        /// <summary>
+        /// Creates a new BlobDownloadInfo instance for mocking.
+        /// </summary>
+        public static BlobDownloadInfo BlobDownloadInfo(
+            System.DateTimeOffset lastModified = default,
+            long blobSequenceNumber = default,
+            Azure.Storage.Blobs.Models.BlobType blobType = default,
+            byte[] contentCrc64 = default,
+            string contentLanguage = default,
+            string copyStatusDescription = default,
+            string copyId = default,
+            string copyProgress = default,
+            System.Uri copySource = default,
+            Azure.Storage.Blobs.Models.CopyStatus copyStatus = default,
+            string contentDisposition = default,
+            Azure.Storage.Blobs.Models.LeaseDurationType leaseDuration = default,
+            string cacheControl = default,
+            Azure.Storage.Blobs.Models.LeaseState leaseState = default,
+            string contentEncoding = default,
+            Azure.Storage.Blobs.Models.LeaseStatus leaseStatus = default,
+            byte[] contentHash = default,
+            string acceptRanges = default,
+            Azure.Core.Http.ETag eTag = default,
+            int blobCommittedBlockCount = default,
+            string contentRange = default,
+            bool isServerEncrypted = default,
+            string contentType = default,
+            string encryptionKeySha256 = default,
+            long contentLength = default,
+            byte[] blobContentHash = default,
+            System.Collections.Generic.IDictionary<string, string> metadata = default,
+            System.IO.Stream content = default,
+            System.DateTimeOffset copyCompletionTime = default)
+        {
+            return new BlobDownloadInfo(
+                new FlattenedDownloadProperties()
+                {
+                    LastModified = lastModified,
+                    BlobSequenceNumber = blobSequenceNumber,
+                    BlobType = blobType,
+                    ContentCrc64 = contentCrc64,
+                    ContentLanguage = contentLanguage,
+                    CopyStatusDescription = copyStatusDescription,
+                    CopyId = copyId,
+                    CopyProgress = copyProgress,
+                    CopySource = copySource,
+                    CopyStatus = copyStatus,
+                    ContentDisposition = contentDisposition,
+                    LeaseDuration = leaseDuration,
+                    CacheControl = cacheControl,
+                    LeaseState = leaseState,
+                    ContentEncoding = contentEncoding,
+                    LeaseStatus = leaseStatus,
+                    ContentHash = contentHash,
+                    AcceptRanges = acceptRanges,
+                    ETag = eTag,
+                    BlobCommittedBlockCount = blobCommittedBlockCount,
+                    ContentRange = contentRange,
+                    IsServerEncrypted = isServerEncrypted,
+                    ContentType = contentType,
+                    EncryptionKeySha256 = encryptionKeySha256,
+                    ContentLength = contentLength,
+                    BlobContentHash = blobContentHash,
+                    Metadata = metadata,
+                    Content = content,
+                    CopyCompletionTime = copyCompletionTime
+                }
+            );
+        }
     }
 }


### PR DESCRIPTION
Something went terribly wrong during the last big file shuffle.  Fix #7839
