### PR TITLE
Rename *DownloadProperties model to be *DownloadDetails

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/Models/BlobInfo.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/BlobInfo.cs
@@ -23,7 +23,7 @@ namespace Azure.Storage.Blobs.Models
     }
 
     /// <summary>
-    /// The properties and Content returned from downloading a blob
+    /// The details and Content returned from downloading a blob
     /// </summary>
     public partial class BlobDownloadInfo : IDisposable
     {
@@ -48,6 +48,11 @@ namespace Azure.Storage.Blobs.Models
         public Stream Content => _flattened.Content;
 
         /// <summary>
+        /// The media type of the body of the response. For Download Blob this is 'application/octet-stream'
+        /// </summary>
+        public string ContentType => _flattened.ContentType;
+
+        /// <summary>
         /// If the blob has an MD5 hash and this operation is to read the full blob, this response header is returned so that the client can check for message content integrity.
         /// </summary>
 #pragma warning disable CA1819 // Properties should not return arrays
@@ -55,9 +60,9 @@ namespace Azure.Storage.Blobs.Models
 #pragma warning restore CA1819 // Properties should not return arrays
 
         /// <summary>
-        /// Properties returned when downloading a Blob
+        /// Details returned when downloading a Blob
         /// </summary>
-        public BlobDownloadProperties Properties { get; private set; }
+        public BlobDownloadDetails Details { get; private set; }
 
         /// <summary>
         /// Creates a new DownloadInfo backed by FlattenedDownloadProperties
@@ -66,7 +71,7 @@ namespace Azure.Storage.Blobs.Models
         internal BlobDownloadInfo(FlattenedDownloadProperties flattened)
         {
             _flattened = flattened;
-            Properties = new BlobDownloadProperties() { _flattened = flattened };
+            Details = new BlobDownloadDetails() { _flattened = flattened };
         }
 
         /// <summary>
@@ -80,9 +85,9 @@ namespace Azure.Storage.Blobs.Models
     }
 
     /// <summary>
-    /// Properties returned when downloading a Blob
+    /// Details returned when downloading a Blob
     /// </summary>
-    public partial class BlobDownloadProperties
+    public partial class BlobDownloadDetails
     {
         /// <summary>
         /// Internal flattened property representation
@@ -98,11 +103,6 @@ namespace Azure.Storage.Blobs.Models
         /// x-ms-meta
         /// </summary>
         public IDictionary<string, string> Metadata => _flattened.Metadata;
-
-        /// <summary>
-        /// The media type of the body of the response. For Download Blob this is 'application/octet-stream'
-        /// </summary>
-        public string ContentType => _flattened.ContentType;
 
         /// <summary>
         /// Indicates the range of bytes returned in the event that the client requested a subset of the blob by setting the 'Range' request header.

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -178,7 +178,7 @@ namespace Azure.Storage.Blobs.Test
                 Response<BlobDownloadInfo> response = await blob.DownloadAsync();
 
                 // Assert
-                Assert.AreEqual(customerProvidedKey.EncryptionKeyHash, response.Value.Properties.EncryptionKeySha256);
+                Assert.AreEqual(customerProvidedKey.EncryptionKeyHash, response.Value.Details.EncryptionKeySha256);
             }
         }
 

