### PR TITLE
[Storage] Change acronyms to PascalCase for enum fields

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
@@ -716,7 +716,7 @@ namespace Azure.Storage.Blobs
         /// The <see cref="GetStatistics"/> operation retrieves
         /// statistics related to replication for the Blob service.  It is
         /// only available on the secondary location endpoint when read-access
-        /// geo-redundant replication (<see cref="Models.SkuName.StandardRAGRS"/>)
+        /// geo-redundant replication (<see cref="Models.SkuName.StandardRagrs"/>)
         /// is enabled for the storage account.
         ///
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-stats"/>.
@@ -744,7 +744,7 @@ namespace Azure.Storage.Blobs
         /// The <see cref="GetStatisticsAsync"/> operation retrieves
         /// statistics related to replication for the Blob service.  It is
         /// only available on the secondary location endpoint when read-access
-        /// geo-redundant replication (<see cref="Models.SkuName.StandardRAGRS"/>)
+        /// geo-redundant replication (<see cref="Models.SkuName.StandardRagrs"/>)
         /// is enabled for the storage account.
         ///
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-stats"/>.
@@ -772,7 +772,7 @@ namespace Azure.Storage.Blobs
         /// The <see cref="GetStatisticsInternal"/> operation retrieves
         /// statistics related to replication for the Blob service.  It is
         /// only available on the secondary location endpoint when read-access
-        /// geo-redundant replication (<see cref="Models.SkuName.StandardRAGRS"/>)
+        /// geo-redundant replication (<see cref="Models.SkuName.StandardRagrs"/>)
         /// is enabled for the storage account.
         ///
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-stats"/>.

--- a/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
@@ -3309,7 +3309,7 @@ namespace Azure.Storage.Blobs
                 }
                 if (encryptionKey != null) { _request.Headers.SetValue("x-ms-encryption-key", encryptionKey); }
                 if (encryptionKeySha256 != null) { _request.Headers.SetValue("x-ms-encryption-key-sha256", encryptionKeySha256); }
-                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", encryptionAlgorithm.Value.ToString()); }
+                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(encryptionAlgorithm.Value)); }
                 if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
                 if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
                 if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
@@ -3747,7 +3747,7 @@ namespace Azure.Storage.Blobs
                 if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
                 if (encryptionKey != null) { _request.Headers.SetValue("x-ms-encryption-key", encryptionKey); }
                 if (encryptionKeySha256 != null) { _request.Headers.SetValue("x-ms-encryption-key-sha256", encryptionKeySha256); }
-                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", encryptionAlgorithm.Value.ToString()); }
+                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(encryptionAlgorithm.Value)); }
                 if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
                 if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
                 if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
@@ -5244,7 +5244,7 @@ namespace Azure.Storage.Blobs
                 if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
                 if (encryptionKey != null) { _request.Headers.SetValue("x-ms-encryption-key", encryptionKey); }
                 if (encryptionKeySha256 != null) { _request.Headers.SetValue("x-ms-encryption-key-sha256", encryptionKeySha256); }
-                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", encryptionAlgorithm.Value.ToString()); }
+                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(encryptionAlgorithm.Value)); }
                 if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
                 if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
                 if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
@@ -6337,7 +6337,7 @@ namespace Azure.Storage.Blobs
                 }
                 if (encryptionKey != null) { _request.Headers.SetValue("x-ms-encryption-key", encryptionKey); }
                 if (encryptionKeySha256 != null) { _request.Headers.SetValue("x-ms-encryption-key-sha256", encryptionKeySha256); }
-                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", encryptionAlgorithm.Value.ToString()); }
+                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(encryptionAlgorithm.Value)); }
                 if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
                 if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
                 if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
@@ -7364,7 +7364,7 @@ namespace Azure.Storage.Blobs
                 if (blobContentDisposition != null) { _request.Headers.SetValue("x-ms-blob-content-disposition", blobContentDisposition); }
                 if (encryptionKey != null) { _request.Headers.SetValue("x-ms-encryption-key", encryptionKey); }
                 if (encryptionKeySha256 != null) { _request.Headers.SetValue("x-ms-encryption-key-sha256", encryptionKeySha256); }
