### PR TITLE
Treat request failure to IDMS as unavailability

### DIFF
--- a/sdk/identity/Azure.Identity/src/ManagedIdentityClient.cs
+++ b/sdk/identity/Azure.Identity/src/ManagedIdentityClient.cs
@@ -345,6 +345,12 @@ namespace Azure.Identity
 
                     return true;
                 }
+                // if the request failed for some reason, take that to mean the idms endpoint is not available.
+                catch (RequestFailedException)
+                {
+                    // todo: log
+                    return false;
+                }
                 // we only want to handle the case when the imdsTimeout resulted in the request being cancelled.
                 // this indicates that the request timed out and that imds is not available.  If the operation
                 // was user cancelled we don't wan't to handle the exception so s_identityAvailable will


### PR DESCRIPTION
While the timeout we include often means that we do not observe request
failures (since our timeout fires before the overall operation fails) I
was running into issues locally where `HttpRequestException`'s were
flying out of this method (because of the attempt to hit an unroutable
network).

In #7669 we changed the `HttpClientTransport` to wrap all exceptions in a
`RequestFailedException` so lets take a failing request to this endpoint
to mean that IDMS isn't available.