### PR TITLE
Make Response<T> abstract

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample8_MockClient.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample8_MockClient.cs
@@ -19,7 +19,7 @@ namespace Azure.Data.AppConfiguration.Samples
             var mock = new Mock<ConfigurationClient>();
             // Setup client method
             mock.Setup(c => c.Get("Key", It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
-                .Returns(new Response<ConfigurationSetting>(mockResponse.Object, ConfigurationModelFactory.ConfigurationSetting("Key", "Value")));
+                .Returns(mockResponse.Object.WithValue(ConfigurationModelFactory.ConfigurationSetting("Key", "Value")));
 
             // Use the client mock
             ConfigurationClient client = mock.Object;

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample8_MockClient.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample8_MockClient.cs
@@ -19,7 +19,7 @@ namespace Azure.Data.AppConfiguration.Samples
             var mock = new Mock<ConfigurationClient>();
             // Setup client method
             mock.Setup(c => c.Get("Key", It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
-                .Returns(mockResponse.Object.WithValue(ConfigurationModelFactory.ConfigurationSetting("Key", "Value")));
+                .Returns(Response.FromValue(mockResponse.Object, ConfigurationModelFactory.ConfigurationSetting("Key", "Value")));
 
             // Use the client mock
             ConfigurationClient client = mock.Object;

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
@@ -687,7 +687,7 @@ namespace Azure.Data.AppConfiguration
                             etag = etag.Trim('\"');
                         }
 
-                        return new Response<bool>(response, setting.ETag != new ETag(etag));
+                        return response.WithValue(setting.ETag != new ETag(etag));
 
                     default:
                         throw await response.CreateRequestFailedExceptionAsync().ConfigureAwait(false);
@@ -727,7 +727,7 @@ namespace Azure.Data.AppConfiguration
                                 etag = etag.Trim('\"');
                             }
 
-                            return new Response<bool>(response, setting.ETag != new ETag(etag));
+                            return response.WithValue(setting.ETag != new ETag(etag));
 
                         default:
                             throw response.CreateRequestFailedException();

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
@@ -687,7 +687,7 @@ namespace Azure.Data.AppConfiguration
                             etag = etag.Trim('\"');
                         }
 
-                        return response.WithValue(setting.ETag != new ETag(etag));
+                        return Response.FromValue(response, setting.ETag != new ETag(etag));
 
                     default:
                         throw await response.CreateRequestFailedExceptionAsync().ConfigureAwait(false);
@@ -727,7 +727,7 @@ namespace Azure.Data.AppConfiguration
                                 etag = etag.Trim('\"');
                             }
 
-                            return response.WithValue(setting.ETag != new ETag(etag));
+                            return Response.FromValue(response, setting.ETag != new ETag(etag));
 
                         default:
                             throw response.CreateRequestFailedException();

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient_private.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient_private.cs
@@ -37,12 +37,12 @@ namespace Azure.Data.AppConfiguration
         private static async Task<Response<ConfigurationSetting>> CreateResponseAsync(Response response, CancellationToken cancellation)
         {
             ConfigurationSetting result = await ConfigurationServiceSerializer.DeserializeSettingAsync(response.ContentStream, cancellation).ConfigureAwait(false);
-            return response.WithValue(result);
+            return Response.FromValue(response, result);
         }
 
         private static Response<ConfigurationSetting> CreateResponse(Response response)
         {
-            return response.WithValue(ConfigurationServiceSerializer.DeserializeSetting(response.ContentStream));
+            return Response.FromValue(response, ConfigurationServiceSerializer.DeserializeSetting(response.ContentStream));
         }
 
         private static void ParseConnectionString(string connectionString, out Uri uri, out string credential, out byte[] secret)

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient_private.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient_private.cs
@@ -37,12 +37,12 @@ namespace Azure.Data.AppConfiguration
         private static async Task<Response<ConfigurationSetting>> CreateResponseAsync(Response response, CancellationToken cancellation)
         {
             ConfigurationSetting result = await ConfigurationServiceSerializer.DeserializeSettingAsync(response.ContentStream, cancellation).ConfigureAwait(false);
-            return new Response<ConfigurationSetting>(response, result);
+            return response.WithValue(result);
         }
 
         private static Response<ConfigurationSetting> CreateResponse(Response response)
         {
-            return new Response<ConfigurationSetting>(response, ConfigurationServiceSerializer.DeserializeSetting(response.ContentStream));
+            return response.WithValue(ConfigurationServiceSerializer.DeserializeSetting(response.ContentStream));
         }
 
         private static void ParseConnectionString(string connectionString, out Uri uri, out string credential, out byte[] secret)

--- a/sdk/core/Azure.Core/src/AsyncCollection.cs
+++ b/sdk/core/Azure.Core/src/AsyncCollection.cs
@@ -73,7 +73,7 @@ namespace Azure
             {
                 foreach (T value in page.Values)
                 {
-                    yield return new Response<T>(page.GetRawResponse(), value);
+                    yield return page.GetRawResponse().WithValue(value);
                 }
             }
         }

--- a/sdk/core/Azure.Core/src/AsyncCollection.cs
+++ b/sdk/core/Azure.Core/src/AsyncCollection.cs
@@ -73,7 +73,7 @@ namespace Azure
             {
                 foreach (T value in page.Values)
                 {
-                    yield return page.GetRawResponse().WithValue(value);
+                    yield return Response.FromValue(page.GetRawResponse(), value);
                 }
             }
         }

--- a/sdk/core/Azure.Core/src/Operation{T}.cs
+++ b/sdk/core/Azure.Core/src/Operation{T}.cs
@@ -102,7 +102,7 @@ namespace Azure
                 await UpdateStatusAsync(cancellationToken).ConfigureAwait(false);
                 if (HasCompleted)
                 {
-                    return new Response<T>(_response, Value);
+                    return _response.WithValue(Value);
                 }
                 await Task.Delay(PollingInterval, cancellationToken).ConfigureAwait(false);
             }

--- a/sdk/core/Azure.Core/src/Operation{T}.cs
+++ b/sdk/core/Azure.Core/src/Operation{T}.cs
@@ -102,7 +102,7 @@ namespace Azure
                 await UpdateStatusAsync(cancellationToken).ConfigureAwait(false);
                 if (HasCompleted)
                 {
-                    return _response.WithValue(Value);
+                    return Response.FromValue(_response, Value);
                 }
                 await Task.Delay(PollingInterval, cancellationToken).ConfigureAwait(false);
             }

--- a/sdk/core/Azure.Core/src/Response.cs
+++ b/sdk/core/Azure.Core/src/Response.cs
@@ -31,5 +31,9 @@ namespace Azure
 
         protected internal abstract IEnumerable<HttpHeader> EnumerateHeaders();
 
+        public Response<T> WithValue<T>(T value)
+        {
+            return new ValueResponse<T>(this, value);
+        }
     }
 }

--- a/sdk/core/Azure.Core/src/Response.cs
+++ b/sdk/core/Azure.Core/src/Response.cs
@@ -31,9 +31,9 @@ namespace Azure
 
         protected internal abstract IEnumerable<HttpHeader> EnumerateHeaders();
 
-        public Response<T> WithValue<T>(T value)
+        public static Response<T> FromValue<T>(Response response, T value)
         {
-            return new ValueResponse<T>(this, value);
+            return new ValueResponse<T>(response, value);
         }
     }
 }

--- a/sdk/core/Azure.Core/src/Response{T}.cs
+++ b/sdk/core/Azure.Core/src/Response{T}.cs
@@ -5,19 +5,11 @@ using System.ComponentModel;
 
 namespace Azure
 {
-    public class Response<T>
+    public abstract class Response<T>
     {
-        private readonly Response _rawResponse;
+        public abstract Response GetRawResponse();
 
-        public Response(Response response, T parsed)
-        {
-            _rawResponse = response;
-            Value = parsed;
-        }
-
-        public virtual Response GetRawResponse() => _rawResponse;
-
-        public virtual T Value { get; }
+        public abstract T Value { get; }
 
         public static implicit operator T(Response<T> response) => response.Value;
 

--- a/sdk/core/Azure.Core/src/Shared/PageResponseEnumerator.cs
+++ b/sdk/core/Azure.Core/src/Shared/PageResponseEnumerator.cs
@@ -19,7 +19,7 @@ namespace Azure.Core
                 Page<T> pageResponse = pageFunc(nextLink);
                 foreach (T setting in pageResponse.Values)
                 {
-                    yield return new Response<T>(pageResponse.GetRawResponse(), setting);
+                    yield return pageResponse.GetRawResponse().WithValue(setting);
                 }
                 nextLink = pageResponse.ContinuationToken;
             } while (nextLink != null);

--- a/sdk/core/Azure.Core/src/Shared/PageResponseEnumerator.cs
+++ b/sdk/core/Azure.Core/src/Shared/PageResponseEnumerator.cs
@@ -19,7 +19,7 @@ namespace Azure.Core
                 Page<T> pageResponse = pageFunc(nextLink);
                 foreach (T setting in pageResponse.Values)
                 {
-                    yield return pageResponse.GetRawResponse().WithValue(setting);
+                    yield return Response.FromValue(pageResponse.GetRawResponse(), setting);
                 }
                 nextLink = pageResponse.ContinuationToken;
             } while (nextLink != null);

--- a/sdk/core/Azure.Core/src/ValueResponse.cs
+++ b/sdk/core/Azure.Core/src/ValueResponse.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+namespace Azure
+{
+    internal class ValueResponse<T>: Response<T>
+    {
+        private readonly Response _response;
+
+        public ValueResponse(Response response, T value)
+        {
+            _response = response;
+            Value = value;
+        }
+
+        public override T Value { get; }
+
+        public override Response GetRawResponse() => _response;
+    }
+}

