### PR TITLE
rename (blob|http)AccessConditions parameters to accessConditions; re…

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -865,7 +865,7 @@ namespace Azure.Storage.Blobs.Specialized
             CancellationToken cancellationToken) =>
             Download(
                 destination,
-                blobAccessConditions: default, // Pass anything else so we don't recurse on this overload
+                accessConditions: default, // Pass anything else so we don't recurse on this overload
                 cancellationToken: cancellationToken);
 #pragma warning restore AZC0002 // Client method should have cancellationToken as the last optional parameter
 
@@ -895,7 +895,7 @@ namespace Azure.Storage.Blobs.Specialized
             CancellationToken cancellationToken) =>
             Download(
                 destination,
-                blobAccessConditions: default, // Pass anything else so we don't recurse on this overload
+                accessConditions: default, // Pass anything else so we don't recurse on this overload
                 cancellationToken: cancellationToken);
 #pragma warning restore AZC0002 // Client method should have cancellationToken as the last optional parameter
 
@@ -925,7 +925,7 @@ namespace Azure.Storage.Blobs.Specialized
             CancellationToken cancellationToken) =>
             DownloadAsync(
                 destination,
-                blobAccessConditions: default, // Pass anything else so we don't recurse on this overload
+                accessConditions: default, // Pass anything else so we don't recurse on this overload
                 cancellationToken: cancellationToken);
 #pragma warning restore AZC0002 // Client method should have cancellationToken as the last optional parameter
 
@@ -955,7 +955,7 @@ namespace Azure.Storage.Blobs.Specialized
             CancellationToken cancellationToken) =>
             DownloadAsync(
                 destination,
-                blobAccessConditions: default, // Pass anything else so we don't recurse on this overload
+                accessConditions: default, // Pass anything else so we don't recurse on this overload
                 cancellationToken: cancellationToken);
 #pragma warning restore AZC0002 // Client method should have cancellationToken as the last optional parameter
 
@@ -967,7 +967,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="destination">
         /// A <see cref="Stream"/> to write the downloaded content to.
         /// </param>
-        /// <param name="blobAccessConditions">
+        /// <param name="accessConditions">
         /// Optional <see cref="BlobAccessConditions"/> to add conditions on
         /// the creation of this new block blob.
         /// </param>
