### PR TITLE
static method prototypes

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasPermissions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasPermissions.cs
@@ -16,6 +16,52 @@ namespace Azure.Storage.Sas
     public struct BlobSasPermissions : IEquatable<BlobSasPermissions>
     {
         /// <summary>
+        /// CreatePermissions
+        /// </summary>
+        /// <param name="read"></param>
+        /// <param name="add"></param>
+        /// <param name="create"></param>
+        /// <param name="write"></param>
+        /// <param name="delete"></param>
+        /// <returns></returns>
+        public static BlobSasPermissions CreatePermissions(
+            bool read = false,
+            bool add = false,
+            bool create = false,
+            bool write = false,
+            bool delete = false)
+        {
+            BlobSasPermissions permissions = new BlobSasPermissions
+            {
+                Read = read,
+                Add = add,
+                Create = create,
+                Write = write,
+                Delete = delete
+            };
+            return permissions;
+        }
+
+        /// <summary>
+        /// GeneratePermissionsString
+        /// </summary>
+        /// <param name="read"></param>
+        /// <param name="add"></param>
+        /// <param name="create"></param>
+        /// <param name="write"></param>
+        /// <param name="delete"></param>
+        /// <returns></returns>
+        public static string GeneratePermissionsString(
+            bool read = false,
+            bool add = false,
+            bool create = false,
+            bool write = false,
+            bool delete = false)
+        {
+            return CreatePermissions(read, add, create, write, delete).ToString();
+        }
+
+        /// <summary>
         /// Get or sets whether Read is permitted.
         /// </summary>
         public bool Read { get; set; }

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -286,7 +286,7 @@ namespace Azure.Storage.Test.Shared
                 Protocol = SasProtocol.None,
                 StartTime = Recording.UtcNow.AddHours(-1),
                 ExpiryTime = Recording.UtcNow.AddHours(+1),
-                Permissions = new BlobSasPermissions { Read = true, Add = true, Create = true, Write = true, Delete = true }.ToString(),
+                Permissions = BlobSasPermissions.CreatePermissions(read: true, add: true, create: true, write: true, delete: true).ToString(),
                 IPRange = new IPRange(IPAddress.None, IPAddress.None)
             }.ToSasQueryParameters(sharedKeyCredentials ?? GetNewSharedKeyCredentials());
 
@@ -298,7 +298,7 @@ namespace Azure.Storage.Test.Shared
                 Protocol = SasProtocol.None,
                 StartTime = Recording.UtcNow.AddHours(-1),
                 ExpiryTime = Recording.UtcNow.AddHours(+1),
-                Permissions = new BlobSasPermissions { Read = true, Add = true, Create = true, Write = true, Delete = true }.ToString(),
+                Permissions = BlobSasPermissions.GeneratePermissionsString(read: true, add: true, create: true, write: true, delete: true),
                 IPRange = new IPRange(IPAddress.None, IPAddress.None)
             }.ToSasQueryParameters(userDelegationKey, accountName);
 


### PR DESCRIPTION
Prototype to see look at usability improvements from having either 
 - a static create method that can be used in place of constructor for getting a BlobSasPermissions instance
- a GeneratePermissions method that directly returns the permissions string if the use case doesn't call for mutating the permissions after creating it.
- or both? 