--- a/sdk/core/Azure.Core/src/ValueResponse.cs
+++ b/sdk/core/Azure.Core/src/ValueResponse.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 namespace Azure
 {
     internal class ValueResponse<T>: Response<T>

--- a/sdk/identity/Azure.Identity/src/AadIdentityClient.cs
+++ b/sdk/identity/Azure.Identity/src/AadIdentityClient.cs
@@ -148,7 +148,7 @@ namespace Azure.Identity
             {
                 AccessToken result = await DeserializeAsync(response.ContentStream, cancellationToken).ConfigureAwait(false);
 
-                return new Response<AccessToken>(response, result);
+                return response.WithValue(result);
             }
 
             throw await response.CreateRequestFailedExceptionAsync().ConfigureAwait(false);
@@ -162,7 +162,7 @@ namespace Azure.Identity
             {
                 AccessToken result = Deserialize(response.ContentStream);
 
-                return new Response<AccessToken>(response, result);
+                return response.WithValue(result);
             }
 
             throw response.CreateRequestFailedException();

--- a/sdk/identity/Azure.Identity/src/AadIdentityClient.cs
+++ b/sdk/identity/Azure.Identity/src/AadIdentityClient.cs
@@ -148,7 +148,7 @@ namespace Azure.Identity
             {
                 AccessToken result = await DeserializeAsync(response.ContentStream, cancellationToken).ConfigureAwait(false);
 
-                return response.WithValue(result);
+                return Response.FromValue(response, result);
             }
 
             throw await response.CreateRequestFailedExceptionAsync().ConfigureAwait(false);
@@ -162,7 +162,7 @@ namespace Azure.Identity
             {
                 AccessToken result = Deserialize(response.ContentStream);
 
-                return response.WithValue(result);
+                return Response.FromValue(response, result);
             }
 
             throw response.CreateRequestFailedException();

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateClient.cs
@@ -561,7 +561,7 @@ namespace Azure.Security.KeyVault.Certificates
             {
                 Response<CertificateBackup> backup = _pipeline.SendRequest(RequestMethod.Post, () => new CertificateBackup(), cancellationToken, CertificatesPath, name, "/backup");
 
-                return backup.GetRawResponse().WithValue(backup.Value.Value);
+                return Response.FromValue(backup.GetRawResponse(), backup.Value.Value);
             }
             catch (Exception e)
             {
@@ -589,7 +589,7 @@ namespace Azure.Security.KeyVault.Certificates
             {
                 Response<CertificateBackup> backup = await _pipeline.SendRequestAsync(RequestMethod.Post, () => new CertificateBackup(), cancellationToken, CertificatesPath, name, "/backup").ConfigureAwait(false);
 
-                return backup.GetRawResponse().WithValue(backup.Value.Value);
+                return Response.FromValue(backup.GetRawResponse(), backup.Value.Value);
             }
             catch (Exception e)
             {
@@ -1313,7 +1313,7 @@ namespace Azure.Security.KeyVault.Certificates
             {
                 Response<ContactList> contactList = _pipeline.SendRequest(RequestMethod.Put, new ContactList(contacts), () => new ContactList(), cancellationToken, ContactsPath);
 
-                return contactList.GetRawResponse().WithValue(contactList.Value.ToList());
+                return Response.FromValue(contactList.GetRawResponse(), contactList.Value.ToList());
             }
             catch (Exception e)
             {
@@ -1339,7 +1339,7 @@ namespace Azure.Security.KeyVault.Certificates
             {
                 Response<ContactList> contactList = await _pipeline.SendRequestAsync(RequestMethod.Put, new ContactList(contacts), () => new ContactList(), cancellationToken, ContactsPath).ConfigureAwait(false);
 
-                return contactList.GetRawResponse().WithValue(contactList.Value.ToList());
+                return Response.FromValue(contactList.GetRawResponse(), contactList.Value.ToList());
             }
             catch (Exception e)
             {
@@ -1362,7 +1362,7 @@ namespace Azure.Security.KeyVault.Certificates
             {
                 Response<ContactList> contactList = _pipeline.SendRequest(RequestMethod.Get, () => new ContactList(), cancellationToken, ContactsPath);
 
-                return contactList.GetRawResponse().WithValue(contactList.Value.ToList());
+                return Response.FromValue(contactList.GetRawResponse(), contactList.Value.ToList());
             }
             catch (Exception e)
             {
@@ -1385,7 +1385,7 @@ namespace Azure.Security.KeyVault.Certificates
             {
                 Response<ContactList> contactList = await _pipeline.SendRequestAsync(RequestMethod.Get, () => new ContactList(), cancellationToken, ContactsPath).ConfigureAwait(false);
 
-                return contactList.GetRawResponse().WithValue(contactList.Value.ToList());
+                return Response.FromValue(contactList.GetRawResponse(), contactList.Value.ToList());
             }
             catch (Exception e)
             {
@@ -1408,7 +1408,7 @@ namespace Azure.Security.KeyVault.Certificates
             {
                 Response<ContactList> contactList = _pipeline.SendRequest(RequestMethod.Delete, () => new ContactList(), cancellationToken, ContactsPath);
 
-                return contactList.GetRawResponse().WithValue(contactList.Value.ToList());
+                return Response.FromValue(contactList.GetRawResponse(), contactList.Value.ToList());
             }
             catch (Exception e)
             {
@@ -1431,7 +1431,7 @@ namespace Azure.Security.KeyVault.Certificates
             {
                 Response<ContactList> contactList = await _pipeline.SendRequestAsync(RequestMethod.Delete, () => new ContactList(), cancellationToken, ContactsPath).ConfigureAwait(false);
 
-                return contactList.GetRawResponse().WithValue(contactList.Value.ToList());
+                return Response.FromValue(contactList.GetRawResponse(), contactList.Value.ToList());
             }
             catch (Exception e)
             {

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateClient.cs
@@ -561,7 +561,7 @@ namespace Azure.Security.KeyVault.Certificates
             {
                 Response<CertificateBackup> backup = _pipeline.SendRequest(RequestMethod.Post, () => new CertificateBackup(), cancellationToken, CertificatesPath, name, "/backup");
 
-                return new Response<byte[]>(backup.GetRawResponse(), backup.Value.Value);
+                return backup.GetRawResponse().WithValue(backup.Value.Value);
             }
             catch (Exception e)
             {
@@ -589,7 +589,7 @@ namespace Azure.Security.KeyVault.Certificates
             {
                 Response<CertificateBackup> backup = await _pipeline.SendRequestAsync(RequestMethod.Post, () => new CertificateBackup(), cancellationToken, CertificatesPath, name, "/backup").ConfigureAwait(false);
 
-                return new Response<byte[]>(backup.GetRawResponse(), backup.Value.Value);
+                return backup.GetRawResponse().WithValue(backup.Value.Value);
             }
             catch (Exception e)
             {
@@ -1313,7 +1313,7 @@ namespace Azure.Security.KeyVault.Certificates
             {
                 Response<ContactList> contactList = _pipeline.SendRequest(RequestMethod.Put, new ContactList(contacts), () => new ContactList(), cancellationToken, ContactsPath);
 
-                return new Response<IList<Contact>>(contactList.GetRawResponse(), contactList.Value.ToList());
+                return contactList.GetRawResponse().WithValue(contactList.Value.ToList());
             }
             catch (Exception e)
             {
@@ -1339,7 +1339,7 @@ namespace Azure.Security.KeyVault.Certificates
             {
                 Response<ContactList> contactList = await _pipeline.SendRequestAsync(RequestMethod.Put, new ContactList(contacts), () => new ContactList(), cancellationToken, ContactsPath).ConfigureAwait(false);
 
-                return new Response<IList<Contact>>(contactList.GetRawResponse(), contactList.Value.ToList());
+                return contactList.GetRawResponse().WithValue(contactList.Value.ToList());
             }
             catch (Exception e)
             {
@@ -1362,7 +1362,7 @@ namespace Azure.Security.KeyVault.Certificates
             {
                 Response<ContactList> contactList = _pipeline.SendRequest(RequestMethod.Get, () => new ContactList(), cancellationToken, ContactsPath);
 
-                return new Response<IList<Contact>>(contactList.GetRawResponse(), contactList.Value.ToList());
+                return contactList.GetRawResponse().WithValue(contactList.Value.ToList());
             }
             catch (Exception e)
             {
@@ -1385,7 +1385,7 @@ namespace Azure.Security.KeyVault.Certificates
             {
                 Response<ContactList> contactList = await _pipeline.SendRequestAsync(RequestMethod.Get, () => new ContactList(), cancellationToken, ContactsPath).ConfigureAwait(false);
 
-                return new Response<IList<Contact>>(contactList.GetRawResponse(), contactList.Value.ToList());
+                return contactList.GetRawResponse().WithValue(contactList.Value.ToList());
             }
             catch (Exception e)
             {
@@ -1408,7 +1408,7 @@ namespace Azure.Security.KeyVault.Certificates
             {
                 Response<ContactList> contactList = _pipeline.SendRequest(RequestMethod.Delete, () => new ContactList(), cancellationToken, ContactsPath);
 
-                return new Response<IList<Contact>>(contactList.GetRawResponse(), contactList.Value.ToList());
+                return contactList.GetRawResponse().WithValue(contactList.Value.ToList());
             }
             catch (Exception e)
             {
@@ -1431,7 +1431,7 @@ namespace Azure.Security.KeyVault.Certificates
             {
                 Response<ContactList> contactList = await _pipeline.SendRequestAsync(RequestMethod.Delete, () => new ContactList(), cancellationToken, ContactsPath).ConfigureAwait(false);
 
-                return new Response<IList<Contact>>(contactList.GetRawResponse(), contactList.Value.ToList());
+                return contactList.GetRawResponse().WithValue(contactList.Value.ToList());
             }
             catch (Exception e)
             {

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/KeyResolver.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/KeyResolver.cs
@@ -159,7 +159,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
                 case 202:
                 case 204:
                     result.Deserialize(response.ContentStream);
-                    return response.WithValue(result);
+                    return Response.FromValue(response, result);
                 default:
                     throw response.CreateRequestFailedException();
             }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/KeyResolver.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/KeyResolver.cs
@@ -159,7 +159,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
                 case 202:
                 case 204:
                     result.Deserialize(response.ContentStream);
-                    return new Response<T>(response, result);
+                    return response.WithValue(result);
                 default:
                     throw response.CreateRequestFailedException();
             }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient.cs
@@ -826,7 +826,7 @@ namespace Azure.Security.KeyVault.Keys
             {
                 Response<KeyBackup> backup = _pipeline.SendRequest(RequestMethod.Post, () => new KeyBackup(), cancellationToken, KeysPath, name, "/backup");
 
-                return backup.GetRawResponse().WithValue(backup.Value.Value);
+                return Response.FromValue(backup.GetRawResponse(), backup.Value.Value);
             }
             catch (Exception e)
             {
@@ -870,7 +870,7 @@ namespace Azure.Security.KeyVault.Keys
             {
                 Response<KeyBackup> backup = await _pipeline.SendRequestAsync(RequestMethod.Post, () => new KeyBackup(), cancellationToken, KeysPath, name, "/backup").ConfigureAwait(false);
 
-                return backup.GetRawResponse().WithValue(backup.Value.Value);
+                return Response.FromValue(backup.GetRawResponse(), backup.Value.Value);
             }
             catch (Exception e)
             {

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient.cs
@@ -826,7 +826,7 @@ namespace Azure.Security.KeyVault.Keys
             {
                 Response<KeyBackup> backup = _pipeline.SendRequest(RequestMethod.Post, () => new KeyBackup(), cancellationToken, KeysPath, name, "/backup");
 
-                return new Response<byte[]>(backup.GetRawResponse(), backup.Value.Value);
+                return backup.GetRawResponse().WithValue(backup.Value.Value);
             }
             catch (Exception e)
             {
@@ -870,7 +870,7 @@ namespace Azure.Security.KeyVault.Keys
             {
                 Response<KeyBackup> backup = await _pipeline.SendRequestAsync(RequestMethod.Post, () => new KeyBackup(), cancellationToken, KeysPath, name, "/backup").ConfigureAwait(false);
 
-                return new Response<byte[]>(backup.GetRawResponse(), backup.Value.Value);
+                return backup.GetRawResponse().WithValue(backup.Value.Value);
             }
             catch (Exception e)
             {

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClient.cs
@@ -632,7 +632,7 @@ namespace Azure.Security.KeyVault.Secrets
             {
                 Response<VaultBackup> backup = await _pipeline.SendRequestAsync(RequestMethod.Post, () => new VaultBackup(), cancellationToken, SecretsPath, name, "/backup").ConfigureAwait(false);
 
-                return backup.GetRawResponse().WithValue(backup.Value.Value);
+                return Response.FromValue(backup.GetRawResponse(), backup.Value.Value);
             }
             catch (Exception e)
             {
@@ -663,7 +663,7 @@ namespace Azure.Security.KeyVault.Secrets
             {
                 Response<VaultBackup> backup = _pipeline.SendRequest(RequestMethod.Post, () => new VaultBackup(), cancellationToken, SecretsPath, name, "/backup");
 
-                return backup.GetRawResponse().WithValue(backup.Value.Value);
+                return Response.FromValue(backup.GetRawResponse(), backup.Value.Value);
             }
             catch (Exception e)
             {

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClient.cs
@@ -632,7 +632,7 @@ namespace Azure.Security.KeyVault.Secrets
             {
                 Response<VaultBackup> backup = await _pipeline.SendRequestAsync(RequestMethod.Post, () => new VaultBackup(), cancellationToken, SecretsPath, name, "/backup").ConfigureAwait(false);
 
-                return new Response<byte[]>(backup.GetRawResponse(), backup.Value.Value);
+                return backup.GetRawResponse().WithValue(backup.Value.Value);
             }
             catch (Exception e)
             {
@@ -663,7 +663,7 @@ namespace Azure.Security.KeyVault.Secrets
             {
                 Response<VaultBackup> backup = _pipeline.SendRequest(RequestMethod.Post, () => new VaultBackup(), cancellationToken, SecretsPath, name, "/backup");
 
-                return new Response<byte[]>(backup.GetRawResponse(), backup.Value.Value);
+                return backup.GetRawResponse().WithValue(backup.Value.Value);
             }
             catch (Exception e)
             {

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/KeyVaultPipeline.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/KeyVaultPipeline.cs
@@ -87,7 +87,7 @@ namespace Azure.Security.KeyVault
             where T : IJsonDeserializable
         {
             result.Deserialize(response.ContentStream);
-            return response.WithValue(result);
+            return Response.FromValue(response, result);
         }
 
         public DiagnosticScope CreateScope(string name)

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/KeyVaultPipeline.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/KeyVaultPipeline.cs
@@ -87,7 +87,7 @@ namespace Azure.Security.KeyVault
             where T : IJsonDeserializable
         {
             result.Deserialize(response.ContentStream);
-            return new Response<T>(response, result);
+            return response.WithValue(result);
         }
 
         public DiagnosticScope CreateScope(string name)

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -662,7 +662,7 @@ namespace Azure.Storage.Blobs.Specialized
 
                     // Wrap the FlattenedDownloadProperties into a BlobDownloadOperation
                     // to make the Content easier to find
-                    return new Response<BlobDownloadInfo>(response.GetRawResponse(), new BlobDownloadInfo(response.Value));
+                    return response.GetRawResponse().WithValue(new BlobDownloadInfo(response.Value));
                 }
                 catch (Exception ex)
                 {
@@ -2348,14 +2348,12 @@ namespace Azure.Storage.Blobs.Specialized
                             operationName: "Azure.Storage.Blobs.Specialized.BlobBaseClient.SetHttpHeaders",
                             cancellationToken: cancellationToken)
                             .ConfigureAwait(false);
-                    return new Response<BlobInfo>(
-                        response.GetRawResponse(),
-                        new BlobInfo
-                        {
-                            LastModified = response.Value.LastModified,
-                            ETag = response.Value.ETag,
-                            BlobSequenceNumber = response.Value.BlobSequenceNumber
-                        });
+                    return response.GetRawResponse().WithValue(new BlobInfo
+                    {
+                        LastModified = response.Value.LastModified,
+                        ETag = response.Value.ETag,
+                        BlobSequenceNumber = response.Value.BlobSequenceNumber
+                    });
                 }
                 catch (Exception ex)
                 {
@@ -2505,13 +2503,11 @@ namespace Azure.Storage.Blobs.Specialized
                             operationName: "Azure.Storage.Blobs.Specialized.BlobBaseClient.SetMetadata",
                             cancellationToken: cancellationToken)
                             .ConfigureAwait(false);
-                    return new Response<BlobInfo>(
-                        response.GetRawResponse(),
-                        new BlobInfo
-                        {
-                            LastModified = response.Value.LastModified,
-                            ETag = response.Value.ETag
-                        });
+                    return response.GetRawResponse().WithValue(new BlobInfo
+                    {
+                        LastModified = response.Value.LastModified,
+                        ETag = response.Value.ETag
+                    });
                 }
                 catch (Exception ex)
                 {

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -662,7 +662,7 @@ namespace Azure.Storage.Blobs.Specialized
 
                     // Wrap the FlattenedDownloadProperties into a BlobDownloadOperation
                     // to make the Content easier to find
-                    return response.GetRawResponse().WithValue(new BlobDownloadInfo(response.Value));
+                    return Response.FromValue(response.GetRawResponse(), new BlobDownloadInfo(response.Value));
                 }
                 catch (Exception ex)
                 {
@@ -2348,7 +2348,7 @@ namespace Azure.Storage.Blobs.Specialized
                             operationName: "Azure.Storage.Blobs.Specialized.BlobBaseClient.SetHttpHeaders",
                             cancellationToken: cancellationToken)
                             .ConfigureAwait(false);
-                    return response.GetRawResponse().WithValue(new BlobInfo
+                    return Response.FromValue(response.GetRawResponse(), new BlobInfo
                     {
                         LastModified = response.Value.LastModified,
                         ETag = response.Value.ETag,
@@ -2503,7 +2503,7 @@ namespace Azure.Storage.Blobs.Specialized
                             operationName: "Azure.Storage.Blobs.Specialized.BlobBaseClient.SetMetadata",
                             cancellationToken: cancellationToken)
                             .ConfigureAwait(false);
-                    return response.GetRawResponse().WithValue(new BlobInfo
+                    return Response.FromValue(response.GetRawResponse(), new BlobInfo
                     {
                         LastModified = response.Value.LastModified,
                         ETag = response.Value.ETag

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -674,24 +674,22 @@ namespace Azure.Storage.Blobs
 
                     // Turn the flattened properties into a ContainerItem
                     var uri = new BlobUriBuilder(Uri);
-                    return new Response<ContainerItem>(
-                        response.GetRawResponse(),
-                        new ContainerItem(false)
+                    return response.GetRawResponse().WithValue(new ContainerItem(false)
+                    {
+                        Name = uri.ContainerName,
+                        Metadata = response.Value.Metadata,
+                        Properties = new ContainerProperties()
                         {
-                            Name = uri.ContainerName,
-                            Metadata = response.Value.Metadata,
-                            Properties = new ContainerProperties()
-                            {
-                                LastModified = response.Value.LastModified,
-                                ETag = response.Value.ETag,
-                                LeaseStatus = response.Value.LeaseStatus,
-                                LeaseState = response.Value.LeaseState,
-                                LeaseDuration = response.Value.LeaseDuration,
-                                PublicAccess = response.Value.BlobPublicAccess,
-                                HasImmutabilityPolicy = response.Value.HasImmutabilityPolicy,
-                                HasLegalHold = response.Value.HasLegalHold
-                            }
-                        });
+                            LastModified = response.Value.LastModified,
+                            ETag = response.Value.ETag,
+                            LeaseStatus = response.Value.LeaseStatus,
+                            LeaseState = response.Value.LeaseState,
+                            LeaseDuration = response.Value.LeaseDuration,
+                            PublicAccess = response.Value.BlobPublicAccess,
+                            HasImmutabilityPolicy = response.Value.HasImmutabilityPolicy,
+                            HasLegalHold = response.Value.HasLegalHold
+                        }
+                    });
                 }
                 catch (Exception ex)
                 {

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -674,7 +674,7 @@ namespace Azure.Storage.Blobs
 
                     // Turn the flattened properties into a ContainerItem
                     var uri = new BlobUriBuilder(Uri);
-                    return response.GetRawResponse().WithValue(new ContainerItem(false)
+                    return Response.FromValue(response.GetRawResponse(), new ContainerItem(false)
                     {
                         Name = uri.ContainerName,
                         Metadata = response.Value.Metadata,

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
@@ -1002,7 +1002,7 @@ namespace Azure.Storage.Blobs
         {
             BlobContainerClient container = GetBlobContainerClient(containerName);
             Response<ContainerInfo> response = container.Create(publicAccessType, metadata, cancellationToken);
-            return response.GetRawResponse().WithValue(container);
+            return Response.FromValue(response.GetRawResponse(), container);
         }
 
         /// <summary>
@@ -1052,7 +1052,7 @@ namespace Azure.Storage.Blobs
         {
             BlobContainerClient container = GetBlobContainerClient(containerName);
             Response<ContainerInfo> response = await container.CreateAsync(publicAccessType, metadata, cancellationToken).ConfigureAwait(false);
-            return response.GetRawResponse().WithValue(container);
+            return Response.FromValue(response.GetRawResponse(), container);
         }
         #endregion CreateBlobContainer
 

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
@@ -1002,7 +1002,7 @@ namespace Azure.Storage.Blobs
         {
             BlobContainerClient container = GetBlobContainerClient(containerName);
             Response<ContainerInfo> response = container.Create(publicAccessType, metadata, cancellationToken);
-            return new Response<BlobContainerClient>(response.GetRawResponse(), container);
+            return response.GetRawResponse().WithValue(container);
         }
 
         /// <summary>
@@ -1052,7 +1052,7 @@ namespace Azure.Storage.Blobs
         {
             BlobContainerClient container = GetBlobContainerClient(containerName);
             Response<ContainerInfo> response = await container.CreateAsync(publicAccessType, metadata, cancellationToken).ConfigureAwait(false);
-            return new Response<BlobContainerClient>(response.GetRawResponse(), container);
+            return response.GetRawResponse().WithValue(container);
         }
         #endregion CreateBlobContainer
 

--- a/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
@@ -277,7 +277,7 @@ namespace Azure.Storage.Blobs
                         Azure.Storage.Blobs.Models.BlobServiceProperties _value = Azure.Storage.Blobs.Models.BlobServiceProperties.FromXml(_xml.Root);
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -406,7 +406,7 @@ namespace Azure.Storage.Blobs
                         Azure.Storage.Blobs.Models.BlobServiceStatistics _value = Azure.Storage.Blobs.Models.BlobServiceStatistics.FromXml(_xml.Root);
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -558,7 +558,7 @@ namespace Azure.Storage.Blobs
                         Azure.Storage.Blobs.Models.ContainersSegment _value = Azure.Storage.Blobs.Models.ContainersSegment.FromXml(_xml.Root);
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -703,7 +703,7 @@ namespace Azure.Storage.Blobs
                         Azure.Storage.Blobs.Models.UserDelegationKey _value = Azure.Storage.Blobs.Models.UserDelegationKey.FromXml(_xml.Root);
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -830,7 +830,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -993,7 +993,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -1156,7 +1156,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -1332,7 +1332,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -1635,7 +1635,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -1790,7 +1790,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -1972,7 +1972,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -2140,7 +2140,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -2302,7 +2302,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -2468,7 +2468,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -2630,7 +2630,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -2806,7 +2806,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -2959,7 +2959,7 @@ namespace Azure.Storage.Blobs
                         Azure.Storage.Blobs.Models.BlobsFlatSegment _value = Azure.Storage.Blobs.Models.BlobsFlatSegment.FromXml(_xml.Root);
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -3118,7 +3118,7 @@ namespace Azure.Storage.Blobs
                         Azure.Storage.Blobs.Models.BlobsHierarchySegment _value = Azure.Storage.Blobs.Models.BlobsHierarchySegment.FromXml(_xml.Root);
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -3450,7 +3450,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     case 206:
                     {
@@ -3578,7 +3578,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     case 304:
                     {
@@ -3907,7 +3907,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     case 304:
                     {
@@ -4283,7 +4283,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -4477,7 +4477,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -4742,7 +4742,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -5083,7 +5083,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -5288,7 +5288,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -5467,7 +5467,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -5640,7 +5640,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -5817,7 +5817,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -6004,7 +6004,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -6177,7 +6177,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -6382,7 +6382,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -6614,7 +6614,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -6841,7 +6841,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -7413,7 +7413,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -7670,7 +7670,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -7899,7 +7899,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -8192,7 +8192,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     case 304:
                     {
@@ -8392,7 +8392,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     case 304:
                     {
@@ -8598,7 +8598,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     case 304:
                     {
@@ -8808,7 +8808,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -8992,7 +8992,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -9172,7 +9172,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -9441,7 +9441,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -9693,7 +9693,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -9979,7 +9979,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     case 304:
                     {
@@ -10280,7 +10280,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -10486,7 +10486,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -10720,7 +10720,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     case 304:
                     {
@@ -11023,7 +11023,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -11189,7 +11189,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -11417,7 +11417,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -11692,7 +11692,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -11871,7 +11871,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -12063,7 +12063,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -12257,7 +12257,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {

--- a/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
@@ -277,12 +277,7 @@ namespace Azure.Storage.Blobs
                         Azure.Storage.Blobs.Models.BlobServiceProperties _value = Azure.Storage.Blobs.Models.BlobServiceProperties.FromXml(_xml.Root);
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.BlobServiceProperties> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.BlobServiceProperties>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -411,12 +406,7 @@ namespace Azure.Storage.Blobs
                         Azure.Storage.Blobs.Models.BlobServiceStatistics _value = Azure.Storage.Blobs.Models.BlobServiceStatistics.FromXml(_xml.Root);
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.BlobServiceStatistics> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.BlobServiceStatistics>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -568,12 +558,7 @@ namespace Azure.Storage.Blobs
                         Azure.Storage.Blobs.Models.ContainersSegment _value = Azure.Storage.Blobs.Models.ContainersSegment.FromXml(_xml.Root);
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.ContainersSegment> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.ContainersSegment>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -718,12 +703,7 @@ namespace Azure.Storage.Blobs
                         Azure.Storage.Blobs.Models.UserDelegationKey _value = Azure.Storage.Blobs.Models.UserDelegationKey.FromXml(_xml.Root);
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.UserDelegationKey> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.UserDelegationKey>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -850,12 +830,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.AccountInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.AccountInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -1018,12 +993,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.ServiceSubmitBatchResult> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.ServiceSubmitBatchResult>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -1186,12 +1156,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.ContainerInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.ContainerInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -1367,12 +1332,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.FlattenedContainerItem> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.FlattenedContainerItem>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -1675,12 +1635,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.ContainerInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.ContainerInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -1835,12 +1790,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.ContainerAccessPolicy> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.ContainerAccessPolicy>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -2022,12 +1972,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.ContainerInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.ContainerInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -2195,12 +2140,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.Lease> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.Lease>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -2362,12 +2302,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.ContainerInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.ContainerInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -2533,12 +2468,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.Lease> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.Lease>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -2700,12 +2630,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.BrokenLease> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.BrokenLease>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -2881,12 +2806,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.Lease> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.Lease>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -3039,12 +2959,7 @@ namespace Azure.Storage.Blobs
                         Azure.Storage.Blobs.Models.BlobsFlatSegment _value = Azure.Storage.Blobs.Models.BlobsFlatSegment.FromXml(_xml.Root);
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.BlobsFlatSegment> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.BlobsFlatSegment>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -3203,12 +3118,7 @@ namespace Azure.Storage.Blobs
                         Azure.Storage.Blobs.Models.BlobsHierarchySegment _value = Azure.Storage.Blobs.Models.BlobsHierarchySegment.FromXml(_xml.Root);
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.BlobsHierarchySegment> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.BlobsHierarchySegment>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -3540,12 +3450,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.FlattenedDownloadProperties> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.FlattenedDownloadProperties>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     case 206:
                     {
@@ -3673,12 +3578,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.FlattenedDownloadProperties> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.FlattenedDownloadProperties>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     case 304:
                     {
@@ -4007,12 +3907,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.BlobProperties> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.BlobProperties>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     case 304:
                     {
@@ -4388,12 +4283,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.BlobSetAccessControlResult> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.BlobSetAccessControlResult>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -4587,12 +4477,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.BlobGetAccessControlResult> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.BlobGetAccessControlResult>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -4857,12 +4742,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.BlobRenameResult> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.BlobRenameResult>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -5203,12 +5083,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.SetHttpHeadersOperation> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.SetHttpHeadersOperation>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -5413,12 +5288,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.SetMetadataOperation> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.SetMetadataOperation>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -5597,12 +5467,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.Lease> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.Lease>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -5775,12 +5640,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.BlobInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.BlobInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -5957,12 +5817,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.Lease> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.Lease>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -6149,12 +6004,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.Lease> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.Lease>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -6327,12 +6177,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.BrokenLease> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.BrokenLease>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -6537,12 +6382,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.BlobSnapshotInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.BlobSnapshotInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -6774,12 +6614,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.BlobCopyInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.BlobCopyInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -7006,12 +6841,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.BlobCopyInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.BlobCopyInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -7583,12 +7413,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -7845,12 +7670,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.PageInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.PageInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -8079,12 +7899,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.PageInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.PageInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -8377,12 +8192,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.PageInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.PageInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     case 304:
                     {
@@ -8582,12 +8392,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.PageRangesInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.PageRangesInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     case 304:
                     {
@@ -8793,12 +8598,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.PageRangesInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.PageRangesInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     case 304:
                     {
@@ -9008,12 +8808,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.PageBlobInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.PageBlobInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -9197,12 +8992,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.PageBlobInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.PageBlobInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -9382,12 +9172,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.BlobCopyInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.BlobCopyInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -9656,12 +9441,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -9913,12 +9693,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.BlobAppendInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.BlobAppendInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -10204,12 +9979,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.BlobAppendInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.BlobAppendInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     case 304:
                     {
@@ -10510,12 +10280,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -10721,12 +10486,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.BlockInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.BlockInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -10960,12 +10720,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.BlockInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.BlockInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     case 304:
                     {
@@ -11268,12 +11023,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -11439,12 +11189,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.GetBlockListOperation> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.GetBlockListOperation>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -11672,12 +11417,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.DirectoryCreateResult> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.DirectoryCreateResult>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -11952,12 +11692,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.DirectoryRenameResult> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.DirectoryRenameResult>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -12136,12 +11871,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.DirectoryDeleteResult> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.DirectoryDeleteResult>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -12333,12 +12063,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.DirectorySetAccessControlResult> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.DirectorySetAccessControlResult>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -12532,12 +12257,7 @@ namespace Azure.Storage.Blobs
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Blobs.Models.DirectoryGetAccessControlResult> _result =
-                            new Azure.Response<Azure.Storage.Blobs.Models.DirectoryGetAccessControlResult>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {

--- a/sdk/storage/Azure.Storage.Blobs/src/LeaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/LeaseClient.cs
@@ -619,7 +619,7 @@ namespace Azure.Storage.Blobs.Specialized
                                 operationName: Constants.Blob.Lease.ReleaseOperationName,
                                 cancellationToken: cancellationToken)
                                 .ConfigureAwait(false);
-                        return response.GetRawResponse().WithValue(new ReleasedObjectInfo(response.Value));
+                        return Response.FromValue(response.GetRawResponse(), new ReleasedObjectInfo(response.Value));
                     }
                     else
                     {
@@ -640,7 +640,7 @@ namespace Azure.Storage.Blobs.Specialized
                                 operationName: Constants.Blob.Lease.ReleaseOperationName,
                                 cancellationToken: cancellationToken)
                                 .ConfigureAwait(false);
-                        return response.GetRawResponse().WithValue(new ReleasedObjectInfo(response.Value));
+                        return Response.FromValue(response.GetRawResponse(), new ReleasedObjectInfo(response.Value));
                     }
                 }
                 catch (Exception ex)

--- a/sdk/storage/Azure.Storage.Blobs/src/LeaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/LeaseClient.cs
@@ -619,9 +619,7 @@ namespace Azure.Storage.Blobs.Specialized
                                 operationName: Constants.Blob.Lease.ReleaseOperationName,
                                 cancellationToken: cancellationToken)
                                 .ConfigureAwait(false);
-                        return new Response<ReleasedObjectInfo>(
-                            response.GetRawResponse(),
-                            new ReleasedObjectInfo(response.Value));
+                        return response.GetRawResponse().WithValue(new ReleasedObjectInfo(response.Value));
                     }
                     else
                     {
@@ -642,9 +640,7 @@ namespace Azure.Storage.Blobs.Specialized
                                 operationName: Constants.Blob.Lease.ReleaseOperationName,
                                 cancellationToken: cancellationToken)
                                 .ConfigureAwait(false);
-                        return new Response<ReleasedObjectInfo>(
-                            response.GetRawResponse(),
-                            new ReleasedObjectInfo(response.Value));
+                        return response.GetRawResponse().WithValue(new ReleasedObjectInfo(response.Value));
                     }
                 }
                 catch (Exception ex)

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/BlockList.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/BlockList.cs
@@ -63,7 +63,7 @@ namespace Azure.Storage.Blobs
             blocks.ETag = response.Value.ETag;
             blocks.ContentType = response.Value.ContentType;
             blocks.BlobContentLength = response.Value.BlobContentLength;
-            return response.GetRawResponse().WithValue(blocks);
+            return Response.FromValue(response.GetRawResponse(), blocks);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/BlockList.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/BlockList.cs
@@ -63,7 +63,7 @@ namespace Azure.Storage.Blobs
             blocks.ETag = response.Value.ETag;
             blocks.ContentType = response.Value.ContentType;
             blocks.BlobContentLength = response.Value.BlobContentLength;
-            return new Response<BlockList>(response.GetRawResponse(), blocks);
+            return response.GetRawResponse().WithValue(blocks);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/Lease.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/Lease.cs
@@ -36,7 +36,7 @@ namespace Azure.Storage.Blobs
         /// <param name="response">The original response.</param>
         /// <returns>The Lease response.</returns>
         internal static Response<Lease> ToLease(this Response<BrokenLease> response)
-            => response.GetRawResponse().WithValue(new Lease
+            => Response.FromValue(response.GetRawResponse(), new Lease
             {
                 ETag = response.Value.ETag,
                 LastModified = response.Value.LastModified,

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/Lease.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/Lease.cs
@@ -36,13 +36,11 @@ namespace Azure.Storage.Blobs
         /// <param name="response">The original response.</param>
         /// <returns>The Lease response.</returns>
         internal static Response<Lease> ToLease(this Response<BrokenLease> response)
-            => new Response<Lease>(
-                response.GetRawResponse(),
-                new Lease
-                {
-                    ETag = response.Value.ETag,
-                    LastModified = response.Value.LastModified,
-                    LeaseTime = response.Value.LeaseTime
-                });
+            => response.GetRawResponse().WithValue(new Lease
+            {
+                ETag = response.Value.ETag,
+                LastModified = response.Value.LastModified,
+                LeaseTime = response.Value.LeaseTime
+            });
     }
 }

--- a/sdk/storage/Azure.Storage.Common/src/StorageAsyncCollection.cs
+++ b/sdk/storage/Azure.Storage.Common/src/StorageAsyncCollection.cs
@@ -127,7 +127,7 @@ namespace Azure.Storage
                 continuationToken = page.ContinuationToken;
                 foreach (T item in page.Values)
                 {
-                    yield return page.GetRawResponse().WithValue(item);
+                    yield return Response.FromValue(page.GetRawResponse(), item);
                 }
             } while (CanContinue(continuationToken));
         }
@@ -151,7 +151,7 @@ namespace Azure.Storage
                 continuationToken = page.ContinuationToken;
                 foreach (T item in page.Values)
                 {
-                    yield return page.GetRawResponse().WithValue(item);
+                    yield return Response.FromValue(page.GetRawResponse(), item);
                 }
             } while (CanContinue(continuationToken));
         }

--- a/sdk/storage/Azure.Storage.Common/src/StorageAsyncCollection.cs
+++ b/sdk/storage/Azure.Storage.Common/src/StorageAsyncCollection.cs
@@ -127,7 +127,7 @@ namespace Azure.Storage
                 continuationToken = page.ContinuationToken;
                 foreach (T item in page.Values)
                 {
-                    yield return new Response<T>(page.GetRawResponse(), item);
+                    yield return page.GetRawResponse().WithValue(item);
                 }
             } while (CanContinue(continuationToken));
         }
@@ -151,7 +151,7 @@ namespace Azure.Storage
                 continuationToken = page.ContinuationToken;
                 foreach (T item in page.Values)
                 {
-                    yield return new Response<T>(page.GetRawResponse(), item);
+                    yield return page.GetRawResponse().WithValue(item);
                 }
             } while (CanContinue(continuationToken));
         }

--- a/sdk/storage/Azure.Storage.Common/swagger/Generator/src/generator.ts
+++ b/sdk/storage/Azure.Storage.Common/swagger/Generator/src/generator.ts
@@ -137,7 +137,6 @@ function generateOperation(w: IndentWriter, serviceModel: IServiceModel, group: 
     const valueName = "_value";
     const pairName = `_headerPair`;
     let responseName = "_response";
-    const resultName = "_result";
     const scopeName = "_scope";
     const operationName = "operationName";
     const result = operation.response.model;
@@ -467,18 +466,8 @@ function generateOperation(w: IndentWriter, serviceModel: IServiceModel, group: 
                     } else {
                         processResponse(response);
 
-                        w.line(`// Create the response`)
-                        w.write(`${returnType} ${resultName} =`);
-                        w.scope(() => {
-                            w.write(`new ${returnType}(`);
-                            w.scope(() => {
-                                w.line(`${responseName},`);
-                                w.line(`${valueName});`);
-                            });
-                        });
-                        w.line();
-
-                        w.line(`return ${resultName};`);
+                        w.line(`// Create the response`);
+                        w.line(`return ${responseName}.WithValue(${valueName});`);
                     }
                 });
             }

--- a/sdk/storage/Azure.Storage.Common/swagger/Generator/src/generator.ts
+++ b/sdk/storage/Azure.Storage.Common/swagger/Generator/src/generator.ts
@@ -467,7 +467,7 @@ function generateOperation(w: IndentWriter, serviceModel: IServiceModel, group: 
                         processResponse(response);
 
                         w.line(`// Create the response`);
-                        w.line(`return ${responseName}.WithValue(${valueName});`);
+                        w.line(`return Response.FromValue(${responseName}, ${valueName});`);
                     }
                 });
             }

--- a/sdk/storage/Azure.Storage.Files/src/DirectoryClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/DirectoryClient.cs
@@ -421,9 +421,7 @@ namespace Azure.Storage.Files
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
-                    return new Response<StorageDirectoryInfo>(
-                        response.GetRawResponse(),
-                        new StorageDirectoryInfo(response.Value));
+                    return response.GetRawResponse().WithValue(new StorageDirectoryInfo(response.Value));
                 }
                 catch (Exception ex)
                 {
@@ -654,9 +652,7 @@ namespace Azure.Storage.Files
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
-                    return new Response<StorageDirectoryProperties>(
-                        response.GetRawResponse(),
-                        new StorageDirectoryProperties(response.Value));
+                    return response.GetRawResponse().WithValue(new StorageDirectoryProperties(response.Value));
                 }
                 catch (Exception ex)
                 {
@@ -804,9 +800,7 @@ namespace Azure.Storage.Files
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
-                    return new Response<StorageDirectoryInfo>(
-                        response.GetRawResponse(),
-                        new StorageDirectoryInfo(response.Value));
+                    return response.GetRawResponse().WithValue(new StorageDirectoryInfo(response.Value));
                 }
                 catch (Exception ex)
                 {
@@ -925,9 +919,7 @@ namespace Azure.Storage.Files
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
-                    return new Response<StorageDirectoryInfo>(
-                        response.GetRawResponse(),
-                        new StorageDirectoryInfo(response.Value));
+                    return response.GetRawResponse().WithValue(new StorageDirectoryInfo(response.Value));
                 }
                 catch (Exception ex)
                 {
@@ -1456,7 +1448,7 @@ namespace Azure.Storage.Files
                 smbProperties,
                 filePermission,
                 cancellationToken);
-            return new Response<DirectoryClient>(response.GetRawResponse(), subdir);
+            return response.GetRawResponse().WithValue(subdir);
         }
 
         /// <summary>
@@ -1502,7 +1494,7 @@ namespace Azure.Storage.Files
                     filePermission,
                     cancellationToken)
                 .ConfigureAwait(false);
-            return new Response<DirectoryClient>(response.GetRawResponse(), subdir);
+            return response.GetRawResponse().WithValue(subdir);
         }
         #endregion CreateSubdirectory
 
@@ -1611,7 +1603,7 @@ namespace Azure.Storage.Files
                 smbProperties,
                 filePermission,
                 cancellationToken);
-            return new Response<FileClient>(response.GetRawResponse(), file);
+            return response.GetRawResponse().WithValue(file);
         }
 
         /// <summary>
@@ -1668,7 +1660,7 @@ namespace Azure.Storage.Files
                 smbProperties,
                 filePermission,
                 cancellationToken).ConfigureAwait(false);
-            return new Response<FileClient>(response.GetRawResponse(), file);
+            return response.GetRawResponse().WithValue(file);
         }
         #endregion CreateFile
 

--- a/sdk/storage/Azure.Storage.Files/src/DirectoryClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/DirectoryClient.cs
@@ -421,7 +421,7 @@ namespace Azure.Storage.Files
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
-                    return response.GetRawResponse().WithValue(new StorageDirectoryInfo(response.Value));
+                    return Response.FromValue(response.GetRawResponse(), new StorageDirectoryInfo(response.Value));
                 }
                 catch (Exception ex)
                 {
@@ -652,7 +652,7 @@ namespace Azure.Storage.Files
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
-                    return response.GetRawResponse().WithValue(new StorageDirectoryProperties(response.Value));
+                    return Response.FromValue(response.GetRawResponse(), new StorageDirectoryProperties(response.Value));
                 }
                 catch (Exception ex)
                 {
@@ -800,7 +800,7 @@ namespace Azure.Storage.Files
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
-                    return response.GetRawResponse().WithValue(new StorageDirectoryInfo(response.Value));
+                    return Response.FromValue(response.GetRawResponse(), new StorageDirectoryInfo(response.Value));
                 }
                 catch (Exception ex)
                 {
@@ -919,7 +919,7 @@ namespace Azure.Storage.Files
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
-                    return response.GetRawResponse().WithValue(new StorageDirectoryInfo(response.Value));
+                    return Response.FromValue(response.GetRawResponse(), new StorageDirectoryInfo(response.Value));
                 }
                 catch (Exception ex)
                 {
@@ -1448,7 +1448,7 @@ namespace Azure.Storage.Files
                 smbProperties,
                 filePermission,
                 cancellationToken);
-            return response.GetRawResponse().WithValue(subdir);
+            return Response.FromValue(response.GetRawResponse(), subdir);
         }
 
         /// <summary>
@@ -1494,7 +1494,7 @@ namespace Azure.Storage.Files
                     filePermission,
                     cancellationToken)
                 .ConfigureAwait(false);
-            return response.GetRawResponse().WithValue(subdir);
+            return Response.FromValue(response.GetRawResponse(), subdir);
         }
         #endregion CreateSubdirectory
 
@@ -1603,7 +1603,7 @@ namespace Azure.Storage.Files
                 smbProperties,
                 filePermission,
                 cancellationToken);
-            return response.GetRawResponse().WithValue(file);
+            return Response.FromValue(response.GetRawResponse(), file);
         }
 
         /// <summary>
@@ -1660,7 +1660,7 @@ namespace Azure.Storage.Files
                 smbProperties,
                 filePermission,
                 cancellationToken).ConfigureAwait(false);
-            return response.GetRawResponse().WithValue(file);
+            return Response.FromValue(response.GetRawResponse(), file);
         }
         #endregion CreateFile
 

--- a/sdk/storage/Azure.Storage.Files/src/FileClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/FileClient.cs
@@ -478,9 +478,7 @@ namespace Azure.Storage.Files
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
-                    return new Response<StorageFileInfo>(
-                        response.GetRawResponse(),
-                        new StorageFileInfo(response.Value));
+                    return response.GetRawResponse().WithValue(new StorageFileInfo(response.Value));
                 }
                 catch (Exception ex)
                 {
@@ -910,9 +908,7 @@ namespace Azure.Storage.Files
 
                     // Wrap the FlattenedStorageFileProperties into a StorageFileDownloadInfo
                     // to make the Content easier to find
-                    return new Response<StorageFileDownloadInfo>(
-                        response.GetRawResponse(),
-                        new StorageFileDownloadInfo(response.Value));
+                    return response.GetRawResponse().WithValue(new StorageFileDownloadInfo(response.Value));
                 }
                 catch (Exception ex)
                 {
@@ -1195,9 +1191,7 @@ namespace Azure.Storage.Files
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
-                    return new Response<StorageFileProperties>(
-                        response.GetRawResponse(),
-                        new StorageFileProperties(response.Value));
+                    return response.GetRawResponse().WithValue(new StorageFileProperties(response.Value));
                 }
                 catch (Exception ex)
                 {
@@ -1391,9 +1385,7 @@ namespace Azure.Storage.Files
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
-                    return new Response<StorageFileInfo>(
-                        response.GetRawResponse(),
-                        new StorageFileInfo(response.Value));
+                    return response.GetRawResponse().WithValue(new StorageFileInfo(response.Value));
                 }
                 catch (Exception ex)
                 {
@@ -1513,9 +1505,7 @@ namespace Azure.Storage.Files
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
-                    return new Response<StorageFileInfo>(
-                        response.GetRawResponse(),
-                        new StorageFileInfo(response.Value));
+                    return response.GetRawResponse().WithValue(new StorageFileInfo(response.Value));
                 }
                 catch (Exception ex)
                 {
@@ -1881,15 +1871,13 @@ namespace Azure.Storage.Files
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
-                    return new Response<StorageFileUploadInfo>(
-                        response.GetRawResponse(),
-                        new StorageFileUploadInfo
-                        {
-                            ETag = response.Value.ETag,
-                            LastModified = response.Value.LastModified,
-                            ContentHash = response.Value.XMSContentCrc64,
-                            IsServerEncrypted = response.Value.IsServerEncrypted
-                        });
+                    return response.GetRawResponse().WithValue(new StorageFileUploadInfo
+                    {
+                        ETag = response.Value.ETag,
+                        LastModified = response.Value.LastModified,
+                        ContentHash = response.Value.XMSContentCrc64,
+                        IsServerEncrypted = response.Value.IsServerEncrypted
+                    });
                 }
                 catch (Exception ex)
                 {

--- a/sdk/storage/Azure.Storage.Files/src/FileClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/FileClient.cs
@@ -478,7 +478,7 @@ namespace Azure.Storage.Files
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
-                    return response.GetRawResponse().WithValue(new StorageFileInfo(response.Value));
+                    return Response.FromValue(response.GetRawResponse(), new StorageFileInfo(response.Value));
                 }
                 catch (Exception ex)
                 {
@@ -908,7 +908,7 @@ namespace Azure.Storage.Files
 
                     // Wrap the FlattenedStorageFileProperties into a StorageFileDownloadInfo
                     // to make the Content easier to find
-                    return response.GetRawResponse().WithValue(new StorageFileDownloadInfo(response.Value));
+                    return Response.FromValue(response.GetRawResponse(), new StorageFileDownloadInfo(response.Value));
                 }
                 catch (Exception ex)
                 {
@@ -1191,7 +1191,7 @@ namespace Azure.Storage.Files
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
-                    return response.GetRawResponse().WithValue(new StorageFileProperties(response.Value));
+                    return Response.FromValue(response.GetRawResponse(), new StorageFileProperties(response.Value));
                 }
                 catch (Exception ex)
                 {
@@ -1385,7 +1385,7 @@ namespace Azure.Storage.Files
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
-                    return response.GetRawResponse().WithValue(new StorageFileInfo(response.Value));
+                    return Response.FromValue(response.GetRawResponse(), new StorageFileInfo(response.Value));
                 }
                 catch (Exception ex)
                 {
@@ -1505,7 +1505,7 @@ namespace Azure.Storage.Files
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
-                    return response.GetRawResponse().WithValue(new StorageFileInfo(response.Value));
+                    return Response.FromValue(response.GetRawResponse(), new StorageFileInfo(response.Value));
                 }
                 catch (Exception ex)
                 {
@@ -1871,7 +1871,7 @@ namespace Azure.Storage.Files
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
-                    return response.GetRawResponse().WithValue(new StorageFileUploadInfo
+                    return Response.FromValue(response.GetRawResponse(), new StorageFileUploadInfo
                     {
                         ETag = response.Value.ETag,
                         LastModified = response.Value.LastModified,

--- a/sdk/storage/Azure.Storage.Files/src/FileServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/FileServiceClient.cs
@@ -609,7 +609,7 @@ namespace Azure.Storage.Files
         {
             ShareClient share = GetShareClient(shareName);
             Response<ShareInfo> response = share.Create(metadata, quotaInBytes, cancellationToken);
-            return new Response<ShareClient>(response.GetRawResponse(), share);
+            return response.GetRawResponse().WithValue(share);
         }
 
         /// <summary>
@@ -649,7 +649,7 @@ namespace Azure.Storage.Files
         {
             ShareClient share = GetShareClient(shareName);
             Response<ShareInfo> response = await share.CreateAsync(metadata, quotaInBytes, cancellationToken).ConfigureAwait(false);
-            return new Response<ShareClient>(response.GetRawResponse(), share);
+            return response.GetRawResponse().WithValue(share);
         }
         #endregion CreateShare
 

--- a/sdk/storage/Azure.Storage.Files/src/FileServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/FileServiceClient.cs
@@ -609,7 +609,7 @@ namespace Azure.Storage.Files
         {
             ShareClient share = GetShareClient(shareName);
             Response<ShareInfo> response = share.Create(metadata, quotaInBytes, cancellationToken);
-            return response.GetRawResponse().WithValue(share);
+            return Response.FromValue(response.GetRawResponse(), share);
         }
 
         /// <summary>
@@ -649,7 +649,7 @@ namespace Azure.Storage.Files
         {
             ShareClient share = GetShareClient(shareName);
             Response<ShareInfo> response = await share.CreateAsync(metadata, quotaInBytes, cancellationToken).ConfigureAwait(false);
-            return response.GetRawResponse().WithValue(share);
+            return Response.FromValue(response.GetRawResponse(), share);
         }
         #endregion CreateShare
 

--- a/sdk/storage/Azure.Storage.Files/src/Generated/FileRestClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Generated/FileRestClient.cs
@@ -265,7 +265,7 @@ namespace Azure.Storage.Files
                         Azure.Storage.Files.Models.FileServiceProperties _value = Azure.Storage.Files.Models.FileServiceProperties.FromXml(_xml.Root);
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -411,7 +411,7 @@ namespace Azure.Storage.Files
                         Azure.Storage.Files.Models.SharesSegment _value = Azure.Storage.Files.Models.SharesSegment.FromXml(_xml.Root);
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -568,7 +568,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -718,7 +718,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -995,7 +995,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -1139,7 +1139,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -1275,7 +1275,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -1414,7 +1414,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -1558,7 +1558,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -1685,7 +1685,7 @@ namespace Azure.Storage.Files
                                     Azure.Storage.Files.Models.SignedIdentifier.FromXml));
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -1837,7 +1837,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -1960,7 +1960,7 @@ namespace Azure.Storage.Files
                         Azure.Storage.Files.Models.ShareStatistics _value = Azure.Storage.Files.Models.ShareStatistics.FromXml(_xml.Root);
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -2181,7 +2181,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -2359,7 +2359,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -2679,7 +2679,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -2823,7 +2823,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -2970,7 +2970,7 @@ namespace Azure.Storage.Files
                         Azure.Storage.Files.Models.FilesAndDirectoriesSegment _value = Azure.Storage.Files.Models.FilesAndDirectoriesSegment.FromXml(_xml.Root);
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -3120,7 +3120,7 @@ namespace Azure.Storage.Files
                         Azure.Storage.Files.Models.StorageHandlesSegment _value = Azure.Storage.Files.Models.StorageHandlesSegment.FromXml(_xml.Root);
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -3284,7 +3284,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -3561,7 +3561,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -3815,7 +3815,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     case 206:
                     {
@@ -3939,7 +3939,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -4172,7 +4172,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -4552,7 +4552,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -4699,7 +4699,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -4875,7 +4875,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -5066,7 +5066,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -5220,7 +5220,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -5380,7 +5380,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -5648,7 +5648,7 @@ namespace Azure.Storage.Files
                         Azure.Storage.Files.Models.StorageHandlesSegment _value = Azure.Storage.Files.Models.StorageHandlesSegment.FromXml(_xml.Root);
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -5802,7 +5802,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {

--- a/sdk/storage/Azure.Storage.Files/src/Generated/FileRestClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Generated/FileRestClient.cs
@@ -265,12 +265,7 @@ namespace Azure.Storage.Files
                         Azure.Storage.Files.Models.FileServiceProperties _value = Azure.Storage.Files.Models.FileServiceProperties.FromXml(_xml.Root);
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.FileServiceProperties> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.FileServiceProperties>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -416,12 +411,7 @@ namespace Azure.Storage.Files
                         Azure.Storage.Files.Models.SharesSegment _value = Azure.Storage.Files.Models.SharesSegment.FromXml(_xml.Root);
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.SharesSegment> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.SharesSegment>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -578,12 +568,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.ShareInfo> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.ShareInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -733,12 +718,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.ShareProperties> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.ShareProperties>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -1015,12 +995,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.ShareSnapshotInfo> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.ShareSnapshotInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -1164,12 +1139,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.PermissionInfo> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.PermissionInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -1305,12 +1275,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        Azure.Response<string> _result =
-                            new Azure.Response<string>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -1449,12 +1414,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.ShareInfo> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.ShareInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -1598,12 +1558,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.ShareInfo> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.ShareInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -1730,12 +1685,7 @@ namespace Azure.Storage.Files
                                     Azure.Storage.Files.Models.SignedIdentifier.FromXml));
 
                         // Create the response
-                        Azure.Response<System.Collections.Generic.IEnumerable<Azure.Storage.Files.Models.SignedIdentifier>> _result =
-                            new Azure.Response<System.Collections.Generic.IEnumerable<Azure.Storage.Files.Models.SignedIdentifier>>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -1887,12 +1837,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.ShareInfo> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.ShareInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -2015,12 +1960,7 @@ namespace Azure.Storage.Files
                         Azure.Storage.Files.Models.ShareStatistics _value = Azure.Storage.Files.Models.ShareStatistics.FromXml(_xml.Root);
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.ShareStatistics> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.ShareStatistics>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -2241,12 +2181,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.RawStorageDirectoryInfo> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.RawStorageDirectoryInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -2424,12 +2359,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.RawStorageDirectoryProperties> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.RawStorageDirectoryProperties>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -2749,12 +2679,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.RawStorageDirectoryInfo> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.RawStorageDirectoryInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -2898,12 +2823,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.RawStorageDirectoryInfo> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.RawStorageDirectoryInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -3050,12 +2970,7 @@ namespace Azure.Storage.Files
                         Azure.Storage.Files.Models.FilesAndDirectoriesSegment _value = Azure.Storage.Files.Models.FilesAndDirectoriesSegment.FromXml(_xml.Root);
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.FilesAndDirectoriesSegment> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.FilesAndDirectoriesSegment>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -3205,12 +3120,7 @@ namespace Azure.Storage.Files
                         Azure.Storage.Files.Models.StorageHandlesSegment _value = Azure.Storage.Files.Models.StorageHandlesSegment.FromXml(_xml.Root);
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.StorageHandlesSegment> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.StorageHandlesSegment>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -3374,12 +3284,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.StorageClosedHandlesSegment> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.StorageClosedHandlesSegment>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -3656,12 +3561,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.RawStorageFileInfo> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.RawStorageFileInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -3915,12 +3815,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.FlattenedStorageFileProperties> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.FlattenedStorageFileProperties>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     case 206:
                     {
@@ -4044,12 +3939,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.FlattenedStorageFileProperties> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.FlattenedStorageFileProperties>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -4282,12 +4172,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.RawStorageFileProperties> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.RawStorageFileProperties>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -4667,12 +4552,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.RawStorageFileInfo> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.RawStorageFileInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -4819,12 +4699,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.RawStorageFileInfo> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.RawStorageFileInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -5000,12 +4875,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.StorageFileUploadInfo> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.StorageFileUploadInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -5196,12 +5066,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.FileUploadRangeFromURLResult> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.FileUploadRangeFromURLResult>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -5355,12 +5220,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.StorageFileRangeInfo> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.StorageFileRangeInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -5520,12 +5380,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.StorageFileCopyInfo> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.StorageFileCopyInfo>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -5793,12 +5648,7 @@ namespace Azure.Storage.Files
                         Azure.Storage.Files.Models.StorageHandlesSegment _value = Azure.Storage.Files.Models.StorageHandlesSegment.FromXml(_xml.Root);
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.StorageHandlesSegment> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.StorageHandlesSegment>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -5952,12 +5802,7 @@ namespace Azure.Storage.Files
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Files.Models.StorageClosedHandlesSegment> _result =
-                            new Azure.Response<Azure.Storage.Files.Models.StorageClosedHandlesSegment>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {

--- a/sdk/storage/Azure.Storage.Files/src/ShareClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/ShareClient.cs
@@ -1413,9 +1413,7 @@ namespace Azure.Storage.Files
                     var permission = permissionProperty.GetString();
 
                     // Return the Permission string
-                    return new Response<string>(
-                        jsonResponse.GetRawResponse(),
-                        permission);
+                    return jsonResponse.GetRawResponse().WithValue(permission);
                 }
                 catch (Exception ex)
                 {
@@ -1576,7 +1574,7 @@ namespace Azure.Storage.Files
                 smbProperties,
                 filePermission,
                 cancellationToken);
-            return new Response<DirectoryClient>(response.GetRawResponse(), directory);
+            return response.GetRawResponse().WithValue(directory);
         }
 
         /// <summary>
@@ -1623,7 +1621,7 @@ namespace Azure.Storage.Files
                 smbProperties,
                 filePermission,
                 cancellationToken).ConfigureAwait(false);
-            return new Response<DirectoryClient>(response.GetRawResponse(), directory);
+            return response.GetRawResponse().WithValue(directory);
         }
         #endregion CreateDirectory
 

--- a/sdk/storage/Azure.Storage.Files/src/ShareClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/ShareClient.cs
@@ -1413,7 +1413,7 @@ namespace Azure.Storage.Files
                     var permission = permissionProperty.GetString();
 
                     // Return the Permission string
-                    return jsonResponse.GetRawResponse().WithValue(permission);
+                    return Response.FromValue(jsonResponse.GetRawResponse(), permission);
                 }
                 catch (Exception ex)
                 {
@@ -1574,7 +1574,7 @@ namespace Azure.Storage.Files
                 smbProperties,
                 filePermission,
                 cancellationToken);
-            return response.GetRawResponse().WithValue(directory);
+            return Response.FromValue(response.GetRawResponse(), directory);
         }
 
         /// <summary>
@@ -1621,7 +1621,7 @@ namespace Azure.Storage.Files
                 smbProperties,
                 filePermission,
                 cancellationToken).ConfigureAwait(false);
-            return response.GetRawResponse().WithValue(directory);
+            return Response.FromValue(response.GetRawResponse(), directory);
         }
         #endregion CreateDirectory
 

--- a/sdk/storage/Azure.Storage.Queues/src/Generated/QueueRestClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Generated/QueueRestClient.cs
@@ -277,7 +277,7 @@ namespace Azure.Storage.Queues
                         Azure.Storage.Queues.Models.QueueServiceProperties _value = Azure.Storage.Queues.Models.QueueServiceProperties.FromXml(_xml.Root);
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -406,7 +406,7 @@ namespace Azure.Storage.Queues
                         Azure.Storage.Queues.Models.QueueServiceStatistics _value = Azure.Storage.Queues.Models.QueueServiceStatistics.FromXml(_xml.Root);
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -558,7 +558,7 @@ namespace Azure.Storage.Queues
                         Azure.Storage.Queues.Models.QueuesSegment _value = Azure.Storage.Queues.Models.QueuesSegment.FromXml(_xml.Root);
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -967,7 +967,7 @@ namespace Azure.Storage.Queues
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -1233,7 +1233,7 @@ namespace Azure.Storage.Queues
                                     Azure.Storage.Queues.Models.SignedIdentifier.FromXml));
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -1526,7 +1526,7 @@ namespace Azure.Storage.Queues
                                     Azure.Storage.Queues.Models.DequeuedMessage.FromXml));
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -1807,7 +1807,7 @@ namespace Azure.Storage.Queues
                                     Azure.Storage.Queues.Models.EnqueuedMessage.FromXml));
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -1945,7 +1945,7 @@ namespace Azure.Storage.Queues
                                     Azure.Storage.Queues.Models.PeekedMessage.FromXml));
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {
@@ -2122,7 +2122,7 @@ namespace Azure.Storage.Queues
                         }
 
                         // Create the response