@@ -989,7 +989,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         public virtual Response<BlobProperties> Download(
             Stream destination,
-            BlobAccessConditions? blobAccessConditions = default,
+            BlobAccessConditions? accessConditions = default,
             ///// <param name="progressHandler">
             ///// Optional <see cref="IProgress{StorageProgress}"/> to provide
             ///// progress updates about data transfers.
@@ -999,7 +999,7 @@ namespace Azure.Storage.Blobs.Specialized
             CancellationToken cancellationToken = default) =>
             StagedDownloadAsync(
                 destination,
-                blobAccessConditions,
+                accessConditions,
                 //progressHandler,
                 parallelTransferOptions: parallelTransferOptions,
                 async: false,
@@ -1014,7 +1014,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="destination">
         /// A <see cref="FileInfo"/> representing a file to write the downloaded content to.
         /// </param>
-        /// <param name="blobAccessConditions">
+        /// <param name="accessConditions">
         /// Optional <see cref="BlobAccessConditions"/> to add conditions on
         /// the creation of this new block blob.
         /// </param>
@@ -1036,7 +1036,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         public virtual Response<BlobProperties> Download(
             FileInfo destination,
-            BlobAccessConditions? blobAccessConditions = default,
+            BlobAccessConditions? accessConditions = default,
             ///// <param name="progressHandler">
             ///// Optional <see cref="IProgress{StorageProgress}"/> to provide
             ///// progress updates about data transfers.
@@ -1046,7 +1046,7 @@ namespace Azure.Storage.Blobs.Specialized
             CancellationToken cancellationToken = default) =>
             StagedDownloadAsync(
                 destination,
-                blobAccessConditions,
+                accessConditions,
                 //progressHandler,
                 parallelTransferOptions: parallelTransferOptions,
                 async: false,
@@ -1061,7 +1061,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="destination">
         /// A <see cref="Stream"/> to write the downloaded content to.
         /// </param>
-        /// <param name="blobAccessConditions">
+        /// <param name="accessConditions">
         /// Optional <see cref="BlobAccessConditions"/> to add conditions on
         /// the creation of this new block blob.
         /// </param>
@@ -1083,7 +1083,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         public virtual Task<Response<BlobProperties>> DownloadAsync(
             Stream destination,
-            BlobAccessConditions? blobAccessConditions = default,
+            BlobAccessConditions? accessConditions = default,
             ///// <param name="progressHandler">
             ///// Optional <see cref="IProgress{StorageProgress}"/> to provide
             ///// progress updates about data transfers.
@@ -1093,7 +1093,7 @@ namespace Azure.Storage.Blobs.Specialized
             CancellationToken cancellationToken = default) =>
             StagedDownloadAsync(
                 destination,
-                blobAccessConditions,
+                accessConditions,
                 //progressHandler,
                 parallelTransferOptions: parallelTransferOptions,
                 async: true,
@@ -1107,7 +1107,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="destination">
         /// A <see cref="FileInfo"/> representing a file to write the downloaded content to.
         /// </param>
-        /// <param name="blobAccessConditions">
+        /// <param name="accessConditions">
         /// Optional <see cref="BlobAccessConditions"/> to add conditions on
         /// the creation of this new block blob.
         /// </param>
@@ -1129,7 +1129,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         public virtual Task<Response<BlobProperties>> DownloadAsync(
             FileInfo destination,
-            BlobAccessConditions? blobAccessConditions = default,
+            BlobAccessConditions? accessConditions = default,
             ///// <param name="progressHandler">
             ///// Optional <see cref="IProgress{StorageProgress}"/> to provide
             ///// progress updates about data transfers.
@@ -1139,7 +1139,7 @@ namespace Azure.Storage.Blobs.Specialized
             CancellationToken cancellationToken = default) =>
             StagedDownloadAsync(
                 destination,
-                blobAccessConditions,
+                accessConditions,
                 //progressHandler,
                 parallelTransferOptions: parallelTransferOptions,
                 async: true,
@@ -1260,7 +1260,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="destination">
         /// A <see cref="FileInfo"/> representing a file to write the downloaded content to.
         /// </param>
-        /// <param name="blobAccessConditions">
+        /// <param name="accessConditions">
         /// Optional <see cref="BlobAccessConditions"/> to add conditions on
         /// the creation of this new block blob.
         /// </param>
@@ -1289,7 +1289,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         internal Task<Response<BlobProperties>> StagedDownloadAsync(
             FileInfo destination,
-            BlobAccessConditions? blobAccessConditions = default,
+            BlobAccessConditions? accessConditions = default,
             ///// <param name="progressHandler">
             ///// Optional <see cref="IProgress{StorageProgress}"/> to provide
             ///// progress updates about data transfers.
@@ -1304,7 +1304,7 @@ namespace Azure.Storage.Blobs.Specialized
 
             return StagedDownloadAsync(
                 stream,
-                blobAccessConditions,
+                accessConditions,
                 //progressHandler,
                 singleBlockThreshold,
                 parallelTransferOptions,

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClient.cs
@@ -316,7 +316,7 @@ namespace Azure.Storage.Blobs
             CancellationToken cancellationToken) =>
             Upload(
                 content,
-                blobAccessConditions: default, // Pass anything else so we don't recurse on this overload
+                accessConditions: default, // Pass anything else so we don't recurse on this overload
                 cancellationToken: cancellationToken);
 #pragma warning restore AZC0002 // Client method should have cancellationToken as the last optional parameter
 
@@ -355,7 +355,7 @@ namespace Azure.Storage.Blobs
             CancellationToken cancellationToken) =>
             Upload(
                 content,
-                blobAccessConditions: default, // Pass anything else so we don't recurse on this overload
+                accessConditions: default, // Pass anything else so we don't recurse on this overload
                 cancellationToken: cancellationToken);
 #pragma warning restore AZC0002 // Client method should have cancellationToken as the last optional parameter
 
@@ -394,7 +394,7 @@ namespace Azure.Storage.Blobs
             CancellationToken cancellationToken) =>
             UploadAsync(
                 content,
-                blobAccessConditions: default, // Pass anything else so we don't recurse on this overload
+                accessConditions: default, // Pass anything else so we don't recurse on this overload
                 cancellationToken: cancellationToken);
 #pragma warning restore AZC0002 // Client method should have cancellationToken as the last optional parameter
 
@@ -433,7 +433,7 @@ namespace Azure.Storage.Blobs
             CancellationToken cancellationToken) =>
             UploadAsync(
                 content,
-                blobAccessConditions: default, // Pass anything else so we don't recurse on this overload
+                accessConditions: default, // Pass anything else so we don't recurse on this overload
                 cancellationToken: cancellationToken);
 #pragma warning restore AZC0002 // Client method should have cancellationToken as the last optional parameter
 
@@ -453,14 +453,14 @@ namespace Azure.Storage.Blobs
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
         /// </param>
-        /// <param name="blobHttpHeaders">
+        /// <param name="httpHeaders">
         /// Optional standard HTTP header properties that can be set for the
         /// block blob.
         /// </param>
         /// <param name="metadata">
         /// Optional custom metadata to set for this block blob.
         /// </param>
-        /// <param name="blobAccessConditions">
+        /// <param name="accessConditions">
         /// Optional <see cref="BlobAccessConditions"/> to add conditions on
         /// the creation of this new block blob.
         /// </param>
@@ -491,18 +491,18 @@ namespace Azure.Storage.Blobs
         [ForwardsClientCalls]
         public virtual Response<BlobContentInfo> Upload(
             Stream content,
-            BlobHttpHeaders? blobHttpHeaders = default,
+            BlobHttpHeaders? httpHeaders = default,
             Metadata metadata = default,
-            BlobAccessConditions? blobAccessConditions = default,
+            BlobAccessConditions? accessConditions = default,
             IProgress<StorageProgress> progressHandler = default,
             AccessTier? accessTier = default,
             ParallelTransferOptions parallelTransferOptions = default,
             CancellationToken cancellationToken = default) =>
             StagedUploadAsync(
                 content,
-                blobHttpHeaders,
+                httpHeaders,
                 metadata,
-                blobAccessConditions,
+                accessConditions,
                 progressHandler,
                 accessTier,
                 parallelTransferOptions: parallelTransferOptions,
@@ -526,14 +526,14 @@ namespace Azure.Storage.Blobs
         /// <param name="content">
         /// A <see cref="FileInfo"/> containing the content to upload.
         /// </param>
-        /// <param name="blobHttpHeaders">
+        /// <param name="httpHeaders">
         /// Optional standard HTTP header properties that can be set for the
         /// block blob.
         /// </param>
         /// <param name="metadata">
         /// Optional custom metadata to set for this block blob.
         /// </param>
-        /// <param name="blobAccessConditions">
+        /// <param name="accessConditions">
         /// Optional <see cref="BlobAccessConditions"/> to add conditions on
         /// the creation of this new block blob.
         /// </param>
@@ -564,18 +564,18 @@ namespace Azure.Storage.Blobs
         [ForwardsClientCalls]
         public virtual Response<BlobContentInfo> Upload(
             FileInfo content,
-            BlobHttpHeaders? blobHttpHeaders = default,
+            BlobHttpHeaders? httpHeaders = default,
             Metadata metadata = default,
-            BlobAccessConditions? blobAccessConditions = default,
+            BlobAccessConditions? accessConditions = default,
             IProgress<StorageProgress> progressHandler = default,
             AccessTier? accessTier = default,
             ParallelTransferOptions parallelTransferOptions = default,
             CancellationToken cancellationToken = default) =>
             StagedUploadAsync(
                 content,
-                blobHttpHeaders,
+                httpHeaders,
                 metadata,
-                blobAccessConditions,
+                accessConditions,
                 progressHandler,
                 accessTier,
                 parallelTransferOptions: parallelTransferOptions,
@@ -599,14 +599,14 @@ namespace Azure.Storage.Blobs
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
         /// </param>
-        /// <param name="blobHttpHeaders">
+        /// <param name="httpHeaders">
         /// Optional standard HTTP header properties that can be set for the
         /// block blob.
         /// </param>
         /// <param name="metadata">
         /// Optional custom metadata to set for this block blob.
         /// </param>
-        /// <param name="blobAccessConditions">
+        /// <param name="accessConditions">
         /// Optional <see cref="BlobAccessConditions"/> to add conditions on
         /// the creation of this new block blob.
         /// </param>
@@ -637,18 +637,18 @@ namespace Azure.Storage.Blobs
         [ForwardsClientCalls]
         public virtual Task<Response<BlobContentInfo>> UploadAsync(
             Stream content,
-            BlobHttpHeaders? blobHttpHeaders = default,
+            BlobHttpHeaders? httpHeaders = default,
             Metadata metadata = default,
-            BlobAccessConditions? blobAccessConditions = default,
+            BlobAccessConditions? accessConditions = default,
             IProgress<StorageProgress> progressHandler = default,
             AccessTier? accessTier = default,
             ParallelTransferOptions parallelTransferOptions = default,
             CancellationToken cancellationToken = default) =>
             StagedUploadAsync(
                 content,
-                blobHttpHeaders,
+                httpHeaders,
                 metadata,
-                blobAccessConditions,
+                accessConditions,
                 progressHandler,
                 accessTier,
                 parallelTransferOptions: parallelTransferOptions,
@@ -671,14 +671,14 @@ namespace Azure.Storage.Blobs
         /// <param name="content">
         /// A <see cref="FileInfo"/> containing the content to upload.
         /// </param>
-        /// <param name="blobHttpHeaders">
+        /// <param name="httpHeaders">
         /// Optional standard HTTP header properties that can be set for the
         /// block blob.
         /// </param>
         /// <param name="metadata">
         /// Optional custom metadata to set for this block blob.
         /// </param>
-        /// <param name="blobAccessConditions">
+        /// <param name="accessConditions">
         /// Optional <see cref="BlobAccessConditions"/> to add conditions on
         /// the creation of this new block blob.
         /// </param>
@@ -709,18 +709,18 @@ namespace Azure.Storage.Blobs
         [ForwardsClientCalls]
         public virtual Task<Response<BlobContentInfo>> UploadAsync(
             FileInfo content,
-            BlobHttpHeaders? blobHttpHeaders = default,
+            BlobHttpHeaders? httpHeaders = default,
             Metadata metadata = default,
-            BlobAccessConditions? blobAccessConditions = default,
+            BlobAccessConditions? accessConditions = default,
             IProgress<StorageProgress> progressHandler = default,
             AccessTier? accessTier = default,
             ParallelTransferOptions parallelTransferOptions = default,
             CancellationToken cancellationToken = default) =>
             StagedUploadAsync(
                 content,
-                blobHttpHeaders,
+                httpHeaders,
                 metadata,
-                blobAccessConditions,
+                accessConditions,
                 progressHandler,
                 accessTier,
                 parallelTransferOptions: parallelTransferOptions,

--- a/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
@@ -337,14 +337,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
         /// </param>
-        /// <param name="blobHttpHeaders">
+        /// <param name="httpHeaders">
         /// Optional standard HTTP header properties that can be set for the
         /// block blob.
         /// </param>
         /// <param name="metadata">
         /// Optional custom metadata to set for this block blob.
         /// </param>
-        /// <param name="blobAccessConditions">
+        /// <param name="accessConditions">
         /// Optional <see cref="BlockBlobClient"/> to add
         /// conditions on the creation of this new block blob.
         /// </param>
@@ -370,17 +370,17 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         public virtual Response<BlobContentInfo> Upload(
             Stream content,
-            BlobHttpHeaders? blobHttpHeaders = default,
+            BlobHttpHeaders? httpHeaders = default,
             Metadata metadata = default,
-            BlobAccessConditions? blobAccessConditions = default,
+            BlobAccessConditions? accessConditions = default,
             AccessTier? accessTier = default,
             IProgress<StorageProgress> progressHandler = default,
             CancellationToken cancellationToken = default) =>
             UploadInternal(
                 content,
-                blobHttpHeaders,
+                httpHeaders,
                 metadata,
-                blobAccessConditions,
+                accessConditions,
                 accessTier: accessTier,
                 progressHandler,
                 false, // async
@@ -403,14 +403,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="content">
         /// A <see cref="Stream"/> containing the content to upload.
         /// </param>
-        /// <param name="blobHttpHeaders">
+        /// <param name="httpHeaders">
         /// Optional standard HTTP header properties that can be set for the
         /// block blob.
         /// </param>
         /// <param name="metadata">
         /// Optional custom metadata to set for this block blob.
         /// </param>
-        /// <param name="blobAccessConditions">
+        /// <param name="accessConditions">
         /// Optional <see cref="BlobAccessConditions"/> to add
         /// conditions on the creation of this new block blob.
         /// </param>
@@ -436,17 +436,17 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         public virtual async Task<Response<BlobContentInfo>> UploadAsync(
             Stream content,
-            BlobHttpHeaders? blobHttpHeaders = default,
+            BlobHttpHeaders? httpHeaders = default,
             Metadata metadata = default,
-            BlobAccessConditions? blobAccessConditions = default,
+            BlobAccessConditions? accessConditions = default,
             AccessTier? accessTier = default,
             IProgress<StorageProgress> progressHandler = default,
             CancellationToken cancellationToken = default) =>
             await UploadInternal(
                 content,
-                blobHttpHeaders,
+                httpHeaders,
                 metadata,
-                blobAccessConditions,
+                accessConditions,
                 accessTier: accessTier,
                 progressHandler,
                 true, // async
@@ -1116,14 +1116,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// block list, it will not be written as part of the blob, and a
         /// <see cref="StorageRequestFailedException"/> will be thrown.
         /// </param>
-        /// <param name="blobHttpHeaders">
+        /// <param name="httpHeaders">
         /// Optional standard HTTP header properties that can be set for the
         /// block blob.
         /// </param>
         /// <param name="metadata">
         /// Optional custom metadata to set for this block blob.
         /// </param>
-        /// <param name="blobAccessConditions">
+        /// <param name="accessConditions">
         /// Optional <see cref="BlockBlobClient"/> to add
         /// conditions on committing this block list.
         /// </param>
@@ -1145,16 +1145,16 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         public virtual Response<BlobContentInfo> CommitBlockList(
             IEnumerable<string> base64BlockIds,
-            BlobHttpHeaders? blobHttpHeaders = default,
+            BlobHttpHeaders? httpHeaders = default,
             Metadata metadata = default,
-            BlobAccessConditions? blobAccessConditions = default,
+            BlobAccessConditions? accessConditions = default,
             AccessTier? accessTier = default,
             CancellationToken cancellationToken = default) =>
             CommitBlockListInternal(
                 base64BlockIds,
-                blobHttpHeaders,
+                httpHeaders,
                 metadata,
-                blobAccessConditions,
+                accessConditions,
                 accessTier,
                 false, // async
                 cancellationToken)
@@ -1183,14 +1183,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// block list, it will not be written as part of the blob, and a
         /// <see cref="StorageRequestFailedException"/> will be thrown.
         /// </param>
-        /// <param name="blobHttpHeaders">
+        /// <param name="httpHeaders">
         /// Optional standard HTTP header properties that can be set for the
         /// block blob.
         /// </param>
         /// <param name="metadata">
         /// Optional custom metadata to set for this block blob.
         /// </param>
-        /// <param name="blobAccessConditions">
+        /// <param name="accessConditions">
         /// Optional <see cref="BlockBlobClient"/> to add
         /// conditions on committing this block list.
         /// </param>
@@ -1212,16 +1212,16 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         public virtual async Task<Response<BlobContentInfo>> CommitBlockListAsync(
             IEnumerable<string> base64BlockIds,
-            BlobHttpHeaders? blobHttpHeaders = default,
+            BlobHttpHeaders? httpHeaders = default,
             Metadata metadata = default,
-            BlobAccessConditions? blobAccessConditions = default,
+            BlobAccessConditions? accessConditions = default,
             AccessTier? accessTier = default,
             CancellationToken cancellationToken = default) =>
             await CommitBlockListInternal(
                 base64BlockIds,
-                blobHttpHeaders,
+                httpHeaders,
                 metadata,
-                blobAccessConditions,
+                accessConditions,
                 accessTier,
                 true, // async
                 cancellationToken)

--- a/sdk/storage/Azure.Storage.Blobs/src/LeaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/LeaseClient.cs
@@ -142,7 +142,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// A non-infinite lease can be between 15 and 60 seconds.
         /// A lease duration cannot be changed using <see cref="RenewAsync"/> or <see cref="ChangeAsync"/>.
         /// </param>
-        /// <param name="httpAccessConditions">
+        /// <param name="accessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on acquiring a lease.
         /// </param>
@@ -159,11 +159,11 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         public virtual Response<Lease> Acquire(
             TimeSpan duration,
-            HttpAccessConditions? httpAccessConditions = default,
+            HttpAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
             AcquireInternal(
                 duration,
-                httpAccessConditions,
+                accessConditions,
                 false, // async
                 cancellationToken)
                 .EnsureCompleted();
@@ -187,7 +187,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// A non-infinite lease can be between 15 and 60 seconds.
         /// A lease duration cannot be changed using <see cref="RenewAsync"/> or <see cref="ChangeAsync"/>.
         /// </param>
-        /// <param name="httpAccessConditions">
+        /// <param name="accessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on acquiring a lease.
         /// </param>
@@ -204,11 +204,11 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         public virtual async Task<Response<Lease>> AcquireAsync(
             TimeSpan duration,
-            HttpAccessConditions? httpAccessConditions = default,
+            HttpAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
             await AcquireInternal(
                 duration,
-                httpAccessConditions,
+                accessConditions,
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
@@ -332,7 +332,7 @@ namespace Azure.Storage.Blobs.Specialized
         ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
         /// </summary>
-        /// <param name="httpAccessConditions">
+        /// <param name="accessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on renewing a lease.
         /// </param>
@@ -348,10 +348,10 @@ namespace Azure.Storage.Blobs.Specialized
         /// a failure occurs.
         /// </remarks>
         public virtual Response<Lease> Renew(
-            HttpAccessConditions? httpAccessConditions = default,
+            HttpAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
             RenewInternal(
-                httpAccessConditions,
+                accessConditions,
                 false, // async
                 cancellationToken)
                 .EnsureCompleted();
@@ -368,7 +368,7 @@ namespace Azure.Storage.Blobs.Specialized
         ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
         /// </summary>
-        /// <param name="httpAccessConditions">
+        /// <param name="accessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on renewing a lease.
         /// </param>
@@ -384,10 +384,10 @@ namespace Azure.Storage.Blobs.Specialized
         /// a failure occurs.
         /// </remarks>
         public virtual async Task<Response<Lease>> RenewAsync(
-            HttpAccessConditions? httpAccessConditions = default,
+            HttpAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
             await RenewInternal(
-                httpAccessConditions,
+                accessConditions,
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
@@ -497,7 +497,7 @@ namespace Azure.Storage.Blobs.Specialized
         ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
         /// </summary>
-        /// <param name="httpAccessConditions">
+        /// <param name="accessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on releasing a lease.
         /// </param>
@@ -514,10 +514,10 @@ namespace Azure.Storage.Blobs.Specialized
         /// a failure occurs.
         /// </remarks>
         public virtual Response<ReleasedObjectInfo> Release(
-            HttpAccessConditions? httpAccessConditions = default,
+            HttpAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
             ReleaseInternal(
-                httpAccessConditions,
+                accessConditions,
                 false, // async
                 cancellationToken)
                 .EnsureCompleted();
@@ -533,7 +533,7 @@ namespace Azure.Storage.Blobs.Specialized
         ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
         /// </summary>
-        /// <param name="httpAccessConditions">
+        /// <param name="accessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on releasing a lease.
         /// </param>
@@ -550,10 +550,10 @@ namespace Azure.Storage.Blobs.Specialized
         /// a failure occurs.
         /// </remarks>
         public virtual async Task<Response<ReleasedObjectInfo>> ReleaseAsync(
-            HttpAccessConditions? httpAccessConditions = default,
+            HttpAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
             await ReleaseInternal(
-                httpAccessConditions,
+                accessConditions,
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
@@ -569,7 +569,7 @@ namespace Azure.Storage.Blobs.Specialized
         ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
         /// </summary>
-        /// <param name="httpAccessConditions">
+        /// <param name="accessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on releasing a lease.
         /// </param>
@@ -589,7 +589,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// a failure occurs.
         /// </remarks>
         public virtual async Task<Response<ReleasedObjectInfo>> ReleaseInternal(
-            HttpAccessConditions? httpAccessConditions,
+            HttpAccessConditions? accessConditions,
             bool async,
             CancellationToken cancellationToken)
         {
@@ -601,7 +601,7 @@ namespace Azure.Storage.Blobs.Specialized
                     message:
                     $"{nameof(Uri)}: {Uri}\n" +
                     $"{nameof(LeaseId)}: {LeaseId}\n" +
-                    $"{nameof(httpAccessConditions)}: {httpAccessConditions}");
+                    $"{nameof(accessConditions)}: {accessConditions}");
                 try
                 {
                     if (BlobClient != null)
@@ -611,10 +611,10 @@ namespace Azure.Storage.Blobs.Specialized
                                 Pipeline,
                                 Uri,
                                 leaseId: LeaseId,
-                                ifModifiedSince: httpAccessConditions?.IfModifiedSince,
-                                ifUnmodifiedSince: httpAccessConditions?.IfUnmodifiedSince,
-                                ifMatch: httpAccessConditions?.IfMatch,
-                                ifNoneMatch: httpAccessConditions?.IfNoneMatch,
+                                ifModifiedSince: accessConditions?.IfModifiedSince,
+                                ifUnmodifiedSince: accessConditions?.IfUnmodifiedSince,
+                                ifMatch: accessConditions?.IfMatch,
+                                ifNoneMatch: accessConditions?.IfNoneMatch,
                                 async: async,
                                 operationName: Constants.Blob.Lease.ReleaseOperationName,
                                 cancellationToken: cancellationToken)
@@ -623,7 +623,7 @@ namespace Azure.Storage.Blobs.Specialized
                     }
                     else
                     {
-                        if (httpAccessConditions?.IfMatch != default || httpAccessConditions?.IfNoneMatch != default)
+                        if (accessConditions?.IfMatch != default || accessConditions?.IfNoneMatch != default)
                         {
                             throw BlobErrors.BlobConditionsMustBeDefault(
                                 nameof(HttpAccessConditions.IfMatch),
@@ -634,8 +634,8 @@ namespace Azure.Storage.Blobs.Specialized
                                 Pipeline,
                                 Uri,
                                 leaseId: LeaseId,
-                                ifModifiedSince: httpAccessConditions?.IfModifiedSince,
-                                ifUnmodifiedSince: httpAccessConditions?.IfUnmodifiedSince,
+                                ifModifiedSince: accessConditions?.IfModifiedSince,
+                                ifUnmodifiedSince: accessConditions?.IfUnmodifiedSince,
                                 async: async,
                                 operationName: Constants.Blob.Lease.ReleaseOperationName,
                                 cancellationToken: cancellationToken)
@@ -669,7 +669,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <see cref="StorageRequestFailedException"/> will be thrown if the
         /// proposed lease ID is not in the correct format.
         /// </param>
-        /// <param name="httpAccessConditions">
+        /// <param name="accessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on changing a lease.
         /// </param>
@@ -686,11 +686,11 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         public virtual Response<Lease> Change(
             string proposedId,
-            HttpAccessConditions? httpAccessConditions = default,
+            HttpAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
             ChangeInternal(
                 proposedId,
-                httpAccessConditions,
+                accessConditions,
                 false, // async
                 cancellationToken)
                 .EnsureCompleted();
@@ -707,7 +707,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <see cref="StorageRequestFailedException"/> will be thrown if the
         /// proposed lease ID is not in the correct format.
         /// </param>
-        /// <param name="httpAccessConditions">
+        /// <param name="accessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on changing a lease.
         /// </param>
@@ -724,11 +724,11 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         public virtual async Task<Response<Lease>> ChangeAsync(
             string proposedId,
-            HttpAccessConditions? httpAccessConditions = default,
+            HttpAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
             await ChangeInternal(
                 proposedId,
-                httpAccessConditions,
+                accessConditions,
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
@@ -862,7 +862,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// is not provided, a fixed-duration lease breaks after the remaining
         /// lease period elapses, and an infinite lease breaks immediately.
         /// </param>
-        /// <param name="httpAccessConditions">
+        /// <param name="accessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on breaking a lease.
         /// </param>
@@ -879,11 +879,11 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         public virtual Response<Lease> Break(
             TimeSpan? breakPeriod = default,
-            HttpAccessConditions? httpAccessConditions = default,
+            HttpAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
             BreakInternal(
                 breakPeriod,
-                httpAccessConditions,
+                accessConditions,
                 false, // async
                 cancellationToken)
                 .EnsureCompleted();
@@ -918,7 +918,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// is not provided, a fixed-duration lease breaks after the remaining
         /// lease period elapses, and an infinite lease breaks immediately.
         /// </param>
-        /// <param name="httpAccessConditions">
+        /// <param name="accessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on breaking a lease.
         /// </param>
@@ -935,11 +935,11 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         public virtual async Task<Response<Lease>> BreakAsync(
             TimeSpan? breakPeriod = default,
-            HttpAccessConditions? httpAccessConditions = default,
+            HttpAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
             await BreakInternal(
                 breakPeriod,
-                httpAccessConditions,
+                accessConditions,
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -1850,7 +1850,7 @@ namespace Azure.Storage.Blobs.Test
                     // Act
                     Response<Lease> response = await InstrumentClient(blob.GetLeaseClient(leaseId)).AcquireAsync(
                         duration: duration,
-                        httpAccessConditions: accessConditions);
+                        accessConditions: accessConditions);
 
                     // Assert
                     Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
@@ -1878,7 +1878,7 @@ namespace Azure.Storage.Blobs.Test
                     await TestHelper.AssertExpectedExceptionAsync<StorageRequestFailedException>(
                         InstrumentClient(blob.GetLeaseClient(leaseId)).AcquireAsync(
                             duration: duration,
-                            httpAccessConditions: accessConditions),
+                            accessConditions: accessConditions),
                         e => { });
                 }
             }
@@ -1944,7 +1944,7 @@ namespace Azure.Storage.Blobs.Test
                     await lease.AcquireAsync(duration: duration);
 
                     // Act
-                    Response<Lease> response = await lease.RenewAsync(httpAccessConditions: accessConditions);
+                    Response<Lease> response = await lease.RenewAsync(accessConditions: accessConditions);
 
                     // Assert
                     Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
@@ -1973,7 +1973,7 @@ namespace Azure.Storage.Blobs.Test
 
                     // Act
                     await TestHelper.AssertExpectedExceptionAsync<StorageRequestFailedException>(
-                        lease.RenewAsync(httpAccessConditions: accessConditions),
+                        lease.RenewAsync(accessConditions: accessConditions),
                         e => { });
                 }
             }
@@ -2038,7 +2038,7 @@ namespace Azure.Storage.Blobs.Test
                     await lease.AcquireAsync(duration: duration);
 
                     // Act
-                    Response<ReleasedObjectInfo> response = await lease.ReleaseAsync(httpAccessConditions: accessConditions);
+                    Response<ReleasedObjectInfo> response = await lease.ReleaseAsync(accessConditions: accessConditions);
 
                     // Assert
                     Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
@@ -2067,7 +2067,7 @@ namespace Azure.Storage.Blobs.Test
 
                     // Act
                     await TestHelper.AssertExpectedExceptionAsync<StorageRequestFailedException>(
-                        lease.ReleaseAsync(httpAccessConditions: accessConditions),
+                        lease.ReleaseAsync(accessConditions: accessConditions),
                         e => { });
                 }
             }
@@ -2155,7 +2155,7 @@ namespace Azure.Storage.Blobs.Test
                     await lease.AcquireAsync(duration: duration);
 
                     // Act
-                    Response<Lease> response = await lease.BreakAsync(httpAccessConditions: accessConditions);
+                    Response<Lease> response = await lease.BreakAsync(accessConditions: accessConditions);
 
                     // Assert
                     Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
@@ -2184,7 +2184,7 @@ namespace Azure.Storage.Blobs.Test
 
                     // Act
                     await TestHelper.AssertExpectedExceptionAsync<StorageRequestFailedException>(
-                        lease.BreakAsync(httpAccessConditions: accessConditions),
+                        lease.BreakAsync(accessConditions: accessConditions),
                         e => { });
                 }
             }
@@ -2252,7 +2252,7 @@ namespace Azure.Storage.Blobs.Test
                     // Act
                     Response<Lease> response = await lease.ChangeAsync(
                         proposedId: newLeaseId,
-                        httpAccessConditions: accessConditions);
+                        accessConditions: accessConditions);
 
                     // Assert
                     Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
@@ -2284,7 +2284,7 @@ namespace Azure.Storage.Blobs.Test
                     await TestHelper.AssertExpectedExceptionAsync<StorageRequestFailedException>(
                         lease.ChangeAsync(
                             proposedId: newLeaseId,
-                            httpAccessConditions: accessConditions),
+                            accessConditions: accessConditions),
                         e => { });
                 }
             }

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
@@ -669,7 +669,7 @@ namespace Azure.Storage.Blobs.Test
                 // Act
                 await blob.CommitBlockListAsync(
                     base64BlockIds: new string[] { ToBase64(blockName) },
-                    blobHttpHeaders: new BlobHttpHeaders
+                    httpHeaders: new BlobHttpHeaders
                     {
                         CacheControl = constants.CacheControl,
                         ContentDisposition = constants.ContentDisposition,
@@ -741,7 +741,7 @@ namespace Azure.Storage.Blobs.Test
                 // Act
                 Response<BlobContentInfo> response = await blob.CommitBlockListAsync(
                     base64BlockIds: new string[] { ToBase64(blockName) },
-                    blobAccessConditions: new BlobAccessConditions
+                    accessConditions: new BlobAccessConditions
                     {
                         LeaseAccessConditions = new LeaseAccessConditions
                         {
@@ -775,7 +775,7 @@ namespace Azure.Storage.Blobs.Test
                 await TestHelper.AssertExpectedExceptionAsync<StorageRequestFailedException>(
                     blob.CommitBlockListAsync(
                         base64BlockIds: new string[] { ToBase64(GetNewBlockName()) },
-                        blobAccessConditions: new BlobAccessConditions
+                        accessConditions: new BlobAccessConditions
                         {
                             LeaseAccessConditions = new LeaseAccessConditions
                             {
@@ -820,7 +820,7 @@ namespace Azure.Storage.Blobs.Test
                     // Act
                     Response<BlobContentInfo> response = await blob.CommitBlockListAsync(
                         base64BlockIds: new string[] { ToBase64(blockName) },
-                        blobAccessConditions: new BlobAccessConditions
+                        accessConditions: new BlobAccessConditions
                         {
                             HttpAccessConditions = accessConditions
                         });
@@ -868,7 +868,7 @@ namespace Azure.Storage.Blobs.Test
                     await TestHelper.AssertExpectedExceptionAsync<StorageRequestFailedException>(
                         blob.CommitBlockListAsync(
                             base64BlockIds: new string[] { ToBase64(blockName) },
-                            blobAccessConditions: new BlobAccessConditions
+                            accessConditions: new BlobAccessConditions
                             {
                                 HttpAccessConditions = accessConditions
                             }),
@@ -1266,7 +1266,7 @@ namespace Azure.Storage.Blobs.Test
                 {
                     await blob.UploadAsync(
                         content: stream,
-                        blobHttpHeaders: new BlobHttpHeaders
+                        httpHeaders: new BlobHttpHeaders
                         {
                             CacheControl = constants.CacheControl,
                             ContentDisposition = constants.ContentDisposition,
@@ -1311,7 +1311,7 @@ namespace Azure.Storage.Blobs.Test
                     {
                         Response<BlobContentInfo> response = await blob.UploadAsync(
                             content: stream,
-                            blobAccessConditions: new BlobAccessConditions
+                            accessConditions: new BlobAccessConditions
                             {
                                 HttpAccessConditions = accessConditions
                             });
@@ -1349,7 +1349,7 @@ namespace Azure.Storage.Blobs.Test
                         await TestHelper.AssertExpectedExceptionAsync<StorageRequestFailedException>(
                             blob.UploadAsync(
                                 content: stream,
-                                blobAccessConditions: new BlobAccessConditions
+                                accessConditions: new BlobAccessConditions
                                 {
                                     HttpAccessConditions = accessConditions
                                 }),
@@ -1375,7 +1375,7 @@ namespace Azure.Storage.Blobs.Test
                     await TestHelper.AssertExpectedExceptionAsync<StorageRequestFailedException>(
                         blob.UploadAsync(
                             content: stream,
-                            blobAccessConditions: new BlobAccessConditions
+                            accessConditions: new BlobAccessConditions
                             {
                                 LeaseAccessConditions = new LeaseAccessConditions
                                 {

--- a/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
@@ -747,7 +747,7 @@ namespace Azure.Storage.Blobs.Test
                 // Act
                 Response<Lease> response = await InstrumentClient(container.GetLeaseClient(id)).AcquireAsync(
                     duration: duration,
-                    httpAccessConditions: accessConditions.HttpAccessConditions);
+                    accessConditions: accessConditions.HttpAccessConditions);
 
                 // Assert
                 Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
@@ -783,7 +783,7 @@ namespace Azure.Storage.Blobs.Test
                     await TestHelper.AssertExpectedExceptionAsync<StorageRequestFailedException>(
                         InstrumentClient(container.GetLeaseClient(id)).AcquireAsync(
                             duration: duration,
-                            httpAccessConditions: accessConditions.HttpAccessConditions),
+                            accessConditions: accessConditions.HttpAccessConditions),
                         e => { });
                 }
             }
@@ -853,7 +853,7 @@ namespace Azure.Storage.Blobs.Test
                 _ = await lease.AcquireAsync(duration: duration);
 
                 // Act
-                Response<Lease> response = await lease.RenewAsync(httpAccessConditions: accessConditions.HttpAccessConditions);
+                Response<Lease> response = await lease.RenewAsync(accessConditions: accessConditions.HttpAccessConditions);
 
                 // Assert
                 Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
@@ -891,7 +891,7 @@ namespace Azure.Storage.Blobs.Test
 
                 // Act
                 await TestHelper.AssertExpectedExceptionAsync<StorageRequestFailedException>(
-                    lease.RenewAsync(httpAccessConditions: accessConditions.HttpAccessConditions),
+                    lease.RenewAsync(accessConditions: accessConditions.HttpAccessConditions),
                     e => { });
 
                 // cleanup
@@ -960,7 +960,7 @@ namespace Azure.Storage.Blobs.Test
                     Response<Lease> aquireLeaseResponse = await lease.AcquireAsync(duration: duration);
 
                     // Act
-                    Response<ReleasedObjectInfo> response = await lease.ReleaseAsync(httpAccessConditions: accessConditions.HttpAccessConditions);
+                    Response<ReleasedObjectInfo> response = await lease.ReleaseAsync(accessConditions: accessConditions.HttpAccessConditions);
 
                     // Assert
                     Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
@@ -990,7 +990,7 @@ namespace Azure.Storage.Blobs.Test
 
                 // Act
                 await TestHelper.AssertExpectedExceptionAsync<StorageRequestFailedException>(
-                    lease.ReleaseAsync(httpAccessConditions: accessConditions.HttpAccessConditions),
+                    lease.ReleaseAsync(accessConditions: accessConditions.HttpAccessConditions),
                     e => { });
 
                 // cleanup
@@ -1061,7 +1061,7 @@ namespace Azure.Storage.Blobs.Test
 
                 // Act
                 Response<Lease> response = await InstrumentClient(container.GetLeaseClient()).BreakAsync(
-                    httpAccessConditions: accessConditions.HttpAccessConditions);
+                    accessConditions: accessConditions.HttpAccessConditions);
 
                 // Assert
                 Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
@@ -1099,7 +1099,7 @@ namespace Azure.Storage.Blobs.Test
                 // Act
                 await TestHelper.AssertExpectedExceptionAsync<StorageRequestFailedException>(
                     InstrumentClient(container.GetLeaseClient()).BreakAsync(
-                        httpAccessConditions: accessConditions.HttpAccessConditions),
+                        accessConditions: accessConditions.HttpAccessConditions),
                     e => { });
 
                 // cleanup
@@ -1173,7 +1173,7 @@ namespace Azure.Storage.Blobs.Test
                 // Act
                 Response<Lease> response = await InstrumentClient(container.GetLeaseClient(aquireLeaseResponse.Value.LeaseId)).ChangeAsync(
                     proposedId: newId,
-                    httpAccessConditions: accessConditions.HttpAccessConditions);
+                    accessConditions: accessConditions.HttpAccessConditions);
 
                 // Assert
                 Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
@@ -1213,7 +1213,7 @@ namespace Azure.Storage.Blobs.Test
                 await TestHelper.AssertExpectedExceptionAsync<StorageRequestFailedException>(
                     InstrumentClient(container.GetLeaseClient(aquireLeaseResponse.Value.LeaseId)).ChangeAsync(
                         proposedId: newId,
-                        httpAccessConditions: accessConditions.HttpAccessConditions),
+                        accessConditions: accessConditions.HttpAccessConditions),
                     e => { });
 
                 // cleanup


### PR DESCRIPTION
…name blobHttpHeaders to httpHeaders.
Fixes #7832 

blobAccessConditions will soon be deriving from HttpAccessConditions so BlobAccessCondition params will be able to access a superset of the properties of HttpAccessConditions, and thus the distinction in the parameter naming is less useful.