--- a/sdk/storage/Azure.Storage.Files/src/Models/StorageFileDownloadDetails.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Models/StorageFileDownloadDetails.cs
@@ -9,9 +9,9 @@ using System.Collections.Generic;
 namespace Azure.Storage.Files.Models
 {
     /// <summary>
-    /// Properties returned when downloading a File
+    /// Details returned when downloading a File
     /// </summary>
-    public partial class StorageFileDownloadProperties
+    public partial class StorageFileDownloadDetails
     {
         /// <summary>
         /// Internal flattened property representation
@@ -115,7 +115,7 @@ namespace Azure.Storage.Files.Models
         /// </summary>
         public FileSmbProperties SmbProperties { get; set; }
 
-        internal StorageFileDownloadProperties(FlattenedStorageFileProperties flattened)
+        internal StorageFileDownloadDetails(FlattenedStorageFileProperties flattened)
         {
             _flattened = flattened;
             SmbProperties = new FileSmbProperties(flattened);
@@ -130,7 +130,7 @@ namespace Azure.Storage.Files.Models
         /// <summary>
         /// Creates a new StorageFileDownloadProperties instance for mocking.
         /// </summary>
-        public static StorageFileDownloadProperties StorageFileDownloadProperties(
+        public static StorageFileDownloadDetails StorageFileDownloadProperties(
             DateTimeOffset lastModified,
             IDictionary<string, string> metadata,
             string contentType,
@@ -171,7 +171,7 @@ namespace Azure.Storage.Files.Models
                 FileContentHash = fileContentHash,
                 IsServerEncrypted = isServiceEncrypted
             };
-            return new StorageFileDownloadProperties(flattened);
+            return new StorageFileDownloadDetails(flattened);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Files/src/Models/StorageFileDownloadInfo.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Models/StorageFileDownloadInfo.cs
@@ -38,9 +38,9 @@ namespace Azure.Storage.Files.Models
 #pragma warning restore CA1819 // Properties should not return arrays
 
         /// <summary>
-        /// Properties returned when downloading a file
+        /// Details returned when downloading a file
         /// </summary>
-        public StorageFileDownloadProperties Properties { get; private set; }
+        public StorageFileDownloadDetails Details { get; private set; }
 
         /// <summary>
         /// Creates a new StorageFileDownloadInfo backed by FlattenedStorageFileProperties
@@ -49,7 +49,7 @@ namespace Azure.Storage.Files.Models
         internal StorageFileDownloadInfo(FlattenedStorageFileProperties flattened)
         {
             _flattened = flattened;
-            Properties = new StorageFileDownloadProperties(flattened);
+            Details = new StorageFileDownloadDetails(flattened);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Files/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files/tests/FileClientTests.cs
@@ -764,22 +764,22 @@ namespace Azure.Storage.Files.Test
                 TestHelper.AssertSequenceEqual(data, actual.ToArray());
 
                 // Properties are equal
-                Assert.AreEqual(getPropertiesResponse.Value.LastModified, downloadResponse.Value.Properties.LastModified);
-                AssertMetadataEquality(getPropertiesResponse.Value.Metadata, downloadResponse.Value.Properties.Metadata);
-                Assert.AreEqual(getPropertiesResponse.Value.ContentType, downloadResponse.Value.Properties.ContentType);
-                Assert.AreEqual(getPropertiesResponse.Value.ETag, downloadResponse.Value.Properties.ETag);
-                Assert.AreEqual(getPropertiesResponse.Value.ContentEncoding, downloadResponse.Value.Properties.ContentEncoding);
-                Assert.AreEqual(getPropertiesResponse.Value.CacheControl, downloadResponse.Value.Properties.CacheControl);
-                Assert.AreEqual(getPropertiesResponse.Value.ContentDisposition, downloadResponse.Value.Properties.ContentDisposition);
-                Assert.AreEqual(getPropertiesResponse.Value.ContentLanguage, downloadResponse.Value.Properties.ContentLanguage);
-                Assert.AreEqual(getPropertiesResponse.Value.CopyCompletionTime, downloadResponse.Value.Properties.CopyCompletionTime);
-                Assert.AreEqual(getPropertiesResponse.Value.CopyStatusDescription, downloadResponse.Value.Properties.CopyStatusDescription);
-                Assert.AreEqual(getPropertiesResponse.Value.CopyId, downloadResponse.Value.Properties.CopyId);
-                Assert.AreEqual(getPropertiesResponse.Value.CopyProgress, downloadResponse.Value.Properties.CopyProgress);
-                Assert.AreEqual(getPropertiesResponse.Value.CopySource, downloadResponse.Value.Properties.CopySource);
-                Assert.AreEqual(getPropertiesResponse.Value.CopyStatus, downloadResponse.Value.Properties.CopyStatus);
-                Assert.AreEqual(getPropertiesResponse.Value.IsServerEncrypted, downloadResponse.Value.Properties.IsServerEncrypted);
-                Assert.AreEqual(getPropertiesResponse.Value.SmbProperties, downloadResponse.Value.Properties.SmbProperties);
+                Assert.AreEqual(getPropertiesResponse.Value.LastModified, downloadResponse.Value.Details.LastModified);
+                AssertMetadataEquality(getPropertiesResponse.Value.Metadata, downloadResponse.Value.Details.Metadata);
+                Assert.AreEqual(getPropertiesResponse.Value.ContentType, downloadResponse.Value.Details.ContentType);
+                Assert.AreEqual(getPropertiesResponse.Value.ETag, downloadResponse.Value.Details.ETag);
+                Assert.AreEqual(getPropertiesResponse.Value.ContentEncoding, downloadResponse.Value.Details.ContentEncoding);
+                Assert.AreEqual(getPropertiesResponse.Value.CacheControl, downloadResponse.Value.Details.CacheControl);
+                Assert.AreEqual(getPropertiesResponse.Value.ContentDisposition, downloadResponse.Value.Details.ContentDisposition);
+                Assert.AreEqual(getPropertiesResponse.Value.ContentLanguage, downloadResponse.Value.Details.ContentLanguage);
+                Assert.AreEqual(getPropertiesResponse.Value.CopyCompletionTime, downloadResponse.Value.Details.CopyCompletionTime);
+                Assert.AreEqual(getPropertiesResponse.Value.CopyStatusDescription, downloadResponse.Value.Details.CopyStatusDescription);
+                Assert.AreEqual(getPropertiesResponse.Value.CopyId, downloadResponse.Value.Details.CopyId);
+                Assert.AreEqual(getPropertiesResponse.Value.CopyProgress, downloadResponse.Value.Details.CopyProgress);
+                Assert.AreEqual(getPropertiesResponse.Value.CopySource, downloadResponse.Value.Details.CopySource);
+                Assert.AreEqual(getPropertiesResponse.Value.CopyStatus, downloadResponse.Value.Details.CopyStatus);
+                Assert.AreEqual(getPropertiesResponse.Value.IsServerEncrypted, downloadResponse.Value.Details.IsServerEncrypted);
+                Assert.AreEqual(getPropertiesResponse.Value.SmbProperties, downloadResponse.Value.Details.SmbProperties);
             }
         }
 


### PR DESCRIPTION

Also move ContentType from BlobDownloadDetails to BlobDownloadInfo so that it is consistent with Content and ContentLength.

Fixes #7993 