-                        return response.WithValue(_value);
+                        return Response.FromValue(response, _value);
                     }
                     default:
                     {

--- a/sdk/storage/Azure.Storage.Queues/src/Generated/QueueRestClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Generated/QueueRestClient.cs
@@ -277,12 +277,7 @@ namespace Azure.Storage.Queues
                         Azure.Storage.Queues.Models.QueueServiceProperties _value = Azure.Storage.Queues.Models.QueueServiceProperties.FromXml(_xml.Root);
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Queues.Models.QueueServiceProperties> _result =
-                            new Azure.Response<Azure.Storage.Queues.Models.QueueServiceProperties>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -411,12 +406,7 @@ namespace Azure.Storage.Queues
                         Azure.Storage.Queues.Models.QueueServiceStatistics _value = Azure.Storage.Queues.Models.QueueServiceStatistics.FromXml(_xml.Root);
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Queues.Models.QueueServiceStatistics> _result =
-                            new Azure.Response<Azure.Storage.Queues.Models.QueueServiceStatistics>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -568,12 +558,7 @@ namespace Azure.Storage.Queues
                         Azure.Storage.Queues.Models.QueuesSegment _value = Azure.Storage.Queues.Models.QueuesSegment.FromXml(_xml.Root);
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Queues.Models.QueuesSegment> _result =
-                            new Azure.Response<Azure.Storage.Queues.Models.QueuesSegment>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -982,12 +967,7 @@ namespace Azure.Storage.Queues
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Queues.Models.QueueProperties> _result =
-                            new Azure.Response<Azure.Storage.Queues.Models.QueueProperties>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -1253,12 +1233,7 @@ namespace Azure.Storage.Queues
                                     Azure.Storage.Queues.Models.SignedIdentifier.FromXml));
 
                         // Create the response
