### PR TITLE
[Azure Search] Add ability to generate from a path using tags

### DIFF
--- a/sdk/search/Microsoft.Azure.Search.Data/src/generate.ps1
+++ b/sdk/search/Microsoft.Azure.Search.Data/src/generate.ps1
@@ -24,15 +24,15 @@
 
 Param(
     [string] $SpecsRepoFork = "Azure",
-    [string] $SpecsRepoBranch = "master"
+    [string] $SpecsRepoBranch = "master",
+    [string] $Tag = ""
 )
 
 "$PSScriptRoot\..\..\Install-BuildTools.ps1"
 
 $generateFolder = "$PSScriptRoot\Generated"
 
-# TODO: Change AutoRestVersion back to "latest" when the hanging issue is fixed.
-Start-AutoRestCodeGeneration -ResourceProvider "search/data-plane/Microsoft.Azure.Search.Data" -AutoRestVersion "2.0.4302" -SpecsRepoFork $SpecsRepoFork -SpecsRepoBranch $SpecsRepoBranch
+Start-AutoRestCodeGeneration -ResourceProvider "search/data-plane/Microsoft.Azure.Search.Data" -AutoRestVersion "latest" -SpecsRepoFork $SpecsRepoFork -SpecsRepoBranch $SpecsRepoBranch -ConfigFileTag $Tag
 
 Write-Output "Deleting extra files and cleaning up..."
 

--- a/sdk/search/Microsoft.Azure.Search.Data/src/generate.ps1
+++ b/sdk/search/Microsoft.Azure.Search.Data/src/generate.ps1
@@ -32,7 +32,8 @@ Param(
 
 $generateFolder = "$PSScriptRoot\Generated"
 
-Start-AutoRestCodeGeneration -ResourceProvider "search/data-plane/Microsoft.Azure.Search.Data" -AutoRestVersion "latest" -SpecsRepoFork $SpecsRepoFork -SpecsRepoBranch $SpecsRepoBranch -ConfigFileTag $Tag
+# TODO: Change AutoRestVersion back to "latest" when the hanging issue is fixed.
+Start-AutoRestCodeGeneration -ResourceProvider "search/data-plane/Microsoft.Azure.Search.Data" -AutoRestVersion "2.0.4302" -SpecsRepoFork $SpecsRepoFork -SpecsRepoBranch $SpecsRepoBranch -ConfigFileTag $Tag
 
 Write-Output "Deleting extra files and cleaning up..."
 

--- a/sdk/search/Microsoft.Azure.Search.Service/src/generate.ps1
+++ b/sdk/search/Microsoft.Azure.Search.Service/src/generate.ps1
@@ -54,6 +54,11 @@ Remove-Item -Force "$generateFolder\Models\TokenFilterName.cs"
 Remove-Item -Force "$generateFolder\Models\CharFilterName.cs"
 Remove-Item -Force "$generateFolder\Models\RegexFlags.cs"
 Remove-Item -Force "$generateFolder\Models\DataType.cs"
+
+# NOTE: THE FOLLOWING LINE SHOULD NOT BE REMOVED
+# This is because DataSourceType contains a symbol (DocumentDb) which isn't removed for backwards compatibility reason
+# but is marked as obsolete, which we can only do it via a customization. This can only be removed if the SDK version decides
+# to get rid of the symbol altogether.
 Remove-Item -Force "$generateFolder\Models\DataSourceType.cs"
 
 # NOTE: THE FOLLOWING LINE SHOULD NOT BE REMOVED

--- a/sdk/search/Microsoft.Azure.Search.Service/src/generate.ps1
+++ b/sdk/search/Microsoft.Azure.Search.Service/src/generate.ps1
@@ -24,7 +24,8 @@
 
 Param(
     [string] $SpecsRepoFork = "Azure",
-    [string] $SpecsRepoBranch = "master"
+    [string] $SpecsRepoBranch = "master",
+    [string] $Tag = ""
 )
 
 "$PSScriptRoot\..\..\Install-BuildTools.ps1"
@@ -32,7 +33,7 @@ Param(
 $generateFolder = "$PSScriptRoot\Generated"
 $sharedGenerateFolder = "$PSScriptRoot\..\..\Microsoft.Azure.Search.Common\src\Generated"
 
-Start-AutoRestCodeGeneration -ResourceProvider "search/data-plane/Microsoft.Azure.Search.Service" -AutoRestVersion "latest" -SpecsRepoFork $SpecsRepoFork -SpecsRepoBranch $SpecsRepoBranch
+Start-AutoRestCodeGeneration -ResourceProvider "search/data-plane/Microsoft.Azure.Search.Service" -AutoRestVersion "latest" -SpecsRepoFork $SpecsRepoFork -SpecsRepoBranch $SpecsRepoBranch -ConfigFileTag $Tag
 
 Write-Output "Deleting extra files and cleaning up..."
 


### PR DESCRIPTION
To facilitate targeting specific swagger versions (data plane) generate scripts now take a tag parameter.
To generate from track 1 swagger

`.\generate.ps1 -SpecsRepoFork arv100kri -SpecsRepoBranch arv100kri/track1-freeze -Tag track1-package-2019-05`