### PR TITLE
[Storage] Fix:  QueueClient.GetAccessPolicy fails with null Start/Expiry

### DIFF
--- a/sdk/storage/Azure.Storage.Queues/src/Generated/QueueRestClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Generated/QueueRestClient.cs
@@ -2285,12 +2285,12 @@ namespace Azure.Storage.Queues.Models
         /// <summary>
         /// the date-time the policy is active
         /// </summary>
-        public System.DateTimeOffset Start { get; set; }
+        public System.DateTimeOffset? Start { get; set; }
 
         /// <summary>
         /// the date-time the policy expires
         /// </summary>
-        public System.DateTimeOffset Expiry { get; set; }
+        public System.DateTimeOffset? Expiry { get; set; }
 
         /// <summary>
         /// the permissions for the acl policy
@@ -2314,15 +2314,24 @@ namespace Azure.Storage.Queues.Models
         {
             System.Diagnostics.Debug.Assert(value != null);
             System.Xml.Linq.XElement _element = new System.Xml.Linq.XElement(System.Xml.Linq.XName.Get(name, ns));
-            _element.Add(new System.Xml.Linq.XElement(
-                System.Xml.Linq.XName.Get("Start", ""),
-                value.Start.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.fffffffZ", System.Globalization.CultureInfo.InvariantCulture)));
-            _element.Add(new System.Xml.Linq.XElement(
-                System.Xml.Linq.XName.Get("Expiry", ""),
-                value.Expiry.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.fffffffZ", System.Globalization.CultureInfo.InvariantCulture)));
-            _element.Add(new System.Xml.Linq.XElement(
-                System.Xml.Linq.XName.Get("Permission", ""),
-                value.Permission));
+            if (value.Start != null)
+            {
+                _element.Add(new System.Xml.Linq.XElement(
+                    System.Xml.Linq.XName.Get("Start", ""),
+                    value.Start.Value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.fffffffZ", System.Globalization.CultureInfo.InvariantCulture)));
+            }
+            if (value.Expiry != null)
+            {
+                _element.Add(new System.Xml.Linq.XElement(
+                    System.Xml.Linq.XName.Get("Expiry", ""),
+                    value.Expiry.Value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.fffffffZ", System.Globalization.CultureInfo.InvariantCulture)));
+            }
+            if (value.Permission != null)
+            {
+                _element.Add(new System.Xml.Linq.XElement(
+                    System.Xml.Linq.XName.Get("Permission", ""),
+                    value.Permission));
+            }
             return _element;
         }
 

--- a/sdk/storage/Azure.Storage.Queues/swagger/readme.md
+++ b/sdk/storage/Azure.Storage.Queues/swagger/readme.md
@@ -287,6 +287,15 @@ directive:
     $.name = "permissions";
 ```
 
+### ShareItemProperties
+``` yaml
+directive:
+- from: swagger-document
+  where: $.definitions.AccessPolicy
+  transform: >
+     delete $.required;
+```
+
 ### Url
 ``` yaml
 directive:

--- a/sdk/storage/Azure.Storage.Queues/swagger/readme.md
+++ b/sdk/storage/Azure.Storage.Queues/swagger/readme.md
@@ -287,7 +287,7 @@ directive:
     $.name = "permissions";
 ```
 
-### ShareItemProperties
+### Set Start/Expiry nullable in AccessPolicy 
 ``` yaml
 directive:
 - from: swagger-document


### PR DESCRIPTION
This was caused by not having a start time and end time defined. The Azure Portal does not require those, but the SDK requires them (they’re not nullable). The access policies for file shares are set up to be nullable, so updated queues similarly in this PR.