### PR TITLE
Rename SetTier to SetAccessTier

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -2674,9 +2674,9 @@ namespace Azure.Storage.Blobs.Specialized
         }
         #endregion CreateSnapshot
 
-        #region SetTier
+        #region SetAccessTier
         /// <summary>
-        /// The <see cref="SetTier"/> operation sets the tier on a blob.
+        /// The <see cref="SetAccessTier"/> operation sets the tier on a blob.
         /// The operation is allowed on a page blob in a premium storage
         /// account and on a block blob in a blob storage or general purpose
         /// v2 account.
@@ -2712,12 +2712,12 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual Response SetTier(
+        public virtual Response SetAccessTier(
             AccessTier accessTier,
             LeaseAccessConditions? leaseAccessConditions = default,
             RehydratePriority? rehydratePriority = default,
             CancellationToken cancellationToken = default) =>
-            SetTierInternal(
+            SetAccessTierInternal(
                 accessTier,
                 leaseAccessConditions,
                 rehydratePriority,
@@ -2726,7 +2726,7 @@ namespace Azure.Storage.Blobs.Specialized
                 .EnsureCompleted();
 
         /// <summary>
-        /// The <see cref="SetTierAsync"/> operation sets the tier on a blob.
+        /// The <see cref="SetAccessTierAsync"/> operation sets the tier on a blob.
         /// The operation is allowed on a page blob in a premium storage
         /// account and on a block blob in a blob storage or general purpose
         /// v2 account.
@@ -2762,12 +2762,12 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response> SetTierAsync(
+        public virtual async Task<Response> SetAccessTierAsync(
             AccessTier accessTier,
             LeaseAccessConditions? leaseAccessConditions = default,
             RehydratePriority? rehydratePriority = default,
             CancellationToken cancellationToken = default) =>
-            await SetTierInternal(
+            await SetAccessTierInternal(
                 accessTier,
                 leaseAccessConditions,
                 rehydratePriority,
@@ -2776,7 +2776,7 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="SetTierInternal"/> operation sets the tier on a blob.
+        /// The <see cref="SetAccessTierInternal"/> operation sets the tier on a blob.
         /// The operation is allowed on a page blob in a premium storage
         /// account and on a block blob in a blob storage or general purpose
         /// v2 account.
@@ -2815,7 +2815,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response> SetTierInternal(
+        private async Task<Response> SetAccessTierInternal(
             AccessTier accessTier,
             LeaseAccessConditions? leaseAccessConditions,
             RehydratePriority? rehydratePriority,
@@ -2832,14 +2832,14 @@ namespace Azure.Storage.Blobs.Specialized
                     $"{nameof(leaseAccessConditions)}: {leaseAccessConditions}");
                 try
                 {
-                    return await BlobRestClient.Blob.SetTierAsync(
+                    return await BlobRestClient.Blob.SetAccessTierAsync(
                         Pipeline,
                         Uri,
                         tier: accessTier,
                         rehydratePriority: rehydratePriority,
                         leaseId: leaseAccessConditions?.LeaseId,
                         async: async,
-                        operationName: "Azure.Storage.Blobs.Specialized.BlobBaseClient.SetTier",
+                        operationName: "Azure.Storage.Blobs.Specialized.BlobBaseClient.SetAccessTier",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -2854,7 +2854,7 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
-        #endregion SetTier
+        #endregion SetAccessTier
     }
 
     /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
@@ -7165,7 +7165,7 @@ namespace Azure.Storage.Blobs
             }
             #endregion Blob.AbortCopyFromUriAsync
 
-            #region Blob.SetTierAsync
+            #region Blob.SetAccessTierAsync
             /// <summary>
             /// The Set Tier operation sets the tier on a blob. The operation is allowed on a page blob in a premium storage account and on a block blob in a blob storage account (locally redundant storage only). A premium page blob's tier determines the allowed size, IOPS, and bandwidth of the blob. A block blob's tier determines Hot/Cool/Archive storage type. This operation does not update the blob's ETag.
             /// </summary>
@@ -7180,7 +7180,7 @@ namespace Azure.Storage.Blobs
             /// <param name="operationName">Operation name.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
             /// <returns>Azure.Response</returns>
-            public static async System.Threading.Tasks.ValueTask<Azure.Response> SetTierAsync(
+            public static async System.Threading.Tasks.ValueTask<Azure.Response> SetAccessTierAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
                 Azure.Storage.Blobs.Models.AccessTier tier,
@@ -7189,7 +7189,7 @@ namespace Azure.Storage.Blobs
                 string requestId = default,
                 string leaseId = default,
                 bool async = true,
-                string operationName = "Azure.Storage.Blobs.BlobClient.SetTier",
+                string operationName = "Azure.Storage.Blobs.BlobClient.SetAccessTier",
                 System.Threading.CancellationToken cancellationToken = default)
             {
                 Azure.Core.Pipeline.DiagnosticScope _scope = pipeline.Diagnostics.CreateScope(operationName);
@@ -7197,7 +7197,7 @@ namespace Azure.Storage.Blobs
                 {
                     _scope.AddAttribute("url", resourceUri);
                     _scope.Start();
-                    using (Azure.Core.Pipeline.HttpPipelineMessage _message = SetTierAsync_CreateMessage(
+                    using (Azure.Core.Pipeline.HttpPipelineMessage _message = SetAccessTierAsync_CreateMessage(
                         pipeline,
                         resourceUri,
                         tier,
@@ -7219,7 +7219,7 @@ namespace Azure.Storage.Blobs
                         }
                         Azure.Response _response = _message.Response;
                         cancellationToken.ThrowIfCancellationRequested();
-                        return SetTierAsync_CreateResponse(_response);
+                        return SetAccessTierAsync_CreateResponse(_response);
                     }
                 }
                 catch (System.Exception ex)
@@ -7234,7 +7234,7 @@ namespace Azure.Storage.Blobs
             }
 
             /// <summary>
-            /// Create the Blob.SetTierAsync request.
+            /// Create the Blob.SetAccessTierAsync request.
             /// </summary>
             /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
@@ -7243,8 +7243,8 @@ namespace Azure.Storage.Blobs
             /// <param name="rehydratePriority">Optional: Indicates the priority with which to rehydrate an archived blob.</param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="leaseId">If specified, the operation only succeeds if the resource's lease is active and matches this ID.</param>
-            /// <returns>The Blob.SetTierAsync Message.</returns>
-            internal static Azure.Core.Pipeline.HttpPipelineMessage SetTierAsync_CreateMessage(
+            /// <returns>The Blob.SetAccessTierAsync Message.</returns>
+            internal static Azure.Core.Pipeline.HttpPipelineMessage SetAccessTierAsync_CreateMessage(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
                 Azure.Storage.Blobs.Models.AccessTier tier,
@@ -7280,11 +7280,11 @@ namespace Azure.Storage.Blobs
             }
 
             /// <summary>
-            /// Create the Blob.SetTierAsync response or throw a failure exception.
+            /// Create the Blob.SetAccessTierAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Blob.SetTierAsync Azure.Response.</returns>
-            internal static Azure.Response SetTierAsync_CreateResponse(
+            /// <returns>The Blob.SetAccessTierAsync Azure.Response.</returns>
+            internal static Azure.Response SetAccessTierAsync_CreateResponse(
                 Azure.Response response)
             {
                 // Process the response
@@ -7308,7 +7308,7 @@ namespace Azure.Storage.Blobs
                     }
                 }
             }
-            #endregion Blob.SetTierAsync
+            #endregion Blob.SetAccessTierAsync
         }
         #endregion Blob operations
 

--- a/sdk/storage/Azure.Storage.Blobs/swagger/readme.md
+++ b/sdk/storage/Azure.Storage.Blobs/swagger/readme.md
@@ -1143,3 +1143,12 @@ directive:
   transform: >
     $.put.responses["201"].headers["x-ms-content-crc64"]["x-ms-client-name"] = "ContentCrc64";
 ```
+
+### Rename SetTier to SetAccessTier
+``` yaml
+directive:
+- from: swagger-document
+  where: $["x-ms-paths"]["/{containerName}/{blob}?comp=tier"]
+  transform: >
+    $.put.operationId = "Blob_SetAccessTier";
+```

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -749,7 +749,7 @@ namespace Azure.Storage.Blobs.Test
                 Assert.IsTrue(operation.HasValue);
 
                 // Act
-                await destBlob.SetTierAsync(AccessTier.Cool);
+                await destBlob.SetAccessTierAsync(AccessTier.Cool);
                 Response<BlobProperties> propertiesResponse = await destBlob.GetPropertiesAsync();
 
                 // Assert
@@ -2299,7 +2299,7 @@ namespace Azure.Storage.Blobs.Test
                 BlobBaseClient blob = await GetNewBlobClient(container);
 
                 // Act
-                Response response = await blob.SetTierAsync(AccessTier.Cool);
+                Response response = await blob.SetAccessTierAsync(AccessTier.Cool);
 
                 // Assert
                 Assert.IsNotNull(response.Headers.RequestId);
@@ -2320,7 +2320,7 @@ namespace Azure.Storage.Blobs.Test
                 await InstrumentClient(blob.GetLeaseClient(leaseId)).AcquireAsync(duration);
 
                 // Act
-                Response response = await blob.SetTierAsync(
+                Response response = await blob.SetAccessTierAsync(
                     accessTier: AccessTier.Cool,
                     leaseAccessConditions: new LeaseAccessConditions
                     {
@@ -2350,7 +2350,7 @@ namespace Azure.Storage.Blobs.Test
 
                 // Act
                 await TestHelper.AssertExpectedExceptionAsync<StorageRequestFailedException>(
-                    blob.SetTierAsync(
+                    blob.SetAccessTierAsync(
                         accessTier: AccessTier.Cool,
                         leaseAccessConditions: new LeaseAccessConditions
                         {
@@ -2372,7 +2372,7 @@ namespace Azure.Storage.Blobs.Test
 
                 // Act
                 await TestHelper.AssertExpectedExceptionAsync<StorageRequestFailedException>(
-                    blob.SetTierAsync(AccessTier.Cool),
+                    blob.SetAccessTierAsync(AccessTier.Cool),
                     e => Assert.AreEqual("BlobNotFound", e.ErrorCode));
             }
         }
@@ -2384,10 +2384,10 @@ namespace Azure.Storage.Blobs.Test
             {
                 // arrange
                 BlobBaseClient blob = await GetNewBlobClient(container);
-                await blob.SetTierAsync(AccessTier.Archive);
+                await blob.SetAccessTierAsync(AccessTier.Archive);
 
                 // Act
-                Response setTierResponse = await blob.SetTierAsync(
+                Response setTierResponse = await blob.SetAccessTierAsync(
                     accessTier: AccessTier.Cool,
                     rehydratePriority: RehydratePriority.High);
                 Response<BlobProperties> propertiesResponse = await blob.GetPropertiesAsync();
@@ -2405,10 +2405,10 @@ namespace Azure.Storage.Blobs.Test
 
                 // arrange
                 BlobBaseClient blob = await GetNewBlobClient(container);
-                await blob.SetTierAsync(AccessTier.Archive);
+                await blob.SetAccessTierAsync(AccessTier.Archive);
 
                 await TestHelper.AssertExpectedExceptionAsync<StorageRequestFailedException>(
-                    blob.SetTierAsync(accessTier: AccessTier.Cool, rehydratePriority: "None"),
+                    blob.SetAccessTierAsync(accessTier: AccessTier.Cool, rehydratePriority: "None"),
                     e => Assert.AreEqual("InvalidHeaderValue", e.ErrorCode));
             }
         }

--- a/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
@@ -1489,7 +1489,7 @@ namespace Azure.Storage.Blobs.Test
                 PageBlobClient blob = await CreatePageBlobClientAsync(container, Constants.KB);
 
                 // Act
-                Response response = await blob.SetTierAsync(AccessTier.P20);
+                Response response = await blob.SetAccessTierAsync(AccessTier.P20);
 
                 // Assert
                 Response<BlobProperties> responseProperties = await blob.GetPropertiesAsync();
@@ -1508,7 +1508,7 @@ namespace Azure.Storage.Blobs.Test
 
                 // Assert
                 await TestHelper.AssertExpectedExceptionAsync<StorageRequestFailedException>(
-                    blob.SetTierAsync(AccessTier.Cool),
+                    blob.SetAccessTierAsync(AccessTier.Cool),
                     e => Assert.AreEqual(BlobErrorCode.InvalidBlobTier.ToString(), e.ErrorCode));
             }
         }


### PR DESCRIPTION
Fixes #7846 
Updated swagger for the sake of consistency. Without this update, we would have a default value set for the operationName parameter in SetAccessTierAsync that differed from the value passed in from BlobBaseClient. Since all platforms are aligned with this change, we may want to update the spec itself.