### PR TITLE
Fix some API Documentation links

### DIFF
--- a/sdk/identity/Azure.Identity/README.md
+++ b/sdk/identity/Azure.Identity/README.md
@@ -213,6 +213,6 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 [queues_client_library]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/storage/Azure.Storage.Queues
 [eventhubs_client_library]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/eventhub/Azure.Messaging.EventHubs
 [azure_core_library]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/core/Azure.Core
-[identity_api_docs]: https://azure.github.io/azure-sdk-for-net/api/Identity/Azure.Identity.html
+[identity_api_docs]: https://azure.github.io/azure-sdk-for-net/api/Azure.Identity.html
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsdk%2Fidentity%2FAzure.Identity%2FFREADME.png)

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/README.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/README.md
@@ -202,7 +202,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 <!-- LINKS -->
 [certificate_client_src]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/keyvault/Azure.Security.KeyVault.Certificates/src
 [certificate_client_nuget_package]: https://www.nuget.org/packages/Azure.Security.KeyVault.Certificate/
-[API_reference]: https://azure.github.io/azure-sdk-for-net/api/KeyVault/Azure.Security.KeyVault.Certificates.html
+[API_reference]: https://azure.github.io/azure-sdk-for-net/api/Azure.Security.KeyVault.Certificates.html
 [keyvault_docs]: https://docs.microsoft.com/en-us/azure/key-vault/
 [certificate_client_samples]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/keyvault/Azure.Security.KeyVault.Certificates/samples
 [nuget]: https://www.nuget.org/

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/README.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/README.md
@@ -317,7 +317,7 @@ When you submit a pull request, a CLA-bot will automatically determine whether y
 This project has adopted the [Microsoft Open Source Code of Conduct][code_of_conduct]. For more information see the Code of Conduct FAQ or contact opencode@microsoft.com with any additional questions or comments.
 
 <!-- LINKS -->
-[API_reference]: https://azure.github.io/azure-sdk-for-net/api/KeyVault/Azure.Security.KeyVault.Keys.html
+[API_reference]: https://azure.github.io/azure-sdk-for-net/api/Azure.Security.KeyVault.Keys.html
 [azure_cli]: https://docs.microsoft.com/cli/azure
 [azure_identity]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/identity/Azure.Identity
 [azure_sub]: https://azure.microsoft.com/free/

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/README.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/README.md
@@ -255,7 +255,7 @@ When you submit a pull request, a CLA-bot will automatically determine whether y
 This project has adopted the [Microsoft Open Source Code of Conduct][code_of_conduct]. For more information see the Code of Conduct FAQ or contact opencode@microsoft.com with any additional questions or comments.
 
 <!-- LINKS -->
-[API_reference]: https://azure.github.io/azure-sdk-for-net/api/KeyVault/Azure.Security.KeyVault.Secrets.html
+[API_reference]: https://azure.github.io/azure-sdk-for-net/api/Azure.Security.KeyVault.Secrets.html
 [azure_cli]: https://docs.microsoft.com/cli/azure
 [azure_identity]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/identity/Azure.Identity
 [azure_sub]: https://azure.microsoft.com/free/


### PR DESCRIPTION
While trying to learn more about the identity package, I noticed the link to API level documentation was wrong in the README.md.  It looked like there were a few other packages where the documentation still included the "service name" as part of the URL, while it appears that the documentation site itself no longer uses this convention.