-                        Azure.Response<System.Collections.Generic.IEnumerable<Azure.Storage.Queues.Models.SignedIdentifier>> _result =
-                            new Azure.Response<System.Collections.Generic.IEnumerable<Azure.Storage.Queues.Models.SignedIdentifier>>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -1551,12 +1526,7 @@ namespace Azure.Storage.Queues
                                     Azure.Storage.Queues.Models.DequeuedMessage.FromXml));
 
                         // Create the response
-                        Azure.Response<System.Collections.Generic.IEnumerable<Azure.Storage.Queues.Models.DequeuedMessage>> _result =
-                            new Azure.Response<System.Collections.Generic.IEnumerable<Azure.Storage.Queues.Models.DequeuedMessage>>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -1837,12 +1807,7 @@ namespace Azure.Storage.Queues
                                     Azure.Storage.Queues.Models.EnqueuedMessage.FromXml));
 
                         // Create the response
-                        Azure.Response<System.Collections.Generic.IEnumerable<Azure.Storage.Queues.Models.EnqueuedMessage>> _result =
-                            new Azure.Response<System.Collections.Generic.IEnumerable<Azure.Storage.Queues.Models.EnqueuedMessage>>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -1980,12 +1945,7 @@ namespace Azure.Storage.Queues
                                     Azure.Storage.Queues.Models.PeekedMessage.FromXml));
 
                         // Create the response
