### PR TITLE
[ENG] Update props files to reference preview 4 EventHubs and Blobs packages

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -11,8 +11,8 @@
     <PackageReference Update="ApprovalUtilities" Version="3.0.22" />
     <PackageReference Update="Azure.Core" Version="1.0.0-preview.9" />
     <PackageReference Update="Azure.Identity" Version="1.0.0-preview.5" />
-    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.0.0-preview.3" />
-    <PackageReference Update="Azure.Storage.Blobs" Version="12.0.0-preview.3" />
+    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.0.0-preview.4" />
+    <PackageReference Update="Azure.Storage.Blobs" Version="12.0.0-preview.4" />
     <PackageReference Update="BenchmarkDotNet" Version="0.11.5" />
     <PackageReference Update="FsCheck.Xunit" Version="2.14.0" />
     <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/Directory.Build.props
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blob/Directory.Build.props
@@ -28,6 +28,6 @@
     <EnableClientSdkAnalyzers>false</EnableClientSdkAnalyzers>
 
     <!-- If there was no override specified, set the type of reference to use for client libraries from the Azure SDK repository -->
-    <UseProjectReferenceToAzureClients Condition="'$(UseProjectReferenceToAzureClients)' == ''">true</UseProjectReferenceToAzureClients>
+    <UseProjectReferenceToAzureClients Condition="'$(UseProjectReferenceToAzureClients)' == ''">$(UseProjectReferenceToAzureCore)</UseProjectReferenceToAzureClients>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
**Do not merge this commit before Storage preview 4 release!!!**

Make the package references in `Packages.Data.props` point to preview 4 versions of `EventHubs` and `Blobs`. This is necessary to release the `CheckpointStore.Blob` package.