-                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", encryptionAlgorithm.Value.ToString()); }
+                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(encryptionAlgorithm.Value)); }
                 if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
                 if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
                 if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
@@ -7612,7 +7612,7 @@ namespace Azure.Storage.Blobs
                 if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
                 if (encryptionKey != null) { _request.Headers.SetValue("x-ms-encryption-key", encryptionKey); }
                 if (encryptionKeySha256 != null) { _request.Headers.SetValue("x-ms-encryption-key-sha256", encryptionKeySha256); }
-                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", encryptionAlgorithm.Value.ToString()); }
+                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(encryptionAlgorithm.Value)); }
                 if (ifSequenceNumberLessThanOrEqualTo != null) { _request.Headers.SetValue("x-ms-if-sequence-number-le", ifSequenceNumberLessThanOrEqualTo.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
                 if (ifSequenceNumberLessThan != null) { _request.Headers.SetValue("x-ms-if-sequence-number-lt", ifSequenceNumberLessThan.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
                 if (ifSequenceNumberEqualTo != null) { _request.Headers.SetValue("x-ms-if-sequence-number-eq", ifSequenceNumberEqualTo.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
@@ -7854,7 +7854,7 @@ namespace Azure.Storage.Blobs
                 if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
                 if (encryptionKey != null) { _request.Headers.SetValue("x-ms-encryption-key", encryptionKey); }
                 if (encryptionKeySha256 != null) { _request.Headers.SetValue("x-ms-encryption-key-sha256", encryptionKeySha256); }
-                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", encryptionAlgorithm.Value.ToString()); }
+                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(encryptionAlgorithm.Value)); }
                 if (ifSequenceNumberLessThanOrEqualTo != null) { _request.Headers.SetValue("x-ms-if-sequence-number-le", ifSequenceNumberLessThanOrEqualTo.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
                 if (ifSequenceNumberLessThan != null) { _request.Headers.SetValue("x-ms-if-sequence-number-lt", ifSequenceNumberLessThan.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
                 if (ifSequenceNumberEqualTo != null) { _request.Headers.SetValue("x-ms-if-sequence-number-eq", ifSequenceNumberEqualTo.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
@@ -8148,7 +8148,7 @@ namespace Azure.Storage.Blobs
                 if (sourceContentcrc64 != null) { _request.Headers.SetValue("x-ms-source-content-crc64", System.Convert.ToBase64String(sourceContentcrc64)); }
                 if (encryptionKey != null) { _request.Headers.SetValue("x-ms-encryption-key", encryptionKey); }
                 if (encryptionKeySha256 != null) { _request.Headers.SetValue("x-ms-encryption-key-sha256", encryptionKeySha256); }
-                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", encryptionAlgorithm.Value.ToString()); }
+                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(encryptionAlgorithm.Value)); }
                 if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
                 if (ifSequenceNumberLessThanOrEqualTo != null) { _request.Headers.SetValue("x-ms-if-sequence-number-le", ifSequenceNumberLessThanOrEqualTo.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
                 if (ifSequenceNumberLessThan != null) { _request.Headers.SetValue("x-ms-if-sequence-number-lt", ifSequenceNumberLessThan.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
@@ -8790,7 +8790,7 @@ namespace Azure.Storage.Blobs
                 if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
                 if (encryptionKey != null) { _request.Headers.SetValue("x-ms-encryption-key", encryptionKey); }
                 if (encryptionKeySha256 != null) { _request.Headers.SetValue("x-ms-encryption-key-sha256", encryptionKeySha256); }
-                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", encryptionAlgorithm.Value.ToString()); }
+                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(encryptionAlgorithm.Value)); }
                 if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
                 if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
                 if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
@@ -9415,7 +9415,7 @@ namespace Azure.Storage.Blobs
                 if (blobContentDisposition != null) { _request.Headers.SetValue("x-ms-blob-content-disposition", blobContentDisposition); }
                 if (encryptionKey != null) { _request.Headers.SetValue("x-ms-encryption-key", encryptionKey); }
                 if (encryptionKeySha256 != null) { _request.Headers.SetValue("x-ms-encryption-key-sha256", encryptionKeySha256); }
-                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", encryptionAlgorithm.Value.ToString()); }
+                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(encryptionAlgorithm.Value)); }
                 if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
                 if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
                 if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
@@ -9652,7 +9652,7 @@ namespace Azure.Storage.Blobs
                 if (appendPosition != null) { _request.Headers.SetValue("x-ms-blob-condition-appendpos", appendPosition.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
                 if (encryptionKey != null) { _request.Headers.SetValue("x-ms-encryption-key", encryptionKey); }
                 if (encryptionKeySha256 != null) { _request.Headers.SetValue("x-ms-encryption-key-sha256", encryptionKeySha256); }
-                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", encryptionAlgorithm.Value.ToString()); }
+                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(encryptionAlgorithm.Value)); }
                 if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
                 if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
                 if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
@@ -9934,7 +9934,7 @@ namespace Azure.Storage.Blobs
                 if (transactionalContentHash != null) { _request.Headers.SetValue("Content-MD5", System.Convert.ToBase64String(transactionalContentHash)); }
                 if (encryptionKey != null) { _request.Headers.SetValue("x-ms-encryption-key", encryptionKey); }
                 if (encryptionKeySha256 != null) { _request.Headers.SetValue("x-ms-encryption-key-sha256", encryptionKeySha256); }
-                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", encryptionAlgorithm.Value.ToString()); }
+                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(encryptionAlgorithm.Value)); }
                 if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
                 if (maxSize != null) { _request.Headers.SetValue("x-ms-blob-condition-maxsize", maxSize.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
                 if (appendPosition != null) { _request.Headers.SetValue("x-ms-blob-condition-appendpos", appendPosition.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
@@ -10250,7 +10250,7 @@ namespace Azure.Storage.Blobs
                 if (blobContentDisposition != null) { _request.Headers.SetValue("x-ms-blob-content-disposition", blobContentDisposition); }
                 if (encryptionKey != null) { _request.Headers.SetValue("x-ms-encryption-key", encryptionKey); }
                 if (encryptionKeySha256 != null) { _request.Headers.SetValue("x-ms-encryption-key-sha256", encryptionKeySha256); }
-                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", encryptionAlgorithm.Value.ToString()); }
+                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(encryptionAlgorithm.Value)); }
                 if (tier != null) { _request.Headers.SetValue("x-ms-access-tier", tier); }
                 if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
                 if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
@@ -10469,7 +10469,7 @@ namespace Azure.Storage.Blobs
                 if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
                 if (encryptionKey != null) { _request.Headers.SetValue("x-ms-encryption-key", encryptionKey); }
                 if (encryptionKeySha256 != null) { _request.Headers.SetValue("x-ms-encryption-key-sha256", encryptionKeySha256); }
-                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", encryptionAlgorithm.Value.ToString()); }
+                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(encryptionAlgorithm.Value)); }
                 if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 // Create the body
@@ -10701,7 +10701,7 @@ namespace Azure.Storage.Blobs
                 if (sourceContentcrc64 != null) { _request.Headers.SetValue("x-ms-source-content-crc64", System.Convert.ToBase64String(sourceContentcrc64)); }
                 if (encryptionKey != null) { _request.Headers.SetValue("x-ms-encryption-key", encryptionKey); }
                 if (encryptionKeySha256 != null) { _request.Headers.SetValue("x-ms-encryption-key-sha256", encryptionKeySha256); }
-                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", encryptionAlgorithm.Value.ToString()); }
+                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(encryptionAlgorithm.Value)); }
                 if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
                 if (sourceIfModifiedSince != null) { _request.Headers.SetValue("x-ms-source-if-modified-since", sourceIfModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
                 if (sourceIfUnmodifiedSince != null) { _request.Headers.SetValue("x-ms-source-if-unmodified-since", sourceIfUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
@@ -10989,7 +10989,7 @@ namespace Azure.Storage.Blobs
                 if (blobContentDisposition != null) { _request.Headers.SetValue("x-ms-blob-content-disposition", blobContentDisposition); }
                 if (encryptionKey != null) { _request.Headers.SetValue("x-ms-encryption-key", encryptionKey); }
                 if (encryptionKeySha256 != null) { _request.Headers.SetValue("x-ms-encryption-key-sha256", encryptionKeySha256); }
-                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", encryptionAlgorithm.Value.ToString()); }
+                if (encryptionAlgorithm != null) { _request.Headers.SetValue("x-ms-encryption-algorithm", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(encryptionAlgorithm.Value)); }
                 if (tier != null) { _request.Headers.SetValue("x-ms-access-tier", tier); }
                 if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
                 if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
@@ -17039,7 +17039,34 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// AES256
         /// </summary>
-        AES256
+        Aes256
+    }
+}
+
+namespace Azure.Storage.Blobs
+{
+    internal static partial class BlobRestClient
+    {
+        public static partial class Serialization
+        {
+            public static string ToString(Azure.Storage.Blobs.Models.EncryptionAlgorithmType value)
+            {
+                return value switch
+                {
+                    Azure.Storage.Blobs.Models.EncryptionAlgorithmType.Aes256 => "AES256",
+                    _ => throw new System.ArgumentOutOfRangeException(nameof(value), value, "Unknown Azure.Storage.Blobs.Models.EncryptionAlgorithmType value.")
+                };
+            }
+
+            public static Azure.Storage.Blobs.Models.EncryptionAlgorithmType ParseEncryptionAlgorithmType(string value)
+            {
+                return value switch
+                {
+                    "AES256" => Azure.Storage.Blobs.Models.EncryptionAlgorithmType.Aes256,
+                    _ => throw new System.ArgumentOutOfRangeException(nameof(value), value, "Unknown Azure.Storage.Blobs.Models.EncryptionAlgorithmType value.")
+                };
+            }
+        }
     }
 }
 #endregion enum EncryptionAlgorithmType
@@ -18711,27 +18738,27 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// Standard_LRS
         /// </summary>
-        StandardLRS,
+        StandardLrs,
 
         /// <summary>
         /// Standard_GRS
         /// </summary>
-        StandardGRS,
+        StandardGrs,
 
         /// <summary>
         /// Standard_RAGRS
         /// </summary>
-        StandardRAGRS,
+        StandardRagrs,
 
         /// <summary>
         /// Standard_ZRS
         /// </summary>
-        StandardZRS,
+        StandardZrs,
 
         /// <summary>
         /// Premium_LRS
         /// </summary>
-        PremiumLRS
+        PremiumLrs
     }
 }
 
@@ -18745,11 +18772,11 @@ namespace Azure.Storage.Blobs
             {
                 return value switch
                 {
-                    Azure.Storage.Blobs.Models.SkuName.StandardLRS => "Standard_LRS",
-                    Azure.Storage.Blobs.Models.SkuName.StandardGRS => "Standard_GRS",
-                    Azure.Storage.Blobs.Models.SkuName.StandardRAGRS => "Standard_RAGRS",
-                    Azure.Storage.Blobs.Models.SkuName.StandardZRS => "Standard_ZRS",
-                    Azure.Storage.Blobs.Models.SkuName.PremiumLRS => "Premium_LRS",
+                    Azure.Storage.Blobs.Models.SkuName.StandardLrs => "Standard_LRS",
+                    Azure.Storage.Blobs.Models.SkuName.StandardGrs => "Standard_GRS",
+                    Azure.Storage.Blobs.Models.SkuName.StandardRagrs => "Standard_RAGRS",
+                    Azure.Storage.Blobs.Models.SkuName.StandardZrs => "Standard_ZRS",
+                    Azure.Storage.Blobs.Models.SkuName.PremiumLrs => "Premium_LRS",
                     _ => throw new System.ArgumentOutOfRangeException(nameof(value), value, "Unknown Azure.Storage.Blobs.Models.SkuName value.")
                 };
             }
@@ -18758,11 +18785,11 @@ namespace Azure.Storage.Blobs
             {
                 return value switch
                 {
-                    "Standard_LRS" => Azure.Storage.Blobs.Models.SkuName.StandardLRS,
-                    "Standard_GRS" => Azure.Storage.Blobs.Models.SkuName.StandardGRS,
-                    "Standard_RAGRS" => Azure.Storage.Blobs.Models.SkuName.StandardRAGRS,
-                    "Standard_ZRS" => Azure.Storage.Blobs.Models.SkuName.StandardZRS,
-                    "Premium_LRS" => Azure.Storage.Blobs.Models.SkuName.PremiumLRS,
+                    "Standard_LRS" => Azure.Storage.Blobs.Models.SkuName.StandardLrs,
+                    "Standard_GRS" => Azure.Storage.Blobs.Models.SkuName.StandardGrs,
+                    "Standard_RAGRS" => Azure.Storage.Blobs.Models.SkuName.StandardRagrs,
+                    "Standard_ZRS" => Azure.Storage.Blobs.Models.SkuName.StandardZrs,
+                    "Premium_LRS" => Azure.Storage.Blobs.Models.SkuName.PremiumLrs,
                     _ => throw new System.ArgumentOutOfRangeException(nameof(value), value, "Unknown Azure.Storage.Blobs.Models.SkuName value.")
                 };
             }

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/CustomerProvidedKey.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/CustomerProvidedKey.cs
@@ -34,7 +34,7 @@ namespace Azure.Storage.Blobs.Models
         public CustomerProvidedKey(string key)
         {
             EncryptionKey = key;
-            EncryptionAlgorithm = EncryptionAlgorithmType.AES256;
+            EncryptionAlgorithm = EncryptionAlgorithmType.Aes256;
             using var sha256 = SHA256.Create();
             var encodedHash = sha256.ComputeHash(Convert.FromBase64String(key));
             EncryptionKeyHash = Convert.ToBase64String(encodedHash);

--- a/sdk/storage/Azure.Storage.Common/swagger/Generator/src/naming.ts
+++ b/sdk/storage/Azure.Storage.Common/swagger/Generator/src/naming.ts
@@ -50,16 +50,13 @@ export function enumField(name: string) {
     // Convert acronyms to PascalCase
     // example: StorageAPI -> StorageApi, StorageAPIGenerator -> StorageApiGenerator
     if (name && name.length > 2) {
-        for (let index = 1; index < name.length; index++) {
-            if (isUpper(name.charAt(index)) && isUpper(name.charAt(index - 1))) {
-                let latterString = name.substring(index, name.length);
-                var found = latterString.match(/[A-Z][a-z]+/g);
-                if (found) {
-                    latterString = latterString.substring(0, latterString.indexOf(found[0]));
-                }
-                name = name.replace(latterString, latterString.toLowerCase());
+        let nameArray = name.split(/(?=[A-Z]|[0-9]+)/);
+        for (let index = 1; index < nameArray.length; index++) {
+            if (nameArray[index].length === 1 && nameArray[index - 1].length === 1 && !(/^[0-9]$/.test(nameArray[index - 1]))) {
+                nameArray[index] = nameArray[index].toLowerCase();
             }
         }
+        name = nameArray.join('');
     }
 
     return pascalCase(name);

--- a/sdk/storage/Azure.Storage.Common/swagger/Generator/src/naming.ts
+++ b/sdk/storage/Azure.Storage.Common/swagger/Generator/src/naming.ts
@@ -48,7 +48,7 @@ export function interfaceName(name: string) { return "I" + type(name); }
 export function namespace(name: string) { return pascalCase(name); }
 export function enumField(name: string) {
     // Convert acronyms to PascalCase
-    // example: StorageAPI -> StorageApi, StorageAPIGenerator -> StorageApiGenerator, ETag -> ETag
+    // example: StorageAPI -> StorageApi, StorageAPIGenerator -> StorageApiGenerator
     if (name && name.length > 2) {
         for (let index = 1; index < name.length; index++) {
             if (isUpper(name.charAt(index)) && isUpper(name.charAt(index - 1))) {

--- a/sdk/storage/Azure.Storage.Common/swagger/Generator/src/naming.ts
+++ b/sdk/storage/Azure.Storage.Common/swagger/Generator/src/naming.ts
@@ -5,7 +5,7 @@
 // Check if a string is entirely uppercase
 function isUpper(ch: string) {
     return ch !== ch.toLowerCase() && ch === ch.toUpperCase();
-} 
+}
 
 // Change the case of a name (either the first character or the whole thing
 // for 2-letter-acronyms)
@@ -21,7 +21,7 @@ function changeCase(name: string, lower: boolean): string {
 }
 
 // Split a name apart and format it accordingly
-function formatName(name: string|null, fn: ((t: string, i: number) => string), regex: RegExp = /[ _-]/g) {
+function formatName(name: string | null, fn: ((t: string, i: number) => string), regex: RegExp = /[ _-]/g) {
     return (name || "")
         .split(regex)
         .filter(p => p && p.length > 0)
@@ -29,11 +29,11 @@ function formatName(name: string|null, fn: ((t: string, i: number) => string), r
         .join('');
 }
 
-export function pascalCase(name: string|null, regex?: RegExp) {
+export function pascalCase(name: string | null, regex?: RegExp) {
     return formatName(name, p => changeCase(p, false), regex);
 }
 
-export function camelCase(name: string|null) {
+export function camelCase(name: string | null) {
     // Lowercase the first part
     return formatName(name, (p, i) => changeCase(p, i === 0));
 }
@@ -46,5 +46,22 @@ export function parameter(name: string) { return variable(name); }
 export function type(name: string) { return pascalCase(name); }
 export function interfaceName(name: string) { return "I" + type(name); }
 export function namespace(name: string) { return pascalCase(name); }
-export function enumField(name: string) { return pascalCase(name); }
+export function enumField(name: string) {
+    // Convert acronyms to PascalCase
+    // example: StorageAPI -> StorageApi, StorageAPIGenerator -> StorageApiGenerator, ETag -> ETag
+    if (name && name.length > 2) {
+        for (let index = 1; index < name.length; index++) {
+            if (isUpper(name.charAt(index)) && isUpper(name.charAt(index - 1))) {
+                let latterString = name.substring(index, name.length);
+                var found = latterString.match(/[A-Z][a-z]+/g);
+                if (found) {
+                    latterString = latterString.substring(0, latterString.indexOf(found[0]));
+                }
+                name = name.replace(latterString, latterString.toLowerCase());
+            }
+        }
+    }
+
+    return pascalCase(name);
+}
 export function file(name: string) { return `${pascalCase(name)}.cs`; }


### PR DESCRIPTION
[As per the API Review](https://apiview.azurewebsites.net/Assemblies/Review/c52f059a-6d57-4d40-b7d2-a5816565a660#Azure.Storage.Blobs.Models.SkuName), change acronyms to PascalCase.

Few examples on [enumField()](https://github.com/Azure/azure-sdk-for-net/blob/516288494822c54328b4f20d1471f50cea215408/sdk/storage/Azure.Storage.Common/swagger/Generator/src/naming.ts#L49) method if we pass the following:
* `enumField("StorageAPI")` -> `StorageApi`
* `enumField("StorageAPIGenerator")` -> `StorageApiGenerator`
* `enumField("ETag")` -> `ETag`

