### PR TITLE
[Event Hubs Client] Track Two: Fourth Preview (AMQP Receiver Scope)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/tests/Infrastructure/StorageScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/tests/Infrastructure/StorageScope.cs
@@ -24,10 +24,10 @@ namespace Azure.Messaging.EventHubs.CheckpointStore.Blob.Tests.Infrastructure
     public sealed class StorageScope : IAsyncDisposable
     {
         /// <summary>The set of characters considered invalid in a blob container name.</summary>
-        private static readonly Regex s_invalidContainerCharactersExpression = new Regex("[^a-z0-9]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex InvalidContainerCharactersExpression = new Regex("[^a-z0-9]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         /// <summary>The manager for common live test resource operations.</summary>
-        private static readonly LiveResourceManager s_resourceManager = new LiveResourceManager();
+        private static readonly LiveResourceManager ResourceManager = new LiveResourceManager();
 
         /// <summary>Serves as a sentinel flag to denote when the instance has been disposed.</summary>
         private bool _disposed = false;
@@ -62,12 +62,12 @@ namespace Azure.Messaging.EventHubs.CheckpointStore.Blob.Tests.Infrastructure
 
             var resourceGroup = TestEnvironment.EventHubsResourceGroup;
             var storageAccount = StorageTestEnvironment.StorageAccountName;
-            var token = await s_resourceManager.AquireManagementTokenAsync();
+            var token = await ResourceManager.AquireManagementTokenAsync();
             var client = new StorageManagementClient(new TokenCredentials(token)) { SubscriptionId = TestEnvironment.EventHubsSubscription };
 
             try
             {
-                await s_resourceManager.CreateRetryPolicy().ExecuteAsync(() => client.BlobContainers.DeleteAsync(resourceGroup, storageAccount, ContainerName));
+                await ResourceManager.CreateRetryPolicy().ExecuteAsync(() => client.BlobContainers.DeleteAsync(resourceGroup, storageAccount, ContainerName));
             }
             catch
             {
@@ -96,18 +96,18 @@ namespace Azure.Messaging.EventHubs.CheckpointStore.Blob.Tests.Infrastructure
         ///
         public static async Task<StorageScope> CreateAsync([CallerMemberName] string caller = "")
         {
-            caller = s_invalidContainerCharactersExpression.Replace(caller.ToLowerInvariant(), string.Empty);
+            caller = InvalidContainerCharactersExpression.Replace(caller.ToLowerInvariant(), string.Empty);
             caller = (caller.Length < 16) ? caller : caller.Substring(0, 15);
 
             var resourceGroup = TestEnvironment.EventHubsResourceGroup;
             var storageAccount = StorageTestEnvironment.StorageAccountName;
-            var token = await s_resourceManager.AquireManagementTokenAsync();
+            var token = await ResourceManager.AquireManagementTokenAsync();
 
             string CreateName() => $"{ Guid.NewGuid().ToString("D").Substring(0, 13) }-{ caller }";
 
             using (var client = new StorageManagementClient(new TokenCredentials(token)) { SubscriptionId = TestEnvironment.EventHubsSubscription })
             {
-                BlobContainer container = await s_resourceManager.CreateRetryPolicy().ExecuteAsync(() => client.BlobContainers.CreateAsync(resourceGroup, storageAccount, CreateName(), PublicAccess.None));
+                BlobContainer container = await ResourceManager.CreateRetryPolicy().ExecuteAsync(() => client.BlobContainers.CreateAsync(resourceGroup, storageAccount, CreateName(), PublicAccess.None));
                 return new StorageScope(container.Name);
             }
         }
@@ -123,18 +123,18 @@ namespace Azure.Messaging.EventHubs.CheckpointStore.Blob.Tests.Infrastructure
         {
             var subscription = TestEnvironment.EventHubsSubscription;
             var resourceGroup = TestEnvironment.EventHubsResourceGroup;
-            var token = await s_resourceManager.AquireManagementTokenAsync();
+            var token = await ResourceManager.AquireManagementTokenAsync();
 
             static string CreateName() => $"neteventhubs{ Guid.NewGuid().ToString("N").Substring(0, 12) }";
 
             using (var client = new StorageManagementClient(new TokenCredentials(token)) { SubscriptionId = subscription })
             {
-                var location = await s_resourceManager.QueryResourceGroupLocationAsync(token, resourceGroup, subscription);
+                var location = await ResourceManager.QueryResourceGroupLocationAsync(token, resourceGroup, subscription);
                 var sku = new Sku(SkuName.StandardLRS, SkuTier.Standard);
-                var parameters = new StorageAccountCreateParameters(sku, Kind.BlobStorage, location: location, tags: s_resourceManager.GenerateTags(), accessTier: AccessTier.Hot);
-                StorageAccount storageAccount = await s_resourceManager.CreateRetryPolicy<StorageAccount>().ExecuteAsync(() => client.StorageAccounts.CreateAsync(resourceGroup, CreateName(), parameters));
+                var parameters = new StorageAccountCreateParameters(sku, Kind.BlobStorage, location: location, tags: ResourceManager.GenerateTags(), accessTier: AccessTier.Hot);
+                StorageAccount storageAccount = await ResourceManager.CreateRetryPolicy<StorageAccount>().ExecuteAsync(() => client.StorageAccounts.CreateAsync(resourceGroup, CreateName(), parameters));
 
-                StorageAccountListKeysResult storageKeys = await s_resourceManager.CreateRetryPolicy<StorageAccountListKeysResult>().ExecuteAsync(() => client.StorageAccounts.ListKeysAsync(resourceGroup, storageAccount.Name));
+                StorageAccountListKeysResult storageKeys = await ResourceManager.CreateRetryPolicy<StorageAccountListKeysResult>().ExecuteAsync(() => client.StorageAccounts.ListKeysAsync(resourceGroup, storageAccount.Name));
                 return new StorageProperties(storageAccount.Name, $"DefaultEndpointsProtocol=https;AccountName={ storageAccount.Name };AccountKey={ storageKeys.Keys[0].Value };EndpointSuffix=core.windows.net");
             }
         }
@@ -150,11 +150,11 @@ namespace Azure.Messaging.EventHubs.CheckpointStore.Blob.Tests.Infrastructure
         {
             var subscription = TestEnvironment.EventHubsSubscription;
             var resourceGroup = TestEnvironment.EventHubsResourceGroup;
-            var token = await s_resourceManager.AquireManagementTokenAsync();
+            var token = await ResourceManager.AquireManagementTokenAsync();
 
             using (var client = new StorageManagementClient(new TokenCredentials(token)) { SubscriptionId = subscription })
             {
-                await s_resourceManager.CreateRetryPolicy().ExecuteAsync(() => client.StorageAccounts.DeleteAsync(resourceGroup, accountName));
+                await ResourceManager.CreateRetryPolicy().ExecuteAsync(() => client.StorageAccounts.DeleteAsync(resourceGroup, accountName));
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpEventHubConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpEventHubConsumer.cs
@@ -1,0 +1,148 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Messaging.EventHubs.Core;
+using Azure.Messaging.EventHubs.Metadata;
+using Microsoft.Azure.Amqp;
+
+namespace Azure.Messaging.EventHubs.Amqp
+{
+    /// <summary>
+    ///   A transport client abstraction responsible for brokering operations for AMQP-based connections.
+    ///   It is intended that the public <see cref="EventHubConsumer" /> make use of an instance
+    ///   via containment and delegate operations to it.
+    /// </summary>
+    ///
+    /// <seealso cref="Azure.Messaging.EventHubs.Core.TransportEventHubConsumer" />
+    ///
+    internal class AmqpEventHubConsumer : TransportEventHubConsumer
+    {
+        /// <summary>The active retry policy for the consumer.</summary>
+        private EventHubRetryPolicy _retryPolicy;
+
+        /// <summary>The amount of time to allow for an operation to complete before considering it to have timed out.</summary>
+        private TimeSpan _tryTimeout;
+
+        /// <summary>Indicates whether or not this instance has been closed.</summary>
+        private bool _closed = false;
+
+        /// <summary>
+        ///   Indicates whether or not this consumer has been closed.
+        /// </summary>
+        ///
+        /// <value>
+        ///   <c>true</c> if the consumer is closed; otherwise, <c>false</c>.
+        /// </value>
+        ///
+        public override bool Closed => _closed;
+
+        /// <summary>
+        ///   The converter to use for translating between AMQP messages and client library
+        ///   types.
+        /// </summary>
+        ///
+        private AmqpMessageConverter MessageConverter { get; }
+
+        /// <summary>
+        ///   The AMQP connection scope responsible for managing transport constructs for this instance.
+        /// </summary>
+        ///
+        private AmqpConnectionScope ConnectionScope { get; }
+
+        /// <summary>
+        ///   The AMQP link intended for use with receiving operations.
+        /// </summary>
+        ///
+        private FaultTolerantAmqpObject<ReceivingAmqpLink> ReceiveLink { get; }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="AmqpEventHubConsumer"/> class.
+        /// </summary>
+        ///
+        /// <param name="consumerGroup">The name of the consumer group this consumer is associated with.  Events are read in the context of this group.</param>
+        /// <param name="partitionId">The identifier of the Event Hub partition from which events will be received.</param>
+        /// <param name="consumerOptions">The set of active options for the consumer that will make use of the link.</param>
+        /// <param name="eventPosition">The position of the event in the partition where the consumer should begin reading.</param>
+        /// <param name="connectionScope">The AMQP connection context for operations .</param>
+        /// <param name="messageConverter">The converter to use for translating between AMQP messages and client types.</param>
+        /// <param name="retryPolicy">The retry policy to consider when an operation fails.</param>
+        /// <param name="lastEnqueuedEventProperties">The set of properties for the last event enqueued in a partition; if not requested in the consumer options, it is expected that this is <c>null</c>.</param>
+        ///
+        /// <remarks>
+        ///   As an internal type, this class performs only basic sanity checks against its arguments.  It
+        ///   is assumed that callers are trusted and have performed deep validation.
+        ///
+        ///   Any parameters passed are assumed to be owned by this instance and safe to mutate or dispose;
+        ///   creation of clones or otherwise protecting the parameters is assumed to be the purview of the
+        ///   caller.
+        /// </remarks>
+        ///
+        public AmqpEventHubConsumer(string consumerGroup,
+                                    string partitionId,
+                                    EventPosition eventPosition,
+                                    EventHubConsumerOptions consumerOptions,
+                                    AmqpConnectionScope connectionScope,
+                                    AmqpMessageConverter messageConverter,
+                                    EventHubRetryPolicy retryPolicy,
+                                    LastEnqueuedEventProperties lastEnqueuedEventProperties) : base(lastEnqueuedEventProperties)
+        {
+            Argument.AssertNotNullOrEmpty(consumerGroup, nameof(consumerGroup));
+            Argument.AssertNotNullOrEmpty(partitionId, nameof(partitionId));
+            Argument.AssertNotNull(connectionScope, nameof(connectionScope));
+            Argument.AssertNotNull(messageConverter, nameof(messageConverter));
+            Argument.AssertNotNull(retryPolicy, nameof(retryPolicy));
+
+            ConnectionScope = connectionScope;
+            MessageConverter = messageConverter;
+            ReceiveLink = new FaultTolerantAmqpObject<ReceivingAmqpLink>(timeout => ConnectionScope.OpenConsumerLinkAsync(consumerGroup, partitionId, eventPosition, consumerOptions, timeout, CancellationToken.None), link => link.SafeClose());
+
+            _retryPolicy = retryPolicy;
+            _tryTimeout = retryPolicy.CalculateTryTimeout(0);
+        }
+
+        /// <summary>
+        ///   Updates the active retry policy for the consumer.
+        /// </summary>
+        ///
+        /// <param name="newRetryPolicy">The retry policy to set as active.</param>
+        ///
+        public override void UpdateRetryPolicy(EventHubRetryPolicy newRetryPolicy)
+        {
+            Argument.AssertNotNull(newRetryPolicy, nameof(newRetryPolicy));
+
+            _retryPolicy = newRetryPolicy;
+            _tryTimeout = _retryPolicy.CalculateTryTimeout(0);
+        }
+
+        /// <summary>
+        ///   Receives a batch of <see cref="EventData" /> from the Event Hub partition.
+        /// </summary>
+        ///
+        /// <param name="maximumMessageCount">The maximum number of messages to receive in this batch.</param>
+        /// <param name="maximumWaitTime">The maximum amount of time to wait to build up the requested message count for the batch; if not specified, the default wait time specified when the consumer was created will be used.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        /// <returns>The batch of <see cref="EventData" /> from the Event Hub partition this consumer is associated with.  If no events are present, an empty enumerable is returned.</returns>
+        ///
+        public override Task<IEnumerable<EventData>> ReceiveAsync(int maximumMessageCount,
+                                                                  TimeSpan? maximumWaitTime,
+                                                                  CancellationToken cancellationToken)
+        {
+             throw new NotImplementedException();
+        }
+
+        /// <summary>
+        ///   Closes the connection to the transport consumer instance.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        public override Task CloseAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpFilter.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpFilter.cs
@@ -1,6 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using Azure.Core;
+using Microsoft.Azure.Amqp;
+using Microsoft.Azure.Amqp.Framing;
+
 namespace Azure.Messaging.EventHubs
 {
     /// <summary>
@@ -11,12 +16,66 @@ namespace Azure.Messaging.EventHubs
     internal static class AmqpFilter
     {
         /// <summary>Indicates filtering based on the sequence number of a message.</summary>
-        public const string SeqNumberName = "amqp.annotation.x-opt-sequence-number";
+        public const string SequenceNumberName = "amqp.annotation.x-opt-sequence-number";
 
         /// <summary>Indicates filtering based on the offset of a message.</summary>
-        public const string OffsetPartName = "amqp.annotation.x-opt-offset";
+        public const string OffsetName = "amqp.annotation.x-opt-offset";
 
         /// <summary>Indicates filtering based on time that a message was enqueued.</summary>
-        public const string ReceivedAtName = "amqp.annotation.x-opt-enqueued-time";
+        public const string EnqueuedTimeName = "amqp.annotation.x-opt-enqueued-time";
+
+        /// <summary>Identifies the filter type name.</summary>
+        public const string ConsumerFilterName = AmqpConstants.Apache + ":selector-filter:string";
+
+        /// <summary>Identifies the filter type code.</summary>
+        public const ulong ConsumerFilterCode = 0x00000137000000A;
+
+        /// <summary>
+        ///   Creates an event consumer filter based on the specified expression.
+        /// </summary>
+        ///
+        /// <param name="filterExpression">The SQL-like expression to use for filtering events in the partition.</param>
+        ///
+        /// <returns>An <see cref="AmqpDescribed"/> type to use in the filter map for a consumer AMQP link.</returns>
+        ///
+        public static AmqpDescribed CreateConsumerFilter(string filterExpression)
+        {
+            Argument.AssertNotNullOrEmpty(filterExpression, nameof(filterExpression));
+            return new AmqpDescribed(ConsumerFilterName, ConsumerFilterCode) { Value = filterExpression };
+        }
+
+        /// <summary>
+        ///   Builds an AMQP filter expression for the specified event position.
+        /// </summary>
+        ///
+        /// <param name="eventPosition">The event position to use as the source for filtering.</param>
+        ///
+        /// <returns>The AMQP filter expression that corresponds to the <paramref name="eventPosition"/>.</returns>
+        ///
+        public static string BuildFilterExpression(EventPosition eventPosition)
+        {
+            Argument.AssertNotNull(eventPosition, nameof(eventPosition));
+
+            // Build the filter expression, in the order of significance.
+
+            if (!string.IsNullOrEmpty(eventPosition.Offset))
+            {
+                return $"{ OffsetName } { (eventPosition.IsInclusive ? ">=" : ">") } { eventPosition.Offset }";
+            }
+
+            if (eventPosition.SequenceNumber.HasValue)
+            {
+                return $"{ SequenceNumberName } { (eventPosition.IsInclusive ? ">=" : ">") } { eventPosition.SequenceNumber.Value }";
+            }
+
+            if (eventPosition.EnqueuedTime.HasValue)
+            {
+                return $"{ EnqueuedTimeName } > { eventPosition.EnqueuedTime.Value.ToUnixTimeMilliseconds() }";
+            }
+
+            // If no filter was built, than the event position is not valid for filtering.
+
+            throw new ArgumentException(Resources.InvalidEventPositionForFilter, nameof(eventPosition));
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProperty.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProperty.cs
@@ -26,6 +26,12 @@ namespace Azure.Messaging.EventHubs
         public static AmqpSymbol EntityType { get; } = AmqpConstants.Vendor + ":entity-type";
 
         /// <summary>
+        ///   The capability for tracking the last event enqueued in a partition, to associate with a link.
+        /// </summary>
+        ///
+        public static AmqpSymbol TrackLastEnqueuedEventInformation { get; } = AmqpConstants.Vendor + ":enable-receiver-runtime-metric";
+
+        /// <summary>
         ///   The timeout to associate with a link.
         /// </summary>
         ///
@@ -85,6 +91,31 @@ namespace Azure.Messaging.EventHubs
             /// </summary>
             ///
             public static AmqpSymbol DateTimeOffset { get; } = AmqpConstants.Vendor + ":datetime-offset";
+        }
+
+        /// <summary>
+        ///   Represents the entity mapping for AMQP properties between the client library and
+        ///   the Event Hubs service.
+        /// </summary>
+        ///
+        /// <remarks>
+        ///   WARNING:
+        ///     These values are synchronized between the Event Hubs service and the client
+        ///     library.  You must consult with the Event Hubs service team before making
+        ///     changes, including adding a new member.
+        ///
+        ///     When adding a new member, remember to always do so before the Unknown
+        ///     member.
+        /// </remarks>
+        ///
+        public enum Entity
+        {
+            Namespace = 4,
+            EventHub = 7,
+            ConsumerGroup = 8,
+            Partition = 9,
+            Checkpoint = 10,
+            Unknown = 0x7FFFFFFE
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/CbsTokenProvider.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/CbsTokenProvider.cs
@@ -64,7 +64,9 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// <param name="requiredClaims">The set of claims that are required for authorization.</param>
         /// <returns>The token to use for authorization.</returns>
         ///
-        public async Task<CbsToken> GetTokenAsync(Uri namespaceAddress, string appliesTo, string[] requiredClaims)
+        public async Task<CbsToken> GetTokenAsync(Uri namespaceAddress,
+                                                  string appliesTo,
+                                                  string[] requiredClaims)
         {
             AccessToken token = await _credential.GetTokenAsync(new TokenRequest(requiredClaims), _cancellationToken);
             return new CbsToken(token.Token, _tokenType, token.ExpiresOn.UtcDateTime);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -30,10 +30,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="Azure.Messaging.EventHubs.Reference.props" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="System.Reflection.TypeExtensions" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubConsumer.cs
@@ -35,6 +35,16 @@ namespace Azure.Messaging.EventHubs.Compatibility
         private TrackOne.PartitionReceiver TrackOneReceiver => _trackOneReceiver.Value;
 
         /// <summary>
+        ///   Indicates whether or not this consumer has been closed.
+        /// </summary>
+        ///
+        /// <value>
+        ///   <c>true</c> if the consumer is closed; otherwise, <c>false</c>.
+        /// </value>
+        ///
+        public override bool Closed => (_trackOneReceiver.IsValueCreated) ? _trackOneReceiver.Value.EventHubClient.CloseCalled : false;
+
+        /// <summary>
         ///     Initializes a new instance of the <see cref="TrackOneEventHubConsumer"/> class.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventHubConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventHubConsumer.cs
@@ -19,6 +19,16 @@ namespace Azure.Messaging.EventHubs.Core
     internal abstract class TransportEventHubConsumer
     {
         /// <summary>
+        ///   Indicates whether or not this consumer has been closed.
+        /// </summary>
+        ///
+        /// <value>
+        ///   <c>true</c> if the consumer is closed; otherwise, <c>false</c>.
+        /// </value>
+        ///
+        public virtual bool Closed { get; }
+
+        /// <summary>
         ///   A set of information about the enqueued state of a partition, as observed by the consumer as
         ///   events are received from the Event Hubs service.
         /// </summary>
@@ -39,7 +49,7 @@ namespace Azure.Messaging.EventHubs.Core
         }
 
         /// <summary>
-        ///   Updates the active retry policy for the client.
+        ///   Updates the active retry policy for the consumer.
         /// </summary>
         ///
         /// <param name="newRetryPolicy">The retry policy to set as active.</param>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -398,6 +398,59 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
+        ///   Indicates that refreshing authorization for an AMQP link has started.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the Event Hub that the link is associated with.</param>
+        /// <param name="endpoint">The service endpoint that the link is bound to for communication.</param>
+        ///
+        [Event(21, Level = EventLevel.Informational, Message = "Beginning refresh of AMQP link authorization for Event Hub: {0} (Service Endpoint: '{1}').")]
+        public void AmqpLinkAuthorizationRefreshStart(string eventHubName,
+                                                      string endpoint)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(21, eventHubName ?? string.Empty, endpoint ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that refreshing authorization for an AMQP link has completed.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the Event Hub that the link is associated with.</param>
+        /// <param name="endpoint">The service endpoint that the link is bound to for communication.</param>
+        ///
+        [Event(22, Level = EventLevel.Informational, Message = "Completed refresh of AMQP link authorization for Event Hub: {0} (Service Endpoint: '{1}').")]
+        public void AmqpLinkAuthorizationRefreshComplete(string eventHubName,
+                                                         string endpoint)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(22, eventHubName ?? string.Empty, endpoint ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an exception was encountered while refreshing authorization for an AMQP link has started.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the Event Hub that the link is associated with.</param>
+        /// <param name="endpoint">The service endpoint that the link is bound to for communication.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(23, Level = EventLevel.Error, Message = "An exception occurred while refreshing AMQP link authorization for Event Hub: {0} (Service Endpoint: '{1}'). Error Message: '{2}'")]
+        public void AmqpLinkAuthorizationRefreshError(string eventHubName,
+                                                      string endpoint,
+                                                      string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(23, eventHubName ?? string.Empty, endpoint ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
         ///   Indicates that an exception was encountered in an unexpected code path, not directly associated with
         ///   an Event Hubs operation.
         /// </summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventPosition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventPosition.cs
@@ -183,6 +183,4 @@ namespace Azure.Messaging.EventHubs
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override string ToString() => base.ToString();
     }
-
-    //TODO: Implement the AMQP-specific methods from track 1 to a new abstraction. (They were not brought forward)
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.Designer.cs
@@ -338,5 +338,23 @@ namespace Azure.Messaging.EventHubs {
                 return ResourceManager.GetString("ValueOutOfRange", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The event position is not valid for filtering.  It must have an offset, sequence number, or enqueued time available to filter against..
+        /// </summary>
+        internal static string InvalidEventPositionForFilter {
+            get {
+                return ResourceManager.GetString("InvalidEventPositionForFilter", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to create the items needed to communicate with the Event Hubs service..
+        /// </summary>
+        internal static string CouldNotCreateLink {
+            get {
+                return ResourceManager.GetString("CouldNotCreateLink", resourceCulture);
+            }
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.resx
@@ -210,4 +210,10 @@
   <data name="InvalidMessageBody" xml:space="preserve">
     <value>An invalid message body was encountered.  Either the body was null or an incorrect type. Expected: {0}</value>
   </data>
+  <data name="InvalidEventPositionForFilter" xml:space="preserve">
+    <value>The event position is not valid for filtering.  It must have an offset, sequence number, or enqueued time available to filter against.</value>
+  </data>
+  <data name="CouldNotCreateLink" xml:space="preserve">
+    <value>Unable to create the items needed to communicate with the Event Hubs service.</value>
+  </data>
 </root>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConnectionScopeTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConnectionScopeTests.cs
@@ -2,13 +2,18 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
+using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Messaging.EventHubs.Amqp;
+using Azure.Messaging.EventHubs.Authorization;
 using Microsoft.Azure.Amqp;
+using Microsoft.Azure.Amqp.Encoding;
+using Microsoft.Azure.Amqp.Framing;
 using Microsoft.Azure.Amqp.Transport;
 using Moq;
 using Moq.Protected;
@@ -86,7 +91,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockScope
                 .Protected()
-                .Setup<Task<AmqpConnection>>("CreateConnectionAsync",
+                .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
                     ItExpr.IsAny<Version>(),
                     ItExpr.Is<Uri>(value => value == endpoint),
                     ItExpr.Is<TransportType>(value => value == transport),
@@ -159,6 +164,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var identifier = "customIdentIFIER";
             var cancellationSource = new CancellationTokenSource();
             var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
+            var mockSession = new AmqpSession(mockConnection, new AmqpSessionSettings(), Mock.Of<ILinkFactory>());
+            var mockLink = new RequestResponseAmqpLink("test", "test", mockSession, "test");
 
             var mockScope = new Mock<AmqpConnectionScope>(endpoint, eventHub, credential, transport, null, identifier)
             {
@@ -167,7 +174,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockScope
                 .Protected()
-                .Setup<Task<AmqpConnection>>("CreateConnectionAsync",
+                .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
                     ItExpr.IsAny<Version>(),
                     ItExpr.Is<Uri>(value => value == endpoint),
                     ItExpr.Is<TransportType>(value => value == transport),
@@ -179,17 +186,1100 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockScope
                 .Protected()
-                .Setup<Task<RequestResponseAmqpLink>>("OpenManagementLinkAsync",
+                .Setup<Task<RequestResponseAmqpLink>>("CreateManagementLinkAsync",
                     ItExpr.Is<AmqpConnection>(value => value == mockConnection),
                     ItExpr.IsAny<TimeSpan>(),
                     ItExpr.Is<CancellationToken>(value => value == cancellationSource.Token))
-                .Returns(Task.FromResult(default(RequestResponseAmqpLink)))
+                .Returns(Task.FromResult(mockLink))
                 .Verifiable();
 
-            RequestResponseAmqpLink link = await mockScope.Object.OpenManagementLinkAsync(TimeSpan.FromDays(1), cancellationSource.Token);
-            Assert.That(link, Is.Null, "The mock return was null");
+            mockScope
+                .Protected()
+                .Setup<Task>("OpenAmqpObjectAsync",
+                    ItExpr.IsAny<AmqpObject>(),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+
+            var link = await mockScope.Object.OpenManagementLinkAsync(TimeSpan.FromDays(1), cancellationSource.Token);
+            Assert.That(link, Is.EqualTo(mockLink), "The mock return was incorrect");
 
             mockScope.VerifyAll();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConnectionScope.OpenManagementLinkAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task OpenManagementLinkAsyncManagesActiveLinks()
+        {
+            var endpoint = new Uri("amqp://test.service.gov");
+            var eventHub = "myHub";
+            var credential = Mock.Of<TokenCredential>();
+            var transport = TransportType.AmqpTcp;
+            var identifier = "customIdentIFIER";
+            var cancellationSource = new CancellationTokenSource();
+            var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
+
+            var mockScope = new Mock<AmqpConnectionScope>(endpoint, eventHub, credential, transport, null, identifier)
+            {
+                CallBase = true
+            };
+
+            mockScope
+                .Protected()
+                .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
+                    ItExpr.IsAny<Version>(),
+                    ItExpr.Is<Uri>(value => value == endpoint),
+                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<IWebProxy>(value => value == null),
+                    ItExpr.Is<string>(value => value == identifier),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.FromResult(mockConnection));
+
+            mockScope
+                .Protected()
+                .Setup<Task>("OpenAmqpObjectAsync",
+                    ItExpr.IsAny<AmqpObject>(),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.CompletedTask);
+
+            var activeLinks = GetActiveLinks(mockScope.Object);
+            Assert.That(activeLinks, Is.Not.Null, "The set of active links was null.");
+            Assert.That(activeLinks.Count, Is.Zero, "There should be no active links when none have been created.");
+
+            var link = await mockScope.Object.OpenManagementLinkAsync(TimeSpan.FromDays(1), cancellationSource.Token);
+            Assert.That(link, Is.Not.Null, "The link produced was null");
+
+            Assert.That(activeLinks.Count, Is.EqualTo(1), "There should be an active link being tracked.");
+            Assert.That(activeLinks.ContainsKey(link), Is.True, "The management link should be tracked as active.");
+
+            activeLinks.TryGetValue(link, out var refreshTimer);
+            Assert.That(refreshTimer, Is.Null, "The link should have a null timer since it has no authorization refresh needs.");
+
+            link.SafeClose();
+            Assert.That(activeLinks.Count, Is.Zero, "Closing the link should stop tracking it as active.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConnectionScope.OpenConsumerLinkAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void OpenConsumerLinkAsyncValidatesTheConsumerGroup(string consumerGroup)
+        {
+            var endpoint = new Uri("amqp://test.service.gov");
+            var eventHub = "myHub";
+            var partitionId = "0";
+            var options = new EventHubConsumerOptions();
+            var position = EventPosition.Latest;
+            var credential = Mock.Of<TokenCredential>();
+            var transport = TransportType.AmqpTcp;
+            var identifier = "customIdentIFIER";
+
+            using var scope = new AmqpConnectionScope(endpoint, eventHub, credential, transport, null, identifier);
+            Assert.That(() => scope.OpenConsumerLinkAsync(consumerGroup, partitionId, position, options, TimeSpan.FromDays(1), CancellationToken.None), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConnectionScope.OpenConsumerLinkAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void OpenConsumerLinkAsyncValidatesThePartitionId(string partitionId)
+        {
+            var endpoint = new Uri("amqp://test.service.gov");
+            var eventHub = "myHub";
+            var consumerGroup = "$Default";
+            var options = new EventHubConsumerOptions();
+            var position = EventPosition.Latest;
+            var credential = Mock.Of<TokenCredential>();
+            var transport = TransportType.AmqpTcp;
+            var identifier = "customIdentIFIER";
+
+            using var scope = new AmqpConnectionScope(endpoint, eventHub, credential, transport, null, identifier);
+            Assert.That(() => scope.OpenConsumerLinkAsync(consumerGroup, partitionId, position, options, TimeSpan.FromDays(1), CancellationToken.None), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConnectionScope.OpenConsumerLinkAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void OpenConsumerLinkAsyncValidatesTheEventPosition()
+        {
+            var endpoint = new Uri("amqp://test.service.gov");
+            var eventHub = "myHub";
+            var consumerGroup = "$Default";
+            var partitionId = "0";
+            var options = new EventHubConsumerOptions();
+            var credential = Mock.Of<TokenCredential>();
+            var transport = TransportType.AmqpTcp;
+            var identifier = "customIdentIFIER";
+
+            using var scope = new AmqpConnectionScope(endpoint, eventHub, credential, transport, null, identifier);
+            Assert.That(() => scope.OpenConsumerLinkAsync(consumerGroup, partitionId, null, options, TimeSpan.FromDays(1), CancellationToken.None), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConnectionScope.OpenConsumerLinkAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void OpenConsumerLinkAsyncValidatesTheConsumerOptions()
+        {
+            var endpoint = new Uri("amqp://test.service.gov");
+            var eventHub = "myHub";
+            var consumerGroup = "$Default";
+            var partitionId = "0";
+            var position = EventPosition.Latest;
+            var credential = Mock.Of<TokenCredential>();
+            var transport = TransportType.AmqpTcp;
+            var identifier = "customIdentIFIER";
+
+            using var scope = new AmqpConnectionScope(endpoint, eventHub, credential, transport, null, identifier);
+            Assert.That(() => scope.OpenConsumerLinkAsync(consumerGroup, partitionId, position, null, TimeSpan.FromDays(1), CancellationToken.None), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConnectionScope.OpenConsumerLinkAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void OpenConsumerLinkAsyncRespectsTokenCancellation()
+        {
+            var endpoint = new Uri("amqp://test.service.gov");
+            var eventHub = "myHub";
+            var consumerGroup = "group";
+            var partitionId = "0";
+            var options = new EventHubConsumerOptions();
+            var position = EventPosition.Latest;
+            var credential = Mock.Of<TokenCredential>();
+            var transport = TransportType.AmqpTcp;
+            var identifier = "customIdentIFIER";
+
+            using var scope = new AmqpConnectionScope(endpoint, eventHub, credential, transport, null, identifier);
+
+            var cancellationSource = new CancellationTokenSource();
+            cancellationSource.Cancel();
+
+            Assert.That(() => scope.OpenConsumerLinkAsync(consumerGroup, partitionId, position, options, TimeSpan.FromDays(1), cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConnectionScope.OpenConsumerLinkAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void OpenConsumerLinkAsyncRespectsDisposal()
+        {
+            var endpoint = new Uri("amqp://test.service.gov");
+            var eventHub = "myHub";
+            var consumerGroup = "group";
+            var partitionId = "0";
+            var options = new EventHubConsumerOptions();
+            var position = EventPosition.Latest;
+            var credential = Mock.Of<TokenCredential>();
+            var transport = TransportType.AmqpTcp;
+            var identifier = "customIdentIFIER";
+
+            var scope = new AmqpConnectionScope(endpoint, eventHub, credential, transport, null, identifier);
+            scope.Dispose();
+
+            Assert.That(() => scope.OpenConsumerLinkAsync(consumerGroup, partitionId, position, options, TimeSpan.FromDays(1), CancellationToken.None), Throws.InstanceOf<ObjectDisposedException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConnectionScope.OpenConsumerLinkAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task OpenConsumerLinkAsyncRequestsTheLink()
+        {
+            var endpoint = new Uri("amqp://test.service.gov");
+            var eventHub = "myHub";
+            var consumerGroup = "group";
+            var partitionId = "0";
+            var options = new EventHubConsumerOptions();
+            var position = EventPosition.Latest;
+            var credential = Mock.Of<TokenCredential>();
+            var transport = TransportType.AmqpTcp;
+            var identifier = "customIdentIFIER";
+            var cancellationSource = new CancellationTokenSource();
+            var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
+            var mockSession = new AmqpSession(mockConnection, new AmqpSessionSettings(), Mock.Of<ILinkFactory>());
+            var mockLink = new ReceivingAmqpLink(new AmqpLinkSettings());
+
+            var mockScope = new Mock<AmqpConnectionScope>(endpoint, eventHub, credential, transport, null, identifier)
+            {
+                CallBase = true
+            };
+
+            mockScope
+                .Protected()
+                .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
+                    ItExpr.IsAny<Version>(),
+                    ItExpr.Is<Uri>(value => value == endpoint),
+                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<IWebProxy>(value => value == null),
+                    ItExpr.Is<string>(value => value == identifier),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.FromResult(mockConnection))
+                .Verifiable();
+
+            mockScope
+                .Protected()
+                .Setup<Task<ReceivingAmqpLink>>("CreateReceivingLinkAsync",
+                    ItExpr.Is<AmqpConnection>(value => value == mockConnection),
+                    ItExpr.Is<Uri>(value => value.AbsoluteUri.StartsWith(endpoint.AbsoluteUri)),
+                    ItExpr.Is<EventPosition>(value => value == position),
+                    ItExpr.Is<EventHubConsumerOptions>(value => value == options),
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.Is<CancellationToken>(value => value == cancellationSource.Token))
+                .Returns(Task.FromResult(mockLink))
+                .Verifiable();
+
+            mockScope
+                .Protected()
+                .Setup<Task>("OpenAmqpObjectAsync",
+                    ItExpr.IsAny<AmqpObject>(),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+
+            var link = await mockScope.Object.OpenConsumerLinkAsync(consumerGroup, partitionId, position, options, TimeSpan.FromDays(1), cancellationSource.Token);
+            Assert.That(link, Is.EqualTo(mockLink), "The mock return was incorrect");
+
+            mockScope.VerifyAll();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConnectionScope.OpenConsumerLinkAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task OpenConsumerLinkAsyncConfiguresTheLink()
+        {
+            var endpoint = new Uri("amqp://test.service.gov");
+            var eventHub = "myHub";
+            var consumerGroup = "group";
+            var partitionId = "0";
+            var position = EventPosition.Latest;
+            var credential = Mock.Of<TokenCredential>();
+            var transport = TransportType.AmqpTcp;
+            var identifier = "customIdentIFIER";
+            var cancellationSource = new CancellationTokenSource();
+            var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
+            var mockSession = new AmqpSession(mockConnection, new AmqpSessionSettings(), Mock.Of<ILinkFactory>());
+
+            var options = new EventHubConsumerOptions
+            {
+               Identifier = "testIdentifier123",
+               OwnerLevel = 459,
+               PrefetchCount = 697,
+               TrackLastEnqueuedEventInformation = true
+            };
+
+            var mockScope = new Mock<AmqpConnectionScope>(endpoint, eventHub, credential, transport, null, identifier)
+            {
+                CallBase = true
+            };
+
+            mockScope
+                .Protected()
+                .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
+                    ItExpr.IsAny<Version>(),
+                    ItExpr.Is<Uri>(value => value == endpoint),
+                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<IWebProxy>(value => value == null),
+                    ItExpr.Is<string>(value => value == identifier),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.FromResult(mockConnection));
+
+            mockScope
+                .Protected()
+                .Setup<Task<DateTime>>("RequestAuthorizationUsingCbsAsync",
+                    ItExpr.Is<AmqpConnection>(value => value == mockConnection),
+                    ItExpr.IsAny<CbsTokenProvider>(),
+                    ItExpr.Is<Uri>(value => value.AbsoluteUri.StartsWith(endpoint.AbsoluteUri)),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.Is<string[]>(value => value.SingleOrDefault() == EventHubsClaim.Listen),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.FromResult(DateTime.UtcNow.AddDays(1)));
+
+            mockScope
+                .Protected()
+                .Setup<Task>("OpenAmqpObjectAsync",
+                    ItExpr.IsAny<AmqpObject>(),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.CompletedTask);
+
+            var link = await mockScope.Object.OpenConsumerLinkAsync(consumerGroup, partitionId, position, options, TimeSpan.FromDays(1), cancellationSource.Token);
+            Assert.That(link, Is.Not.Null, "The link produced was null");
+
+            var linkSource = (Source)link.Settings.Source;
+            Assert.That(linkSource.FilterSet.Any(item => item.Key.Key.ToString() == AmqpFilter.ConsumerFilterName), Is.True, "There should have been a consumer filter set.");
+            Assert.That(linkSource.Address.ToString(), Contains.Substring($"/{ partitionId }"), "The partition identifier should have been part of the link address.");
+            Assert.That(linkSource.Address.ToString(), Contains.Substring($"/{ consumerGroup }"), "The consumer group should have been part of the link address.");
+
+            Assert.That(link.Settings.TotalLinkCredit, Is.EqualTo((uint)options.PrefetchCount), "The prefetch count should have been used to set the credits.");
+            Assert.That(link.Settings.Properties.Any(item => item.Key.Key.ToString() == AmqpProperty.EntityType.ToString()), Is.True, "There should be an entity type specified.");
+            Assert.That(link.GetSettingPropertyOrDefault<string>(AmqpProperty.ConsumerIdentifier, null), Is.EqualTo(options.Identifier), "The consumer identifier should have been used.");
+            Assert.That(link.GetSettingPropertyOrDefault<long>(AmqpProperty.OwnerLevel, -1), Is.EqualTo(options.OwnerLevel.Value), "The owner level should have been used.");
+
+            Assert.That(link.Settings.DesiredCapabilities, Is.Not.Null, "There should have been a set of desired capabilities created.");
+            Assert.That(link.Settings.DesiredCapabilities.Contains(AmqpProperty.TrackLastEnqueuedEventInformation), Is.True, "Last event tracking should be requested.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConnectionScope.OpenConsumerLinkAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public async Task OpenConsumerLinkAsyncRespectsTheIdentifierOption(string consumerIdentifier)
+        {
+            var endpoint = new Uri("amqp://test.service.gov");
+            var eventHub = "myHub";
+            var consumerGroup = "group";
+            var partitionId = "0";
+            var position = EventPosition.Latest;
+            var credential = Mock.Of<TokenCredential>();
+            var transport = TransportType.AmqpTcp;
+            var identifier = "customIdentIFIER";
+            var cancellationSource = new CancellationTokenSource();
+            var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
+            var mockSession = new AmqpSession(mockConnection, new AmqpSessionSettings(), Mock.Of<ILinkFactory>());
+
+            var options = new EventHubConsumerOptions
+            {
+               Identifier = consumerIdentifier,
+               OwnerLevel = 459,
+               PrefetchCount = 697,
+               TrackLastEnqueuedEventInformation = true
+            };
+
+            var mockScope = new Mock<AmqpConnectionScope>(endpoint, eventHub, credential, transport, null, identifier)
+            {
+                CallBase = true
+            };
+
+            mockScope
+                .Protected()
+                .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
+                    ItExpr.IsAny<Version>(),
+                    ItExpr.Is<Uri>(value => value == endpoint),
+                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<IWebProxy>(value => value == null),
+                    ItExpr.Is<string>(value => value == identifier),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.FromResult(mockConnection));
+
+            mockScope
+                .Protected()
+                .Setup<Task<DateTime>>("RequestAuthorizationUsingCbsAsync",
+                    ItExpr.Is<AmqpConnection>(value => value == mockConnection),
+                    ItExpr.IsAny<CbsTokenProvider>(),
+                    ItExpr.Is<Uri>(value => value.AbsoluteUri.StartsWith(endpoint.AbsoluteUri)),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.Is<string[]>(value => value.SingleOrDefault() == EventHubsClaim.Listen),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.FromResult(DateTime.UtcNow.AddDays(1)));
+
+            mockScope
+                .Protected()
+                .Setup<Task>("OpenAmqpObjectAsync",
+                    ItExpr.IsAny<AmqpObject>(),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.CompletedTask);
+
+            var link = await mockScope.Object.OpenConsumerLinkAsync(consumerGroup, partitionId, position, options, TimeSpan.FromDays(1), cancellationSource.Token);
+            Assert.That(link, Is.Not.Null, "The link produced was null");
+            Assert.That(link.GetSettingPropertyOrDefault<string>(AmqpProperty.ConsumerIdentifier, "NONE"), Is.EqualTo("NONE"), "The consumer identifier should not have been set.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConnectionScope.OpenConsumerLinkAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task OpenConsumerLinkAsyncRespectsTheOwnerLevelOption()
+        {
+            var endpoint = new Uri("amqp://test.service.gov");
+            var eventHub = "myHub";
+            var consumerGroup = "group";
+            var partitionId = "0";
+            var position = EventPosition.Latest;
+            var credential = Mock.Of<TokenCredential>();
+            var transport = TransportType.AmqpTcp;
+            var identifier = "customIdentIFIER";
+            var cancellationSource = new CancellationTokenSource();
+            var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
+            var mockSession = new AmqpSession(mockConnection, new AmqpSessionSettings(), Mock.Of<ILinkFactory>());
+
+            var options = new EventHubConsumerOptions
+            {
+               Identifier = "testIdentifier123",
+               OwnerLevel = null,
+               PrefetchCount = 697,
+               TrackLastEnqueuedEventInformation = true
+            };
+
+            var mockScope = new Mock<AmqpConnectionScope>(endpoint, eventHub, credential, transport, null, identifier)
+            {
+                CallBase = true
+            };
+
+            mockScope
+                .Protected()
+                .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
+                    ItExpr.IsAny<Version>(),
+                    ItExpr.Is<Uri>(value => value == endpoint),
+                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<IWebProxy>(value => value == null),
+                    ItExpr.Is<string>(value => value == identifier),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.FromResult(mockConnection));
+
+            mockScope
+                .Protected()
+                .Setup<Task<DateTime>>("RequestAuthorizationUsingCbsAsync",
+                    ItExpr.Is<AmqpConnection>(value => value == mockConnection),
+                    ItExpr.IsAny<CbsTokenProvider>(),
+                    ItExpr.Is<Uri>(value => value.AbsoluteUri.StartsWith(endpoint.AbsoluteUri)),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.Is<string[]>(value => value.SingleOrDefault() == EventHubsClaim.Listen),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.FromResult(DateTime.UtcNow.AddDays(1)));
+
+            mockScope
+                .Protected()
+                .Setup<Task>("OpenAmqpObjectAsync",
+                    ItExpr.IsAny<AmqpObject>(),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.CompletedTask);
+
+            var link = await mockScope.Object.OpenConsumerLinkAsync(consumerGroup, partitionId, position, options, TimeSpan.FromDays(1), cancellationSource.Token);
+            Assert.That(link, Is.Not.Null, "The link produced was null");
+            Assert.That(link.GetSettingPropertyOrDefault<long>(AmqpProperty.OwnerLevel, long.MinValue), Is.EqualTo(long.MinValue), "The owner level should have been used.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConnectionScope.OpenConsumerLinkAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task OpenConsumerLinkAsyncRespectsTheTrackLastEventOption()
+        {
+            var endpoint = new Uri("amqp://test.service.gov");
+            var eventHub = "myHub";
+            var consumerGroup = "group";
+            var partitionId = "0";
+            var position = EventPosition.Latest;
+            var credential = Mock.Of<TokenCredential>();
+            var transport = TransportType.AmqpTcp;
+            var identifier = "customIdentIFIER";
+            var cancellationSource = new CancellationTokenSource();
+            var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
+            var mockSession = new AmqpSession(mockConnection, new AmqpSessionSettings(), Mock.Of<ILinkFactory>());
+
+            var options = new EventHubConsumerOptions
+            {
+               Identifier = "testIdentifier123",
+               OwnerLevel = 9987,
+               PrefetchCount = 697,
+               TrackLastEnqueuedEventInformation = false
+            };
+
+            var mockScope = new Mock<AmqpConnectionScope>(endpoint, eventHub, credential, transport, null, identifier)
+            {
+                CallBase = true
+            };
+
+            mockScope
+                .Protected()
+                .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
+                    ItExpr.IsAny<Version>(),
+                    ItExpr.Is<Uri>(value => value == endpoint),
+                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<IWebProxy>(value => value == null),
+                    ItExpr.Is<string>(value => value == identifier),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.FromResult(mockConnection));
+
+            mockScope
+                .Protected()
+                .Setup<Task<DateTime>>("RequestAuthorizationUsingCbsAsync",
+                    ItExpr.Is<AmqpConnection>(value => value == mockConnection),
+                    ItExpr.IsAny<CbsTokenProvider>(),
+                    ItExpr.Is<Uri>(value => value.AbsoluteUri.StartsWith(endpoint.AbsoluteUri)),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.Is<string[]>(value => value.SingleOrDefault() == EventHubsClaim.Listen),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.FromResult(DateTime.UtcNow.AddDays(1)));
+
+            mockScope
+                .Protected()
+                .Setup<Task>("OpenAmqpObjectAsync",
+                    ItExpr.IsAny<AmqpObject>(),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.CompletedTask);
+
+            var link = await mockScope.Object.OpenConsumerLinkAsync(consumerGroup, partitionId, position, options, TimeSpan.FromDays(1), cancellationSource.Token);
+            Assert.That(link, Is.Not.Null, "The link produced was null");
+            Assert.That(link.Settings.DesiredCapabilities, Is.Null, "There should have not have been a set of desired capabilities created, as we're not tracking the last event.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConnectionScope.OpenConsumerLinkAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task OpenConsumerLinkAsyncManagesActiveLinks()
+        {
+            var endpoint = new Uri("amqp://test.service.gov");
+            var eventHub = "myHub";
+            var consumerGroup = "group";
+            var partitionId = "0";
+            var options = new EventHubConsumerOptions();
+            var position = EventPosition.Latest;
+            var credential = Mock.Of<TokenCredential>();
+            var transport = TransportType.AmqpTcp;
+            var identifier = "customIdentIFIER";
+            var cancellationSource = new CancellationTokenSource();
+            var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
+            var mockSession = new AmqpSession(mockConnection, new AmqpSessionSettings(), Mock.Of<ILinkFactory>());
+
+            var mockScope = new Mock<AmqpConnectionScope>(endpoint, eventHub, credential, transport, null, identifier)
+            {
+                CallBase = true
+            };
+
+            mockScope
+                .Protected()
+                .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
+                    ItExpr.IsAny<Version>(),
+                    ItExpr.Is<Uri>(value => value == endpoint),
+                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<IWebProxy>(value => value == null),
+                    ItExpr.Is<string>(value => value == identifier),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.FromResult(mockConnection));
+
+            mockScope
+                .Protected()
+                .Setup<Task<DateTime>>("RequestAuthorizationUsingCbsAsync",
+                    ItExpr.Is<AmqpConnection>(value => value == mockConnection),
+                    ItExpr.IsAny<CbsTokenProvider>(),
+                    ItExpr.Is<Uri>(value => value.AbsoluteUri.StartsWith(endpoint.AbsoluteUri)),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.Is<string[]>(value => value.SingleOrDefault() == EventHubsClaim.Listen),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.FromResult(DateTime.UtcNow.AddDays(1)));
+
+            mockScope
+                .Protected()
+                .Setup<Task>("OpenAmqpObjectAsync",
+                    ItExpr.IsAny<AmqpObject>(),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.CompletedTask);
+
+            var activeLinks = GetActiveLinks(mockScope.Object);
+            Assert.That(activeLinks, Is.Not.Null, "The set of active links was null.");
+            Assert.That(activeLinks.Count, Is.Zero, "There should be no active links when none have been created.");
+
+            var link = await mockScope.Object.OpenConsumerLinkAsync(consumerGroup, partitionId, position, options, TimeSpan.FromDays(1), cancellationSource.Token);
+            Assert.That(link, Is.Not.Null, "The link produced was null");
+
+            Assert.That(activeLinks.Count, Is.EqualTo(1), "There should be an active link being tracked.");
+            Assert.That(activeLinks.ContainsKey(link), Is.True, "The consumer link should be tracked as active.");
+
+            activeLinks.TryGetValue(link, out var refreshTimer);
+            Assert.That(refreshTimer, Is.Not.Null, "The link should have a non-null timer.");
+
+            link.SafeClose();
+            Assert.That(activeLinks.Count, Is.Zero, "Closing the link should stop tracking it as active.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConnectionScope.OpenConsumerLinkAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task OpenConsumerLinkAsyncConfiguresAuthorizationRefresh()
+        {
+            var timerCallbackInvoked = false;
+            var endpoint = new Uri("amqp://test.service.gov");
+            var eventHub = "myHub";
+            var consumerGroup = "group";
+            var partitionId = "0";
+            var options = new EventHubConsumerOptions();
+            var position = EventPosition.Latest;
+            var credential = Mock.Of<TokenCredential>();
+            var transport = TransportType.AmqpTcp;
+            var identifier = "customIdentIFIER";
+            var cancellationSource = new CancellationTokenSource();
+            var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
+            var mockSession = new AmqpSession(mockConnection, new AmqpSessionSettings(), Mock.Of<ILinkFactory>());
+
+            var mockScope = new Mock<AmqpConnectionScope>(endpoint, eventHub, credential, transport, null, identifier)
+            {
+                CallBase = true
+            };
+
+            mockScope
+                .Protected()
+                .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
+                    ItExpr.IsAny<Version>(),
+                    ItExpr.Is<Uri>(value => value == endpoint),
+                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<IWebProxy>(value => value == null),
+                    ItExpr.Is<string>(value => value == identifier),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.FromResult(mockConnection));
+
+            mockScope
+                .Protected()
+                .Setup<Task<DateTime>>("RequestAuthorizationUsingCbsAsync",
+                    ItExpr.IsAny<AmqpConnection>(),
+                    ItExpr.IsAny<CbsTokenProvider>(),
+                    ItExpr.IsAny<Uri>(),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<string[]>(),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.FromResult(DateTime.UtcNow.AddDays(5)));
+
+            mockScope
+                .Protected()
+                .Setup<TimerCallback>("CreateAuthorizationRefreshHandler",
+                    ItExpr.IsAny<AmqpConnection>(),
+                    ItExpr.IsAny<AmqpObject>(),
+                    ItExpr.IsAny<CbsTokenProvider>(),
+                    ItExpr.IsAny<Uri>(),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<string[]>(),
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<Func<Timer>>())
+                .Returns(_ => timerCallbackInvoked = true);
+
+            mockScope
+                .Protected()
+                .Setup<TimeSpan>("CalculateLinkAuthorizationRefreshInterval",
+                    ItExpr.IsAny<DateTime>())
+                .Returns(TimeSpan.Zero);
+
+            mockScope
+                .Protected()
+                .Setup<Task>("OpenAmqpObjectAsync",
+                    ItExpr.IsAny<AmqpObject>(),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.CompletedTask);
+
+            var link = await mockScope.Object.OpenConsumerLinkAsync(consumerGroup, partitionId, position, options, TimeSpan.FromDays(1), cancellationSource.Token);
+            Assert.That(link, Is.Not.Null, "The link produced was null");
+
+            var activeLinks = GetActiveLinks(mockScope.Object);
+            Assert.That(activeLinks.ContainsKey(link), Is.True, "The consumer link should be tracked as active.");
+
+            activeLinks.TryGetValue(link, out var refreshTimer);
+            Assert.That(refreshTimer, Is.Not.Null, "The link should have a non-null timer.");
+
+            // The timer be configured to fire immediately and set the flag.  Because the timer
+            // runs in the background, there is a level of non-determinism in when that callback will execute.
+            // Allow for a small number of delay and retries to account for it.
+
+            var attemptCount = 0;
+            var remainingAttempts = 5;
+
+            while ((--remainingAttempts >= 0) && (!timerCallbackInvoked))
+            {
+                await Task.Delay(250 * ++attemptCount).ConfigureAwait(false);
+            }
+
+            Assert.That(timerCallbackInvoked, Is.True, "The timer should have been configured and running when the link was created.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConnectionScope.OpenConsumerLinkAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task OpenConsumerLinkAsyncRefreshesAuthorization()
+        {
+            var endpoint = new Uri("amqp://test.service.gov");
+            var eventHub = "myHub";
+            var consumerGroup = "group";
+            var partitionId = "0";
+            var options = new EventHubConsumerOptions();
+            var position = EventPosition.Latest;
+            var credential = Mock.Of<TokenCredential>();
+            var transport = TransportType.AmqpTcp;
+            var identifier = "customIdentIFIER";
+            var cancellationSource = new CancellationTokenSource();
+            var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
+            var mockSession = new AmqpSession(mockConnection, new AmqpSessionSettings(), Mock.Of<ILinkFactory>());
+
+            var mockScope = new Mock<AmqpConnectionScope>(endpoint, eventHub, credential, transport, null, identifier)
+            {
+                CallBase = true
+            };
+
+            mockScope
+                .Protected()
+                .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
+                    ItExpr.IsAny<Version>(),
+                    ItExpr.Is<Uri>(value => value == endpoint),
+                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<IWebProxy>(value => value == null),
+                    ItExpr.Is<string>(value => value == identifier),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.FromResult(mockConnection));
+
+            mockScope
+                .Protected()
+                .Setup<Task<DateTime>>("RequestAuthorizationUsingCbsAsync",
+                    ItExpr.IsAny<AmqpConnection>(),
+                    ItExpr.IsAny<CbsTokenProvider>(),
+                    ItExpr.IsAny<Uri>(),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<string[]>(),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.FromResult(DateTime.UtcNow.AddDays(5)));
+
+            mockScope
+                .Protected()
+                .Setup<Task>("OpenAmqpObjectAsync",
+                    ItExpr.IsAny<AmqpObject>(),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.CompletedTask);
+
+            var link = await mockScope.Object.OpenConsumerLinkAsync(consumerGroup, partitionId, position, options, TimeSpan.FromDays(1), cancellationSource.Token);
+            Assert.That(link, Is.Not.Null, "The link produced was null");
+
+            var activeLinks = GetActiveLinks(mockScope.Object);
+            Assert.That(activeLinks.ContainsKey(link), Is.True, "The consumer link should be tracked as active.");
+
+            activeLinks.TryGetValue(link, out var refreshTimer);
+            Assert.That(refreshTimer, Is.Not.Null, "The link should have a non-null timer.");
+
+            // Verify that there was only a initial request for authorization.
+
+            mockScope
+                .Protected()
+                .Verify("RequestAuthorizationUsingCbsAsync",
+                    Times.Once(),
+                    ItExpr.Is<AmqpConnection>(value => value == mockConnection),
+                    ItExpr.IsAny<CbsTokenProvider>(),
+                    ItExpr.Is<Uri>(value => value.AbsoluteUri.StartsWith(endpoint.AbsoluteUri)),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.Is<string[]>(value => value.SingleOrDefault() == EventHubsClaim.Listen),
+                    ItExpr.IsAny<TimeSpan>());
+
+            // Reset the timer so that it fires immediately and validate that authorization was
+            // requested.  Since opening of the link requests an initial authorization and the expiration
+            // was set way in the future, there should be exactly two calls.
+            //
+            // Because the timer runs in the background, there is a level of non-determinism in when that
+            // callback will execute.  Allow for a small number of delay and retries to account for it.
+
+            refreshTimer.Change(0, Timeout.Infinite);
+
+            var attemptCount = 0;
+            var remainingAttempts = 5;
+            var success = false;
+
+            while ((--remainingAttempts >= 0) && (!success))
+            {
+                try
+                {
+                    await Task.Delay(250 * ++attemptCount).ConfigureAwait(false);
+
+                    mockScope
+                        .Protected()
+                        .Verify("RequestAuthorizationUsingCbsAsync",
+                            Times.Exactly(2),
+                            ItExpr.Is<AmqpConnection>(value => value == mockConnection),
+                            ItExpr.IsAny<CbsTokenProvider>(),
+                            ItExpr.Is<Uri>(value => value.AbsoluteUri.StartsWith(endpoint.AbsoluteUri)),
+                            ItExpr.IsAny<string>(),
+                            ItExpr.IsAny<string>(),
+                            ItExpr.Is<string[]>(value => value.SingleOrDefault() == EventHubsClaim.Listen),
+                            ItExpr.IsAny<TimeSpan>());
+
+                    success = true;
+                }
+                catch when (remainingAttempts <= 0)
+                {
+                    throw;
+                }
+                catch
+                {
+                    // No action needed.
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConnectionScope.Dispose" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void DisposeCancelsOperations()
+        {
+            var endpoint = new Uri("amqp://test.service.gov");
+            var eventHub = "myHub";
+            var credential = Mock.Of<TokenCredential>();
+            var transport = TransportType.AmqpTcp;
+            var identifier = "customIdentIFIER";
+            var scope = new AmqpConnectionScope(endpoint, eventHub, credential, transport, null, identifier);
+            var cancellation = GetOperationCancellationSource(scope);
+
+            Assert.That(cancellation.IsCancellationRequested, Is.False, "The cancellation source should not be canceled before disposal");
+
+            scope.Dispose();
+            Assert.That(cancellation.IsCancellationRequested, Is.True, "The cancellation source should be canceled by disposal");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConnectionScope.Dispose" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task DisposeClosesTheConnection()
+        {
+            var endpoint = new Uri("amqp://test.service.gov");
+            var eventHub = "myHub";
+            TokenCredential credential = Mock.Of<TokenCredential>();
+            TransportType transport = TransportType.AmqpTcp;
+            var identifier = "customIdentIFIER";
+            var connectionClosed = false;
+            var cancellationSource = new CancellationTokenSource();
+            var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
+            var mockSession = new AmqpSession(mockConnection, new AmqpSessionSettings(), Mock.Of<ILinkFactory>());
+            var mockLink = new RequestResponseAmqpLink("test", "test", mockSession, "test");
+
+            mockConnection.Closed += (snd, args) => connectionClosed = true;
+
+            var mockScope = new Mock<AmqpConnectionScope>(endpoint, eventHub, credential, transport, null, identifier)
+            {
+                CallBase = true
+            };
+
+            mockScope
+                .Protected()
+                .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
+                    ItExpr.IsAny<Version>(),
+                    ItExpr.Is<Uri>(value => value == endpoint),
+                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<IWebProxy>(value => value == null),
+                    ItExpr.Is<string>(value => value == identifier),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.FromResult(mockConnection))
+                .Verifiable();
+
+            mockScope
+                .Protected()
+                .Setup<Task<RequestResponseAmqpLink>>("CreateManagementLinkAsync",
+                    ItExpr.Is<AmqpConnection>(value => value == mockConnection),
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.Is<CancellationToken>(value => value == cancellationSource.Token))
+                .Returns(Task.FromResult(mockLink))
+                .Verifiable();
+
+            mockScope
+                .Protected()
+                .Setup<Task>("OpenAmqpObjectAsync",
+                    ItExpr.IsAny<AmqpObject>(),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+
+            // Create the mock management link to force lazy creation of the connection.
+
+            await mockScope.Object.OpenManagementLinkAsync(TimeSpan.FromDays(1), cancellationSource.Token);
+
+            mockScope.Object.Dispose();
+            Assert.That(connectionClosed, Is.True, "The link should have been closed when the scope was disposed.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConnectionScope.Dispose" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task DisposeClosesActiveLinks()
+        {
+            var endpoint = new Uri("amqp://test.service.gov");
+            var eventHub = "myHub";
+            var consumerGroup = "group";
+            var partitionId = "0";
+            var options = new EventHubConsumerOptions();
+            var position = EventPosition.Latest;
+            var credential = Mock.Of<TokenCredential>();
+            var transport = TransportType.AmqpTcp;
+            var identifier = "customIdentIFIER";
+            var cancellationSource = new CancellationTokenSource();
+            var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
+            var mockSession = new AmqpSession(mockConnection, new AmqpSessionSettings(), Mock.Of<ILinkFactory>());
+
+            var mockScope = new Mock<AmqpConnectionScope>(endpoint, eventHub, credential, transport, null, identifier)
+            {
+                CallBase = true
+            };
+
+            mockScope
+                .Protected()
+                .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
+                    ItExpr.IsAny<Version>(),
+                    ItExpr.Is<Uri>(value => value == endpoint),
+                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<IWebProxy>(value => value == null),
+                    ItExpr.Is<string>(value => value == identifier),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.FromResult(mockConnection));
+
+            mockScope
+                .Protected()
+                .Setup<Task<DateTime>>("RequestAuthorizationUsingCbsAsync",
+                    ItExpr.Is<AmqpConnection>(value => value == mockConnection),
+                    ItExpr.IsAny<CbsTokenProvider>(),
+                    ItExpr.Is<Uri>(value => value.AbsoluteUri.StartsWith(endpoint.AbsoluteUri)),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.Is<string[]>(value => value.SingleOrDefault() == EventHubsClaim.Listen),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.FromResult(DateTime.UtcNow.AddDays(1)));
+
+            mockScope
+                .Protected()
+                .Setup<Task>("OpenAmqpObjectAsync",
+                    ItExpr.IsAny<AmqpObject>(),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.CompletedTask);
+
+            var activeLinks = GetActiveLinks(mockScope.Object);
+            Assert.That(activeLinks, Is.Not.Null, "The set of active links was null.");
+            Assert.That(activeLinks.Count, Is.Zero, "There should be no active links when none have been created.");
+
+            var consumerLink = await mockScope.Object.OpenConsumerLinkAsync(consumerGroup, partitionId, position, options, TimeSpan.FromDays(1), cancellationSource.Token);
+            Assert.That(consumerLink, Is.Not.Null, "The consumer link produced was null");
+
+            var managementLink = await mockScope.Object.OpenManagementLinkAsync(TimeSpan.FromDays(1), cancellationSource.Token);
+            Assert.That(managementLink, Is.Not.Null, "The management link produced was null");
+
+            Assert.That(activeLinks.Count, Is.EqualTo(2), "There should be active links being tracked.");
+            Assert.That(activeLinks.ContainsKey(managementLink), Is.True, "The management link should be tracked as active.");
+            Assert.That(activeLinks.ContainsKey(consumerLink), Is.True, "The consumer link should be tracked as active.");
+
+            mockScope.Object.Dispose();
+            Assert.That(activeLinks.Count, Is.Zero, "Disposal should stop tracking it as active.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConnectionScope.Dispose" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task DisposeStopsManagingLinkAuthorizations()
+        {
+            var endpoint = new Uri("amqp://test.service.gov");
+            var eventHub = "myHub";
+            var consumerGroup = "group";
+            var partitionId = "0";
+            var options = new EventHubConsumerOptions();
+            var position = EventPosition.Latest;
+            var credential = Mock.Of<TokenCredential>();
+            var transport = TransportType.AmqpTcp;
+            var identifier = "customIdentIFIER";
+            var cancellationSource = new CancellationTokenSource();
+            var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
+            var mockSession = new AmqpSession(mockConnection, new AmqpSessionSettings(), Mock.Of<ILinkFactory>());
+
+            var mockScope = new Mock<AmqpConnectionScope>(endpoint, eventHub, credential, transport, null, identifier)
+            {
+                CallBase = true
+            };
+
+            mockScope
+                .Protected()
+                .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
+                    ItExpr.IsAny<Version>(),
+                    ItExpr.Is<Uri>(value => value == endpoint),
+                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<IWebProxy>(value => value == null),
+                    ItExpr.Is<string>(value => value == identifier),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.FromResult(mockConnection));
+
+            mockScope
+                .Protected()
+                .Setup<Task<DateTime>>("RequestAuthorizationUsingCbsAsync",
+                    ItExpr.Is<AmqpConnection>(value => value == mockConnection),
+                    ItExpr.IsAny<CbsTokenProvider>(),
+                    ItExpr.Is<Uri>(value => value.AbsoluteUri.StartsWith(endpoint.AbsoluteUri)),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.Is<string[]>(value => value.SingleOrDefault() == EventHubsClaim.Listen),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.FromResult(DateTime.UtcNow.AddDays(1)));
+
+            mockScope
+                .Protected()
+                .Setup<Task>("OpenAmqpObjectAsync",
+                    ItExpr.IsAny<AmqpObject>(),
+                    ItExpr.IsAny<TimeSpan>())
+                .Returns(Task.CompletedTask);
+
+            var managedAuthorizations = GetActiveLinks(mockScope.Object);
+            Assert.That(managedAuthorizations, Is.Not.Null, "The set of managed authorizations was null.");
+            Assert.That(managedAuthorizations.Count, Is.Zero, "There should be no managed authorizations when none have been created.");
+
+            var link = await mockScope.Object.OpenConsumerLinkAsync(consumerGroup, partitionId, position, options, TimeSpan.FromDays(1), cancellationSource.Token);
+            Assert.That(link, Is.Not.Null, "The consumer link produced was null");
+
+            Assert.That(managedAuthorizations.Count, Is.EqualTo(1), "There should be a managed authorization being tracked.");
+            Assert.That(managedAuthorizations.ContainsKey(link), Is.True, "The consumer link should be tracked for authorization.");
+
+            managedAuthorizations.TryGetValue(link, out var refreshTimer);
+            Assert.That(refreshTimer, Is.Not.Null, "The link should have a non-null timer.");
+
+            mockScope.Object.Dispose();
+            Assert.That(managedAuthorizations.Count, Is.Zero, "Disposal should stop managing authorizations.");
+            Assert.That(() => refreshTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan), Throws.InstanceOf<ObjectDisposedException>(), "The timer should have been disposed.");
         }
 
         /// <summary>
@@ -201,6 +1291,28 @@ namespace Azure.Messaging.EventHubs.Tests
             (FaultTolerantAmqpObject<AmqpConnection>)
                 typeof(AmqpConnectionScope)
                     .GetProperty("ActiveConnection", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.GetProperty)
+                    .GetValue(target);
+
+        /// <summary>
+        ///   Gets the set of active links for the given scope, using the
+        ///   private property accessor.
+        /// </summary>
+        ///
+        private static ConcurrentDictionary<AmqpObject, Timer> GetActiveLinks(AmqpConnectionScope target) =>
+            (ConcurrentDictionary<AmqpObject, Timer>)
+                typeof(AmqpConnectionScope)
+                    .GetProperty("ActiveLinks", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.GetProperty)
+                    .GetValue(target);
+
+        /// <summary>
+        ///   Gets the CBS token provider for the given scope, using the
+        ///   private property accessor.
+        /// </summary>
+        ///
+        private static CancellationTokenSource GetOperationCancellationSource(AmqpConnectionScope target) =>
+            (CancellationTokenSource)
+                typeof(AmqpConnectionScope)
+                    .GetProperty("OperationCancellationSource", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.GetProperty)
                     .GetValue(target);
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpFilterTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpFilterTests.cs
@@ -1,0 +1,212 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Azure.Messaging.EventHubs.Errors;
+using Microsoft.Azure.Amqp;
+using Microsoft.Azure.Amqp.Encoding;
+using Microsoft.Azure.Amqp.Framing;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="AmqpFilter" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class AmqpFilterTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpFilter.BuildFilterExpression(EventPosition)" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void BuildFilterExpressionValidatesTheEventPosition()
+        {
+            Assert.That(() => AmqpFilter.BuildFilterExpression(null), Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpFilter.BuildFilterExpression(EventPosition)" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void BuildFilterExpressionEnsuresAnEventPositionIsFilterable()
+        {
+            // Unset all properties for the event position.
+
+            var position = EventPosition.FromOffset(1);
+            position.Offset = null;
+
+            Assert.That(() => AmqpFilter.BuildFilterExpression(position), Throws.ArgumentException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpFilter.BuildFilterExpression(EventPosition)" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void BuildFilterExpressionPrefersOffset()
+        {
+            // Set all properties for the event position.
+
+            var offset = 1;
+            var position = EventPosition.FromOffset(offset);
+            position.SequenceNumber = 222;
+            position.EnqueuedTime = DateTimeOffset.Parse("2015-10-27T12:00:00Z");
+
+            var filter = AmqpFilter.BuildFilterExpression(position);
+            Assert.That(filter, Contains.Substring(AmqpFilter.OffsetName), "The offset should have precedence for filtering.");
+            Assert.That(filter, Contains.Substring(offset.ToString()), "The offset value should be present in the filter.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpFilter.BuildFilterExpression(EventPosition)" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void BuildFilterExpressionPrefersSequenceNumberToEnqueuedTime()
+        {
+            // Set all properties for the event position.
+
+            var sequence = 2345;
+            var position = EventPosition.FromSequenceNumber(sequence);
+            position.EnqueuedTime = DateTimeOffset.Parse("2015-10-27T12:00:00Z");
+
+            var filter = AmqpFilter.BuildFilterExpression(position);
+            Assert.That(filter, Contains.Substring(AmqpFilter.SequenceNumberName), "The sequence number should have precedence over the enqueued time for filtering.");
+            Assert.That(filter, Contains.Substring(sequence.ToString()), "The sequence number value should be present in the filter.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpFilter.BuildFilterExpression(EventPosition)" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void BuildFilterExpressionUsesEnqueuedTime()
+        {
+            // Set all properties for the event position.
+
+            var enqueuedTime = DateTimeOffset.Parse("2015-10-27T12:00:00Z");
+            var position = EventPosition.FromEnqueuedTime(enqueuedTime);
+
+            var filter = AmqpFilter.BuildFilterExpression(position);
+            Assert.That(filter, Contains.Substring(AmqpFilter.EnqueuedTimeName), "The enqueued time should have been used.");
+            Assert.That(filter, Contains.Substring(enqueuedTime.ToUnixTimeMilliseconds().ToString()), "The enqueued time value should be present in the filter.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpFilter.BuildFilterExpression(EventPosition)" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void BuildFilterExpressionAllowsEarliest()
+        {
+            Assert.That(() => AmqpFilter.BuildFilterExpression(EventPosition.Earliest), Throws.Nothing);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpFilter.BuildFilterExpression(EventPosition)" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void BuildFilterExpressionAllowsLatest()
+        {
+            Assert.That(() => AmqpFilter.BuildFilterExpression(EventPosition.Latest), Throws.Nothing);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpFilter.BuildFilterExpression(EventPosition)" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(false)]
+        [TestCase(true)]
+        public void BuildFilterExpressionHonorsInclusiveFlagForOffset(bool inclusive)
+        {
+            var comparison = (inclusive) ? ">=" : ">";
+            var position = EventPosition.FromOffset(1);
+            position.IsInclusive = inclusive;
+
+            var filter = AmqpFilter.BuildFilterExpression(position);
+            Assert.That(filter, Contains.Substring(comparison), "The comparison should be based on the inclusive flag.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpFilter.BuildFilterExpression(EventPosition)" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(false)]
+        [TestCase(true)]
+        public void BuildFilterExpressionHonorsInclusiveFlagForSequenceNumber(bool inclusive)
+        {
+            var comparison = (inclusive) ? ">=" : ">";
+            var position = EventPosition.FromSequenceNumber(123, inclusive);
+            var filter = AmqpFilter.BuildFilterExpression(position);
+
+            Assert.That(filter, Contains.Substring(comparison), "The comparison should be based on the inclusive flag.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpFilter.BuildFilterExpression(EventPosition)" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(false)]
+        [TestCase(true)]
+        public void BuildFilterExpressionIgnoresInclusiveFlagForEnqueuedTime(bool inclusive)
+        {
+            var position = EventPosition.FromEnqueuedTime(DateTimeOffset.Parse("2015-10-27T12:00:00Z"));
+            position.IsInclusive = inclusive;
+
+            var filter = AmqpFilter.BuildFilterExpression(position);
+            Assert.That(filter, Does.Not.Contain("="), "The comparison should not consider the inclusive flag.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpFilter.CreateConsumerFilter" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void CreateConsumerFilterValidatesTheExpression(string expression)
+        {
+            Assert.That(() => AmqpFilter.CreateConsumerFilter(expression), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpFilter.CreateConsumerFilter" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CreateConsumerFilterCreatesTheFilter()
+        {
+            var expression = "test > 1";
+            var filter = AmqpFilter.CreateConsumerFilter(expression);
+
+            Assert.That(filter, Is.Not.Null, "The filter should have been created");
+            Assert.That(filter.DescriptorName, Is.EqualTo((AmqpSymbol)AmqpFilter.ConsumerFilterName), "The filter name should have been populated");
+            Assert.That(filter.DescriptorCode, Is.EqualTo(AmqpFilter.ConsumerFilterCode), "The filter code should have been populated");
+            Assert.That(filter.Value, Is.EqualTo(expression), "The filter expression should have been used as the body of the filter");
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/TypeExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/TypeExtensionsTests.cs
@@ -80,7 +80,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [TestCase(typeof(GuardTests))]
+        [TestCase(typeof(ArgumentTests))]
         [TestCase(typeof(DBNull))]
         [TestCase(typeof(Exception))]
         public void ToAmqpPropertyDoesNotMapUnknownTypes(Type unknownType)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ArgumentTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ArgumentTests.cs
@@ -14,7 +14,7 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    public class GuardTests
+    public class ArgumentTests
     {
         /// <summary>
         ///   Provides the invalid test cases for the <see cref="Argument.AssertNotNegative" /> tests.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerLiveTests.cs
@@ -1868,33 +1868,6 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [Ignore("Expected behavior currently under discussion")]
-        public async Task ConsumerCanReceiveWhenClientIsClosed()
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
-            {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
-                await using (var client = new EventHubClient(connectionString))
-                {
-                    var partition = (await client.GetPartitionIdsAsync()).First();
-
-                    await using (EventHubConsumer consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest))
-                    {
-                        client.Close();
-
-                        Assert.That(async () => await consumer.ReceiveAsync(1, TimeSpan.Zero), Throws.Nothing);
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumer" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
         public async Task ConsumerCannotReceiveEventsSentToAnotherPartition()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(2))

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerTests.cs
@@ -583,7 +583,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, new EventHubConsumerOptions(), Mock.Of<EventHubRetryPolicy>());
             var receivedEvents = new List<EventData>();
 
-            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
             await foreach (EventData eventData in consumer.SubscribeToEvents(cancellation.Token))
             {
@@ -634,7 +634,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 }
             }
 
-            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(75));
 
             var firstSubscriberTask = Task.Run(async () =>
             {
@@ -704,7 +704,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     .Select(index => new EventData(Encoding.UTF8.GetBytes($"Event Number { index }")))
             );
 
-            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
             await foreach (EventData eventData in consumer.SubscribeToEvents(cancellation.Token))
             {
@@ -752,7 +752,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 }
             }
 
-            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(75));
 
             var firstSubscriberTask = Task.Run(async () =>
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerLiveTests.cs
@@ -974,30 +974,6 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [Ignore("Expected behavior currently under discussion")]
-        public async Task ProducerCanSendWhenClientIsClosed()
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
-            {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
-                await using (var client = new EventHubClient(connectionString))
-                await using (EventHubProducer producer = client.CreateProducer())
-                {
-                    client.Close();
-
-                    var events = new EventData(Encoding.UTF8.GetBytes("Do not delete me!"));
-                    Assert.That(async () => await producer.SendAsync(events), Throws.Nothing);
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubProducer" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
         public async Task ProducerCannotSendWhenProxyIsInvalid()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventHubScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventHubScope.cs
@@ -23,7 +23,7 @@ namespace Azure.Messaging.EventHubs.Tests.Infrastructure
     public sealed class EventHubScope : IAsyncDisposable
     {
         /// <summary>The manager for common live test resource operations.</summary>
-        private static readonly LiveResourceManager s_resourceManager = new LiveResourceManager();
+        private static readonly LiveResourceManager ResourceManager = new LiveResourceManager();
 
         /// <summary>Serves as a sentinel flag to denote when the instance has been disposed.</summary>
         private bool _disposed = false;
@@ -69,12 +69,12 @@ namespace Azure.Messaging.EventHubs.Tests.Infrastructure
 
             var resourceGroup = TestEnvironment.EventHubsResourceGroup;
             var eventHubNamespace = TestEnvironment.EventHubsNamespace;
-            var token = await s_resourceManager.AquireManagementTokenAsync();
+            var token = await ResourceManager.AquireManagementTokenAsync();
             var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = TestEnvironment.EventHubsSubscription };
 
             try
             {
-                await s_resourceManager.CreateRetryPolicy().ExecuteAsync(() => client.EventHubs.DeleteAsync(resourceGroup, eventHubNamespace, EventHubName));
+                await ResourceManager.CreateRetryPolicy().ExecuteAsync(() => client.EventHubs.DeleteAsync(resourceGroup, eventHubNamespace, EventHubName));
             }
             catch
             {
@@ -137,16 +137,16 @@ namespace Azure.Messaging.EventHubs.Tests.Infrastructure
             var groups = (consumerGroups ?? Enumerable.Empty<string>()).ToList();
             var resourceGroup = TestEnvironment.EventHubsResourceGroup;
             var eventHubNamespace = TestEnvironment.EventHubsNamespace;
-            var token = await s_resourceManager.AquireManagementTokenAsync();
+            var token = await ResourceManager.AquireManagementTokenAsync();
 
             string CreateName() => $"{ Guid.NewGuid().ToString("D").Substring(0, 13) }-{ caller }";
 
             using (var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = TestEnvironment.EventHubsSubscription })
             {
                 var eventHub = new Eventhub(partitionCount: partitionCount);
-                eventHub = await s_resourceManager.CreateRetryPolicy<Eventhub>().ExecuteAsync(() => client.EventHubs.CreateOrUpdateAsync(resourceGroup, eventHubNamespace, CreateName(), eventHub));
+                eventHub = await ResourceManager.CreateRetryPolicy<Eventhub>().ExecuteAsync(() => client.EventHubs.CreateOrUpdateAsync(resourceGroup, eventHubNamespace, CreateName(), eventHub));
 
-                Polly.IAsyncPolicy<ConsumerGroup> consumerPolicy = s_resourceManager.CreateRetryPolicy<ConsumerGroup>();
+                Polly.IAsyncPolicy<ConsumerGroup> consumerPolicy = ResourceManager.CreateRetryPolicy<ConsumerGroup>();
 
                 await Task.WhenAll
                 (
@@ -172,18 +172,18 @@ namespace Azure.Messaging.EventHubs.Tests.Infrastructure
         {
             var subscription = TestEnvironment.EventHubsSubscription;
             var resourceGroup = TestEnvironment.EventHubsResourceGroup;
-            var token = await s_resourceManager.AquireManagementTokenAsync();
+            var token = await ResourceManager.AquireManagementTokenAsync();
 
             string CreateName() => $"net-eventhubs-{ Guid.NewGuid().ToString("D") }";
 
             using (var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = subscription })
             {
-                var location = await s_resourceManager.QueryResourceGroupLocationAsync(token, resourceGroup, subscription);
+                var location = await ResourceManager.QueryResourceGroupLocationAsync(token, resourceGroup, subscription);
 
-                var eventHubsNamespace = new EHNamespace(sku: new Sku("Standard", "Standard", 12), tags: s_resourceManager.GenerateTags(), isAutoInflateEnabled: true, maximumThroughputUnits: 20, location: location);
-                eventHubsNamespace = await s_resourceManager.CreateRetryPolicy<EHNamespace>().ExecuteAsync(() => client.Namespaces.CreateOrUpdateAsync(resourceGroup, CreateName(), eventHubsNamespace));
+                var eventHubsNamespace = new EHNamespace(sku: new Sku("Standard", "Standard", 12), tags: ResourceManager.GenerateTags(), isAutoInflateEnabled: true, maximumThroughputUnits: 20, location: location);
+                eventHubsNamespace = await ResourceManager.CreateRetryPolicy<EHNamespace>().ExecuteAsync(() => client.Namespaces.CreateOrUpdateAsync(resourceGroup, CreateName(), eventHubsNamespace));
 
-                AccessKeys accessKey = await s_resourceManager.CreateRetryPolicy<AccessKeys>().ExecuteAsync(() => client.Namespaces.ListKeysAsync(resourceGroup, eventHubsNamespace.Name, TestEnvironment.EventHubsDefaultSharedAccessKey));
+                AccessKeys accessKey = await ResourceManager.CreateRetryPolicy<AccessKeys>().ExecuteAsync(() => client.Namespaces.ListKeysAsync(resourceGroup, eventHubsNamespace.Name, TestEnvironment.EventHubsDefaultSharedAccessKey));
                 return new NamespaceProperties(eventHubsNamespace.Name, accessKey.PrimaryConnectionString);
             }
         }
@@ -199,11 +199,11 @@ namespace Azure.Messaging.EventHubs.Tests.Infrastructure
         {
             var subscription = TestEnvironment.EventHubsSubscription;
             var resourceGroup = TestEnvironment.EventHubsResourceGroup;
-            var token = await s_resourceManager.AquireManagementTokenAsync();
+            var token = await ResourceManager.AquireManagementTokenAsync();
 
             using (var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = subscription })
             {
-                await s_resourceManager.CreateRetryPolicy().ExecuteAsync(() => client.Namespaces.DeleteAsync(resourceGroup, namespaceName));
+                await ResourceManager.CreateRetryPolicy().ExecuteAsync(() => client.Namespaces.DeleteAsync(resourceGroup, namespaceName));
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Processor/EventProcessorLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Processor/EventProcessorLiveTests.cs
@@ -434,7 +434,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [Ignore("Failing test: needs debugging")]
+        [Ignore("Failing test: needs debugging (Tracked by: #7458)")]
         public async Task EventProcessorCanStartAgainAfterStopping()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(2))
@@ -513,6 +513,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        [Ignore("Unstable test. (Tracked by: #7458)")]
         public async Task EventProcessorCanReceiveFromCheckpointedEventPosition()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
@@ -731,6 +732,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        [Ignore("Unstable test. (Tracked by: #7458)")]
         public async Task EventProcessorCanReceiveFromSpecifiedInitialEventPosition()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(2))
@@ -1049,6 +1051,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        [Ignore("Unstable test. (Tracked by: #7458)")]
         public async Task LoadBalancingIsEnforcedWhenDistributionIsUneven()
         {
             var partitions = 10;

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
@@ -24,9 +24,9 @@ namespace Microsoft.Azure.EventHubs.Tests
 {
     internal sealed class EventHubScope : IAsyncDisposable
     {
-        private const int RetryMaximumAttemps = 15;
-        private const double RetryExponentialBackoffSeconds = 2.5;
-        private const double RetryBaseJitterSeconds = 10.0;
+        private const int RetryMaximumAttempts = 15;
+        private const double RetryExponentialBackoffSeconds = 3.0;
+        private const double RetryBaseJitterSeconds = 20.0;
 
         private static readonly TimeSpan CredentialRefreshBuffer = TimeSpan.FromMinutes(5);
         private static readonly ThreadLocal<Random> RandomNumberGenerator = new ThreadLocal<Random>(() => new Random(Interlocked.Increment(ref s_randomSeed)), false);
@@ -206,13 +206,13 @@ namespace Microsoft.Azure.EventHubs.Tests
                     { "cleanup-after", $"{ DateTimeOffset.UtcNow.AddDays(1).ToString("s") }Z" }
                 };
 
-        private static IAsyncPolicy<T> CreateRetryPolicy<T>(int maxRetryAttempts = RetryMaximumAttemps, double exponentialBackoffSeconds = RetryExponentialBackoffSeconds, double baseJitterSeconds = RetryBaseJitterSeconds) =>
+        private static IAsyncPolicy<T> CreateRetryPolicy<T>(int maxRetryAttempts = RetryMaximumAttempts, double exponentialBackoffSeconds = RetryExponentialBackoffSeconds, double baseJitterSeconds = RetryBaseJitterSeconds) =>
            Policy<T>
                .Handle<ErrorResponseException>(ex => IsRetriableStatus(ex.Response.StatusCode))
                .Or<CloudException>(ex => IsRetriableStatus(ex.Response.StatusCode))
                .WaitAndRetryAsync(maxRetryAttempts, attempt => CalculateRetryDelay(attempt, exponentialBackoffSeconds, baseJitterSeconds));
 
-        private static IAsyncPolicy CreateRetryPolicy(int maxRetryAttempts = RetryMaximumAttemps, double exponentialBackoffSeconds = RetryExponentialBackoffSeconds, double baseJitterSeconds = RetryBaseJitterSeconds) =>
+        private static IAsyncPolicy CreateRetryPolicy(int maxRetryAttempts = RetryMaximumAttempts, double exponentialBackoffSeconds = RetryExponentialBackoffSeconds, double baseJitterSeconds = RetryBaseJitterSeconds) =>
             Policy
                 .Handle<ErrorResponseException>(ex => IsRetriableStatus(ex.Response.StatusCode))
                 .Or<CloudException>(ex => IsRetriableStatus(ex.Response.StatusCode))


### PR DESCRIPTION
# Summary

The intent of these changes is to refactor and extend the AMQP connection and link management infrastructure to support links using CBS authorization and offer creation of links for receiving events from the Event Hubs Service.  Some small tweaks have also been made to help stablize tests or mark them for further investigation.

# Last Upstream Rebase

Thursday, October 3, 3:11pm (EDT)

# Related and Follow-Up Issues

- [[Epic] Release Event Hubs Track 2 Library Preview 4 for .Net](https://github.com/Azure/azure-sdk-for-net/issues/7562) (#7562) 
- [AMQP Foundation (Links)](https://github.com/Azure/azure-sdk-for-net/issues/7188) (#7188) 
- [AmqpEventHubConsumer](https://github.com/Azure/azure-sdk-for-net/issues/7192) (#7192) 
- [Integrate Logging](https://github.com/Azure/azure-sdk-for-net/issues/7129) (#7129)
- [[Flaky Test] SubscribePublishesEventsWithOneSubscriberAndSingleBatch](https://github.com/Azure/azure-sdk-for-net/issues/7641) (#7641)
- [[Flaky Test] SubscribePublishesEventsWithOneSubscriberAndMultipleBatches](https://github.com/Azure/azure-sdk-for-net/issues/7640) (#7640)