-                        Azure.Response<System.Collections.Generic.IEnumerable<Azure.Storage.Queues.Models.PeekedMessage>> _result =
-                            new Azure.Response<System.Collections.Generic.IEnumerable<Azure.Storage.Queues.Models.PeekedMessage>>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {
@@ -2162,12 +2122,7 @@ namespace Azure.Storage.Queues
                         }
 
                         // Create the response
-                        Azure.Response<Azure.Storage.Queues.Models.UpdatedMessage> _result =
-                            new Azure.Response<Azure.Storage.Queues.Models.UpdatedMessage>(
-                                response,
-                                _value);
-
-                        return _result;
+                        return response.WithValue(_value);
                     }
                     default:
                     {

--- a/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
@@ -1000,9 +1000,7 @@ namespace Azure.Storage.Queues
                             .ConfigureAwait(false);
                     // The service returns a sequence of messages, but the
                     // sequence only ever has one value so we'll unwrap it
-                    return new Response<EnqueuedMessage>(
-                        messages.GetRawResponse(),
-                        messages.Value.FirstOrDefault());
+                    return messages.GetRawResponse().WithValue(messages.Value.FirstOrDefault());
                 }
                 catch (Exception ex)
                 {
@@ -1119,7 +1117,7 @@ namespace Azure.Storage.Queues
                         operationName: Constants.Queue.DequeueMessageOperationName,
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
-                    return new Response<DequeuedMessage[]>(dequeuedMessage.GetRawResponse(), dequeuedMessage.Value.ToArray());
+                    return dequeuedMessage.GetRawResponse().WithValue(dequeuedMessage.Value.ToArray());
                 }
                 catch (Exception ex)
                 {
@@ -1220,7 +1218,7 @@ namespace Azure.Storage.Queues
                         operationName: Constants.Queue.PeekMessagesOperationName,
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
-                    return new Response<PeekedMessage[]>(peekedMessages.GetRawResponse(), peekedMessages.Value.ToArray());
+                    return peekedMessages.GetRawResponse().WithValue(peekedMessages.Value.ToArray());
                 }
                 catch (Exception ex)
                 {

--- a/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
@@ -1000,7 +1000,7 @@ namespace Azure.Storage.Queues
                             .ConfigureAwait(false);
                     // The service returns a sequence of messages, but the
                     // sequence only ever has one value so we'll unwrap it
-                    return messages.GetRawResponse().WithValue(messages.Value.FirstOrDefault());
+                    return Response.FromValue(messages.GetRawResponse(), messages.Value.FirstOrDefault());
                 }
                 catch (Exception ex)
                 {
@@ -1117,7 +1117,7 @@ namespace Azure.Storage.Queues
                         operationName: Constants.Queue.DequeueMessageOperationName,
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
-                    return dequeuedMessage.GetRawResponse().WithValue(dequeuedMessage.Value.ToArray());
+                    return Response.FromValue(dequeuedMessage.GetRawResponse(), dequeuedMessage.Value.ToArray());
                 }
                 catch (Exception ex)
                 {
@@ -1218,7 +1218,7 @@ namespace Azure.Storage.Queues
                         operationName: Constants.Queue.PeekMessagesOperationName,
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
-                    return peekedMessages.GetRawResponse().WithValue(peekedMessages.Value.ToArray());
+                    return Response.FromValue(peekedMessages.GetRawResponse(), peekedMessages.Value.ToArray());
                 }
                 catch (Exception ex)
                 {

--- a/sdk/storage/Azure.Storage.Queues/src/QueueServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueServiceClient.cs
@@ -619,7 +619,7 @@ namespace Azure.Storage.Queues
         {
             QueueClient queue = GetQueueClient(queueName);
             Response response = queue.Create(metadata, cancellationToken);
-            return new Response<QueueClient>(response, queue);
+            return response.WithValue(queue);
         }
 
         /// <summary>
@@ -647,7 +647,7 @@ namespace Azure.Storage.Queues
         {
             QueueClient queue = GetQueueClient(queueName);
             Response response = await queue.CreateAsync(metadata, cancellationToken).ConfigureAwait(false);
-            return new Response<QueueClient>(response, queue);
+            return response.WithValue(queue);
         }
         #endregion CreateQueue
 

--- a/sdk/storage/Azure.Storage.Queues/src/QueueServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueServiceClient.cs
@@ -619,7 +619,7 @@ namespace Azure.Storage.Queues
         {
             QueueClient queue = GetQueueClient(queueName);
             Response response = queue.Create(metadata, cancellationToken);
-            return response.WithValue(queue);
+            return Response.FromValue(response, queue);
         }
 
         /// <summary>
@@ -647,7 +647,7 @@ namespace Azure.Storage.Queues
         {
             QueueClient queue = GetQueueClient(queueName);
             Response response = await queue.CreateAsync(metadata, cancellationToken).ConfigureAwait(false);
-            return response.WithValue(queue);
+            return Response.FromValue(response, queue);
         }
         #endregion CreateQueue
 


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/7854

I was thinking about making `Response<T>` abstract and @annelo-msft PR https://github.com/Azure/azure-sdk-for-net/pull/7803 about throwing in `Value` convinced me.

I don't want additional features like throwing exceptions, lazy calculations, and whatever else we come up in the future expanding the `Response<T>` object size and internal complexity.

@KrzysztofCwalina seems to be fine with this approach.

# Breaking change
![image](https://user-images.githubusercontent.com/1697911/65990520-9926af80-e440-11e9-82cf-f5a6cd76e05f.png)

