### PR TITLE
Use data escaping for query values and path segments

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient_private.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient_private.cs
@@ -94,7 +94,7 @@ namespace Azure.Data.AppConfiguration
         {
             builder.Reset(_baseUri);
             builder.AppendPath(KvRoute);
-            builder.AppendPath(key);
+            builder.AppendPath(key, true);
 
             if (label != null)
             {
@@ -106,7 +106,7 @@ namespace Azure.Data.AppConfiguration
         {
             builder.Reset(_baseUri);
             builder.AppendPath(LocksRoute);
-            builder.AppendPath(key);
+            builder.AppendPath(key, true);
 
             if (label != null)
             {

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient_private.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient_private.cs
@@ -93,8 +93,8 @@ namespace Azure.Data.AppConfiguration
         private void BuildUriForKvRoute(RequestUriBuilder builder, string key, string label)
         {
             builder.Reset(_baseUri);
-            builder.AppendPath(KvRoute);
-            builder.AppendPath(key, true);
+            builder.AppendPath(KvRoute, escape: false);
+            builder.AppendPath(key);
 
             if (label != null)
             {
@@ -105,8 +105,8 @@ namespace Azure.Data.AppConfiguration
         private void BuildUriForLocksRoute(RequestUriBuilder builder, string key, string label)
         {
             builder.Reset(_baseUri);
-            builder.AppendPath(LocksRoute);
-            builder.AppendPath(key, true);
+            builder.AppendPath(LocksRoute, escape: false);
+            builder.AppendPath(key);
 
             if (label != null)
             {
@@ -173,14 +173,14 @@ namespace Azure.Data.AppConfiguration
         private void BuildUriForGetBatch(RequestUriBuilder builder, SettingSelector selector, string pageLink)
         {
             builder.Reset(_baseUri);
-            builder.AppendPath(KvRoute);
+            builder.AppendPath(KvRoute, escape: false);
             BuildBatchQuery(builder, selector, pageLink);
         }
 
         private void BuildUriForRevisions(RequestUriBuilder builder, SettingSelector selector, string pageLink)
         {
             builder.Reset(_baseUri);
-            builder.AppendPath(RevisionsRoute);
+            builder.AppendPath(RevisionsRoute, escape: false);
             BuildBatchQuery(builder, selector, pageLink);
         }
 

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient_private.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient_private.cs
@@ -166,7 +166,7 @@ namespace Azure.Data.AppConfiguration
 
             if (!string.IsNullOrEmpty(pageLink))
             {
-                builder.AppendQuery("after", pageLink);
+                builder.AppendQuery("after", pageLink, escapeValue: false);
             }
         }
 

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationMockTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationMockTests.cs
@@ -560,12 +560,12 @@ namespace Azure.Data.AppConfiguration.Tests
 
             MockRequest request1 = mockTransport.Requests[0];
             Assert.AreEqual(RequestMethod.Get, request1.Method);
-            Assert.AreEqual($"https://contoso.appconfig.io/kv/?key=*&label=*&api-version={s_version}", request1.Uri.ToString());
+            Assert.AreEqual($"https://contoso.appconfig.io/kv/?key=%2A&label=%2A&api-version={s_version}", request1.Uri.ToString());
             AssertRequestCommon(request1);
 
             MockRequest request2 = mockTransport.Requests[1];
             Assert.AreEqual(RequestMethod.Get, request2.Method);
-            Assert.AreEqual($"https://contoso.appconfig.io/kv/?key=*&label=*&after=5&api-version={s_version}", request2.Uri.ToString());
+            Assert.AreEqual($"https://contoso.appconfig.io/kv/?key=%2A&label=%2A&after=5&api-version={s_version}", request2.Uri.ToString());
             AssertRequestCommon(request1);
         }
 

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationSettingTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationSettingTests.cs
@@ -38,7 +38,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             ConfigurationClient.BuildBatchQuery(builder, selector, null);
 
-            Assert.AreEqual(@"http://localhost/?key=my_key,key%5C,key&label=my_label,label%5C,label", builder.ToUri().AbsoluteUri);
+            Assert.AreEqual(@"http://localhost/?key=my_key%2Ckey%5C%2Ckey&label=my_label%2Clabel%5C%2Clabel", builder.ToUri().AbsoluteUri);
 
         }
 
@@ -56,7 +56,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             ConfigurationClient.BuildBatchQuery(builder, selector, null);
 
-            Assert.AreEqual("http://localhost/?key=*key*&label=*label*", builder.ToUri().AbsoluteUri);
+            Assert.AreEqual("http://localhost/?key=%2Akey%2A&label=%2Alabel%2A", builder.ToUri().AbsoluteUri);
         }
 
         [Test]
@@ -72,7 +72,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             ConfigurationClient.BuildBatchQuery(builder, selector, null);
 
-            Assert.AreEqual("http://localhost/?key=*&label=%00", builder.ToUri().AbsoluteUri);
+            Assert.AreEqual("http://localhost/?key=%2A&label=%00", builder.ToUri().AbsoluteUri);
         }
 
         [Test]
@@ -102,7 +102,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             ConfigurationClient.BuildBatchQuery(builder, selector, null);
 
-            Assert.AreEqual($"http://localhost/?key=*&label={label}", builder.ToUri().AbsoluteUri);
+            Assert.AreEqual($"http://localhost/?key=%2A&label={label}", builder.ToUri().AbsoluteUri);
         }
 
         [Test]
@@ -118,7 +118,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             ConfigurationClient.BuildBatchQuery(builder, selector, null);
 
-            Assert.AreEqual($"http://localhost/?key=key&$select=key,%20value", builder.ToUri().AbsoluteUri);
+            Assert.AreEqual($"http://localhost/?key=key&$select=key%2C%20value", builder.ToUri().AbsoluteUri);
         }
 
         [Test]

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/SessionRecords/ConfigurationLiveTests/GetBatchSettingAny.json
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/SessionRecords/ConfigurationLiveTests/GetBatchSettingAny.json
@@ -8,10 +8,10 @@
         "Authorization": "Sanitized",
         "Content-Length": "98",
         "Content-Type": "application/json",
-        "Date": "Wed, 18 Sep 2019 21:33:01 GMT",
-        "traceparent": "00-84ab72bcb779754b80fb98f9408f7677-2532741765188c46-00",
+        "Date": "Mon, 14 Oct 2019 21:27:14 GMT",
+        "traceparent": "00-3a674b96ad7dcb4dafd6dd9785fd5863-60bf4b9c2e4dca47-00",
         "User-Agent": [
-          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20190918.1\u002B0c319f5fd30ac3e2e5bc2936122815be22444424",
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
           "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
         ],
         "x-ms-client-request-id": "2591e073de7eaeac6748b9b57148ddac",
@@ -35,19 +35,19 @@
         "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
         "Connection": "keep-alive",
         "Content-Type": "application/vnd.microsoft.appconfig.kv\u002Bjson; charset=utf-8",
-        "Date": "Wed, 18 Sep 2019 21:33:01 GMT",
-        "ETag": "\u00226I91HJKVVxLd2Auz8FF1rNwbndV\u0022",
-        "Last-Modified": "Wed, 18 Sep 2019 21:33:01 GMT",
-        "Server": "nginx/1.13.12",
+        "Date": "Mon, 14 Oct 2019 21:27:15 GMT",
+        "ETag": "\u0022VmKDNHfAPxXbOqguV5YKNR28p4L\u0022",
+        "Last-Modified": "Mon, 14 Oct 2019 21:27:15 GMT",
+        "Server": "openresty/1.15.8.1",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg2NTI=;sn=538652",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTExMDA=;sn=651100",
         "Transfer-Encoding": "chunked",
         "x-ms-client-request-id": "2591e073de7eaeac6748b9b57148ddac",
-        "x-ms-correlation-request-id": "3c2c833f-070c-43ed-8ac4-75555bff9855",
-        "x-ms-request-id": "3c2c833f-070c-43ed-8ac4-75555bff9855"
+        "x-ms-correlation-request-id": "4f00c0a8-52c1-4a15-87bd-397a73efd0cb",
+        "x-ms-request-id": "4f00c0a8-52c1-4a15-87bd-397a73efd0cb"
       },
       "ResponseBody": {
-        "etag": "6I91HJKVVxLd2Auz8FF1rNwbndV",
+        "etag": "VmKDNHfAPxXbOqguV5YKNR28p4L",
         "key": "key-221701127",
         "label": "test_label",
         "content_type": "test_content_type",
@@ -57,19 +57,19 @@
           "tag2": "value2"
         },
         "locked": false,
-        "last_modified": "2019-09-18T21:33:01\u002B00:00"
+        "last_modified": "2019-10-14T21:27:15\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=*\u0026label=*\u0026api-version=1.0",
+      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=%2A\u0026label=%2A\u0026api-version=1.0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/vnd.microsoft.appconfig.kv\u002Bjson",
         "Authorization": "Sanitized",
-        "Date": "Wed, 18 Sep 2019 21:33:01 GMT",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg2NTI=",
+        "Date": "Mon, 14 Oct 2019 21:27:15 GMT",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTExMDA=",
         "User-Agent": [
-          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20190918.1\u002B0c319f5fd30ac3e2e5bc2936122815be22444424",
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
           "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
         ],
         "x-ms-client-request-id": "84541e8df77daf76efc402134da0cdf1",
@@ -86,70 +86,2025 @@
         "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
         "Connection": "keep-alive",
         "Content-Type": "application/vnd.microsoft.appconfig.kvset\u002Bjson; charset=utf-8",
-        "Date": "Wed, 18 Sep 2019 21:33:01 GMT",
-        "Link": "\u003C/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LWNmNGFjNjc2NDBmYzQ2ZjJiNjgyNTgzYzIxN2IyOGRhCjc%3D\u003E; rel=\u0022next\u0022",
-        "Server": "nginx/1.13.12",
+        "Date": "Mon, 14 Oct 2019 21:27:15 GMT",
+        "Link": "\u003C/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LTE1MDIzMTI1NzAKNTY%3D\u003E; rel=\u0022next\u0022",
+        "Server": "openresty/1.15.8.1",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg2NTI=;sn=538652",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTExMDA=;sn=651100",
         "Transfer-Encoding": "chunked",
         "x-ms-client-request-id": "84541e8df77daf76efc402134da0cdf1",
-        "x-ms-correlation-request-id": "3e23c3ed-7481-46c2-bece-a0f3d07b77c1",
-        "x-ms-request-id": "3e23c3ed-7481-46c2-bece-a0f3d07b77c1"
+        "x-ms-correlation-request-id": "4d2b3043-6242-4dca-b886-84f6d78423c3",
+        "x-ms-request-id": "4d2b3043-6242-4dca-b886-84f6d78423c3"
       },
       "ResponseBody": {
         "items": [
           {
-            "etag": "BSsldiGjNhbX2MznqtuFHcpjkxM",
-            "key": "3b2ddb83-0205-4f11-bd21-660590fbb2f8_0",
-            "label": null,
-            "content_type": "",
-            "value": "0",
-            "tags": {},
-            "locked": false,
-            "last_modified": "2019-04-10T23:14:47\u002B00:00"
-          },
-          {
-            "etag": "7db9w9wCukFEW2sgvZHDkRopoTs",
-            "key": "845b68e0-9617-422a-9db7-e911aed727c6_0",
-            "label": null,
-            "content_type": "",
-            "value": "0",
-            "tags": {},
-            "locked": false,
-            "last_modified": "2019-04-10T23:18:13\u002B00:00"
-          },
-          {
-            "etag": "Swe3KG4Ei41uLWRtchrlYy54PcI",
-            "key": "9805488e-2c43-4317-8bd9-400bef28395a_0",
-            "label": null,
-            "content_type": "",
-            "value": "0",
-            "tags": {},
-            "locked": false,
-            "last_modified": "2019-04-10T23:26:25\u002B00:00"
-          },
-          {
-            "etag": "Al3nrQNM6vuDgq7vYDmjRtW703g",
+            "etag": "do8WQIHwlv4Jz5f1ogkp0zHs2Tc",
             "key": "BatchKey",
             "label": null,
-            "content_type": "",
-            "value": "key-cf4ac67640fc46f2b682583c217b28da",
+            "content_type": null,
+            "value": "key-901817556",
             "tags": {},
             "locked": false,
-            "last_modified": "2019-04-08T20:02:37\u002B00:00"
+            "last_modified": "2019-10-02T21:47:21\u002B00:00"
           },
           {
-            "etag": "s0zd1djtEPdZPdDG2PlUp1i8MZ4",
-            "key": "Sample_key",
+            "etag": "RMiNzaM9pJmxBr28I9WvYkjjLhW",
+            "key": "key-1125484443",
+            "label": "83",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:10\u002B00:00"
+          },
+          {
+            "etag": "LWyiFBJ6EJ4NTGVWKdd2qt8JUFI",
+            "key": "key-1125484443",
+            "label": "84",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:10\u002B00:00"
+          },
+          {
+            "etag": "zjrVDQHqeqR9NUuHaHOMOfEdfhQ",
+            "key": "key-1125484443",
+            "label": "85",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:10\u002B00:00"
+          },
+          {
+            "etag": "0QkdkOVBSVZ3bUrFfwzq7jjWU0D",
+            "key": "key-1125484443",
+            "label": "86",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:10\u002B00:00"
+          },
+          {
+            "etag": "6G7npyYJqJyGRiZtRkQKRRihHdg",
+            "key": "key-1125484443",
+            "label": "87",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:10\u002B00:00"
+          },
+          {
+            "etag": "e7aS8kET6O55Ig9TYIiwL0ZH837",
+            "key": "key-1125484443",
+            "label": "88",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:10\u002B00:00"
+          },
+          {
+            "etag": "601nzWut8EicF02dlXjNLPD9hLu",
+            "key": "key-1125484443",
+            "label": "89",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:10\u002B00:00"
+          },
+          {
+            "etag": "GZFpM0qJXmdW34UpLiUEliWs1eO",
+            "key": "key-1125484443",
+            "label": "9",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:05\u002B00:00"
+          },
+          {
+            "etag": "TnZCbaiSsODRsCvUHS0aexBg2hX",
+            "key": "key-1125484443",
+            "label": "90",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:10\u002B00:00"
+          },
+          {
+            "etag": "NFd090oekM640Xtq9v1DDs1qk4J",
+            "key": "key-1125484443",
+            "label": "91",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:10\u002B00:00"
+          },
+          {
+            "etag": "vNHTgydFclueNJFFuifeRWcv1oF",
+            "key": "key-1125484443",
+            "label": "92",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:11\u002B00:00"
+          },
+          {
+            "etag": "fDjKbv9xGT9A3OwBhf41ZQYG45V",
+            "key": "key-1125484443",
+            "label": "93",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:11\u002B00:00"
+          },
+          {
+            "etag": "t0jNGG2v3l6RVROhPuUM14FPCPY",
+            "key": "key-1125484443",
+            "label": "94",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:11\u002B00:00"
+          },
+          {
+            "etag": "p47s3WJxSqRMxNSq8YoAuL6Ebw0",
+            "key": "key-1125484443",
+            "label": "95",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:11\u002B00:00"
+          },
+          {
+            "etag": "XvgBhO00pHqLfoiU2F8Lb6DWdmB",
+            "key": "key-1125484443",
+            "label": "96",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:11\u002B00:00"
+          },
+          {
+            "etag": "EbvFQy1MnyLIk2haSMBjZ5lk3Tc",
+            "key": "key-1125484443",
+            "label": "97",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:11\u002B00:00"
+          },
+          {
+            "etag": "tffOV5evjE0w21sPSyvtjyE8BAm",
+            "key": "key-1125484443",
+            "label": "98",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:11\u002B00:00"
+          },
+          {
+            "etag": "Spxyf4MPthaPetoS77Sf7F4dVvb",
+            "key": "key-1125484443",
+            "label": "99",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:11\u002B00:00"
+          },
+          {
+            "etag": "Jm0WBu5LdgnIfR3fYhi06f4wyid",
+            "key": "key-1147740173",
             "label": null,
-            "content_type": "",
-            "value": "Sample_value",
+            "content_type": null,
+            "value": "my_value",
             "tags": {},
             "locked": false,
-            "last_modified": "2019-07-12T20:36:44\u002B00:00"
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
           },
           {
-            "etag": "6I91HJKVVxLd2Auz8FF1rNwbndV",
+            "etag": "ra7jHrNYwGCAWoymb4IQ0vCf9Dc",
+            "key": "key-1163835415",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:05:25\u002B00:00"
+          },
+          {
+            "etag": "6xrBoXzeP89iBJRpf5T0we4QNyC",
+            "key": "key-1174564512",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-20T03:01:39\u002B00:00"
+          },
+          {
+            "etag": "kCagdhqBQFNcZIJ5TxAb3jEL49w",
+            "key": "key-1177019792",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          },
+          {
+            "etag": "33Iki4O3nt3ZLflq5CYSSc5uZak",
+            "key": "key-1180708686",
+            "label": null,
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
+          },
+          {
+            "etag": "dHSZTRqmOXNJyLJF5pufiU6dquK",
+            "key": "key-1200977498",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:05\u002B00:00"
+          },
+          {
+            "etag": "9TzQS7loYjGo2dBa7gI8avECM9s",
+            "key": "key-1231954601",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value2",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:05:25\u002B00:00"
+          },
+          {
+            "etag": "uDoIwJFA6EMimAymtZE1ZaSadeR",
+            "key": "key-1233529568",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "IhCaZZtjxhJZOT4kst86ivVrDM9",
+            "key": "key-1252062984",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "3SJLTRLYcKynZOamHZu0ojwaIyJ",
+            "key": "key-1252790990",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:55\u002B00:00"
+          },
+          {
+            "etag": "0O2xWLZV29ZqSe9JbQLXJQR3Sm5",
+            "key": "key-1277519220",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:55\u002B00:00"
+          },
+          {
+            "etag": "hY8crHO0a8k74AawBFGHHlvjm7J",
+            "key": "key-1309283906",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:06:04\u002B00:00"
+          },
+          {
+            "etag": "YufLr1ND2auNin5dZJLuB96Gxpy",
+            "key": "key-1323592047",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:08:00\u002B00:00"
+          },
+          {
+            "etag": "SfxQW7xVa3XkOnp3SllRt84cWlR",
+            "key": "key-1353875726",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:05:26\u002B00:00"
+          },
+          {
+            "etag": "WHB977nXW2zZL8AFGNAI6FpKppK",
+            "key": "key-1364459659",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "LUbaTeaEo7iZWJqwMCEiwZ64N3K",
+            "key": "key-1369197868",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
+          },
+          {
+            "etag": "URTIJGQelXjQVWasVWsg4xe6rLb",
+            "key": "key-13811035",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:18:13\u002B00:00"
+          },
+          {
+            "etag": "JBdU4qVsF5gcgIe1n7zZ77B5eso",
+            "key": "key-1381219121",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
+          },
+          {
+            "etag": "HsSY9HTWZ6d2SkPOzAGuIph6zYt",
+            "key": "key-1420801322",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "c1ATIQnsTAodkleZ5TBN4Xnf8QD",
+            "key": "key-1427269378",
+            "label": "my_label",
+            "content_type": null,
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:54\u002B00:00"
+          },
+          {
+            "etag": "EJsF4QkrbqYXQ44Hy73xuEMwrck",
+            "key": "key-1471881907",
+            "label": null,
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:54\u002B00:00"
+          },
+          {
+            "etag": "sbSjAQthvnfDGiKWz8rQ5NCpKjb",
+            "key": "key-1484301245",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:24:27\u002B00:00"
+          },
+          {
+            "etag": "1tzcwKQvcWBBVv7p3m6uPLyyOa7",
+            "key": "key-1488498371",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
+          },
+          {
+            "etag": "0lkxAiZ6Yz3diKTSBdQcDsvjNUu",
+            "key": "key-1502312570",
+            "label": "0",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:55\u002B00:00"
+          },
+          {
+            "etag": "FnhaQK76PQon48kvtpV65ty5ZvU",
+            "key": "key-1502312570",
+            "label": "1",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:55\u002B00:00"
+          },
+          {
+            "etag": "TyYyTPpvjOBk9nsFJLu3GV9jZlm",
+            "key": "key-1502312570",
+            "label": "10",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "OkN8oJ5bPq30d4BTmrdn0TVWBVx",
+            "key": "key-1502312570",
+            "label": "100",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "tnk9fNNWb2pAD0FzY8yUV6OjeVF",
+            "key": "key-1502312570",
+            "label": "101",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "aHKNXtg0iqCx3fE8bOXEE2X3C3J",
+            "key": "key-1502312570",
+            "label": "102",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "W0xARXufoYcuMgrQ0Cdcqr5o4BG",
+            "key": "key-1502312570",
+            "label": "103",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "yrr44f51P4DUap7P2eZR3fkPSzi",
+            "key": "key-1502312570",
+            "label": "104",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "ZTWFJfYaTIDhy5eBcDws8SX9z3y",
+            "key": "key-1502312570",
+            "label": "11",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "v1uFMy2McKjxJv6E0KHGFhl3iaI",
+            "key": "key-1502312570",
+            "label": "12",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "ndBHUpAWZGibrLbZwWurMkhhX1k",
+            "key": "key-1502312570",
+            "label": "13",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "sNB8KIr1ZEiW8AfdcaHecxHs6ha",
+            "key": "key-1502312570",
+            "label": "14",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "lfcf5HqGHLLMKTKT2TSXfQUDW02",
+            "key": "key-1502312570",
+            "label": "15",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "CjnZU9pq7uEWX7M9AumeeR1JwSM",
+            "key": "key-1502312570",
+            "label": "16",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "cnhvl1eqzehNAzONiRpwywAcRKa",
+            "key": "key-1502312570",
+            "label": "17",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "o3w9OdWAUEDLtZW5fXF3AZ9hpgl",
+            "key": "key-1502312570",
+            "label": "18",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "API10UIUIf5WrtFBqQePDoNPHNh",
+            "key": "key-1502312570",
+            "label": "19",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "9g1tFosplmWMnJOwjb6ewirjQft",
+            "key": "key-1502312570",
+            "label": "2",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:55\u002B00:00"
+          },
+          {
+            "etag": "DSQ5AdRVVvroVjhWaDRY6rF0Jye",
+            "key": "key-1502312570",
+            "label": "20",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "pU6pRTDsXUR370Q5WXroYlwXBy1",
+            "key": "key-1502312570",
+            "label": "21",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "OqaLYAiu8s1VbOwNIC0ETczTrr9",
+            "key": "key-1502312570",
+            "label": "22",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "Q7dsIdIv6Zh1xPuHOAQLjYcPVPK",
+            "key": "key-1502312570",
+            "label": "23",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "21o1vqyARoMdC3968wvpks5Zu8I",
+            "key": "key-1502312570",
+            "label": "24",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "2jDyjfUyZzE1eAg6mi8JIP3X9jB",
+            "key": "key-1502312570",
+            "label": "25",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "5UveB5vM98KegYHPt48klKklRhQ",
+            "key": "key-1502312570",
+            "label": "26",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "LdzSiPVVl9kfgs7WsRCKx5Kpnu4",
+            "key": "key-1502312570",
+            "label": "27",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "xJxtpIroNl7rzDmICaoKgvokJ9l",
+            "key": "key-1502312570",
+            "label": "28",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "nHah9hzylkCoIRcHRw6seMbU8u3",
+            "key": "key-1502312570",
+            "label": "29",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "AUUmJFw6zrz8jp8m2zFBlN9YMDw",
+            "key": "key-1502312570",
+            "label": "3",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:55\u002B00:00"
+          },
+          {
+            "etag": "i89QxpE5hFbezL7cjNzJ4robuYM",
+            "key": "key-1502312570",
+            "label": "30",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "DHMj9rdHY1EcrusMdJoyqMGfKzn",
+            "key": "key-1502312570",
+            "label": "31",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "ZhZbQxbt6OeoVjJQmoq0mnfydgg",
+            "key": "key-1502312570",
+            "label": "32",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "wQ4OwaP4ln0CAveyRLGwchga39S",
+            "key": "key-1502312570",
+            "label": "33",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "jak1Qg85Wh88JpjxyrjBRId2ChO",
+            "key": "key-1502312570",
+            "label": "34",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "fVwPDR1CD386SnUpykGTH68rmjW",
+            "key": "key-1502312570",
+            "label": "35",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "6dMCedZqM86rIifz0uXdrhB3usF",
+            "key": "key-1502312570",
+            "label": "36",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "kpc8drFjl0QbDrIQikaUltx1GBK",
+            "key": "key-1502312570",
+            "label": "37",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "jGZRs5n5sF5rdL4Z7aYiLmdVrVB",
+            "key": "key-1502312570",
+            "label": "38",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "ktEANEMgDbuwxTcps1IxdXyGkJO",
+            "key": "key-1502312570",
+            "label": "39",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "YhZZAWfMCJCgXY1vKjWt0oYdyoT",
+            "key": "key-1502312570",
+            "label": "4",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:55\u002B00:00"
+          },
+          {
+            "etag": "81OKX4d3q2oXKcD32bsYQKw7loo",
+            "key": "key-1502312570",
+            "label": "40",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "1JzfLdTDDrEO3MYiWhTSxFKvVyt",
+            "key": "key-1502312570",
+            "label": "41",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "DvUs1MWntujoZTMVLXEpdrHShZI",
+            "key": "key-1502312570",
+            "label": "42",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "CWKefrbc3soMPSuhgkbOEhtU7gV",
+            "key": "key-1502312570",
+            "label": "43",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "GrIwe22UFwGNMYJTHqYkrrnrT3d",
+            "key": "key-1502312570",
+            "label": "44",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "ibcz24qgIP63fnkAtdJmkagZpLx",
+            "key": "key-1502312570",
+            "label": "45",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "KXIHRBZoHKKkDa6FQRUYlJAhack",
+            "key": "key-1502312570",
+            "label": "46",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "QL1TiWmy50kRo0KrHxjG6mZZqJs",
+            "key": "key-1502312570",
+            "label": "47",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "KsKmga3otFUzFKmBTioD5t29b3f",
+            "key": "key-1502312570",
+            "label": "48",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "uW2bTMYVCv6PlB7ZVfraMk5ZkUb",
+            "key": "key-1502312570",
+            "label": "49",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "SYpH5oGW41KBtv8MggQ1A29L7u1",
+            "key": "key-1502312570",
+            "label": "5",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:55\u002B00:00"
+          },
+          {
+            "etag": "qs80AiihpZ7YpRrtSgLpzbTc6NF",
+            "key": "key-1502312570",
+            "label": "50",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "hxTYUTskexVW3CIB1CcATWVBEGx",
+            "key": "key-1502312570",
+            "label": "51",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "kGCbpPkQ5mnXfl8UXJnudQiCHbZ",
+            "key": "key-1502312570",
+            "label": "52",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "C8utbLtdUnmcskgxbnzzs5O7CgZ",
+            "key": "key-1502312570",
+            "label": "53",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "es6idcm81H6IymnWHKgPO0EPb8R",
+            "key": "key-1502312570",
+            "label": "54",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "S8aJfOUed4fAfdfL62BO1uCfPpc",
+            "key": "key-1502312570",
+            "label": "55",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "C49NpV7lRcs6eAGw3PJFUZWWk1t",
+            "key": "key-1502312570",
+            "label": "56",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          }
+        ],
+        "@nextLink": "/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LTE1MDIzMTI1NzAKNTY%3D"
+      }
+    },
+    {
+      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=%2A\u0026label=%2A\u0026after=a2V5LTE1MDIzMTI1NzAKNTY%3D\u0026api-version=1.0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/vnd.microsoft.appconfig.kv\u002Bjson",
+        "Authorization": "Sanitized",
+        "Date": "Mon, 14 Oct 2019 21:27:15 GMT",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTExMDA=",
+        "User-Agent": [
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
+        ],
+        "x-ms-client-request-id": "cabfcfb72e56965cfa8b42903e0e01d3",
+        "x-ms-content-sha256": "47DEQpj8HBSa\u002B/TImW\u002B5JCeuQeRkm5NMpJWZG3hSuFU=",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Access-Control-Allow-Methods": "GET, PUT, POST, DELETE, PATCH, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Connection": "keep-alive",
+        "Content-Type": "application/vnd.microsoft.appconfig.kvset\u002Bjson; charset=utf-8",
+        "Date": "Mon, 14 Oct 2019 21:27:15 GMT",
+        "Link": "\u003C/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LTMxODIxMjgxOQoxNg%3D%3D\u003E; rel=\u0022next\u0022",
+        "Server": "openresty/1.15.8.1",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTExMDA=;sn=651100",
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "cabfcfb72e56965cfa8b42903e0e01d3",
+        "x-ms-correlation-request-id": "837e6363-3f28-4a5c-a044-4ae2c0c6c03f",
+        "x-ms-request-id": "837e6363-3f28-4a5c-a044-4ae2c0c6c03f"
+      },
+      "ResponseBody": {
+        "items": [
+          {
+            "etag": "VPwwVnSej0zfyU4jvnZCvL2bSBy",
+            "key": "key-1502312570",
+            "label": "57",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "l8eiygGV6pbYV41OQALonyjnpiI",
+            "key": "key-1502312570",
+            "label": "58",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "Kmw5dKmgodAnQdAsqar17XLMsYT",
+            "key": "key-1502312570",
+            "label": "59",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "jlrlXOcGZHLxWM9EnCzFgzfwYL4",
+            "key": "key-1502312570",
+            "label": "6",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:55\u002B00:00"
+          },
+          {
+            "etag": "CsMScNt7U58M6L5iYuZ6FixTvFf",
+            "key": "key-1502312570",
+            "label": "60",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "a09wMCluVqcBkrbDTHPlIuhE3eU",
+            "key": "key-1502312570",
+            "label": "61",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "CaVv9rOSxNkErgHjnAiNXgJg6Kk",
+            "key": "key-1502312570",
+            "label": "62",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "odtvIQcYU0TBfedPNBezMg5wx7s",
+            "key": "key-1502312570",
+            "label": "63",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "tPRn1s53pzHxGfBHS5Q27JESEPZ",
+            "key": "key-1502312570",
+            "label": "64",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "w08UlE1Dnlek3SDOPoYpzhjD7v7",
+            "key": "key-1502312570",
+            "label": "65",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "BEkYYvIoFJYG5vKQm9JIZCj2kJV",
+            "key": "key-1502312570",
+            "label": "66",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "vDHS4nR9tbrdyxr3GX91zLFtf6Q",
+            "key": "key-1502312570",
+            "label": "67",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "YeXVmJGStysIL2ZCItDA0ezlPWr",
+            "key": "key-1502312570",
+            "label": "68",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "iXviTbhMJ16sSudj4rLXh85zpAn",
+            "key": "key-1502312570",
+            "label": "69",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "0Utd9x4iPBitMvfvLGuWAZd2rgD",
+            "key": "key-1502312570",
+            "label": "7",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "gnB2xdM8wWh56Q8eWgzFcJCQoHe",
+            "key": "key-1502312570",
+            "label": "70",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "peBbYkuKBsvA6pNZcqxjZ0mkyMg",
+            "key": "key-1502312570",
+            "label": "71",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "Vew9QJTJAg4UZbkJfChF5t1sKkH",
+            "key": "key-1502312570",
+            "label": "72",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "koAYgDRTitzvkrjphmcHYwY6u5O",
+            "key": "key-1502312570",
+            "label": "73",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "3Ikmp3pB1bdRcJrOhfb08wxckfV",
+            "key": "key-1502312570",
+            "label": "74",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "UTgRpxQAuXcNeCypb0P0FhNqPd9",
+            "key": "key-1502312570",
+            "label": "75",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "3cIWYDgdrTGyEHUYRD50nubdgva",
+            "key": "key-1502312570",
+            "label": "76",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "M3j30XWtCzz8WdPA7GdK9E60j8A",
+            "key": "key-1502312570",
+            "label": "77",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "RTwXyxcwxdxWgfc8kVJrMJCEq33",
+            "key": "key-1502312570",
+            "label": "78",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "W2j7Ght90NGFRQ8RYXcAIWFD2Dp",
+            "key": "key-1502312570",
+            "label": "79",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "gQc7RJEFfoEMLf5uArVNNIaZiMq",
+            "key": "key-1502312570",
+            "label": "8",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "3vKNMenb0KPmseeTEoyDTWx1ZA7",
+            "key": "key-1502312570",
+            "label": "80",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "1KUZcfXGBhc3CSBILtNAXhqXAAT",
+            "key": "key-1502312570",
+            "label": "81",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "DqbKvgLphebxSoyMYd9Jki4V3yE",
+            "key": "key-1502312570",
+            "label": "82",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "6bYeVIfeXmR3qhxGFlE1JsVs2Pp",
+            "key": "key-1502312570",
+            "label": "83",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "G6LDz50xy5TzY88a0orBokuQYLd",
+            "key": "key-1502312570",
+            "label": "84",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "J77Cvl3jRUQUDLw2zzEMzQzMGiB",
+            "key": "key-1502312570",
+            "label": "85",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "5RREWDI0W93Nhz8GvdOguE2i3zf",
+            "key": "key-1502312570",
+            "label": "86",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "AT7nt9VXVIrxxPfZImF8PPDuYFs",
+            "key": "key-1502312570",
+            "label": "87",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "Y8qAK91mm7kFvr8Q00Ey5hRzeMB",
+            "key": "key-1502312570",
+            "label": "88",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "raJiehdtk2E23YHQ8ButJWWRQgJ",
+            "key": "key-1502312570",
+            "label": "89",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "SO263dlpitGB3uK1g5Eh8pJrFMM",
+            "key": "key-1502312570",
+            "label": "9",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "lMl5d3KDqoJVZledLz43xLQzwAu",
+            "key": "key-1502312570",
+            "label": "90",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "vNJ71QWaJj9qTK58Xc0TYwyaXOj",
+            "key": "key-1502312570",
+            "label": "91",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "kLthotmOJwBsDcTv8wgkoukppOW",
+            "key": "key-1502312570",
+            "label": "92",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "gprF8PHVYtJASrPUFHKVEBygRwM",
+            "key": "key-1502312570",
+            "label": "93",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "h8Vw9jRaEqJHLBetams9HYOicVe",
+            "key": "key-1502312570",
+            "label": "94",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "DxUUZYAW89HHxoNzn0Vjqy0Wxvv",
+            "key": "key-1502312570",
+            "label": "95",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "o3oj7tQaU1f7cIMONLPe3PevlNi",
+            "key": "key-1502312570",
+            "label": "96",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "E0Agyl2LJS7JvUUaYi9qzjDmZ43",
+            "key": "key-1502312570",
+            "label": "97",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "QrPD87IE4fWFUS2FAqeZuZUXZeT",
+            "key": "key-1502312570",
+            "label": "98",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "m3MR3zCd2OYIoj7BgaINHvbup4t",
+            "key": "key-1502312570",
+            "label": "99",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "4yCOmwht9r1upewN8Odsi0Bcg8M",
+            "key": "key-1551731413",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "UpMP4mKBUEBjqQRMlD2sXB7FJEs",
+            "key": "key-156242278",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "wYuNxWrI5TQozzYpAciVySHaU7B",
+            "key": "key-1577810526",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "OrmLOlXvKFr9x2E1acXclGZD263",
+            "key": "key-1587818169",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:24:13\u002B00:00"
+          },
+          {
+            "etag": "2OoqjcAo90yAdqgfyVKGWnmpj16",
+            "key": "key-1598438620",
+            "label": null,
+            "content_type": null,
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "wdhs1dq8NYXHheyCbky9eyWIKL5",
+            "key": "key-1603266762",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          },
+          {
+            "etag": "YHGfktoslQCCSNSEVuOCb1hrZcM",
+            "key": "key-1633697425",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "NpP8VyFX5Q6wjrXMNR1ftttz5Py",
+            "key": "key-1661468793",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T18:12:29\u002B00:00"
+          },
+          {
+            "etag": "xd7St6F6CuBJ2ONJelveJ5xaBLH",
+            "key": "key-1715663437",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          },
+          {
+            "etag": "Pn80ku8RIkNrPEza9y1k0aIv4MZ",
+            "key": "key-1716559556",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value2",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:55\u002B00:00"
+          },
+          {
+            "etag": "h3yjTfKtljOrEqb96vZ7jEhGm0o",
+            "key": "key-1720810414",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "3VeGoyPFcP4iGC2ExNPF2fkPvAb",
+            "key": "key-17297920",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "AeSBit4ycm1QEa90sDjW8PlBLaM",
+            "key": "key-1765082280",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "bU5BI1mgZBLYf9HeWYhuYl2IDg0",
+            "key": "key-1768007851",
+            "label": "my_label",
+            "content_type": null,
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
+          },
+          {
+            "etag": "1D0YfHmg2SJuD6zEfhd31o9FNWq",
+            "key": "key-1786217009",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:31\u002B00:00"
+          },
+          {
+            "etag": "DLAYvuZp4EOLhbWpHiORrFQrxlZ",
+            "key": "key-1808461375",
+            "label": null,
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "1BrnR77JndxaL4ndtsKgAkwuyr5",
+            "key": "key-1809216229",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "51F1mjgR1BCXDZyEVIog5KkxsVJ",
+            "key": "key-1828956231",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:55\u002B00:00"
+          },
+          {
+            "etag": "FliZ8FwgQ3NS58dfRL0HZrd5SXr",
+            "key": "key-1844884626",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:05:25\u002B00:00"
+          },
+          {
+            "etag": "Gxaxf0awnjXtA4Bh1MZzONQ1mW2",
+            "key": "key-1875045571",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:09\u002B00:00"
+          },
+          {
+            "etag": "e9o6tiNAhuQngS6rYK436ODRDcO",
+            "key": "key-1910922243",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:55\u002B00:00"
+          },
+          {
+            "etag": "qenIfhBrk88QpsJTwxuSSxm4SzC",
+            "key": "key-1919238788",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:07:04\u002B00:00"
+          },
+          {
+            "etag": "CWNgk6O4YLFZ12jqhHOPnCEDE8m",
+            "key": "key-1922091484",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "2VEHu39Mt7780fVEqtoadyUfE8i",
+            "key": "key-1934649991",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
+          },
+          {
+            "etag": "R8U84YRp2frl9PI0g3F4YYgrRB4",
+            "key": "key-1937393334",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:31\u002B00:00"
+          },
+          {
+            "etag": "8cLzl0ho1NqYl3u7osOR0NftOD7",
+            "key": "key-1965913023",
+            "label": null,
+            "content_type": null,
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:54\u002B00:00"
+          },
+          {
+            "etag": "zmZ65hqvHu2FpIbbMVi2HSGYbvr",
+            "key": "key-1983768591",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "ROiZnOqdsnLVV0G5QdaNHcEKew3",
+            "key": "key-2010525552",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:54\u002B00:00"
+          },
+          {
+            "etag": "h9729v3p9GahZj27TlRlI1sUIw5",
+            "key": "key-204035620",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:31\u002B00:00"
+          },
+          {
+            "etag": "QfOPNXMqjEueWYCaEchCrvT5uLW",
+            "key": "key-2051178311",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value2",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:50\u002B00:00"
+          },
+          {
+            "etag": "5VG77jljuIJ8c2qvTmTzjP5hFFR",
+            "key": "key-2053619125",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:09\u002B00:00"
+          },
+          {
+            "etag": "xurZkkq1lWet0EOqLPkdPwL42Ko",
+            "key": "key-2097465991",
+            "label": null,
+            "content_type": null,
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "rGWi2Wsg21RdGcnFOl3AZxz42vr",
+            "key": "key-2113787248",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "k3sYCiP0mYo8BNoIeSsk97OZIel",
+            "key": "key-212129177",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          },
+          {
+            "etag": "VmKDNHfAPxXbOqguV5YKNR28p4L",
             "key": "key-221701127",
             "label": "test_label",
             "content_type": "test_content_type",
@@ -159,7 +2114,46 @@
               "tag2": "value2"
             },
             "locked": false,
-            "last_modified": "2019-09-18T21:33:01\u002B00:00"
+            "last_modified": "2019-10-14T21:27:15\u002B00:00"
+          },
+          {
+            "etag": "UhZIRQfYWPQzWAELLBfa09ehUvx",
+            "key": "key-222881053",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:15:13\u002B00:00"
+          },
+          {
+            "etag": "pnlSyvJyVdbopuT5WFhpD9ULr3G",
+            "key": "key-277273344",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "slvXjRxhTVg3IcKeO12PuutFgOp",
+            "key": "key-291156113",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
           },
           {
             "etag": "rniPVf34RW2LNcl6lXHzat7XjNo",
@@ -170,6 +2164,1098 @@
             "tags": {},
             "locked": false,
             "last_modified": "2019-04-10T23:26:25\u002B00:00"
+          },
+          {
+            "etag": "5cwUfOWFt41voGSpeOQkkc9klYO",
+            "key": "key-318212819",
+            "label": "0",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "z7MMZZ32BbiRQpcjfnTMW22E72r",
+            "key": "key-318212819",
+            "label": "1",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "AkM7mlWrrG5UhwcDuFgCwDETINi",
+            "key": "key-318212819",
+            "label": "10",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "N4iEqr6McoX0qlZeUxNAjldtv5Y",
+            "key": "key-318212819",
+            "label": "100",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "0g3rVao6C5cn1hlgkziHdbvRqn2",
+            "key": "key-318212819",
+            "label": "101",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "xisITjWgpouicflR1xKkb0koEG0",
+            "key": "key-318212819",
+            "label": "102",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "yuT56q2j5onrUVlGBEV6ewU6FZR",
+            "key": "key-318212819",
+            "label": "103",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "lhzHJ9bgmQMxgOaVzHdreWwCLBO",
+            "key": "key-318212819",
+            "label": "104",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "FLg3ZnfkC9pGBpbpmZabnJ19jLZ",
+            "key": "key-318212819",
+            "label": "11",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "4rn9PHOjNMiJI6ALzq8rNttFw8Y",
+            "key": "key-318212819",
+            "label": "12",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "uNSg7e3wgb1rqFJhn8r36qnPcRd",
+            "key": "key-318212819",
+            "label": "13",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "JNWGXT8VRrla3W0XcFaA8BFTzO8",
+            "key": "key-318212819",
+            "label": "14",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "XTv0hWlpzO3VMs94s3gp9QbE7BP",
+            "key": "key-318212819",
+            "label": "15",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "HjtCmiihempNJLNQbx4WunsU4PV",
+            "key": "key-318212819",
+            "label": "16",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          }
+        ],
+        "@nextLink": "/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LTMxODIxMjgxOQoxNg%3D%3D"
+      }
+    },
+    {
+      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=%2A\u0026label=%2A\u0026after=a2V5LTMxODIxMjgxOQoxNg%3D%3D\u0026api-version=1.0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/vnd.microsoft.appconfig.kv\u002Bjson",
+        "Authorization": "Sanitized",
+        "Date": "Mon, 14 Oct 2019 21:27:15 GMT",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTExMDA=",
+        "User-Agent": [
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
+        ],
+        "x-ms-client-request-id": "0dfd6e30b1887b896ae235b9dc9960c7",
+        "x-ms-content-sha256": "47DEQpj8HBSa\u002B/TImW\u002B5JCeuQeRkm5NMpJWZG3hSuFU=",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Access-Control-Allow-Methods": "GET, PUT, POST, DELETE, PATCH, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Connection": "keep-alive",
+        "Content-Type": "application/vnd.microsoft.appconfig.kvset\u002Bjson; charset=utf-8",
+        "Date": "Mon, 14 Oct 2019 21:27:15 GMT",
+        "Link": "\u003C/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LTQ0MjM1MjAyOAp0ZXN0X2xhYmVs\u003E; rel=\u0022next\u0022",
+        "Server": "openresty/1.15.8.1",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTExMDA=;sn=651100",
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "0dfd6e30b1887b896ae235b9dc9960c7",
+        "x-ms-correlation-request-id": "b52e2404-c674-4084-b661-d94dcf2af186",
+        "x-ms-request-id": "b52e2404-c674-4084-b661-d94dcf2af186"
+      },
+      "ResponseBody": {
+        "items": [
+          {
+            "etag": "4GkmqE7pYsWlf291OeN9AltmTZm",
+            "key": "key-318212819",
+            "label": "17",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "KWRqe7fMBTXSAlF7R9Zu2ASlMUh",
+            "key": "key-318212819",
+            "label": "18",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "vIEUpxgsVTvUnveRularaVAnIC0",
+            "key": "key-318212819",
+            "label": "19",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "vhYNS5rPotsPSMPMZkIM9vTJwGu",
+            "key": "key-318212819",
+            "label": "2",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "tm0F7oBe5f6MAnFMmm8zC5Tr7Ab",
+            "key": "key-318212819",
+            "label": "20",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "WjtLGMVSg9SoE86k5BnECAp6051",
+            "key": "key-318212819",
+            "label": "21",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "EDQCCSvYjMiH8wIzHq36wDckuAw",
+            "key": "key-318212819",
+            "label": "22",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "gHjxZ9lkDeWLA3zMJWamdgvMQXV",
+            "key": "key-318212819",
+            "label": "23",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "rc0j68KTbYeu4lJVEJ1qGT6P3Ql",
+            "key": "key-318212819",
+            "label": "24",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "BsBueEs46SRwyARErsWBd7DW3Bv",
+            "key": "key-318212819",
+            "label": "25",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "qxWTCxic52DEfF4gvrKIIbLAIyr",
+            "key": "key-318212819",
+            "label": "26",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "5enBsRYuMrdayb5q5gI2tkXPgBD",
+            "key": "key-318212819",
+            "label": "27",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "DLFQ5CC0NB8gsMhDp4skWGCsY83",
+            "key": "key-318212819",
+            "label": "28",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "J92kL81ZT6TQZ29CkRZGsEngSB6",
+            "key": "key-318212819",
+            "label": "29",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "eceqDOKrubEZUjDZ8THpq8sXnKn",
+            "key": "key-318212819",
+            "label": "3",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "AV8UUQe8Hhv7K8lheyOboqnhuUa",
+            "key": "key-318212819",
+            "label": "30",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "NGlrHeQzfLwdEBJNlW0TKTFSqho",
+            "key": "key-318212819",
+            "label": "31",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "pUzDbcFgEOHrCsqnWEfDWBEKgvg",
+            "key": "key-318212819",
+            "label": "32",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "ZoyHYhzQObGNK9BzZdEXwSAYlUe",
+            "key": "key-318212819",
+            "label": "33",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "PolnHEx6J9EmNUFDtKy1h2r4Nof",
+            "key": "key-318212819",
+            "label": "34",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "a1KCGdp7Cn1xqxkxFzZ9MPzLRlx",
+            "key": "key-318212819",
+            "label": "35",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "voGU9e79et92C0I4FeFnVicmLdN",
+            "key": "key-318212819",
+            "label": "36",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "cLBRGbNitcLgUlW6r0XjSN6W5Un",
+            "key": "key-318212819",
+            "label": "37",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "pXDFJQX9WXNnNxtqFPbXXBcS8he",
+            "key": "key-318212819",
+            "label": "38",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "zXL6IwlbPqd95EwRVtErypDgTCU",
+            "key": "key-318212819",
+            "label": "39",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "DNK4LTvlPmmITkpzK5kuW5mpZ67",
+            "key": "key-318212819",
+            "label": "4",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "C4yGwIxkw4MKjtpo5PISZ9mqyq3",
+            "key": "key-318212819",
+            "label": "40",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "Mh7Gk1NV4iH2dcHx8aMI7JG4kBe",
+            "key": "key-318212819",
+            "label": "41",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "4cEkSYsE1cnlWopnJ4SjBH25rMl",
+            "key": "key-318212819",
+            "label": "42",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "eJyYJsMSbUksB74IDqXVbLtg04P",
+            "key": "key-318212819",
+            "label": "43",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "AYpANGbRovdTaGZCKi6qtvfQAqZ",
+            "key": "key-318212819",
+            "label": "44",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "0wIL13ji2saK9GgfNxnqslkil5P",
+            "key": "key-318212819",
+            "label": "45",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "m4Au5VKT0JVcZYGi8aN7ExaIAqo",
+            "key": "key-318212819",
+            "label": "46",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "BYr5WWWlnckAxMLHduS68iblypn",
+            "key": "key-318212819",
+            "label": "47",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "rSWkniAXJL27R8iC1IF36eFonX0",
+            "key": "key-318212819",
+            "label": "48",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "isW7ZqY46aeUBLpJ7CF0YYt5QIt",
+            "key": "key-318212819",
+            "label": "49",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "jaK4r1TdNeDNWxZQJZvUYaCBi31",
+            "key": "key-318212819",
+            "label": "5",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "ZqAY6fx3RciOzMMtQpRuyOEK0RK",
+            "key": "key-318212819",
+            "label": "50",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "Hsr6LoOZqq5KZc2PEmKKDm6X71z",
+            "key": "key-318212819",
+            "label": "51",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "BO5xQtBE3BMklxfu5SeNSQVi6nb",
+            "key": "key-318212819",
+            "label": "52",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "e5JNJGx7a0JOWBfG6R7RyYfHdL0",
+            "key": "key-318212819",
+            "label": "53",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "72W64Ts4otEBFkUPIFMLXDOVnsB",
+            "key": "key-318212819",
+            "label": "54",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "Q2V9VXjv38DET3zvCcp2fgJgBoK",
+            "key": "key-318212819",
+            "label": "55",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "xFBmpRqnwjFKyIBoeXgyIkbn4KT",
+            "key": "key-318212819",
+            "label": "56",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "zNCbYWfmDtVkQ3daiFPF8wH4g2J",
+            "key": "key-318212819",
+            "label": "57",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "HnfxPwBolVV4F4ho8kKY1mdfI3F",
+            "key": "key-318212819",
+            "label": "58",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "aybMOdX7a0OFFqJAa2JEHMmVqI8",
+            "key": "key-318212819",
+            "label": "59",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "AQhJNPQVYOsJ5JKxahjJYY1H1hG",
+            "key": "key-318212819",
+            "label": "6",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "xXrARI12MLps0E2wLqZ0albHtQX",
+            "key": "key-318212819",
+            "label": "60",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "oxbG2NenscCQZ5lY6irsqiE6CbJ",
+            "key": "key-318212819",
+            "label": "61",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "T4vIvjkFTNPtzQMsjecHfOHUoyB",
+            "key": "key-318212819",
+            "label": "62",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "9Cn5UUUUQufChfsBbYXVHZq0i1V",
+            "key": "key-318212819",
+            "label": "63",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "JJFAWU9sRiwCq7Vy3kqFHHEw0EJ",
+            "key": "key-318212819",
+            "label": "64",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "23dri1GmmtomMoDZx9zmzE6mHfM",
+            "key": "key-318212819",
+            "label": "65",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "cZctnbyA9WFarRHlOjgqKl04I8K",
+            "key": "key-318212819",
+            "label": "66",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "WBW595bnrK2u9iehMUUJJ67HwOM",
+            "key": "key-318212819",
+            "label": "67",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "YMF1GfyGg81XdrB7GKEaVm0Ejwh",
+            "key": "key-318212819",
+            "label": "68",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "enDpWw6rdMCZJryg4zk5ZbT8ucU",
+            "key": "key-318212819",
+            "label": "69",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "i8sqkxGFlxnzxobOxMZj7ykx49U",
+            "key": "key-318212819",
+            "label": "7",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "xhJF8bq45Ci1dM4VXhzajuaUctO",
+            "key": "key-318212819",
+            "label": "70",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "iXWqnAgLoxiXbEwqhuRHF0wyMom",
+            "key": "key-318212819",
+            "label": "71",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "IY9UDBeaPkxSLsvc56wTrgGeA74",
+            "key": "key-318212819",
+            "label": "72",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "W0a2gS2bWuW1JRAhmd0xD2RigWP",
+            "key": "key-318212819",
+            "label": "73",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "VUwGkCcxOZdYr8nxt4y1whp5IJY",
+            "key": "key-318212819",
+            "label": "74",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "CHQWzmmsQk17tFWtCgEeSw5uHnP",
+            "key": "key-318212819",
+            "label": "75",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "A6ymkAnyLQt8U3n4peSjuWi5C1Y",
+            "key": "key-318212819",
+            "label": "76",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "AjuYFhgNhpdEDtbGOWxVBwZo4hk",
+            "key": "key-318212819",
+            "label": "77",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "YLFvdbM2MQagS87upcmwqPDfdAn",
+            "key": "key-318212819",
+            "label": "78",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "7pdmsOJRq9gXBf1q3gvntjhzrcg",
+            "key": "key-318212819",
+            "label": "79",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "7djUpNqZc2OqdS0jfFShxF91vZt",
+            "key": "key-318212819",
+            "label": "8",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "Yee49ACbd648SwLFpCHURzYwiDo",
+            "key": "key-318212819",
+            "label": "80",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "oEuD35erUuF63XN7VGacKggdNNn",
+            "key": "key-318212819",
+            "label": "81",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "qxjJanqMCXeAhQwECFnZofML6Fz",
+            "key": "key-318212819",
+            "label": "82",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "PRzNf642PZRaqRb7W8ZbkVNHlyL",
+            "key": "key-318212819",
+            "label": "83",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "jQE2QVttT7j3GldvyZJZT5Y1FTr",
+            "key": "key-318212819",
+            "label": "84",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "VVVbwF9xWKTPa7CKOmxEwiaPRRr",
+            "key": "key-318212819",
+            "label": "85",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "8sg1uCKDzTdpSSOS6e05pYU98yt",
+            "key": "key-318212819",
+            "label": "86",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "Ks9H9Vkne4bjMYjkQFU6ASNXgJn",
+            "key": "key-318212819",
+            "label": "87",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "RyWMIhr1IkNCpyt7PKOShZCvV5u",
+            "key": "key-318212819",
+            "label": "88",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "SSjMMj6FCcPFrmrL5gccACQBpYc",
+            "key": "key-318212819",
+            "label": "89",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "5UXM4LYxBt12WA0i0kvjwJBVXYb",
+            "key": "key-318212819",
+            "label": "9",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "1Cy9lgLBDtJ29VJQGRwfojO6sF2",
+            "key": "key-318212819",
+            "label": "90",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "Jk6aHt1WpAqrVKidwU89UDIOqZo",
+            "key": "key-318212819",
+            "label": "91",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "gR6GEUItikQ02CHKl8qEmu1aYvj",
+            "key": "key-318212819",
+            "label": "92",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "36EyMt1NPbs2cXSxAH2KXQ16JV1",
+            "key": "key-318212819",
+            "label": "93",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "7NC96AxyFaG9Uc654bDjTkQAT92",
+            "key": "key-318212819",
+            "label": "94",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "Ig7MGzD5u56Y3ZM4nG8NaTIHDr2",
+            "key": "key-318212819",
+            "label": "95",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "ISsYzhtEPpPiI7uOctlYnVlx3nf",
+            "key": "key-318212819",
+            "label": "96",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "F9hPW4j4VaHoq9VzVPlUPotqKhN",
+            "key": "key-318212819",
+            "label": "97",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "FDF33pwyoxLluLfDzAxNfuwRUIz",
+            "key": "key-318212819",
+            "label": "98",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "uFISRJO3YYvE94SQMWQl3dwNmNN",
+            "key": "key-318212819",
+            "label": "99",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
           },
           {
             "etag": "QB6ZifyjGfUn17lEKZMAK6No3jf",
@@ -198,6 +3284,162 @@
             "last_modified": "2019-05-01T19:08:04\u002B00:00"
           },
           {
+            "etag": "mj5yMpfkn1kdd1K3YhPt5AUqhEf",
+            "key": "key-337032567",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:49\u002B00:00"
+          },
+          {
+            "etag": "briktXnfCCDMeye6LB3uZ3pc7DH",
+            "key": "key-357348821",
+            "label": "my_label",
+            "content_type": null,
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "Do7twZpoyGpe56S9tjkYR7T6oug",
+            "key": "key-407324161",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "Bn8Qww33MB3xLGowUmh9BGJVO4F",
+            "key": "key-429238547",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:06\u002B00:00"
+          },
+          {
+            "etag": "vUvAGXytPKGN4EdsONAZB1ZloOr",
+            "key": "key-439891543",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "RfYfTS1obmR3cR4S9WROiH1FeIE",
+            "key": "key-442070586",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T18:11:33\u002B00:00"
+          },
+          {
+            "etag": "HKbYauu5cqJbjg5dDwq7n3FC4oD",
+            "key": "key-442352028",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          }
+        ],
+        "@nextLink": "/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LTQ0MjM1MjAyOAp0ZXN0X2xhYmVs"
+      }
+    },
+    {
+      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=%2A\u0026label=%2A\u0026after=a2V5LTQ0MjM1MjAyOAp0ZXN0X2xhYmVs\u0026api-version=1.0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/vnd.microsoft.appconfig.kv\u002Bjson",
+        "Authorization": "Sanitized",
+        "Date": "Mon, 14 Oct 2019 21:27:15 GMT",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTExMDA=",
+        "User-Agent": [
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
+        ],
+        "x-ms-client-request-id": "a2fdc87b12885f55c1be89f2b4e570e0",
+        "x-ms-content-sha256": "47DEQpj8HBSa\u002B/TImW\u002B5JCeuQeRkm5NMpJWZG3hSuFU=",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Access-Control-Allow-Methods": "GET, PUT, POST, DELETE, PATCH, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Connection": "keep-alive",
+        "Content-Type": "application/vnd.microsoft.appconfig.kvset\u002Bjson; charset=utf-8",
+        "Date": "Mon, 14 Oct 2019 21:27:15 GMT",
+        "Link": "\u003C/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LTU0MTc2NDUxMAo5\u003E; rel=\u0022next\u0022",
+        "Server": "openresty/1.15.8.1",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTExMDA=;sn=651100",
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "a2fdc87b12885f55c1be89f2b4e570e0",
+        "x-ms-correlation-request-id": "cc0cb244-c927-4486-875e-ff59135f5fca",
+        "x-ms-request-id": "cc0cb244-c927-4486-875e-ff59135f5fca"
+      },
+      "ResponseBody": {
+        "items": [
+          {
+            "etag": "WgaViI04lj7TF2VbpHTkzk3kaXr",
+            "key": "key-451104393",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          },
+          {
+            "etag": "wiUqbDzZboQ4lQ8wFOtMUTWkZ8E",
+            "key": "key-469594127",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:08:00\u002B00:00"
+          },
+          {
             "etag": "JmFAJhlGhqYS9XzZN5ZfdktOK3L",
             "key": "key-4dc1baef29474d1ea11dbf3b5c9a690c",
             "label": "test_label",
@@ -221,6 +3463,1137 @@
             "last_modified": "2019-04-10T23:26:24\u002B00:00"
           },
           {
+            "etag": "Zvd8V3jfPSFrHYk3rhF4Uvjh7ny",
+            "key": "key-52254665",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "FPfEN2dwIt3P2I85RcQCogL0Gni",
+            "key": "key-541764510",
+            "label": "0",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "rmvDXOoiwH4UE9Ed3G1dMZLELOg",
+            "key": "key-541764510",
+            "label": "1",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "0Rx1e1F2svdzwrGufb0yNrmwtUW",
+            "key": "key-541764510",
+            "label": "10",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "gUURJ2MVcp2wwsLMGkLbHTdoT4q",
+            "key": "key-541764510",
+            "label": "100",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "tmOjdS5xrnx8pKfbRoDMNhqC5Ie",
+            "key": "key-541764510",
+            "label": "101",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "1dEKhRqTK5OMAeeBj4ymbSni8h3",
+            "key": "key-541764510",
+            "label": "102",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "ZkggJlpItqvf0sbreLrkcUjDYAN",
+            "key": "key-541764510",
+            "label": "103",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "IoaxhA6fPKtmf7y0aASdphkao5P",
+            "key": "key-541764510",
+            "label": "104",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "LYuUd3YtOq3HggtjTZ6l3uUPmVZ",
+            "key": "key-541764510",
+            "label": "11",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "lgzo8mxT54L42zk4wz7vfi0X1R0",
+            "key": "key-541764510",
+            "label": "12",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "hY9OGVCAkdU7v4iBC8WMtkNx0vF",
+            "key": "key-541764510",
+            "label": "13",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "SQ97eJlpdEFUf3pVJv9L0Oe0Aos",
+            "key": "key-541764510",
+            "label": "14",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "QNlYaoKBeHFGIlROha5MspGl28F",
+            "key": "key-541764510",
+            "label": "15",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "kFcvtV5a2ug6UiKOpckl5srNRtc",
+            "key": "key-541764510",
+            "label": "16",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "fOftYXX18dcd959tQLHPWlWt2nh",
+            "key": "key-541764510",
+            "label": "17",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "EIS4s6MZrKSIjuPB6o5iEG8nAdM",
+            "key": "key-541764510",
+            "label": "18",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "YDP2BymVu5kGy4PhlJ76qaZn7tp",
+            "key": "key-541764510",
+            "label": "19",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "01NefYPwREv7fOfsxQ557glmqx9",
+            "key": "key-541764510",
+            "label": "2",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "kfeqj8MJfkGYD24AhWO5l9MOqAB",
+            "key": "key-541764510",
+            "label": "20",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "rfI6o6WvqpphYhXqDluYLWWrkkz",
+            "key": "key-541764510",
+            "label": "21",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "14Ew2EaurV3ZI29dSiZZbTmWUXu",
+            "key": "key-541764510",
+            "label": "22",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "89rYU8yma2h9aALTV2fHhu8pZ0L",
+            "key": "key-541764510",
+            "label": "23",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "bNwwvphyriDjHqIRFrxflcNCzHz",
+            "key": "key-541764510",
+            "label": "24",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "kbRD7cBNEeMwuo1l1Pk0IUV8SPj",
+            "key": "key-541764510",
+            "label": "25",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "HoaL8giu94j5EyP8bodnbPhk3Tp",
+            "key": "key-541764510",
+            "label": "26",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "X2Ha7DUURU3luWG6uRTrWCyBd6w",
+            "key": "key-541764510",
+            "label": "27",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "18JyD17dA5JOdwWW3efjZ1FbpcZ",
+            "key": "key-541764510",
+            "label": "28",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "duZzxPUAQrpkz8AqB9d4GrOBtmc",
+            "key": "key-541764510",
+            "label": "29",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "x92waZgAIo6KOioqinpd4fShDww",
+            "key": "key-541764510",
+            "label": "3",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "APrbV8HuvZbWqzc7vH9YFLO8fv6",
+            "key": "key-541764510",
+            "label": "30",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "IzjITFyaFrRG2FeXw4sjvYeWfb9",
+            "key": "key-541764510",
+            "label": "31",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "lGrB6duzjrG4riGQD9b4ZpB4l1Q",
+            "key": "key-541764510",
+            "label": "32",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "3tw5eoAdA5InF1Hfq4jtJfvqseG",
+            "key": "key-541764510",
+            "label": "33",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "aJ5zTigPLsT9yeSwnXMcomKCm0c",
+            "key": "key-541764510",
+            "label": "34",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "8cad2D4T0aA62y2Y4j9Oa1NDy0U",
+            "key": "key-541764510",
+            "label": "35",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "G39ixZtekAtJeUgulgj0vu3hOkj",
+            "key": "key-541764510",
+            "label": "36",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "2KdzPxrncjDGeGwgeeFBdlfKGxr",
+            "key": "key-541764510",
+            "label": "37",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "2zKJ5rw9kxLzPPLoFxIhlXbaExr",
+            "key": "key-541764510",
+            "label": "38",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "cqjbZGpT7C3FXzK1PsR4TvcPlk3",
+            "key": "key-541764510",
+            "label": "39",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "9gTz9etVcAuyVnCk0cVCHOfJCsU",
+            "key": "key-541764510",
+            "label": "4",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "QsC9O9Wsr2STHNZRsUrHoEpCpQ3",
+            "key": "key-541764510",
+            "label": "40",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "8mSDlmj44e9hID4HVzUa7fcx8wK",
+            "key": "key-541764510",
+            "label": "41",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "A5y55KQZcZOtLpo8y2PC79vHMVr",
+            "key": "key-541764510",
+            "label": "42",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "3G2ppHCwJeUV15ivdXvTW16MSVP",
+            "key": "key-541764510",
+            "label": "43",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "ZRgNJLXgHPfQhQWY5EnO1k9bmcD",
+            "key": "key-541764510",
+            "label": "44",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "yASrnndVhPzq3ce78suxpn6Ygji",
+            "key": "key-541764510",
+            "label": "45",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "w4p29glD9NydABZpmgQIsdnRGSM",
+            "key": "key-541764510",
+            "label": "46",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "TbFrFZlGuTamT0OFHjsVDDypR5e",
+            "key": "key-541764510",
+            "label": "47",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "IahcOIWFXXOBAXSGsS7prObFNpA",
+            "key": "key-541764510",
+            "label": "48",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "oCgUPMFiRWSy9BeVgmYe8ALk9kk",
+            "key": "key-541764510",
+            "label": "49",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "1ciDTA0AGgCfTSLNXnuwhuWdIgs",
+            "key": "key-541764510",
+            "label": "5",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "1ttKuw6KC98fb7Neq8WxBzPE2Q5",
+            "key": "key-541764510",
+            "label": "50",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "TtyXOeNm6YWbihYyotcHJwuy1lv",
+            "key": "key-541764510",
+            "label": "51",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "yuAXC6Vob80MhMMciffGQ3AOw7C",
+            "key": "key-541764510",
+            "label": "52",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "RFmp6TsyJrDuFHmE7EBt6mh8wE8",
+            "key": "key-541764510",
+            "label": "53",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "wMn35s2VnQvekYnRaM3VYOEuLoa",
+            "key": "key-541764510",
+            "label": "54",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "cXPT7wRJZkX8KdodISdOJ84kuKm",
+            "key": "key-541764510",
+            "label": "55",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "PuiHn1vHimqIz4gGrbKLyW3WyCf",
+            "key": "key-541764510",
+            "label": "56",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "WBod4dvMwgTcAtpkAvc5wC16S70",
+            "key": "key-541764510",
+            "label": "57",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "RYf8LfQDJ6HgavaMRuVac6N9vcO",
+            "key": "key-541764510",
+            "label": "58",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "2NRBSURTdKErkJxnDu8RkDiRFj5",
+            "key": "key-541764510",
+            "label": "59",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "oAToJgKkSkDQAIa4NmDVzYeM8lD",
+            "key": "key-541764510",
+            "label": "6",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "tDllB8vbGFn8TDNiGVx4GVs7jos",
+            "key": "key-541764510",
+            "label": "60",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "1mTMN7uD7dVSe9gUswDzuzWz3ur",
+            "key": "key-541764510",
+            "label": "61",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "fEE3fxnpgnawsDJaP7XKO0Wrlpd",
+            "key": "key-541764510",
+            "label": "62",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "u7H1Lzy0bau2TAf4d7bwcLwnOpT",
+            "key": "key-541764510",
+            "label": "63",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "zAtemhj1hUG56TpKr4uB2Yuil2g",
+            "key": "key-541764510",
+            "label": "64",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "XaloVmyiQNMGk5UsXx9y7Iwc7fp",
+            "key": "key-541764510",
+            "label": "65",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "FeUsNvze8TdApveO7wsvaobIR8p",
+            "key": "key-541764510",
+            "label": "66",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "jIcUHDkcReNVe2ZY3PmCQXK1QW0",
+            "key": "key-541764510",
+            "label": "67",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "CpLZVIK3ycBrjbGGcWQJCO3oAuG",
+            "key": "key-541764510",
+            "label": "68",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "CAnROP3mDHI6ZYh5KRd3XnvqFqX",
+            "key": "key-541764510",
+            "label": "69",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "EitMr1oUU366Qx4Ziy55vdOKVuq",
+            "key": "key-541764510",
+            "label": "7",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "0jmIFB4481LTLb3HipLfBXTPgh4",
+            "key": "key-541764510",
+            "label": "70",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "dIaM1eVDARYgymOoama1RTbmDP6",
+            "key": "key-541764510",
+            "label": "71",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "4mAPPvJfM0GRGbQQWnjzthRe39a",
+            "key": "key-541764510",
+            "label": "72",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "M8FPgNOHaNof3J8vE7DTR2LQY2k",
+            "key": "key-541764510",
+            "label": "73",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "gh5pEm1smxjqN8BgsgubeyoWYoy",
+            "key": "key-541764510",
+            "label": "74",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "3TkSTlCkzNFmXQIpjmw8UJJ2aon",
+            "key": "key-541764510",
+            "label": "75",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "jYN8NgWl3e95iH9BV2sr0JOZD8e",
+            "key": "key-541764510",
+            "label": "76",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "KJcGihm7B0C57T9FJEtpEOdpouJ",
+            "key": "key-541764510",
+            "label": "77",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "V9qwUvqHsXuP3wfSb9McGRxnBeZ",
+            "key": "key-541764510",
+            "label": "78",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "ld4qB2xBDBGThPpxRuREqp5x2XO",
+            "key": "key-541764510",
+            "label": "79",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "OtKtQ8F9cpS3y8kb7O12jVpO9BG",
+            "key": "key-541764510",
+            "label": "8",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "n1R8syFieztYfBzbnzMM3NAvsUv",
+            "key": "key-541764510",
+            "label": "80",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "Hn38uN8ZF45rg0Tq33xTKt6WmSw",
+            "key": "key-541764510",
+            "label": "81",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "0aZuayDWbo8BsOcRJZeLp2kxmHb",
+            "key": "key-541764510",
+            "label": "82",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "fnbMmElSRn0q0g05IKqsCFHWAxG",
+            "key": "key-541764510",
+            "label": "83",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "e7Ih5VfIeMo9CzlEnZPIBtLdtTl",
+            "key": "key-541764510",
+            "label": "84",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "gCYJTCID9JvXhfVudCNgHgjx5Jl",
+            "key": "key-541764510",
+            "label": "85",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "ckb6x5ayvsFAKrUpBcW49U6hkDU",
+            "key": "key-541764510",
+            "label": "86",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "O5VWd0HArsznTxET8otVbvsZyUL",
+            "key": "key-541764510",
+            "label": "87",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "8ldzy3EHy5cJoo5Ob2EsthD6xXN",
+            "key": "key-541764510",
+            "label": "88",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "6lF5F76OxDS58SVxz7FLrlQi8MJ",
+            "key": "key-541764510",
+            "label": "89",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "RgcW0w59IEU3bSGk69Df2f4T6F7",
+            "key": "key-541764510",
+            "label": "9",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          }
+        ],
+        "@nextLink": "/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LTU0MTc2NDUxMAo5"
+      }
+    },
+    {
+      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=%2A\u0026label=%2A\u0026after=a2V5LTU0MTc2NDUxMAo5\u0026api-version=1.0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/vnd.microsoft.appconfig.kv\u002Bjson",
+        "Authorization": "Sanitized",
+        "Date": "Mon, 14 Oct 2019 21:27:15 GMT",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTExMDA=",
+        "User-Agent": [
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
+        ],
+        "x-ms-client-request-id": "dee22fc2bfa2066946436074f8a3ba60",
+        "x-ms-content-sha256": "47DEQpj8HBSa\u002B/TImW\u002B5JCeuQeRkm5NMpJWZG3hSuFU=",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Access-Control-Allow-Methods": "GET, PUT, POST, DELETE, PATCH, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Connection": "keep-alive",
+        "Content-Type": "application/vnd.microsoft.appconfig.kvset\u002Bjson; charset=utf-8",
+        "Date": "Mon, 14 Oct 2019 21:27:15 GMT",
+        "Link": "\u003C/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LTkwMTgxNzU1Ngo1Mw%3D%3D\u003E; rel=\u0022next\u0022",
+        "Server": "openresty/1.15.8.1",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTExMDA=;sn=651100",
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "dee22fc2bfa2066946436074f8a3ba60",
+        "x-ms-correlation-request-id": "37951f7e-708d-42bb-bb84-701dd72fabec",
+        "x-ms-request-id": "37951f7e-708d-42bb-bb84-701dd72fabec"
+      },
+      "ResponseBody": {
+        "items": [
+          {
+            "etag": "epIA58IAZGN9uBL376K7DJqkivG",
+            "key": "key-541764510",
+            "label": "90",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "ZAjqGzEusLANC764bmm9sMk3LZB",
+            "key": "key-541764510",
+            "label": "91",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "JEEgKb1DQD0BshBgYA1FZQMQJGT",
+            "key": "key-541764510",
+            "label": "92",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "JLdw8q0SG6Gx5CI6Js8eRNHFuet",
+            "key": "key-541764510",
+            "label": "93",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "PwAa0qY7JGYN3wrkYxyDjy6v6rC",
+            "key": "key-541764510",
+            "label": "94",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "3dLT7HLwY07tUkbnBSPgXYyKelv",
+            "key": "key-541764510",
+            "label": "95",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "ZdJXAJOsaDPXXTzEuENLqbeVqhw",
+            "key": "key-541764510",
+            "label": "96",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "D2quWYtWVIxY4zWA5iLbTaeLCs3",
+            "key": "key-541764510",
+            "label": "97",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "408wJdRRAfMlDdKL44A9jUSrF7G",
+            "key": "key-541764510",
+            "label": "98",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "uitYWOSaxtCMD4VqL98601d20ym",
+            "key": "key-541764510",
+            "label": "99",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "QGxPc999Q76X1lFLQIzwwhGQSfO",
+            "key": "key-545314302",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value2",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:09\u002B00:00"
+          },
+          {
+            "etag": "nY5ZGit7NiAiLWOfDYMvLAOS1F7",
+            "key": "key-581866371",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:54\u002B00:00"
+          },
+          {
             "etag": "Z5BbCpC5iN2Qw1Tg9GiosFPgNnK",
             "key": "key-5c1bd7cc96cb4f888c94dd435e3d4ed7",
             "label": null,
@@ -229,6 +4602,84 @@
             "tags": {},
             "locked": false,
             "last_modified": "2019-04-10T23:14:47\u002B00:00"
+          },
+          {
+            "etag": "MCSdJnjGySUVPVOgGrdvZYlkkCO",
+            "key": "key-601022664",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "VvjuWikzA4tTZVv7WRJQAs6uHa4",
+            "key": "key-603485485",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:21:29\u002B00:00"
+          },
+          {
+            "etag": "08VxcTF7XOikUwUcjmIaSnf225F",
+            "key": "key-611503496",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-20T03:01:47\u002B00:00"
+          },
+          {
+            "etag": "Jm36tIYyH7m8bPvrifYkVT1ofQb",
+            "key": "key-618631428",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:05\u002B00:00"
+          },
+          {
+            "etag": "BPubg2Ay3ofpoe2DKXrZNAVnt5e",
+            "key": "key-619387967",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:55\u002B00:00"
+          },
+          {
+            "etag": "If3ekPjULycfjcGDqMzCDjS8OmZ",
+            "key": "key-62379019",
+            "label": null,
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
           },
           {
             "etag": "NNkiTFfEo9LzydkJzQXKNJKTyII",
@@ -242,6 +4693,58 @@
             },
             "locked": false,
             "last_modified": "2019-04-08T22:57:05\u002B00:00"
+          },
+          {
+            "etag": "R7nE3UyC94U7dxErKbGYFaUo3DX",
+            "key": "key-646766163",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T18:45:22\u002B00:00"
+          },
+          {
+            "etag": "hnHYu0T2IXWrlVW4iEyIx19J5E8",
+            "key": "key-665260818",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:16:37\u002B00:00"
+          },
+          {
+            "etag": "DLkqNFvqZGvKCUuGqwDtbY2cW8S",
+            "key": "key-674427950",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "dxDyLomTd2b0f9JRmhYcNokTopp",
+            "key": "key-676034902",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
           },
           {
             "etag": "yOAsvJzz97wJK3rXYDNGKswPLfs",
@@ -309,6 +4812,71 @@
             "last_modified": "2019-04-10T23:14:47\u002B00:00"
           },
           {
+            "etag": "cClYgjDuYXVjCdLxK46hyhs1Wi0",
+            "key": "key-708276799",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:54\u002B00:00"
+          },
+          {
+            "etag": "biYITZyCRHSxnnemqwgBOrCPqHa",
+            "key": "key-715857320",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value2",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:05:26\u002B00:00"
+          },
+          {
+            "etag": "uJbsczfnXinqQkeSEXeZVbYkHEg",
+            "key": "key-719454961",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-28T17:38:17\u002B00:00"
+          },
+          {
+            "etag": "fCkWnHvdpPNuvsu9EirkwToLIfb",
+            "key": "key-719690246",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T18:47:40\u002B00:00"
+          },
+          {
+            "etag": "304RpDyEyDoUVc329BbDsv9XAZl",
+            "key": "key-72708449",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
             "etag": "ytubwGBJqHHXmIvJZx23ir8rtah",
             "key": "key-7397ba163fb24443bb60bcf0d7b2fa9b",
             "label": null,
@@ -320,6 +4888,29 @@
             },
             "locked": false,
             "last_modified": "2019-05-15T23:51:11\u002B00:00"
+          },
+          {
+            "etag": "yzHXnBTeRhzlbNUHWHXUm2UHfvF",
+            "key": "key-786619267",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:50\u002B00:00"
+          },
+          {
+            "etag": "TLwfUaPLCrMUK2wTTeqGL9J7yNj",
+            "key": "key-788294418",
+            "label": "my_label",
+            "content_type": null,
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
           },
           {
             "etag": "m7EFRi22ngO0wY2LWxzcDYgMx0G",
@@ -335,6 +4926,84 @@
             "last_modified": "2019-04-10T23:26:25\u002B00:00"
           },
           {
+            "etag": "ziFSi2LSr3sFCFWjVqKJMS1OjS7",
+            "key": "key-825816014",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "p7eYoTmth5EErf3XWFIC2nroaJO",
+            "key": "key-842155684",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:08:15\u002B00:00"
+          },
+          {
+            "etag": "A66N4W2YWHswFYaAJevwOD3bGKk",
+            "key": "key-844845286",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "wMe2GAHNWBGeiGImsphYsmWC1Sx",
+            "key": "key-850661731",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:19:22\u002B00:00"
+          },
+          {
+            "etag": "hJGep8R6IQISAYoQ9QAhPjqFoP6",
+            "key": "key-856544848",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:12:29\u002B00:00"
+          },
+          {
+            "etag": "xxK2VYXZ9lluVoV0RYZ5Nt7deCf",
+            "key": "key-888672085",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
             "etag": "Bl3dmm3GEsNjrsYiDfbVUiC0bI5",
             "key": "key-8ceee39b359e4ce3a2e1c33ff46c86dc",
             "label": "0",
@@ -345,6 +5014,1124 @@
             "last_modified": "2019-04-10T23:14:46\u002B00:00"
           },
           {
+            "etag": "2WBS3VF35CADLzsxDcfnjBYZZ0h",
+            "key": "key-901817556",
+            "label": "0",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:14\u002B00:00"
+          },
+          {
+            "etag": "3tNuz7SI8ioS6mZFTB2mDmQQJOy",
+            "key": "key-901817556",
+            "label": "1",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:14\u002B00:00"
+          },
+          {
+            "etag": "u5mmznxUMa2zdt25UFcjBc0ZczC",
+            "key": "key-901817556",
+            "label": "10",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "2aYqPmnuvaV9amxrQDHxyXXC62s",
+            "key": "key-901817556",
+            "label": "100",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:21\u002B00:00"
+          },
+          {
+            "etag": "SECJLpWFJw93ElK778JYM3mMc1N",
+            "key": "key-901817556",
+            "label": "101",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:21\u002B00:00"
+          },
+          {
+            "etag": "mwtGMSJCjBi6b6KZk8XoxyHjfiJ",
+            "key": "key-901817556",
+            "label": "102",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:21\u002B00:00"
+          },
+          {
+            "etag": "JSpR4GvVmwXtxJnyuthYCUufZXg",
+            "key": "key-901817556",
+            "label": "103",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:21\u002B00:00"
+          },
+          {
+            "etag": "LSrDVA9Lul1RlXcivXBdIMZFd5l",
+            "key": "key-901817556",
+            "label": "104",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:21\u002B00:00"
+          },
+          {
+            "etag": "ucfMHifAFICNSZ165LRl6Meh8yo",
+            "key": "key-901817556",
+            "label": "11",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "qd2FhW3K3rRfIsunkC5sgQeQcUm",
+            "key": "key-901817556",
+            "label": "12",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "JASL1J0dGtqNCiJKylSFk4AsuhD",
+            "key": "key-901817556",
+            "label": "13",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "xVr780IAagd9eqnp4tqmCo7OwSx",
+            "key": "key-901817556",
+            "label": "14",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "o23F98Cg11tLi5OycyVuwmSfPWa",
+            "key": "key-901817556",
+            "label": "15",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "sAXoXttLD5MCpZPddQtplCO2HnT",
+            "key": "key-901817556",
+            "label": "16",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "SERj0FZt4INh75B3TIEI8GZb9Hj",
+            "key": "key-901817556",
+            "label": "17",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "EloVEUV4ZB9ysSrjOz0trTARbqs",
+            "key": "key-901817556",
+            "label": "18",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "O2hiRa482uheYQgs3f91uhwS71D",
+            "key": "key-901817556",
+            "label": "19",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "4zC4uZpPgEIWpZbKv6AMp1ArczG",
+            "key": "key-901817556",
+            "label": "2",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:14\u002B00:00"
+          },
+          {
+            "etag": "g90oHlF7rflbniYGXAmLdxjzRHF",
+            "key": "key-901817556",
+            "label": "20",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "CX7Clh5Vrm8dGboxN2kwQJEVtDZ",
+            "key": "key-901817556",
+            "label": "21",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "RkSGehz10DoDocXndEaohUOB4dh",
+            "key": "key-901817556",
+            "label": "22",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "fjN56XZ0mxIf7WeTWse9qlofLzb",
+            "key": "key-901817556",
+            "label": "23",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "7oWMBvkf2ZSHWNjTKgm7BOqXKnQ",
+            "key": "key-901817556",
+            "label": "24",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "1zY4V9r9yXE6r56blLKz19jqeTi",
+            "key": "key-901817556",
+            "label": "25",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "jftXKZT302GVfX9W5PnowTUYma4",
+            "key": "key-901817556",
+            "label": "26",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "3Tw2NNYAFM48NXGdNGQ7FUlguVu",
+            "key": "key-901817556",
+            "label": "27",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "hqbf1UX5MvS1KbyqqHf5ZEGrUWj",
+            "key": "key-901817556",
+            "label": "28",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "ijmbuiT9qzpUEicFIwM788phkZX",
+            "key": "key-901817556",
+            "label": "29",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "3nW8zP2xVmwPrmYuRuJOFD9GWNs",
+            "key": "key-901817556",
+            "label": "3",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:14\u002B00:00"
+          },
+          {
+            "etag": "wXQp0Gn2PXO4BKkU4qemYnwZZZS",
+            "key": "key-901817556",
+            "label": "30",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "NYXGOyot9U57WvRKr6vk86OnebB",
+            "key": "key-901817556",
+            "label": "31",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "D83rlgxZopHG2FxLXvYbP62tdw9",
+            "key": "key-901817556",
+            "label": "32",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "7MJNVYgPTGDTcPkAbqjOwrmEL3m",
+            "key": "key-901817556",
+            "label": "33",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "wmYVA9eb5oFKwHPFhYgtQVUpm0P",
+            "key": "key-901817556",
+            "label": "34",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "2exUYpDJMh49U3Aqw3GMtwsoHQV",
+            "key": "key-901817556",
+            "label": "35",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "xrlwDI0fovR7A30TzcsL40jHdPx",
+            "key": "key-901817556",
+            "label": "36",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "GEstr0aQtlFSWvlVtMWwFsCMUI2",
+            "key": "key-901817556",
+            "label": "37",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "5hNgpd7k92xBotXCb41wi9bcfCr",
+            "key": "key-901817556",
+            "label": "38",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "moVhOIHsz8rRuYLZf3iWQf4q52Z",
+            "key": "key-901817556",
+            "label": "39",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "UAF1dNrpbcPvHm2f0iDuQcbUwZX",
+            "key": "key-901817556",
+            "label": "4",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:14\u002B00:00"
+          },
+          {
+            "etag": "V0GrdYyd6FThlzlibnQ3mThv3CY",
+            "key": "key-901817556",
+            "label": "40",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "ma1sAj6CuI4hrFIeqtrz93ybImT",
+            "key": "key-901817556",
+            "label": "41",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "exAF2PKxRpK3579yvzqU0q4HSfD",
+            "key": "key-901817556",
+            "label": "42",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          },
+          {
+            "etag": "XrEkn5JjN4gyiJ6QAHEUUq12HQN",
+            "key": "key-901817556",
+            "label": "43",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          },
+          {
+            "etag": "fPmQdiliv67acRCZET5QDAHylfc",
+            "key": "key-901817556",
+            "label": "44",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          },
+          {
+            "etag": "RjmpAq8ykZSZgUnWFg3ZHpiKmhw",
+            "key": "key-901817556",
+            "label": "45",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          },
+          {
+            "etag": "IzLVqCoZd8lkfr0DGXMdzhTmmxy",
+            "key": "key-901817556",
+            "label": "46",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          },
+          {
+            "etag": "24DU8Wr76RjBm3nsewb6z1aJPNm",
+            "key": "key-901817556",
+            "label": "47",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          },
+          {
+            "etag": "5y9mGh534d1i0GQWE6EI0OodgCK",
+            "key": "key-901817556",
+            "label": "48",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          },
+          {
+            "etag": "lGhw2zXMFjyztL8jSnrtqBBE0o4",
+            "key": "key-901817556",
+            "label": "49",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          },
+          {
+            "etag": "BCeo162iiFYs5FScOS4gCVomwd6",
+            "key": "key-901817556",
+            "label": "5",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:14\u002B00:00"
+          },
+          {
+            "etag": "eCbW6iHVyNRGReOtMGjzz0R6ykO",
+            "key": "key-901817556",
+            "label": "50",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          },
+          {
+            "etag": "7Uvp6Pp2RZRUYIS1Lcjk1z8YPuk",
+            "key": "key-901817556",
+            "label": "51",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          },
+          {
+            "etag": "gsTySrNMFJUn7NPN7Y8h2T641R5",
+            "key": "key-901817556",
+            "label": "52",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          },
+          {
+            "etag": "DoS2qa79UKn2PVdeXi427wJZeLj",
+            "key": "key-901817556",
+            "label": "53",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          }
+        ],
+        "@nextLink": "/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LTkwMTgxNzU1Ngo1Mw%3D%3D"
+      }
+    },
+    {
+      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=%2A\u0026label=%2A\u0026after=a2V5LTkwMTgxNzU1Ngo1Mw%3D%3D\u0026api-version=1.0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/vnd.microsoft.appconfig.kv\u002Bjson",
+        "Authorization": "Sanitized",
+        "Date": "Mon, 14 Oct 2019 21:27:15 GMT",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTExMDA=",
+        "User-Agent": [
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
+        ],
+        "x-ms-client-request-id": "76157b2b5f111d4a189e4bc92796c684",
+        "x-ms-content-sha256": "47DEQpj8HBSa\u002B/TImW\u002B5JCeuQeRkm5NMpJWZG3hSuFU=",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Access-Control-Allow-Methods": "GET, PUT, POST, DELETE, PATCH, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Connection": "keep-alive",
+        "Content-Type": "application/vnd.microsoft.appconfig.kvset\u002Bjson; charset=utf-8",
+        "Date": "Mon, 14 Oct 2019 21:27:15 GMT",
+        "Link": "\u003C/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LWNmNGFjNjc2NDBmYzQ2ZjJiNjgyNTgzYzIxN2IyOGRhCjM3\u003E; rel=\u0022next\u0022",
+        "Server": "openresty/1.15.8.1",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTExMDA=;sn=651100",
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "76157b2b5f111d4a189e4bc92796c684",
+        "x-ms-correlation-request-id": "d169ae2f-0154-4e80-9806-3cea3755c384",
+        "x-ms-request-id": "d169ae2f-0154-4e80-9806-3cea3755c384"
+      },
+      "ResponseBody": {
+        "items": [
+          {
+            "etag": "kEx1La6qBMF3zT3QdivgN6FRffc",
+            "key": "key-901817556",
+            "label": "54",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          },
+          {
+            "etag": "hBabux2cYtEg4IfmxN98yGHMQnt",
+            "key": "key-901817556",
+            "label": "55",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "N6pJU8JpgqDvwWqsFeGzW8oUAYa",
+            "key": "key-901817556",
+            "label": "56",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "AYdc78T0ksPxwY8Hf0DvC1yBrGP",
+            "key": "key-901817556",
+            "label": "57",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "EuK1rnNADGLa9uYzz7I2A9jsfrs",
+            "key": "key-901817556",
+            "label": "58",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "KZz2r2IZ7zQTLcN9sDuf44fR6E8",
+            "key": "key-901817556",
+            "label": "59",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "SjKju83rMV65Moylr0vWJUhNHYM",
+            "key": "key-901817556",
+            "label": "6",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:14\u002B00:00"
+          },
+          {
+            "etag": "smF3RvvL5qmLw440H1Iu2ktf8DB",
+            "key": "key-901817556",
+            "label": "60",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "V4yJmeUuqlJ7HukwtJ8q2QK73qW",
+            "key": "key-901817556",
+            "label": "61",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "aBq8SOUjNlNArquWqhaqz1PCIp6",
+            "key": "key-901817556",
+            "label": "62",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "6MTgxZGQ6oB7BE2R2JxEzpUyBUx",
+            "key": "key-901817556",
+            "label": "63",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "NHnKOZGX9XLyfqNj1ldp9QifkK0",
+            "key": "key-901817556",
+            "label": "64",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "EPxvd3BZzmPBBqYnuWvLLbxakYA",
+            "key": "key-901817556",
+            "label": "65",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "2Jds23wbIhoKxZP7ZmIsXZRHS5J",
+            "key": "key-901817556",
+            "label": "66",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "OMV4443b5ponIT1uIySYijySGYO",
+            "key": "key-901817556",
+            "label": "67",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "Or5wb73uK4v64h33k88LycR1mPR",
+            "key": "key-901817556",
+            "label": "68",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "qz4lc0GVowlThXViNJpRsialMqs",
+            "key": "key-901817556",
+            "label": "69",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "GiJT0gcD0spH0jDf7pMLiH6wdpp",
+            "key": "key-901817556",
+            "label": "7",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:14\u002B00:00"
+          },
+          {
+            "etag": "EOIKESN3P2mEKMrHBRQvlClofLW",
+            "key": "key-901817556",
+            "label": "70",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "haGvqOTzokYXsmlNWcGJJFORZnt",
+            "key": "key-901817556",
+            "label": "71",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "L9HfTs9HXmAQC7BCkkLG0JL5IWO",
+            "key": "key-901817556",
+            "label": "72",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "lw6owjc38BbJAuQdMdB6I9vV62Z",
+            "key": "key-901817556",
+            "label": "73",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "lX2nr2wcH9lZTfHlMzAuwJXz2NL",
+            "key": "key-901817556",
+            "label": "74",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "az93AsEMa8qxlNRva3Cwp4x4iEs",
+            "key": "key-901817556",
+            "label": "75",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "OhBf574X7lUXDI760GQzntCFx0O",
+            "key": "key-901817556",
+            "label": "76",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "uCrjjOBoEaLA6l4SFG1GHyglQNZ",
+            "key": "key-901817556",
+            "label": "77",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "Sxo178BVIG4vEcz1iz2l036EvJ3",
+            "key": "key-901817556",
+            "label": "78",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "EJ0hhS1Z3iI8sPs4GEr3ib690m5",
+            "key": "key-901817556",
+            "label": "79",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "6UHEWp9F1SeMCYGTe544NfP8FpM",
+            "key": "key-901817556",
+            "label": "8",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:14\u002B00:00"
+          },
+          {
+            "etag": "HljCOUnAztk7XdMEhkFLmd9mQWB",
+            "key": "key-901817556",
+            "label": "80",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "c3h37yYzivYvW9yHtyDnbIpuoPk",
+            "key": "key-901817556",
+            "label": "81",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "0d8V5UOD3Pt1KfUtNSLE2lPdx4N",
+            "key": "key-901817556",
+            "label": "82",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "i1T3w2up6ALM7kG50jkWa4ukikn",
+            "key": "key-901817556",
+            "label": "83",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "qCcSjim0jbEJT36WAa5W46C9fBK",
+            "key": "key-901817556",
+            "label": "84",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "QuVl7Zhz4dgLc4SzLgGysRr5W7Q",
+            "key": "key-901817556",
+            "label": "85",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "YTiLTZ8clmQgCeEoPWFhYaNkvqP",
+            "key": "key-901817556",
+            "label": "86",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "AxMZeLdbGCxzk7LslKerYzjqfNc",
+            "key": "key-901817556",
+            "label": "87",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "EvwZPwhrmztB2du6EHpqYR7eDjb",
+            "key": "key-901817556",
+            "label": "88",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "Vwwo9VetM4wwiMXElElgvp5I0nX",
+            "key": "key-901817556",
+            "label": "89",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "T3rYgLNyPBQ4njDdZjoLHO9x158",
+            "key": "key-901817556",
+            "label": "9",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:14\u002B00:00"
+          },
+          {
+            "etag": "TqYeMaGB0lnij4ZCfhHSo3GNakv",
+            "key": "key-901817556",
+            "label": "90",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "lPWqzcGN4aVps8BEG7NSWDffDOq",
+            "key": "key-901817556",
+            "label": "91",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "rkOIHii3MFSNzKWdjB0xYUdteRu",
+            "key": "key-901817556",
+            "label": "92",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "zGCIDBV23iV94iDm6a1pfCnTwAx",
+            "key": "key-901817556",
+            "label": "93",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "BiXlR2dlQNZO7ppMhWIfaLWggtQ",
+            "key": "key-901817556",
+            "label": "94",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "h1xZKmnYBRsHckWJdWHVgcl3cpV",
+            "key": "key-901817556",
+            "label": "95",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "84kIDFXhZhFMua2sg1H7ndCO1CL",
+            "key": "key-901817556",
+            "label": "96",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "o5oFLJPc4MCyAlcleYXZsuKYRhE",
+            "key": "key-901817556",
+            "label": "97",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "IQvpH9A7R4YRX1vX3XudhD2AjxG",
+            "key": "key-901817556",
+            "label": "98",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:21\u002B00:00"
+          },
+          {
+            "etag": "HA8Ji7FPmMSIHWNNN9dlKYmmR3G",
+            "key": "key-901817556",
+            "label": "99",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:21\u002B00:00"
+          },
+          {
+            "etag": "swa9FtVZaFSMT2Smpp2uEEOVfc0",
+            "key": "key-906145651",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:15:11\u002B00:00"
+          },
+          {
+            "etag": "ZyRlG0DRH9wpcvCiJSD43HtGP2d",
+            "key": "key-909199832",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:05:26\u002B00:00"
+          },
+          {
             "etag": "8CyYkv9oFg0BAPHmThI4s60qrQY",
             "key": "key-924dfd3642cd49529ec6420627ccfbf3",
             "label": null,
@@ -353,6 +6140,19 @@
             "tags": {},
             "locked": false,
             "last_modified": "2019-04-10T23:18:13\u002B00:00"
+          },
+          {
+            "etag": "hFZ3qz7iVPHs5NFAkeirApwO2zH",
+            "key": "key-928916906",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
           },
           {
             "etag": "m8QLwhqsr8XTjnxCNNumh8AP1M7",
@@ -366,6 +6166,58 @@
             },
             "locked": false,
             "last_modified": "2019-04-10T23:18:12\u002B00:00"
+          },
+          {
+            "etag": "FI4NS8fjFxewlzANoG7VHFp16up",
+            "key": "key-964002372",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:31\u002B00:00"
+          },
+          {
+            "etag": "F5iaae3gfe6Ant9sWkKCPW1QnOu",
+            "key": "key-971667487",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value2",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:06\u002B00:00"
+          },
+          {
+            "etag": "ScRzoMvgTVRpQji2YvKKSg28ikS",
+            "key": "key-98057351",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:50\u002B00:00"
+          },
+          {
+            "etag": "2IAoU9zDlEkqezrn955i8jYmNlt",
+            "key": "key-989748038",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
           },
           {
             "etag": "Hkd41xJvSuXdYustHzporIKJ0wS",
@@ -788,7 +6640,48 @@
             "tags": {},
             "locked": false,
             "last_modified": "2019-04-08T20:02:34\u002B00:00"
-          },
+          }
+        ],
+        "@nextLink": "/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LWNmNGFjNjc2NDBmYzQ2ZjJiNjgyNTgzYzIxN2IyOGRhCjM3"
+      }
+    },
+    {
+      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=%2A\u0026label=%2A\u0026after=a2V5LWNmNGFjNjc2NDBmYzQ2ZjJiNjgyNTgzYzIxN2IyOGRhCjM3\u0026api-version=1.0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/vnd.microsoft.appconfig.kv\u002Bjson",
+        "Authorization": "Sanitized",
+        "Date": "Mon, 14 Oct 2019 21:27:15 GMT",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTExMDA=",
+        "User-Agent": [
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
+        ],
+        "x-ms-client-request-id": "acf6547181b7bb255ef65c44b2e1661e",
+        "x-ms-content-sha256": "47DEQpj8HBSa\u002B/TImW\u002B5JCeuQeRkm5NMpJWZG3hSuFU=",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Access-Control-Allow-Methods": "GET, PUT, POST, DELETE, PATCH, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Connection": "keep-alive",
+        "Content-Type": "application/vnd.microsoft.appconfig.kvset\u002Bjson; charset=utf-8",
+        "Date": "Mon, 14 Oct 2019 21:27:15 GMT",
+        "Server": "openresty/1.15.8.1",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTExMDA=;sn=651100",
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "acf6547181b7bb255ef65c44b2e1661e",
+        "x-ms-correlation-request-id": "59765be1-2b5b-497b-a0e1-cb7d1e58c0b3",
+        "x-ms-request-id": "59765be1-2b5b-497b-a0e1-cb7d1e58c0b3"
+      },
+      "ResponseBody": {
+        "items": [
           {
             "etag": "Bf18rhKxGsiWqm2crApgCVNvIuU",
             "key": "key-cf4ac67640fc46f2b682583c217b28da",
@@ -1148,48 +7041,7 @@
             "tags": {},
             "locked": false,
             "last_modified": "2019-04-08T20:02:33\u002B00:00"
-          }
-        ],
-        "@nextLink": "/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LWNmNGFjNjc2NDBmYzQ2ZjJiNjgyNTgzYzIxN2IyOGRhCjc%3D"
-      }
-    },
-    {
-      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=*\u0026label=*\u0026after=a2V5LWNmNGFjNjc2NDBmYzQ2ZjJiNjgyNTgzYzIxN2IyOGRhCjc%3D\u0026api-version=1.0",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/vnd.microsoft.appconfig.kv\u002Bjson",
-        "Authorization": "Sanitized",
-        "Date": "Wed, 18 Sep 2019 21:33:01 GMT",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg2NTI=",
-        "User-Agent": [
-          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20190918.1\u002B0c319f5fd30ac3e2e5bc2936122815be22444424",
-          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
-        ],
-        "x-ms-client-request-id": "cabfcfb72e56965cfa8b42903e0e01d3",
-        "x-ms-content-sha256": "47DEQpj8HBSa\u002B/TImW\u002B5JCeuQeRkm5NMpJWZG3hSuFU=",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Access-Control-Allow-Credentials": "true",
-        "Access-Control-Allow-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
-        "Access-Control-Allow-Methods": "GET, PUT, POST, DELETE, PATCH, OPTIONS",
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
-        "Connection": "keep-alive",
-        "Content-Type": "application/vnd.microsoft.appconfig.kvset\u002Bjson; charset=utf-8",
-        "Date": "Wed, 18 Sep 2019 21:33:01 GMT",
-        "Server": "nginx/1.13.12",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg2NTI=;sn=538652",
-        "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "cabfcfb72e56965cfa8b42903e0e01d3",
-        "x-ms-correlation-request-id": "8f970789-a6fe-45e7-a421-2c2230da6fce",
-        "x-ms-request-id": "8f970789-a6fe-45e7-a421-2c2230da6fce"
-      },
-      "ResponseBody": {
-        "items": [
+          },
           {
             "etag": "Q2Z5NQszD58WLtEsnI22eJuJADg",
             "key": "key-cf4ac67640fc46f2b682583c217b28da",
@@ -1557,6 +7409,76 @@
             "last_modified": "2019-04-10T23:18:12\u002B00:00"
           },
           {
+            "etag": "sJhXRMt0oFPmiRExBrT1OkoQao4",
+            "key": "keyFields-1371382479",
+            "label": "my_label",
+            "content_type": null,
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          },
+          {
+            "etag": "PpTompYZlgc2s52cMRfcVZK0ock",
+            "key": "keyFields-1540288930",
+            "label": "my_label",
+            "content_type": null,
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "VS47CSVQtEsSHC1HeSiJU9cyfL7",
+            "key": "keyFields-1640774616",
+            "label": "my_label",
+            "content_type": "content-type",
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "Z773tvtnqrQQcaYLNI8bzdZvV0n",
+            "key": "keyFields-1659776538",
+            "label": "my_label",
+            "content_type": "content-type",
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:11\u002B00:00"
+          },
+          {
+            "etag": "qErvzTBxCZXyAzR1l6D1GTSeesz",
+            "key": "keyFields-1877364315",
+            "label": "my_label",
+            "content_type": null,
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "1cclG3RoPU4Bk2sIwgauKRqH5d9",
+            "key": "keyFields-2097297878",
+            "label": "my_label",
+            "content_type": "content-type",
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          },
+          {
+            "etag": "9CeW4shpXV3sXcwndojGKwqlclH",
+            "key": "keyFields-318044282",
+            "label": "my_label",
+            "content_type": null,
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
             "etag": "xRncVWEnGCOgj3BcgbND0N4zq9M",
             "key": "keyFields-4090cd05582f4af7b4c0992cbfcff1cd",
             "label": "my_label",
@@ -1585,6 +7507,26 @@
             "tags": {},
             "locked": false,
             "last_modified": "2019-04-10T23:26:24\u002B00:00"
+          },
+          {
+            "etag": "KghQZTfl8QJTskbJULTUkbqz0el",
+            "key": "keyFields-866062596",
+            "label": "my_label",
+            "content_type": "content-type",
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "6AugBtdAacltSCC5Sj6RZVjqZa0",
+            "key": "some_key",
+            "label": null,
+            "content_type": null,
+            "value": "new_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-11T21:03:44\u002B00:00"
           }
         ]
       }
@@ -1594,14 +7536,14 @@
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "Date": "Wed, 18 Sep 2019 21:33:01 GMT",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg2NTI=",
-        "traceparent": "00-f1685cb7482ec041a4c45304185edc11-4c8e55d034a08049-00",
+        "Date": "Mon, 14 Oct 2019 21:27:15 GMT",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTExMDA=",
+        "traceparent": "00-e145618d09cd69498d854412c9572258-c9b8721a73e20a44-00",
         "User-Agent": [
-          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20190918.1\u002B0c319f5fd30ac3e2e5bc2936122815be22444424",
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
           "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
         ],
-        "x-ms-client-request-id": "0dfd6e30b1887b896ae235b9dc9960c7",
+        "x-ms-client-request-id": "39c62904f9cf63cfe4c5c503739fdeaf",
         "x-ms-content-sha256": "47DEQpj8HBSa\u002B/TImW\u002B5JCeuQeRkm5NMpJWZG3hSuFU=",
         "x-ms-return-client-request-id": "true"
       },
@@ -1615,19 +7557,19 @@
         "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
         "Connection": "keep-alive",
         "Content-Type": "application/vnd.microsoft.appconfig.kv\u002Bjson; charset=utf-8",
-        "Date": "Wed, 18 Sep 2019 21:33:01 GMT",
-        "ETag": "\u00226I91HJKVVxLd2Auz8FF1rNwbndV\u0022",
-        "Last-Modified": "Wed, 18 Sep 2019 21:33:01 GMT",
-        "Server": "nginx/1.13.12",
+        "Date": "Mon, 14 Oct 2019 21:27:15 GMT",
+        "ETag": "\u0022VmKDNHfAPxXbOqguV5YKNR28p4L\u0022",
+        "Last-Modified": "Mon, 14 Oct 2019 21:27:15 GMT",
+        "Server": "openresty/1.15.8.1",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg2NTM=;sn=538653",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTExMDE=;sn=651101",
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "0dfd6e30b1887b896ae235b9dc9960c7",
-        "x-ms-correlation-request-id": "0ed72ed6-4c11-465b-9a58-2e9aeae4f575",
-        "x-ms-request-id": "0ed72ed6-4c11-465b-9a58-2e9aeae4f575"
+        "x-ms-client-request-id": "39c62904f9cf63cfe4c5c503739fdeaf",
+        "x-ms-correlation-request-id": "0a1e2f5e-27e1-4f45-a13c-4c5e3f3a5040",
+        "x-ms-request-id": "0a1e2f5e-27e1-4f45-a13c-4c5e3f3a5040"
       },
       "ResponseBody": {
-        "etag": "6I91HJKVVxLd2Auz8FF1rNwbndV",
+        "etag": "VmKDNHfAPxXbOqguV5YKNR28p4L",
         "key": "key-221701127",
         "label": "test_label",
         "content_type": "test_content_type",
@@ -1637,7 +7579,7 @@
           "tag2": "value2"
         },
         "locked": false,
-        "last_modified": "2019-09-18T21:33:01\u002B00:00"
+        "last_modified": "2019-10-14T21:27:15\u002B00:00"
       }
     }
   ],

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/SessionRecords/ConfigurationLiveTests/GetBatchSettingAnyAsync.json
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/SessionRecords/ConfigurationLiveTests/GetBatchSettingAnyAsync.json
@@ -8,10 +8,10 @@
         "Authorization": "Sanitized",
         "Content-Length": "98",
         "Content-Type": "application/json",
-        "Date": "Wed, 18 Sep 2019 21:33:03 GMT",
-        "traceparent": "00-f3b2ccab5304d64180f7c306adb684e9-3fe5578d7c974746-00",
+        "Date": "Mon, 14 Oct 2019 21:27:08 GMT",
+        "traceparent": "00-9f59d972fad59e4fbe22524ef40094c8-5c7fdb7a635cce47-00",
         "User-Agent": [
-          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20190918.1\u002B0c319f5fd30ac3e2e5bc2936122815be22444424",
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
           "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
         ],
         "x-ms-client-request-id": "a8bc895155b673e868ac6b42d0faa7a1",
@@ -35,19 +35,19 @@
         "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
         "Connection": "keep-alive",
         "Content-Type": "application/vnd.microsoft.appconfig.kv\u002Bjson; charset=utf-8",
-        "Date": "Wed, 18 Sep 2019 21:33:03 GMT",
-        "ETag": "\u0022f0Y8fclWXSyMikdBTEd7JW7AJzM\u0022",
-        "Last-Modified": "Wed, 18 Sep 2019 21:33:04 GMT",
-        "Server": "nginx/1.13.12",
+        "Date": "Mon, 14 Oct 2019 21:27:08 GMT",
+        "ETag": "\u0022V05MJKSeZIfH79ayQILiflCQ1tB\u0022",
+        "Last-Modified": "Mon, 14 Oct 2019 21:27:08 GMT",
+        "Server": "openresty/1.15.8.1",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg3MDc=;sn=538707",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTg=;sn=651098",
         "Transfer-Encoding": "chunked",
         "x-ms-client-request-id": "a8bc895155b673e868ac6b42d0faa7a1",
-        "x-ms-correlation-request-id": "8ebf6740-5dd1-43b4-a629-95e64a524ff9",
-        "x-ms-request-id": "8ebf6740-5dd1-43b4-a629-95e64a524ff9"
+        "x-ms-correlation-request-id": "2fb096bd-fb99-46d8-b3c5-fb0d17650361",
+        "x-ms-request-id": "2fb096bd-fb99-46d8-b3c5-fb0d17650361"
       },
       "ResponseBody": {
-        "etag": "f0Y8fclWXSyMikdBTEd7JW7AJzM",
+        "etag": "V05MJKSeZIfH79ayQILiflCQ1tB",
         "key": "key-1301486225",
         "label": "test_label",
         "content_type": "test_content_type",
@@ -57,19 +57,19 @@
           "tag2": "value2"
         },
         "locked": false,
-        "last_modified": "2019-09-18T21:33:04\u002B00:00"
+        "last_modified": "2019-10-14T21:27:08\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=*\u0026label=*\u0026api-version=1.0",
+      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=%2A\u0026label=%2A\u0026api-version=1.0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/vnd.microsoft.appconfig.kv\u002Bjson",
         "Authorization": "Sanitized",
-        "Date": "Wed, 18 Sep 2019 21:33:03 GMT",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg3MDc=",
+        "Date": "Mon, 14 Oct 2019 21:27:08 GMT",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTg=",
         "User-Agent": [
-          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20190918.1\u002B0c319f5fd30ac3e2e5bc2936122815be22444424",
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
           "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
         ],
         "x-ms-client-request-id": "581c71080662e735257b3a4653a67d1a",
@@ -86,70 +86,350 @@
         "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
         "Connection": "keep-alive",
         "Content-Type": "application/vnd.microsoft.appconfig.kvset\u002Bjson; charset=utf-8",
-        "Date": "Wed, 18 Sep 2019 21:33:04 GMT",
-        "Link": "\u003C/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LWNmNGFjNjc2NDBmYzQ2ZjJiNjgyNTgzYzIxN2IyOGRhCjc%3D\u003E; rel=\u0022next\u0022",
-        "Server": "nginx/1.13.12",
+        "Date": "Mon, 14 Oct 2019 21:27:08 GMT",
+        "Link": "\u003C/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LTE1MDIzMTI1NzAKNTU%3D\u003E; rel=\u0022next\u0022",
+        "Server": "openresty/1.15.8.1",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg3MDc=;sn=538707",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTg=;sn=651098",
         "Transfer-Encoding": "chunked",
         "x-ms-client-request-id": "581c71080662e735257b3a4653a67d1a",
-        "x-ms-correlation-request-id": "374c77c7-fe61-4479-b9ce-8464d6a21f11",
-        "x-ms-request-id": "374c77c7-fe61-4479-b9ce-8464d6a21f11"
+        "x-ms-correlation-request-id": "cbaf9385-e912-4d5a-99a7-6cf64221206b",
+        "x-ms-request-id": "cbaf9385-e912-4d5a-99a7-6cf64221206b"
       },
       "ResponseBody": {
         "items": [
           {
-            "etag": "BSsldiGjNhbX2MznqtuFHcpjkxM",
-            "key": "3b2ddb83-0205-4f11-bd21-660590fbb2f8_0",
-            "label": null,
-            "content_type": "",
-            "value": "0",
-            "tags": {},
-            "locked": false,
-            "last_modified": "2019-04-10T23:14:47\u002B00:00"
-          },
-          {
-            "etag": "7db9w9wCukFEW2sgvZHDkRopoTs",
-            "key": "845b68e0-9617-422a-9db7-e911aed727c6_0",
-            "label": null,
-            "content_type": "",
-            "value": "0",
-            "tags": {},
-            "locked": false,
-            "last_modified": "2019-04-10T23:18:13\u002B00:00"
-          },
-          {
-            "etag": "Swe3KG4Ei41uLWRtchrlYy54PcI",
-            "key": "9805488e-2c43-4317-8bd9-400bef28395a_0",
-            "label": null,
-            "content_type": "",
-            "value": "0",
-            "tags": {},
-            "locked": false,
-            "last_modified": "2019-04-10T23:26:25\u002B00:00"
-          },
-          {
-            "etag": "Al3nrQNM6vuDgq7vYDmjRtW703g",
+            "etag": "do8WQIHwlv4Jz5f1ogkp0zHs2Tc",
             "key": "BatchKey",
             "label": null,
-            "content_type": "",
-            "value": "key-cf4ac67640fc46f2b682583c217b28da",
+            "content_type": null,
+            "value": "key-901817556",
             "tags": {},
             "locked": false,
-            "last_modified": "2019-04-08T20:02:37\u002B00:00"
+            "last_modified": "2019-10-02T21:47:21\u002B00:00"
           },
           {
-            "etag": "s0zd1djtEPdZPdDG2PlUp1i8MZ4",
-            "key": "Sample_key",
+            "etag": "RMiNzaM9pJmxBr28I9WvYkjjLhW",
+            "key": "key-1125484443",
+            "label": "83",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:10\u002B00:00"
+          },
+          {
+            "etag": "LWyiFBJ6EJ4NTGVWKdd2qt8JUFI",
+            "key": "key-1125484443",
+            "label": "84",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:10\u002B00:00"
+          },
+          {
+            "etag": "zjrVDQHqeqR9NUuHaHOMOfEdfhQ",
+            "key": "key-1125484443",
+            "label": "85",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:10\u002B00:00"
+          },
+          {
+            "etag": "0QkdkOVBSVZ3bUrFfwzq7jjWU0D",
+            "key": "key-1125484443",
+            "label": "86",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:10\u002B00:00"
+          },
+          {
+            "etag": "6G7npyYJqJyGRiZtRkQKRRihHdg",
+            "key": "key-1125484443",
+            "label": "87",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:10\u002B00:00"
+          },
+          {
+            "etag": "e7aS8kET6O55Ig9TYIiwL0ZH837",
+            "key": "key-1125484443",
+            "label": "88",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:10\u002B00:00"
+          },
+          {
+            "etag": "601nzWut8EicF02dlXjNLPD9hLu",
+            "key": "key-1125484443",
+            "label": "89",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:10\u002B00:00"
+          },
+          {
+            "etag": "GZFpM0qJXmdW34UpLiUEliWs1eO",
+            "key": "key-1125484443",
+            "label": "9",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:05\u002B00:00"
+          },
+          {
+            "etag": "TnZCbaiSsODRsCvUHS0aexBg2hX",
+            "key": "key-1125484443",
+            "label": "90",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:10\u002B00:00"
+          },
+          {
+            "etag": "NFd090oekM640Xtq9v1DDs1qk4J",
+            "key": "key-1125484443",
+            "label": "91",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:10\u002B00:00"
+          },
+          {
+            "etag": "vNHTgydFclueNJFFuifeRWcv1oF",
+            "key": "key-1125484443",
+            "label": "92",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:11\u002B00:00"
+          },
+          {
+            "etag": "fDjKbv9xGT9A3OwBhf41ZQYG45V",
+            "key": "key-1125484443",
+            "label": "93",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:11\u002B00:00"
+          },
+          {
+            "etag": "t0jNGG2v3l6RVROhPuUM14FPCPY",
+            "key": "key-1125484443",
+            "label": "94",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:11\u002B00:00"
+          },
+          {
+            "etag": "p47s3WJxSqRMxNSq8YoAuL6Ebw0",
+            "key": "key-1125484443",
+            "label": "95",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:11\u002B00:00"
+          },
+          {
+            "etag": "XvgBhO00pHqLfoiU2F8Lb6DWdmB",
+            "key": "key-1125484443",
+            "label": "96",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:11\u002B00:00"
+          },
+          {
+            "etag": "EbvFQy1MnyLIk2haSMBjZ5lk3Tc",
+            "key": "key-1125484443",
+            "label": "97",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:11\u002B00:00"
+          },
+          {
+            "etag": "tffOV5evjE0w21sPSyvtjyE8BAm",
+            "key": "key-1125484443",
+            "label": "98",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:11\u002B00:00"
+          },
+          {
+            "etag": "Spxyf4MPthaPetoS77Sf7F4dVvb",
+            "key": "key-1125484443",
+            "label": "99",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:11\u002B00:00"
+          },
+          {
+            "etag": "Jm0WBu5LdgnIfR3fYhi06f4wyid",
+            "key": "key-1147740173",
             "label": null,
-            "content_type": "",
-            "value": "Sample_value",
+            "content_type": null,
+            "value": "my_value",
             "tags": {},
             "locked": false,
-            "last_modified": "2019-07-12T20:36:44\u002B00:00"
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
           },
           {
-            "etag": "f0Y8fclWXSyMikdBTEd7JW7AJzM",
+            "etag": "ra7jHrNYwGCAWoymb4IQ0vCf9Dc",
+            "key": "key-1163835415",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:05:25\u002B00:00"
+          },
+          {
+            "etag": "6xrBoXzeP89iBJRpf5T0we4QNyC",
+            "key": "key-1174564512",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-20T03:01:39\u002B00:00"
+          },
+          {
+            "etag": "kCagdhqBQFNcZIJ5TxAb3jEL49w",
+            "key": "key-1177019792",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          },
+          {
+            "etag": "33Iki4O3nt3ZLflq5CYSSc5uZak",
+            "key": "key-1180708686",
+            "label": null,
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
+          },
+          {
+            "etag": "dHSZTRqmOXNJyLJF5pufiU6dquK",
+            "key": "key-1200977498",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:05\u002B00:00"
+          },
+          {
+            "etag": "9TzQS7loYjGo2dBa7gI8avECM9s",
+            "key": "key-1231954601",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value2",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:05:25\u002B00:00"
+          },
+          {
+            "etag": "uDoIwJFA6EMimAymtZE1ZaSadeR",
+            "key": "key-1233529568",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "IhCaZZtjxhJZOT4kst86ivVrDM9",
+            "key": "key-1252062984",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "3SJLTRLYcKynZOamHZu0ojwaIyJ",
+            "key": "key-1252790990",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:55\u002B00:00"
+          },
+          {
+            "etag": "0O2xWLZV29ZqSe9JbQLXJQR3Sm5",
+            "key": "key-1277519220",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:55\u002B00:00"
+          },
+          {
+            "etag": "V05MJKSeZIfH79ayQILiflCQ1tB",
             "key": "key-1301486225",
             "label": "test_label",
             "content_type": "test_content_type",
@@ -159,7 +439,1734 @@
               "tag2": "value2"
             },
             "locked": false,
-            "last_modified": "2019-09-18T21:33:04\u002B00:00"
+            "last_modified": "2019-10-14T21:27:08\u002B00:00"
+          },
+          {
+            "etag": "hY8crHO0a8k74AawBFGHHlvjm7J",
+            "key": "key-1309283906",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:06:04\u002B00:00"
+          },
+          {
+            "etag": "YufLr1ND2auNin5dZJLuB96Gxpy",
+            "key": "key-1323592047",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:08:00\u002B00:00"
+          },
+          {
+            "etag": "SfxQW7xVa3XkOnp3SllRt84cWlR",
+            "key": "key-1353875726",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:05:26\u002B00:00"
+          },
+          {
+            "etag": "WHB977nXW2zZL8AFGNAI6FpKppK",
+            "key": "key-1364459659",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "LUbaTeaEo7iZWJqwMCEiwZ64N3K",
+            "key": "key-1369197868",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
+          },
+          {
+            "etag": "URTIJGQelXjQVWasVWsg4xe6rLb",
+            "key": "key-13811035",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:18:13\u002B00:00"
+          },
+          {
+            "etag": "JBdU4qVsF5gcgIe1n7zZ77B5eso",
+            "key": "key-1381219121",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
+          },
+          {
+            "etag": "HsSY9HTWZ6d2SkPOzAGuIph6zYt",
+            "key": "key-1420801322",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "c1ATIQnsTAodkleZ5TBN4Xnf8QD",
+            "key": "key-1427269378",
+            "label": "my_label",
+            "content_type": null,
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:54\u002B00:00"
+          },
+          {
+            "etag": "EJsF4QkrbqYXQ44Hy73xuEMwrck",
+            "key": "key-1471881907",
+            "label": null,
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:54\u002B00:00"
+          },
+          {
+            "etag": "sbSjAQthvnfDGiKWz8rQ5NCpKjb",
+            "key": "key-1484301245",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:24:27\u002B00:00"
+          },
+          {
+            "etag": "1tzcwKQvcWBBVv7p3m6uPLyyOa7",
+            "key": "key-1488498371",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
+          },
+          {
+            "etag": "0lkxAiZ6Yz3diKTSBdQcDsvjNUu",
+            "key": "key-1502312570",
+            "label": "0",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:55\u002B00:00"
+          },
+          {
+            "etag": "FnhaQK76PQon48kvtpV65ty5ZvU",
+            "key": "key-1502312570",
+            "label": "1",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:55\u002B00:00"
+          },
+          {
+            "etag": "TyYyTPpvjOBk9nsFJLu3GV9jZlm",
+            "key": "key-1502312570",
+            "label": "10",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "OkN8oJ5bPq30d4BTmrdn0TVWBVx",
+            "key": "key-1502312570",
+            "label": "100",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "tnk9fNNWb2pAD0FzY8yUV6OjeVF",
+            "key": "key-1502312570",
+            "label": "101",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "aHKNXtg0iqCx3fE8bOXEE2X3C3J",
+            "key": "key-1502312570",
+            "label": "102",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "W0xARXufoYcuMgrQ0Cdcqr5o4BG",
+            "key": "key-1502312570",
+            "label": "103",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "yrr44f51P4DUap7P2eZR3fkPSzi",
+            "key": "key-1502312570",
+            "label": "104",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "ZTWFJfYaTIDhy5eBcDws8SX9z3y",
+            "key": "key-1502312570",
+            "label": "11",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "v1uFMy2McKjxJv6E0KHGFhl3iaI",
+            "key": "key-1502312570",
+            "label": "12",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "ndBHUpAWZGibrLbZwWurMkhhX1k",
+            "key": "key-1502312570",
+            "label": "13",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "sNB8KIr1ZEiW8AfdcaHecxHs6ha",
+            "key": "key-1502312570",
+            "label": "14",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "lfcf5HqGHLLMKTKT2TSXfQUDW02",
+            "key": "key-1502312570",
+            "label": "15",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "CjnZU9pq7uEWX7M9AumeeR1JwSM",
+            "key": "key-1502312570",
+            "label": "16",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "cnhvl1eqzehNAzONiRpwywAcRKa",
+            "key": "key-1502312570",
+            "label": "17",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "o3w9OdWAUEDLtZW5fXF3AZ9hpgl",
+            "key": "key-1502312570",
+            "label": "18",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "API10UIUIf5WrtFBqQePDoNPHNh",
+            "key": "key-1502312570",
+            "label": "19",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "9g1tFosplmWMnJOwjb6ewirjQft",
+            "key": "key-1502312570",
+            "label": "2",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:55\u002B00:00"
+          },
+          {
+            "etag": "DSQ5AdRVVvroVjhWaDRY6rF0Jye",
+            "key": "key-1502312570",
+            "label": "20",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "pU6pRTDsXUR370Q5WXroYlwXBy1",
+            "key": "key-1502312570",
+            "label": "21",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "OqaLYAiu8s1VbOwNIC0ETczTrr9",
+            "key": "key-1502312570",
+            "label": "22",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "Q7dsIdIv6Zh1xPuHOAQLjYcPVPK",
+            "key": "key-1502312570",
+            "label": "23",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "21o1vqyARoMdC3968wvpks5Zu8I",
+            "key": "key-1502312570",
+            "label": "24",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "2jDyjfUyZzE1eAg6mi8JIP3X9jB",
+            "key": "key-1502312570",
+            "label": "25",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "5UveB5vM98KegYHPt48klKklRhQ",
+            "key": "key-1502312570",
+            "label": "26",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "LdzSiPVVl9kfgs7WsRCKx5Kpnu4",
+            "key": "key-1502312570",
+            "label": "27",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "xJxtpIroNl7rzDmICaoKgvokJ9l",
+            "key": "key-1502312570",
+            "label": "28",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "nHah9hzylkCoIRcHRw6seMbU8u3",
+            "key": "key-1502312570",
+            "label": "29",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "AUUmJFw6zrz8jp8m2zFBlN9YMDw",
+            "key": "key-1502312570",
+            "label": "3",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:55\u002B00:00"
+          },
+          {
+            "etag": "i89QxpE5hFbezL7cjNzJ4robuYM",
+            "key": "key-1502312570",
+            "label": "30",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "DHMj9rdHY1EcrusMdJoyqMGfKzn",
+            "key": "key-1502312570",
+            "label": "31",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "ZhZbQxbt6OeoVjJQmoq0mnfydgg",
+            "key": "key-1502312570",
+            "label": "32",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "wQ4OwaP4ln0CAveyRLGwchga39S",
+            "key": "key-1502312570",
+            "label": "33",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:57\u002B00:00"
+          },
+          {
+            "etag": "jak1Qg85Wh88JpjxyrjBRId2ChO",
+            "key": "key-1502312570",
+            "label": "34",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "fVwPDR1CD386SnUpykGTH68rmjW",
+            "key": "key-1502312570",
+            "label": "35",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "6dMCedZqM86rIifz0uXdrhB3usF",
+            "key": "key-1502312570",
+            "label": "36",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "kpc8drFjl0QbDrIQikaUltx1GBK",
+            "key": "key-1502312570",
+            "label": "37",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "jGZRs5n5sF5rdL4Z7aYiLmdVrVB",
+            "key": "key-1502312570",
+            "label": "38",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "ktEANEMgDbuwxTcps1IxdXyGkJO",
+            "key": "key-1502312570",
+            "label": "39",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "YhZZAWfMCJCgXY1vKjWt0oYdyoT",
+            "key": "key-1502312570",
+            "label": "4",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:55\u002B00:00"
+          },
+          {
+            "etag": "81OKX4d3q2oXKcD32bsYQKw7loo",
+            "key": "key-1502312570",
+            "label": "40",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "1JzfLdTDDrEO3MYiWhTSxFKvVyt",
+            "key": "key-1502312570",
+            "label": "41",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "DvUs1MWntujoZTMVLXEpdrHShZI",
+            "key": "key-1502312570",
+            "label": "42",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "CWKefrbc3soMPSuhgkbOEhtU7gV",
+            "key": "key-1502312570",
+            "label": "43",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "GrIwe22UFwGNMYJTHqYkrrnrT3d",
+            "key": "key-1502312570",
+            "label": "44",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "ibcz24qgIP63fnkAtdJmkagZpLx",
+            "key": "key-1502312570",
+            "label": "45",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "KXIHRBZoHKKkDa6FQRUYlJAhack",
+            "key": "key-1502312570",
+            "label": "46",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "QL1TiWmy50kRo0KrHxjG6mZZqJs",
+            "key": "key-1502312570",
+            "label": "47",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "KsKmga3otFUzFKmBTioD5t29b3f",
+            "key": "key-1502312570",
+            "label": "48",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:58\u002B00:00"
+          },
+          {
+            "etag": "uW2bTMYVCv6PlB7ZVfraMk5ZkUb",
+            "key": "key-1502312570",
+            "label": "49",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "SYpH5oGW41KBtv8MggQ1A29L7u1",
+            "key": "key-1502312570",
+            "label": "5",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:55\u002B00:00"
+          },
+          {
+            "etag": "qs80AiihpZ7YpRrtSgLpzbTc6NF",
+            "key": "key-1502312570",
+            "label": "50",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "hxTYUTskexVW3CIB1CcATWVBEGx",
+            "key": "key-1502312570",
+            "label": "51",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "kGCbpPkQ5mnXfl8UXJnudQiCHbZ",
+            "key": "key-1502312570",
+            "label": "52",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "C8utbLtdUnmcskgxbnzzs5O7CgZ",
+            "key": "key-1502312570",
+            "label": "53",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "es6idcm81H6IymnWHKgPO0EPb8R",
+            "key": "key-1502312570",
+            "label": "54",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "S8aJfOUed4fAfdfL62BO1uCfPpc",
+            "key": "key-1502312570",
+            "label": "55",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          }
+        ],
+        "@nextLink": "/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LTE1MDIzMTI1NzAKNTU%3D"
+      }
+    },
+    {
+      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=%2A\u0026label=%2A\u0026after=a2V5LTE1MDIzMTI1NzAKNTU%3D\u0026api-version=1.0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/vnd.microsoft.appconfig.kv\u002Bjson",
+        "Authorization": "Sanitized",
+        "Date": "Mon, 14 Oct 2019 21:27:08 GMT",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTg=",
+        "User-Agent": [
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
+        ],
+        "x-ms-client-request-id": "da388f8719a6e73abbda5f29f8abea72",
+        "x-ms-content-sha256": "47DEQpj8HBSa\u002B/TImW\u002B5JCeuQeRkm5NMpJWZG3hSuFU=",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Access-Control-Allow-Methods": "GET, PUT, POST, DELETE, PATCH, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Connection": "keep-alive",
+        "Content-Type": "application/vnd.microsoft.appconfig.kvset\u002Bjson; charset=utf-8",
+        "Date": "Mon, 14 Oct 2019 21:27:08 GMT",
+        "Link": "\u003C/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LTMxODIxMjgxOQoxNQ%3D%3D\u003E; rel=\u0022next\u0022",
+        "Server": "openresty/1.15.8.1",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTg=;sn=651098",
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "da388f8719a6e73abbda5f29f8abea72",
+        "x-ms-correlation-request-id": "945e9a68-a912-4d91-9dda-a04ef8a3a431",
+        "x-ms-request-id": "945e9a68-a912-4d91-9dda-a04ef8a3a431"
+      },
+      "ResponseBody": {
+        "items": [
+          {
+            "etag": "C49NpV7lRcs6eAGw3PJFUZWWk1t",
+            "key": "key-1502312570",
+            "label": "56",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "VPwwVnSej0zfyU4jvnZCvL2bSBy",
+            "key": "key-1502312570",
+            "label": "57",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "l8eiygGV6pbYV41OQALonyjnpiI",
+            "key": "key-1502312570",
+            "label": "58",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "Kmw5dKmgodAnQdAsqar17XLMsYT",
+            "key": "key-1502312570",
+            "label": "59",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "jlrlXOcGZHLxWM9EnCzFgzfwYL4",
+            "key": "key-1502312570",
+            "label": "6",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:55\u002B00:00"
+          },
+          {
+            "etag": "CsMScNt7U58M6L5iYuZ6FixTvFf",
+            "key": "key-1502312570",
+            "label": "60",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "a09wMCluVqcBkrbDTHPlIuhE3eU",
+            "key": "key-1502312570",
+            "label": "61",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "CaVv9rOSxNkErgHjnAiNXgJg6Kk",
+            "key": "key-1502312570",
+            "label": "62",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:59\u002B00:00"
+          },
+          {
+            "etag": "odtvIQcYU0TBfedPNBezMg5wx7s",
+            "key": "key-1502312570",
+            "label": "63",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "tPRn1s53pzHxGfBHS5Q27JESEPZ",
+            "key": "key-1502312570",
+            "label": "64",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "w08UlE1Dnlek3SDOPoYpzhjD7v7",
+            "key": "key-1502312570",
+            "label": "65",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "BEkYYvIoFJYG5vKQm9JIZCj2kJV",
+            "key": "key-1502312570",
+            "label": "66",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "vDHS4nR9tbrdyxr3GX91zLFtf6Q",
+            "key": "key-1502312570",
+            "label": "67",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "YeXVmJGStysIL2ZCItDA0ezlPWr",
+            "key": "key-1502312570",
+            "label": "68",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "iXviTbhMJ16sSudj4rLXh85zpAn",
+            "key": "key-1502312570",
+            "label": "69",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "0Utd9x4iPBitMvfvLGuWAZd2rgD",
+            "key": "key-1502312570",
+            "label": "7",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "gnB2xdM8wWh56Q8eWgzFcJCQoHe",
+            "key": "key-1502312570",
+            "label": "70",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "peBbYkuKBsvA6pNZcqxjZ0mkyMg",
+            "key": "key-1502312570",
+            "label": "71",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "Vew9QJTJAg4UZbkJfChF5t1sKkH",
+            "key": "key-1502312570",
+            "label": "72",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "koAYgDRTitzvkrjphmcHYwY6u5O",
+            "key": "key-1502312570",
+            "label": "73",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "3Ikmp3pB1bdRcJrOhfb08wxckfV",
+            "key": "key-1502312570",
+            "label": "74",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "UTgRpxQAuXcNeCypb0P0FhNqPd9",
+            "key": "key-1502312570",
+            "label": "75",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "3cIWYDgdrTGyEHUYRD50nubdgva",
+            "key": "key-1502312570",
+            "label": "76",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:00\u002B00:00"
+          },
+          {
+            "etag": "M3j30XWtCzz8WdPA7GdK9E60j8A",
+            "key": "key-1502312570",
+            "label": "77",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "RTwXyxcwxdxWgfc8kVJrMJCEq33",
+            "key": "key-1502312570",
+            "label": "78",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "W2j7Ght90NGFRQ8RYXcAIWFD2Dp",
+            "key": "key-1502312570",
+            "label": "79",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "gQc7RJEFfoEMLf5uArVNNIaZiMq",
+            "key": "key-1502312570",
+            "label": "8",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "3vKNMenb0KPmseeTEoyDTWx1ZA7",
+            "key": "key-1502312570",
+            "label": "80",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "1KUZcfXGBhc3CSBILtNAXhqXAAT",
+            "key": "key-1502312570",
+            "label": "81",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "DqbKvgLphebxSoyMYd9Jki4V3yE",
+            "key": "key-1502312570",
+            "label": "82",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "6bYeVIfeXmR3qhxGFlE1JsVs2Pp",
+            "key": "key-1502312570",
+            "label": "83",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "G6LDz50xy5TzY88a0orBokuQYLd",
+            "key": "key-1502312570",
+            "label": "84",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "J77Cvl3jRUQUDLw2zzEMzQzMGiB",
+            "key": "key-1502312570",
+            "label": "85",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "5RREWDI0W93Nhz8GvdOguE2i3zf",
+            "key": "key-1502312570",
+            "label": "86",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "AT7nt9VXVIrxxPfZImF8PPDuYFs",
+            "key": "key-1502312570",
+            "label": "87",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "Y8qAK91mm7kFvr8Q00Ey5hRzeMB",
+            "key": "key-1502312570",
+            "label": "88",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "raJiehdtk2E23YHQ8ButJWWRQgJ",
+            "key": "key-1502312570",
+            "label": "89",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:01\u002B00:00"
+          },
+          {
+            "etag": "SO263dlpitGB3uK1g5Eh8pJrFMM",
+            "key": "key-1502312570",
+            "label": "9",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:56\u002B00:00"
+          },
+          {
+            "etag": "lMl5d3KDqoJVZledLz43xLQzwAu",
+            "key": "key-1502312570",
+            "label": "90",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "vNJ71QWaJj9qTK58Xc0TYwyaXOj",
+            "key": "key-1502312570",
+            "label": "91",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "kLthotmOJwBsDcTv8wgkoukppOW",
+            "key": "key-1502312570",
+            "label": "92",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "gprF8PHVYtJASrPUFHKVEBygRwM",
+            "key": "key-1502312570",
+            "label": "93",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "h8Vw9jRaEqJHLBetams9HYOicVe",
+            "key": "key-1502312570",
+            "label": "94",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "DxUUZYAW89HHxoNzn0Vjqy0Wxvv",
+            "key": "key-1502312570",
+            "label": "95",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "o3oj7tQaU1f7cIMONLPe3PevlNi",
+            "key": "key-1502312570",
+            "label": "96",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "E0Agyl2LJS7JvUUaYi9qzjDmZ43",
+            "key": "key-1502312570",
+            "label": "97",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "QrPD87IE4fWFUS2FAqeZuZUXZeT",
+            "key": "key-1502312570",
+            "label": "98",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "m3MR3zCd2OYIoj7BgaINHvbup4t",
+            "key": "key-1502312570",
+            "label": "99",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:02\u002B00:00"
+          },
+          {
+            "etag": "4yCOmwht9r1upewN8Odsi0Bcg8M",
+            "key": "key-1551731413",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "UpMP4mKBUEBjqQRMlD2sXB7FJEs",
+            "key": "key-156242278",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "wYuNxWrI5TQozzYpAciVySHaU7B",
+            "key": "key-1577810526",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "OrmLOlXvKFr9x2E1acXclGZD263",
+            "key": "key-1587818169",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:24:13\u002B00:00"
+          },
+          {
+            "etag": "2OoqjcAo90yAdqgfyVKGWnmpj16",
+            "key": "key-1598438620",
+            "label": null,
+            "content_type": null,
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "wdhs1dq8NYXHheyCbky9eyWIKL5",
+            "key": "key-1603266762",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          },
+          {
+            "etag": "YHGfktoslQCCSNSEVuOCb1hrZcM",
+            "key": "key-1633697425",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "NpP8VyFX5Q6wjrXMNR1ftttz5Py",
+            "key": "key-1661468793",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T18:12:29\u002B00:00"
+          },
+          {
+            "etag": "xd7St6F6CuBJ2ONJelveJ5xaBLH",
+            "key": "key-1715663437",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          },
+          {
+            "etag": "Pn80ku8RIkNrPEza9y1k0aIv4MZ",
+            "key": "key-1716559556",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value2",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:55\u002B00:00"
+          },
+          {
+            "etag": "h3yjTfKtljOrEqb96vZ7jEhGm0o",
+            "key": "key-1720810414",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "3VeGoyPFcP4iGC2ExNPF2fkPvAb",
+            "key": "key-17297920",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "AeSBit4ycm1QEa90sDjW8PlBLaM",
+            "key": "key-1765082280",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "bU5BI1mgZBLYf9HeWYhuYl2IDg0",
+            "key": "key-1768007851",
+            "label": "my_label",
+            "content_type": null,
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
+          },
+          {
+            "etag": "1D0YfHmg2SJuD6zEfhd31o9FNWq",
+            "key": "key-1786217009",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:31\u002B00:00"
+          },
+          {
+            "etag": "DLAYvuZp4EOLhbWpHiORrFQrxlZ",
+            "key": "key-1808461375",
+            "label": null,
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "1BrnR77JndxaL4ndtsKgAkwuyr5",
+            "key": "key-1809216229",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "51F1mjgR1BCXDZyEVIog5KkxsVJ",
+            "key": "key-1828956231",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:55\u002B00:00"
+          },
+          {
+            "etag": "FliZ8FwgQ3NS58dfRL0HZrd5SXr",
+            "key": "key-1844884626",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:05:25\u002B00:00"
+          },
+          {
+            "etag": "Gxaxf0awnjXtA4Bh1MZzONQ1mW2",
+            "key": "key-1875045571",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:09\u002B00:00"
+          },
+          {
+            "etag": "e9o6tiNAhuQngS6rYK436ODRDcO",
+            "key": "key-1910922243",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:55\u002B00:00"
+          },
+          {
+            "etag": "qenIfhBrk88QpsJTwxuSSxm4SzC",
+            "key": "key-1919238788",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:07:04\u002B00:00"
+          },
+          {
+            "etag": "CWNgk6O4YLFZ12jqhHOPnCEDE8m",
+            "key": "key-1922091484",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "2VEHu39Mt7780fVEqtoadyUfE8i",
+            "key": "key-1934649991",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
+          },
+          {
+            "etag": "R8U84YRp2frl9PI0g3F4YYgrRB4",
+            "key": "key-1937393334",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:31\u002B00:00"
+          },
+          {
+            "etag": "8cLzl0ho1NqYl3u7osOR0NftOD7",
+            "key": "key-1965913023",
+            "label": null,
+            "content_type": null,
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:54\u002B00:00"
+          },
+          {
+            "etag": "zmZ65hqvHu2FpIbbMVi2HSGYbvr",
+            "key": "key-1983768591",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "ROiZnOqdsnLVV0G5QdaNHcEKew3",
+            "key": "key-2010525552",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:54\u002B00:00"
+          },
+          {
+            "etag": "h9729v3p9GahZj27TlRlI1sUIw5",
+            "key": "key-204035620",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:31\u002B00:00"
+          },
+          {
+            "etag": "QfOPNXMqjEueWYCaEchCrvT5uLW",
+            "key": "key-2051178311",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value2",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:50\u002B00:00"
+          },
+          {
+            "etag": "5VG77jljuIJ8c2qvTmTzjP5hFFR",
+            "key": "key-2053619125",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:09\u002B00:00"
+          },
+          {
+            "etag": "xurZkkq1lWet0EOqLPkdPwL42Ko",
+            "key": "key-2097465991",
+            "label": null,
+            "content_type": null,
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "rGWi2Wsg21RdGcnFOl3AZxz42vr",
+            "key": "key-2113787248",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "k3sYCiP0mYo8BNoIeSsk97OZIel",
+            "key": "key-212129177",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          },
+          {
+            "etag": "agLm7TEWFYKCcksi2UyBz7ZVmn8",
+            "key": "key-221701127",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-14T21:16:39\u002B00:00"
+          },
+          {
+            "etag": "UhZIRQfYWPQzWAELLBfa09ehUvx",
+            "key": "key-222881053",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:15:13\u002B00:00"
+          },
+          {
+            "etag": "pnlSyvJyVdbopuT5WFhpD9ULr3G",
+            "key": "key-277273344",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "slvXjRxhTVg3IcKeO12PuutFgOp",
+            "key": "key-291156113",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
           },
           {
             "etag": "rniPVf34RW2LNcl6lXHzat7XjNo",
@@ -170,6 +2177,1098 @@
             "tags": {},
             "locked": false,
             "last_modified": "2019-04-10T23:26:25\u002B00:00"
+          },
+          {
+            "etag": "5cwUfOWFt41voGSpeOQkkc9klYO",
+            "key": "key-318212819",
+            "label": "0",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "z7MMZZ32BbiRQpcjfnTMW22E72r",
+            "key": "key-318212819",
+            "label": "1",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "AkM7mlWrrG5UhwcDuFgCwDETINi",
+            "key": "key-318212819",
+            "label": "10",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "N4iEqr6McoX0qlZeUxNAjldtv5Y",
+            "key": "key-318212819",
+            "label": "100",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "0g3rVao6C5cn1hlgkziHdbvRqn2",
+            "key": "key-318212819",
+            "label": "101",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "xisITjWgpouicflR1xKkb0koEG0",
+            "key": "key-318212819",
+            "label": "102",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "yuT56q2j5onrUVlGBEV6ewU6FZR",
+            "key": "key-318212819",
+            "label": "103",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "lhzHJ9bgmQMxgOaVzHdreWwCLBO",
+            "key": "key-318212819",
+            "label": "104",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "FLg3ZnfkC9pGBpbpmZabnJ19jLZ",
+            "key": "key-318212819",
+            "label": "11",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "4rn9PHOjNMiJI6ALzq8rNttFw8Y",
+            "key": "key-318212819",
+            "label": "12",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "uNSg7e3wgb1rqFJhn8r36qnPcRd",
+            "key": "key-318212819",
+            "label": "13",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "JNWGXT8VRrla3W0XcFaA8BFTzO8",
+            "key": "key-318212819",
+            "label": "14",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "XTv0hWlpzO3VMs94s3gp9QbE7BP",
+            "key": "key-318212819",
+            "label": "15",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          }
+        ],
+        "@nextLink": "/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LTMxODIxMjgxOQoxNQ%3D%3D"
+      }
+    },
+    {
+      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=%2A\u0026label=%2A\u0026after=a2V5LTMxODIxMjgxOQoxNQ%3D%3D\u0026api-version=1.0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/vnd.microsoft.appconfig.kv\u002Bjson",
+        "Authorization": "Sanitized",
+        "Date": "Mon, 14 Oct 2019 21:27:08 GMT",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTg=",
+        "User-Agent": [
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
+        ],
+        "x-ms-client-request-id": "bb7aad96b4534b2e54d5823a1ba11fc2",
+        "x-ms-content-sha256": "47DEQpj8HBSa\u002B/TImW\u002B5JCeuQeRkm5NMpJWZG3hSuFU=",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Access-Control-Allow-Methods": "GET, PUT, POST, DELETE, PATCH, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Connection": "keep-alive",
+        "Content-Type": "application/vnd.microsoft.appconfig.kvset\u002Bjson; charset=utf-8",
+        "Date": "Mon, 14 Oct 2019 21:27:08 GMT",
+        "Link": "\u003C/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LTQ0MjA3MDU4Ngp0ZXN0X2xhYmVs\u003E; rel=\u0022next\u0022",
+        "Server": "openresty/1.15.8.1",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTg=;sn=651098",
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "bb7aad96b4534b2e54d5823a1ba11fc2",
+        "x-ms-correlation-request-id": "741938fd-9940-4842-88bc-7707d02eb701",
+        "x-ms-request-id": "741938fd-9940-4842-88bc-7707d02eb701"
+      },
+      "ResponseBody": {
+        "items": [
+          {
+            "etag": "HjtCmiihempNJLNQbx4WunsU4PV",
+            "key": "key-318212819",
+            "label": "16",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "4GkmqE7pYsWlf291OeN9AltmTZm",
+            "key": "key-318212819",
+            "label": "17",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "KWRqe7fMBTXSAlF7R9Zu2ASlMUh",
+            "key": "key-318212819",
+            "label": "18",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "vIEUpxgsVTvUnveRularaVAnIC0",
+            "key": "key-318212819",
+            "label": "19",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "vhYNS5rPotsPSMPMZkIM9vTJwGu",
+            "key": "key-318212819",
+            "label": "2",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "tm0F7oBe5f6MAnFMmm8zC5Tr7Ab",
+            "key": "key-318212819",
+            "label": "20",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "WjtLGMVSg9SoE86k5BnECAp6051",
+            "key": "key-318212819",
+            "label": "21",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "EDQCCSvYjMiH8wIzHq36wDckuAw",
+            "key": "key-318212819",
+            "label": "22",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "gHjxZ9lkDeWLA3zMJWamdgvMQXV",
+            "key": "key-318212819",
+            "label": "23",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "rc0j68KTbYeu4lJVEJ1qGT6P3Ql",
+            "key": "key-318212819",
+            "label": "24",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "BsBueEs46SRwyARErsWBd7DW3Bv",
+            "key": "key-318212819",
+            "label": "25",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "qxWTCxic52DEfF4gvrKIIbLAIyr",
+            "key": "key-318212819",
+            "label": "26",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "5enBsRYuMrdayb5q5gI2tkXPgBD",
+            "key": "key-318212819",
+            "label": "27",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "DLFQ5CC0NB8gsMhDp4skWGCsY83",
+            "key": "key-318212819",
+            "label": "28",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "J92kL81ZT6TQZ29CkRZGsEngSB6",
+            "key": "key-318212819",
+            "label": "29",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "eceqDOKrubEZUjDZ8THpq8sXnKn",
+            "key": "key-318212819",
+            "label": "3",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "AV8UUQe8Hhv7K8lheyOboqnhuUa",
+            "key": "key-318212819",
+            "label": "30",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "NGlrHeQzfLwdEBJNlW0TKTFSqho",
+            "key": "key-318212819",
+            "label": "31",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "pUzDbcFgEOHrCsqnWEfDWBEKgvg",
+            "key": "key-318212819",
+            "label": "32",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "ZoyHYhzQObGNK9BzZdEXwSAYlUe",
+            "key": "key-318212819",
+            "label": "33",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "PolnHEx6J9EmNUFDtKy1h2r4Nof",
+            "key": "key-318212819",
+            "label": "34",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "a1KCGdp7Cn1xqxkxFzZ9MPzLRlx",
+            "key": "key-318212819",
+            "label": "35",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "voGU9e79et92C0I4FeFnVicmLdN",
+            "key": "key-318212819",
+            "label": "36",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:27\u002B00:00"
+          },
+          {
+            "etag": "cLBRGbNitcLgUlW6r0XjSN6W5Un",
+            "key": "key-318212819",
+            "label": "37",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "pXDFJQX9WXNnNxtqFPbXXBcS8he",
+            "key": "key-318212819",
+            "label": "38",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "zXL6IwlbPqd95EwRVtErypDgTCU",
+            "key": "key-318212819",
+            "label": "39",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "DNK4LTvlPmmITkpzK5kuW5mpZ67",
+            "key": "key-318212819",
+            "label": "4",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "C4yGwIxkw4MKjtpo5PISZ9mqyq3",
+            "key": "key-318212819",
+            "label": "40",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "Mh7Gk1NV4iH2dcHx8aMI7JG4kBe",
+            "key": "key-318212819",
+            "label": "41",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "4cEkSYsE1cnlWopnJ4SjBH25rMl",
+            "key": "key-318212819",
+            "label": "42",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "eJyYJsMSbUksB74IDqXVbLtg04P",
+            "key": "key-318212819",
+            "label": "43",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "AYpANGbRovdTaGZCKi6qtvfQAqZ",
+            "key": "key-318212819",
+            "label": "44",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "0wIL13ji2saK9GgfNxnqslkil5P",
+            "key": "key-318212819",
+            "label": "45",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "m4Au5VKT0JVcZYGi8aN7ExaIAqo",
+            "key": "key-318212819",
+            "label": "46",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "BYr5WWWlnckAxMLHduS68iblypn",
+            "key": "key-318212819",
+            "label": "47",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "rSWkniAXJL27R8iC1IF36eFonX0",
+            "key": "key-318212819",
+            "label": "48",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "isW7ZqY46aeUBLpJ7CF0YYt5QIt",
+            "key": "key-318212819",
+            "label": "49",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "jaK4r1TdNeDNWxZQJZvUYaCBi31",
+            "key": "key-318212819",
+            "label": "5",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "ZqAY6fx3RciOzMMtQpRuyOEK0RK",
+            "key": "key-318212819",
+            "label": "50",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "Hsr6LoOZqq5KZc2PEmKKDm6X71z",
+            "key": "key-318212819",
+            "label": "51",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "BO5xQtBE3BMklxfu5SeNSQVi6nb",
+            "key": "key-318212819",
+            "label": "52",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "e5JNJGx7a0JOWBfG6R7RyYfHdL0",
+            "key": "key-318212819",
+            "label": "53",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "72W64Ts4otEBFkUPIFMLXDOVnsB",
+            "key": "key-318212819",
+            "label": "54",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "Q2V9VXjv38DET3zvCcp2fgJgBoK",
+            "key": "key-318212819",
+            "label": "55",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "xFBmpRqnwjFKyIBoeXgyIkbn4KT",
+            "key": "key-318212819",
+            "label": "56",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "zNCbYWfmDtVkQ3daiFPF8wH4g2J",
+            "key": "key-318212819",
+            "label": "57",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "HnfxPwBolVV4F4ho8kKY1mdfI3F",
+            "key": "key-318212819",
+            "label": "58",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "aybMOdX7a0OFFqJAa2JEHMmVqI8",
+            "key": "key-318212819",
+            "label": "59",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "AQhJNPQVYOsJ5JKxahjJYY1H1hG",
+            "key": "key-318212819",
+            "label": "6",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "xXrARI12MLps0E2wLqZ0albHtQX",
+            "key": "key-318212819",
+            "label": "60",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "oxbG2NenscCQZ5lY6irsqiE6CbJ",
+            "key": "key-318212819",
+            "label": "61",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:28\u002B00:00"
+          },
+          {
+            "etag": "T4vIvjkFTNPtzQMsjecHfOHUoyB",
+            "key": "key-318212819",
+            "label": "62",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "9Cn5UUUUQufChfsBbYXVHZq0i1V",
+            "key": "key-318212819",
+            "label": "63",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "JJFAWU9sRiwCq7Vy3kqFHHEw0EJ",
+            "key": "key-318212819",
+            "label": "64",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "23dri1GmmtomMoDZx9zmzE6mHfM",
+            "key": "key-318212819",
+            "label": "65",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "cZctnbyA9WFarRHlOjgqKl04I8K",
+            "key": "key-318212819",
+            "label": "66",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "WBW595bnrK2u9iehMUUJJ67HwOM",
+            "key": "key-318212819",
+            "label": "67",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "YMF1GfyGg81XdrB7GKEaVm0Ejwh",
+            "key": "key-318212819",
+            "label": "68",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "enDpWw6rdMCZJryg4zk5ZbT8ucU",
+            "key": "key-318212819",
+            "label": "69",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "i8sqkxGFlxnzxobOxMZj7ykx49U",
+            "key": "key-318212819",
+            "label": "7",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "xhJF8bq45Ci1dM4VXhzajuaUctO",
+            "key": "key-318212819",
+            "label": "70",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "iXWqnAgLoxiXbEwqhuRHF0wyMom",
+            "key": "key-318212819",
+            "label": "71",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "IY9UDBeaPkxSLsvc56wTrgGeA74",
+            "key": "key-318212819",
+            "label": "72",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "W0a2gS2bWuW1JRAhmd0xD2RigWP",
+            "key": "key-318212819",
+            "label": "73",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "VUwGkCcxOZdYr8nxt4y1whp5IJY",
+            "key": "key-318212819",
+            "label": "74",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "CHQWzmmsQk17tFWtCgEeSw5uHnP",
+            "key": "key-318212819",
+            "label": "75",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "A6ymkAnyLQt8U3n4peSjuWi5C1Y",
+            "key": "key-318212819",
+            "label": "76",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "AjuYFhgNhpdEDtbGOWxVBwZo4hk",
+            "key": "key-318212819",
+            "label": "77",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "YLFvdbM2MQagS87upcmwqPDfdAn",
+            "key": "key-318212819",
+            "label": "78",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "7pdmsOJRq9gXBf1q3gvntjhzrcg",
+            "key": "key-318212819",
+            "label": "79",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "7djUpNqZc2OqdS0jfFShxF91vZt",
+            "key": "key-318212819",
+            "label": "8",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "Yee49ACbd648SwLFpCHURzYwiDo",
+            "key": "key-318212819",
+            "label": "80",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "oEuD35erUuF63XN7VGacKggdNNn",
+            "key": "key-318212819",
+            "label": "81",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "qxjJanqMCXeAhQwECFnZofML6Fz",
+            "key": "key-318212819",
+            "label": "82",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "PRzNf642PZRaqRb7W8ZbkVNHlyL",
+            "key": "key-318212819",
+            "label": "83",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "jQE2QVttT7j3GldvyZJZT5Y1FTr",
+            "key": "key-318212819",
+            "label": "84",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "VVVbwF9xWKTPa7CKOmxEwiaPRRr",
+            "key": "key-318212819",
+            "label": "85",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "8sg1uCKDzTdpSSOS6e05pYU98yt",
+            "key": "key-318212819",
+            "label": "86",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "Ks9H9Vkne4bjMYjkQFU6ASNXgJn",
+            "key": "key-318212819",
+            "label": "87",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:29\u002B00:00"
+          },
+          {
+            "etag": "RyWMIhr1IkNCpyt7PKOShZCvV5u",
+            "key": "key-318212819",
+            "label": "88",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "SSjMMj6FCcPFrmrL5gccACQBpYc",
+            "key": "key-318212819",
+            "label": "89",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "5UXM4LYxBt12WA0i0kvjwJBVXYb",
+            "key": "key-318212819",
+            "label": "9",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "1Cy9lgLBDtJ29VJQGRwfojO6sF2",
+            "key": "key-318212819",
+            "label": "90",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "Jk6aHt1WpAqrVKidwU89UDIOqZo",
+            "key": "key-318212819",
+            "label": "91",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "gR6GEUItikQ02CHKl8qEmu1aYvj",
+            "key": "key-318212819",
+            "label": "92",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "36EyMt1NPbs2cXSxAH2KXQ16JV1",
+            "key": "key-318212819",
+            "label": "93",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "7NC96AxyFaG9Uc654bDjTkQAT92",
+            "key": "key-318212819",
+            "label": "94",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "Ig7MGzD5u56Y3ZM4nG8NaTIHDr2",
+            "key": "key-318212819",
+            "label": "95",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "ISsYzhtEPpPiI7uOctlYnVlx3nf",
+            "key": "key-318212819",
+            "label": "96",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "F9hPW4j4VaHoq9VzVPlUPotqKhN",
+            "key": "key-318212819",
+            "label": "97",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "FDF33pwyoxLluLfDzAxNfuwRUIz",
+            "key": "key-318212819",
+            "label": "98",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "uFISRJO3YYvE94SQMWQl3dwNmNN",
+            "key": "key-318212819",
+            "label": "99",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
           },
           {
             "etag": "QB6ZifyjGfUn17lEKZMAK6No3jf",
@@ -198,6 +3297,162 @@
             "last_modified": "2019-05-01T19:08:04\u002B00:00"
           },
           {
+            "etag": "mj5yMpfkn1kdd1K3YhPt5AUqhEf",
+            "key": "key-337032567",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:49\u002B00:00"
+          },
+          {
+            "etag": "briktXnfCCDMeye6LB3uZ3pc7DH",
+            "key": "key-357348821",
+            "label": "my_label",
+            "content_type": null,
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "Do7twZpoyGpe56S9tjkYR7T6oug",
+            "key": "key-407324161",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "Bn8Qww33MB3xLGowUmh9BGJVO4F",
+            "key": "key-429238547",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:06\u002B00:00"
+          },
+          {
+            "etag": "vUvAGXytPKGN4EdsONAZB1ZloOr",
+            "key": "key-439891543",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "RfYfTS1obmR3cR4S9WROiH1FeIE",
+            "key": "key-442070586",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T18:11:33\u002B00:00"
+          }
+        ],
+        "@nextLink": "/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LTQ0MjA3MDU4Ngp0ZXN0X2xhYmVs"
+      }
+    },
+    {
+      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=%2A\u0026label=%2A\u0026after=a2V5LTQ0MjA3MDU4Ngp0ZXN0X2xhYmVs\u0026api-version=1.0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/vnd.microsoft.appconfig.kv\u002Bjson",
+        "Authorization": "Sanitized",
+        "Date": "Mon, 14 Oct 2019 21:27:08 GMT",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTg=",
+        "User-Agent": [
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
+        ],
+        "x-ms-client-request-id": "41ba512eccc1effb36349c88a60bee7a",
+        "x-ms-content-sha256": "47DEQpj8HBSa\u002B/TImW\u002B5JCeuQeRkm5NMpJWZG3hSuFU=",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Access-Control-Allow-Methods": "GET, PUT, POST, DELETE, PATCH, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Connection": "keep-alive",
+        "Content-Type": "application/vnd.microsoft.appconfig.kvset\u002Bjson; charset=utf-8",
+        "Date": "Mon, 14 Oct 2019 21:27:08 GMT",
+        "Link": "\u003C/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LTU0MTc2NDUxMAo4OQ%3D%3D\u003E; rel=\u0022next\u0022",
+        "Server": "openresty/1.15.8.1",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTg=;sn=651098",
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "41ba512eccc1effb36349c88a60bee7a",
+        "x-ms-correlation-request-id": "a6fca89a-bd50-40a3-886d-6f48a942de9c",
+        "x-ms-request-id": "a6fca89a-bd50-40a3-886d-6f48a942de9c"
+      },
+      "ResponseBody": {
+        "items": [
+          {
+            "etag": "HKbYauu5cqJbjg5dDwq7n3FC4oD",
+            "key": "key-442352028",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "WgaViI04lj7TF2VbpHTkzk3kaXr",
+            "key": "key-451104393",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          },
+          {
+            "etag": "wiUqbDzZboQ4lQ8wFOtMUTWkZ8E",
+            "key": "key-469594127",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:08:00\u002B00:00"
+          },
+          {
             "etag": "JmFAJhlGhqYS9XzZN5ZfdktOK3L",
             "key": "key-4dc1baef29474d1ea11dbf3b5c9a690c",
             "label": "test_label",
@@ -221,6 +3476,1137 @@
             "last_modified": "2019-04-10T23:26:24\u002B00:00"
           },
           {
+            "etag": "Zvd8V3jfPSFrHYk3rhF4Uvjh7ny",
+            "key": "key-52254665",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "FPfEN2dwIt3P2I85RcQCogL0Gni",
+            "key": "key-541764510",
+            "label": "0",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "rmvDXOoiwH4UE9Ed3G1dMZLELOg",
+            "key": "key-541764510",
+            "label": "1",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "0Rx1e1F2svdzwrGufb0yNrmwtUW",
+            "key": "key-541764510",
+            "label": "10",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "gUURJ2MVcp2wwsLMGkLbHTdoT4q",
+            "key": "key-541764510",
+            "label": "100",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "tmOjdS5xrnx8pKfbRoDMNhqC5Ie",
+            "key": "key-541764510",
+            "label": "101",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "1dEKhRqTK5OMAeeBj4ymbSni8h3",
+            "key": "key-541764510",
+            "label": "102",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "ZkggJlpItqvf0sbreLrkcUjDYAN",
+            "key": "key-541764510",
+            "label": "103",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "IoaxhA6fPKtmf7y0aASdphkao5P",
+            "key": "key-541764510",
+            "label": "104",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "LYuUd3YtOq3HggtjTZ6l3uUPmVZ",
+            "key": "key-541764510",
+            "label": "11",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "lgzo8mxT54L42zk4wz7vfi0X1R0",
+            "key": "key-541764510",
+            "label": "12",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "hY9OGVCAkdU7v4iBC8WMtkNx0vF",
+            "key": "key-541764510",
+            "label": "13",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "SQ97eJlpdEFUf3pVJv9L0Oe0Aos",
+            "key": "key-541764510",
+            "label": "14",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "QNlYaoKBeHFGIlROha5MspGl28F",
+            "key": "key-541764510",
+            "label": "15",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "kFcvtV5a2ug6UiKOpckl5srNRtc",
+            "key": "key-541764510",
+            "label": "16",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "fOftYXX18dcd959tQLHPWlWt2nh",
+            "key": "key-541764510",
+            "label": "17",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "EIS4s6MZrKSIjuPB6o5iEG8nAdM",
+            "key": "key-541764510",
+            "label": "18",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "YDP2BymVu5kGy4PhlJ76qaZn7tp",
+            "key": "key-541764510",
+            "label": "19",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "01NefYPwREv7fOfsxQ557glmqx9",
+            "key": "key-541764510",
+            "label": "2",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "kfeqj8MJfkGYD24AhWO5l9MOqAB",
+            "key": "key-541764510",
+            "label": "20",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "rfI6o6WvqpphYhXqDluYLWWrkkz",
+            "key": "key-541764510",
+            "label": "21",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "14Ew2EaurV3ZI29dSiZZbTmWUXu",
+            "key": "key-541764510",
+            "label": "22",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "89rYU8yma2h9aALTV2fHhu8pZ0L",
+            "key": "key-541764510",
+            "label": "23",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "bNwwvphyriDjHqIRFrxflcNCzHz",
+            "key": "key-541764510",
+            "label": "24",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "kbRD7cBNEeMwuo1l1Pk0IUV8SPj",
+            "key": "key-541764510",
+            "label": "25",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "HoaL8giu94j5EyP8bodnbPhk3Tp",
+            "key": "key-541764510",
+            "label": "26",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "X2Ha7DUURU3luWG6uRTrWCyBd6w",
+            "key": "key-541764510",
+            "label": "27",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "18JyD17dA5JOdwWW3efjZ1FbpcZ",
+            "key": "key-541764510",
+            "label": "28",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "duZzxPUAQrpkz8AqB9d4GrOBtmc",
+            "key": "key-541764510",
+            "label": "29",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "x92waZgAIo6KOioqinpd4fShDww",
+            "key": "key-541764510",
+            "label": "3",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "APrbV8HuvZbWqzc7vH9YFLO8fv6",
+            "key": "key-541764510",
+            "label": "30",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "IzjITFyaFrRG2FeXw4sjvYeWfb9",
+            "key": "key-541764510",
+            "label": "31",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "lGrB6duzjrG4riGQD9b4ZpB4l1Q",
+            "key": "key-541764510",
+            "label": "32",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "3tw5eoAdA5InF1Hfq4jtJfvqseG",
+            "key": "key-541764510",
+            "label": "33",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "aJ5zTigPLsT9yeSwnXMcomKCm0c",
+            "key": "key-541764510",
+            "label": "34",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "8cad2D4T0aA62y2Y4j9Oa1NDy0U",
+            "key": "key-541764510",
+            "label": "35",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "G39ixZtekAtJeUgulgj0vu3hOkj",
+            "key": "key-541764510",
+            "label": "36",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "2KdzPxrncjDGeGwgeeFBdlfKGxr",
+            "key": "key-541764510",
+            "label": "37",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "2zKJ5rw9kxLzPPLoFxIhlXbaExr",
+            "key": "key-541764510",
+            "label": "38",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "cqjbZGpT7C3FXzK1PsR4TvcPlk3",
+            "key": "key-541764510",
+            "label": "39",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "9gTz9etVcAuyVnCk0cVCHOfJCsU",
+            "key": "key-541764510",
+            "label": "4",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "QsC9O9Wsr2STHNZRsUrHoEpCpQ3",
+            "key": "key-541764510",
+            "label": "40",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "8mSDlmj44e9hID4HVzUa7fcx8wK",
+            "key": "key-541764510",
+            "label": "41",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "A5y55KQZcZOtLpo8y2PC79vHMVr",
+            "key": "key-541764510",
+            "label": "42",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "3G2ppHCwJeUV15ivdXvTW16MSVP",
+            "key": "key-541764510",
+            "label": "43",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "ZRgNJLXgHPfQhQWY5EnO1k9bmcD",
+            "key": "key-541764510",
+            "label": "44",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "yASrnndVhPzq3ce78suxpn6Ygji",
+            "key": "key-541764510",
+            "label": "45",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "w4p29glD9NydABZpmgQIsdnRGSM",
+            "key": "key-541764510",
+            "label": "46",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "TbFrFZlGuTamT0OFHjsVDDypR5e",
+            "key": "key-541764510",
+            "label": "47",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "IahcOIWFXXOBAXSGsS7prObFNpA",
+            "key": "key-541764510",
+            "label": "48",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "oCgUPMFiRWSy9BeVgmYe8ALk9kk",
+            "key": "key-541764510",
+            "label": "49",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "1ciDTA0AGgCfTSLNXnuwhuWdIgs",
+            "key": "key-541764510",
+            "label": "5",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "1ttKuw6KC98fb7Neq8WxBzPE2Q5",
+            "key": "key-541764510",
+            "label": "50",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "TtyXOeNm6YWbihYyotcHJwuy1lv",
+            "key": "key-541764510",
+            "label": "51",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "yuAXC6Vob80MhMMciffGQ3AOw7C",
+            "key": "key-541764510",
+            "label": "52",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:22\u002B00:00"
+          },
+          {
+            "etag": "RFmp6TsyJrDuFHmE7EBt6mh8wE8",
+            "key": "key-541764510",
+            "label": "53",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "wMn35s2VnQvekYnRaM3VYOEuLoa",
+            "key": "key-541764510",
+            "label": "54",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "cXPT7wRJZkX8KdodISdOJ84kuKm",
+            "key": "key-541764510",
+            "label": "55",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "PuiHn1vHimqIz4gGrbKLyW3WyCf",
+            "key": "key-541764510",
+            "label": "56",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "WBod4dvMwgTcAtpkAvc5wC16S70",
+            "key": "key-541764510",
+            "label": "57",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "RYf8LfQDJ6HgavaMRuVac6N9vcO",
+            "key": "key-541764510",
+            "label": "58",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "2NRBSURTdKErkJxnDu8RkDiRFj5",
+            "key": "key-541764510",
+            "label": "59",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "oAToJgKkSkDQAIa4NmDVzYeM8lD",
+            "key": "key-541764510",
+            "label": "6",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "tDllB8vbGFn8TDNiGVx4GVs7jos",
+            "key": "key-541764510",
+            "label": "60",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "1mTMN7uD7dVSe9gUswDzuzWz3ur",
+            "key": "key-541764510",
+            "label": "61",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "fEE3fxnpgnawsDJaP7XKO0Wrlpd",
+            "key": "key-541764510",
+            "label": "62",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "u7H1Lzy0bau2TAf4d7bwcLwnOpT",
+            "key": "key-541764510",
+            "label": "63",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "zAtemhj1hUG56TpKr4uB2Yuil2g",
+            "key": "key-541764510",
+            "label": "64",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "XaloVmyiQNMGk5UsXx9y7Iwc7fp",
+            "key": "key-541764510",
+            "label": "65",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "FeUsNvze8TdApveO7wsvaobIR8p",
+            "key": "key-541764510",
+            "label": "66",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "jIcUHDkcReNVe2ZY3PmCQXK1QW0",
+            "key": "key-541764510",
+            "label": "67",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "CpLZVIK3ycBrjbGGcWQJCO3oAuG",
+            "key": "key-541764510",
+            "label": "68",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "CAnROP3mDHI6ZYh5KRd3XnvqFqX",
+            "key": "key-541764510",
+            "label": "69",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "EitMr1oUU366Qx4Ziy55vdOKVuq",
+            "key": "key-541764510",
+            "label": "7",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "0jmIFB4481LTLb3HipLfBXTPgh4",
+            "key": "key-541764510",
+            "label": "70",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "dIaM1eVDARYgymOoama1RTbmDP6",
+            "key": "key-541764510",
+            "label": "71",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "4mAPPvJfM0GRGbQQWnjzthRe39a",
+            "key": "key-541764510",
+            "label": "72",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "M8FPgNOHaNof3J8vE7DTR2LQY2k",
+            "key": "key-541764510",
+            "label": "73",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "gh5pEm1smxjqN8BgsgubeyoWYoy",
+            "key": "key-541764510",
+            "label": "74",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "3TkSTlCkzNFmXQIpjmw8UJJ2aon",
+            "key": "key-541764510",
+            "label": "75",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "jYN8NgWl3e95iH9BV2sr0JOZD8e",
+            "key": "key-541764510",
+            "label": "76",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "KJcGihm7B0C57T9FJEtpEOdpouJ",
+            "key": "key-541764510",
+            "label": "77",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "V9qwUvqHsXuP3wfSb9McGRxnBeZ",
+            "key": "key-541764510",
+            "label": "78",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:23\u002B00:00"
+          },
+          {
+            "etag": "ld4qB2xBDBGThPpxRuREqp5x2XO",
+            "key": "key-541764510",
+            "label": "79",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "OtKtQ8F9cpS3y8kb7O12jVpO9BG",
+            "key": "key-541764510",
+            "label": "8",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "n1R8syFieztYfBzbnzMM3NAvsUv",
+            "key": "key-541764510",
+            "label": "80",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "Hn38uN8ZF45rg0Tq33xTKt6WmSw",
+            "key": "key-541764510",
+            "label": "81",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "0aZuayDWbo8BsOcRJZeLp2kxmHb",
+            "key": "key-541764510",
+            "label": "82",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "fnbMmElSRn0q0g05IKqsCFHWAxG",
+            "key": "key-541764510",
+            "label": "83",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "e7Ih5VfIeMo9CzlEnZPIBtLdtTl",
+            "key": "key-541764510",
+            "label": "84",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "gCYJTCID9JvXhfVudCNgHgjx5Jl",
+            "key": "key-541764510",
+            "label": "85",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "ckb6x5ayvsFAKrUpBcW49U6hkDU",
+            "key": "key-541764510",
+            "label": "86",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "O5VWd0HArsznTxET8otVbvsZyUL",
+            "key": "key-541764510",
+            "label": "87",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "8ldzy3EHy5cJoo5Ob2EsthD6xXN",
+            "key": "key-541764510",
+            "label": "88",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "6lF5F76OxDS58SVxz7FLrlQi8MJ",
+            "key": "key-541764510",
+            "label": "89",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          }
+        ],
+        "@nextLink": "/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LTU0MTc2NDUxMAo4OQ%3D%3D"
+      }
+    },
+    {
+      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=%2A\u0026label=%2A\u0026after=a2V5LTU0MTc2NDUxMAo4OQ%3D%3D\u0026api-version=1.0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/vnd.microsoft.appconfig.kv\u002Bjson",
+        "Authorization": "Sanitized",
+        "Date": "Mon, 14 Oct 2019 21:27:08 GMT",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTg=",
+        "User-Agent": [
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
+        ],
+        "x-ms-client-request-id": "a6afc791c22cd3c760ed86d096ffcb19",
+        "x-ms-content-sha256": "47DEQpj8HBSa\u002B/TImW\u002B5JCeuQeRkm5NMpJWZG3hSuFU=",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Access-Control-Allow-Methods": "GET, PUT, POST, DELETE, PATCH, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Connection": "keep-alive",
+        "Content-Type": "application/vnd.microsoft.appconfig.kvset\u002Bjson; charset=utf-8",
+        "Date": "Mon, 14 Oct 2019 21:27:08 GMT",
+        "Link": "\u003C/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LTkwMTgxNzU1Ngo1Mg%3D%3D\u003E; rel=\u0022next\u0022",
+        "Server": "openresty/1.15.8.1",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTg=;sn=651098",
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "a6afc791c22cd3c760ed86d096ffcb19",
+        "x-ms-correlation-request-id": "2ce72bd7-ab3f-4142-8259-e7098d7d7fc7",
+        "x-ms-request-id": "2ce72bd7-ab3f-4142-8259-e7098d7d7fc7"
+      },
+      "ResponseBody": {
+        "items": [
+          {
+            "etag": "RgcW0w59IEU3bSGk69Df2f4T6F7",
+            "key": "key-541764510",
+            "label": "9",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:21\u002B00:00"
+          },
+          {
+            "etag": "epIA58IAZGN9uBL376K7DJqkivG",
+            "key": "key-541764510",
+            "label": "90",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "ZAjqGzEusLANC764bmm9sMk3LZB",
+            "key": "key-541764510",
+            "label": "91",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "JEEgKb1DQD0BshBgYA1FZQMQJGT",
+            "key": "key-541764510",
+            "label": "92",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "JLdw8q0SG6Gx5CI6Js8eRNHFuet",
+            "key": "key-541764510",
+            "label": "93",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "PwAa0qY7JGYN3wrkYxyDjy6v6rC",
+            "key": "key-541764510",
+            "label": "94",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "3dLT7HLwY07tUkbnBSPgXYyKelv",
+            "key": "key-541764510",
+            "label": "95",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "ZdJXAJOsaDPXXTzEuENLqbeVqhw",
+            "key": "key-541764510",
+            "label": "96",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "D2quWYtWVIxY4zWA5iLbTaeLCs3",
+            "key": "key-541764510",
+            "label": "97",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "408wJdRRAfMlDdKL44A9jUSrF7G",
+            "key": "key-541764510",
+            "label": "98",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "uitYWOSaxtCMD4VqL98601d20ym",
+            "key": "key-541764510",
+            "label": "99",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:24\u002B00:00"
+          },
+          {
+            "etag": "QGxPc999Q76X1lFLQIzwwhGQSfO",
+            "key": "key-545314302",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value2",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:09\u002B00:00"
+          },
+          {
+            "etag": "nY5ZGit7NiAiLWOfDYMvLAOS1F7",
+            "key": "key-581866371",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:54\u002B00:00"
+          },
+          {
             "etag": "Z5BbCpC5iN2Qw1Tg9GiosFPgNnK",
             "key": "key-5c1bd7cc96cb4f888c94dd435e3d4ed7",
             "label": null,
@@ -229,6 +4615,84 @@
             "tags": {},
             "locked": false,
             "last_modified": "2019-04-10T23:14:47\u002B00:00"
+          },
+          {
+            "etag": "MCSdJnjGySUVPVOgGrdvZYlkkCO",
+            "key": "key-601022664",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "VvjuWikzA4tTZVv7WRJQAs6uHa4",
+            "key": "key-603485485",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:21:29\u002B00:00"
+          },
+          {
+            "etag": "08VxcTF7XOikUwUcjmIaSnf225F",
+            "key": "key-611503496",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-20T03:01:47\u002B00:00"
+          },
+          {
+            "etag": "Jm36tIYyH7m8bPvrifYkVT1ofQb",
+            "key": "key-618631428",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:05\u002B00:00"
+          },
+          {
+            "etag": "BPubg2Ay3ofpoe2DKXrZNAVnt5e",
+            "key": "key-619387967",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:55\u002B00:00"
+          },
+          {
+            "etag": "If3ekPjULycfjcGDqMzCDjS8OmZ",
+            "key": "key-62379019",
+            "label": null,
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
           },
           {
             "etag": "NNkiTFfEo9LzydkJzQXKNJKTyII",
@@ -242,6 +4706,58 @@
             },
             "locked": false,
             "last_modified": "2019-04-08T22:57:05\u002B00:00"
+          },
+          {
+            "etag": "R7nE3UyC94U7dxErKbGYFaUo3DX",
+            "key": "key-646766163",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T18:45:22\u002B00:00"
+          },
+          {
+            "etag": "hnHYu0T2IXWrlVW4iEyIx19J5E8",
+            "key": "key-665260818",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:16:37\u002B00:00"
+          },
+          {
+            "etag": "DLkqNFvqZGvKCUuGqwDtbY2cW8S",
+            "key": "key-674427950",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "dxDyLomTd2b0f9JRmhYcNokTopp",
+            "key": "key-676034902",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
           },
           {
             "etag": "yOAsvJzz97wJK3rXYDNGKswPLfs",
@@ -309,6 +4825,71 @@
             "last_modified": "2019-04-10T23:14:47\u002B00:00"
           },
           {
+            "etag": "cClYgjDuYXVjCdLxK46hyhs1Wi0",
+            "key": "key-708276799",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:54\u002B00:00"
+          },
+          {
+            "etag": "biYITZyCRHSxnnemqwgBOrCPqHa",
+            "key": "key-715857320",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value2",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:05:26\u002B00:00"
+          },
+          {
+            "etag": "uJbsczfnXinqQkeSEXeZVbYkHEg",
+            "key": "key-719454961",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-28T17:38:17\u002B00:00"
+          },
+          {
+            "etag": "fCkWnHvdpPNuvsu9EirkwToLIfb",
+            "key": "key-719690246",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T18:47:40\u002B00:00"
+          },
+          {
+            "etag": "304RpDyEyDoUVc329BbDsv9XAZl",
+            "key": "key-72708449",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
             "etag": "ytubwGBJqHHXmIvJZx23ir8rtah",
             "key": "key-7397ba163fb24443bb60bcf0d7b2fa9b",
             "label": null,
@@ -320,6 +4901,29 @@
             },
             "locked": false,
             "last_modified": "2019-05-15T23:51:11\u002B00:00"
+          },
+          {
+            "etag": "yzHXnBTeRhzlbNUHWHXUm2UHfvF",
+            "key": "key-786619267",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:50\u002B00:00"
+          },
+          {
+            "etag": "TLwfUaPLCrMUK2wTTeqGL9J7yNj",
+            "key": "key-788294418",
+            "label": "my_label",
+            "content_type": null,
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
           },
           {
             "etag": "m7EFRi22ngO0wY2LWxzcDYgMx0G",
@@ -335,6 +4939,84 @@
             "last_modified": "2019-04-10T23:26:25\u002B00:00"
           },
           {
+            "etag": "ziFSi2LSr3sFCFWjVqKJMS1OjS7",
+            "key": "key-825816014",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "p7eYoTmth5EErf3XWFIC2nroaJO",
+            "key": "key-842155684",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:08:15\u002B00:00"
+          },
+          {
+            "etag": "A66N4W2YWHswFYaAJevwOD3bGKk",
+            "key": "key-844845286",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "wMe2GAHNWBGeiGImsphYsmWC1Sx",
+            "key": "key-850661731",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:19:22\u002B00:00"
+          },
+          {
+            "etag": "hJGep8R6IQISAYoQ9QAhPjqFoP6",
+            "key": "key-856544848",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:12:29\u002B00:00"
+          },
+          {
+            "etag": "xxK2VYXZ9lluVoV0RYZ5Nt7deCf",
+            "key": "key-888672085",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
             "etag": "Bl3dmm3GEsNjrsYiDfbVUiC0bI5",
             "key": "key-8ceee39b359e4ce3a2e1c33ff46c86dc",
             "label": "0",
@@ -345,6 +5027,1124 @@
             "last_modified": "2019-04-10T23:14:46\u002B00:00"
           },
           {
+            "etag": "2WBS3VF35CADLzsxDcfnjBYZZ0h",
+            "key": "key-901817556",
+            "label": "0",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:14\u002B00:00"
+          },
+          {
+            "etag": "3tNuz7SI8ioS6mZFTB2mDmQQJOy",
+            "key": "key-901817556",
+            "label": "1",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:14\u002B00:00"
+          },
+          {
+            "etag": "u5mmznxUMa2zdt25UFcjBc0ZczC",
+            "key": "key-901817556",
+            "label": "10",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "2aYqPmnuvaV9amxrQDHxyXXC62s",
+            "key": "key-901817556",
+            "label": "100",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:21\u002B00:00"
+          },
+          {
+            "etag": "SECJLpWFJw93ElK778JYM3mMc1N",
+            "key": "key-901817556",
+            "label": "101",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:21\u002B00:00"
+          },
+          {
+            "etag": "mwtGMSJCjBi6b6KZk8XoxyHjfiJ",
+            "key": "key-901817556",
+            "label": "102",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:21\u002B00:00"
+          },
+          {
+            "etag": "JSpR4GvVmwXtxJnyuthYCUufZXg",
+            "key": "key-901817556",
+            "label": "103",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:21\u002B00:00"
+          },
+          {
+            "etag": "LSrDVA9Lul1RlXcivXBdIMZFd5l",
+            "key": "key-901817556",
+            "label": "104",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:21\u002B00:00"
+          },
+          {
+            "etag": "ucfMHifAFICNSZ165LRl6Meh8yo",
+            "key": "key-901817556",
+            "label": "11",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "qd2FhW3K3rRfIsunkC5sgQeQcUm",
+            "key": "key-901817556",
+            "label": "12",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "JASL1J0dGtqNCiJKylSFk4AsuhD",
+            "key": "key-901817556",
+            "label": "13",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "xVr780IAagd9eqnp4tqmCo7OwSx",
+            "key": "key-901817556",
+            "label": "14",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "o23F98Cg11tLi5OycyVuwmSfPWa",
+            "key": "key-901817556",
+            "label": "15",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "sAXoXttLD5MCpZPddQtplCO2HnT",
+            "key": "key-901817556",
+            "label": "16",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "SERj0FZt4INh75B3TIEI8GZb9Hj",
+            "key": "key-901817556",
+            "label": "17",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "EloVEUV4ZB9ysSrjOz0trTARbqs",
+            "key": "key-901817556",
+            "label": "18",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "O2hiRa482uheYQgs3f91uhwS71D",
+            "key": "key-901817556",
+            "label": "19",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "4zC4uZpPgEIWpZbKv6AMp1ArczG",
+            "key": "key-901817556",
+            "label": "2",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:14\u002B00:00"
+          },
+          {
+            "etag": "g90oHlF7rflbniYGXAmLdxjzRHF",
+            "key": "key-901817556",
+            "label": "20",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "CX7Clh5Vrm8dGboxN2kwQJEVtDZ",
+            "key": "key-901817556",
+            "label": "21",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "RkSGehz10DoDocXndEaohUOB4dh",
+            "key": "key-901817556",
+            "label": "22",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "fjN56XZ0mxIf7WeTWse9qlofLzb",
+            "key": "key-901817556",
+            "label": "23",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "7oWMBvkf2ZSHWNjTKgm7BOqXKnQ",
+            "key": "key-901817556",
+            "label": "24",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:15\u002B00:00"
+          },
+          {
+            "etag": "1zY4V9r9yXE6r56blLKz19jqeTi",
+            "key": "key-901817556",
+            "label": "25",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "jftXKZT302GVfX9W5PnowTUYma4",
+            "key": "key-901817556",
+            "label": "26",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "3Tw2NNYAFM48NXGdNGQ7FUlguVu",
+            "key": "key-901817556",
+            "label": "27",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "hqbf1UX5MvS1KbyqqHf5ZEGrUWj",
+            "key": "key-901817556",
+            "label": "28",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "ijmbuiT9qzpUEicFIwM788phkZX",
+            "key": "key-901817556",
+            "label": "29",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "3nW8zP2xVmwPrmYuRuJOFD9GWNs",
+            "key": "key-901817556",
+            "label": "3",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:14\u002B00:00"
+          },
+          {
+            "etag": "wXQp0Gn2PXO4BKkU4qemYnwZZZS",
+            "key": "key-901817556",
+            "label": "30",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "NYXGOyot9U57WvRKr6vk86OnebB",
+            "key": "key-901817556",
+            "label": "31",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "D83rlgxZopHG2FxLXvYbP62tdw9",
+            "key": "key-901817556",
+            "label": "32",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "7MJNVYgPTGDTcPkAbqjOwrmEL3m",
+            "key": "key-901817556",
+            "label": "33",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "wmYVA9eb5oFKwHPFhYgtQVUpm0P",
+            "key": "key-901817556",
+            "label": "34",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "2exUYpDJMh49U3Aqw3GMtwsoHQV",
+            "key": "key-901817556",
+            "label": "35",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "xrlwDI0fovR7A30TzcsL40jHdPx",
+            "key": "key-901817556",
+            "label": "36",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "GEstr0aQtlFSWvlVtMWwFsCMUI2",
+            "key": "key-901817556",
+            "label": "37",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "5hNgpd7k92xBotXCb41wi9bcfCr",
+            "key": "key-901817556",
+            "label": "38",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "moVhOIHsz8rRuYLZf3iWQf4q52Z",
+            "key": "key-901817556",
+            "label": "39",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "UAF1dNrpbcPvHm2f0iDuQcbUwZX",
+            "key": "key-901817556",
+            "label": "4",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:14\u002B00:00"
+          },
+          {
+            "etag": "V0GrdYyd6FThlzlibnQ3mThv3CY",
+            "key": "key-901817556",
+            "label": "40",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "ma1sAj6CuI4hrFIeqtrz93ybImT",
+            "key": "key-901817556",
+            "label": "41",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:16\u002B00:00"
+          },
+          {
+            "etag": "exAF2PKxRpK3579yvzqU0q4HSfD",
+            "key": "key-901817556",
+            "label": "42",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          },
+          {
+            "etag": "XrEkn5JjN4gyiJ6QAHEUUq12HQN",
+            "key": "key-901817556",
+            "label": "43",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          },
+          {
+            "etag": "fPmQdiliv67acRCZET5QDAHylfc",
+            "key": "key-901817556",
+            "label": "44",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          },
+          {
+            "etag": "RjmpAq8ykZSZgUnWFg3ZHpiKmhw",
+            "key": "key-901817556",
+            "label": "45",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          },
+          {
+            "etag": "IzLVqCoZd8lkfr0DGXMdzhTmmxy",
+            "key": "key-901817556",
+            "label": "46",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          },
+          {
+            "etag": "24DU8Wr76RjBm3nsewb6z1aJPNm",
+            "key": "key-901817556",
+            "label": "47",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          },
+          {
+            "etag": "5y9mGh534d1i0GQWE6EI0OodgCK",
+            "key": "key-901817556",
+            "label": "48",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          },
+          {
+            "etag": "lGhw2zXMFjyztL8jSnrtqBBE0o4",
+            "key": "key-901817556",
+            "label": "49",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          },
+          {
+            "etag": "BCeo162iiFYs5FScOS4gCVomwd6",
+            "key": "key-901817556",
+            "label": "5",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:14\u002B00:00"
+          },
+          {
+            "etag": "eCbW6iHVyNRGReOtMGjzz0R6ykO",
+            "key": "key-901817556",
+            "label": "50",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          },
+          {
+            "etag": "7Uvp6Pp2RZRUYIS1Lcjk1z8YPuk",
+            "key": "key-901817556",
+            "label": "51",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          },
+          {
+            "etag": "gsTySrNMFJUn7NPN7Y8h2T641R5",
+            "key": "key-901817556",
+            "label": "52",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          }
+        ],
+        "@nextLink": "/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LTkwMTgxNzU1Ngo1Mg%3D%3D"
+      }
+    },
+    {
+      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=%2A\u0026label=%2A\u0026after=a2V5LTkwMTgxNzU1Ngo1Mg%3D%3D\u0026api-version=1.0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/vnd.microsoft.appconfig.kv\u002Bjson",
+        "Authorization": "Sanitized",
+        "Date": "Mon, 14 Oct 2019 21:27:08 GMT",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTg=",
+        "User-Agent": [
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
+        ],
+        "x-ms-client-request-id": "a7fa9dbaa8f0cab0b28b841e17a5a448",
+        "x-ms-content-sha256": "47DEQpj8HBSa\u002B/TImW\u002B5JCeuQeRkm5NMpJWZG3hSuFU=",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Access-Control-Allow-Methods": "GET, PUT, POST, DELETE, PATCH, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Connection": "keep-alive",
+        "Content-Type": "application/vnd.microsoft.appconfig.kvset\u002Bjson; charset=utf-8",
+        "Date": "Mon, 14 Oct 2019 21:27:08 GMT",
+        "Link": "\u003C/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LWNmNGFjNjc2NDBmYzQ2ZjJiNjgyNTgzYzIxN2IyOGRhCjM2\u003E; rel=\u0022next\u0022",
+        "Server": "openresty/1.15.8.1",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTg=;sn=651098",
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "a7fa9dbaa8f0cab0b28b841e17a5a448",
+        "x-ms-correlation-request-id": "a2ee5ac1-1160-41a0-8bf5-a06a740ca885",
+        "x-ms-request-id": "a2ee5ac1-1160-41a0-8bf5-a06a740ca885"
+      },
+      "ResponseBody": {
+        "items": [
+          {
+            "etag": "DoS2qa79UKn2PVdeXi427wJZeLj",
+            "key": "key-901817556",
+            "label": "53",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          },
+          {
+            "etag": "kEx1La6qBMF3zT3QdivgN6FRffc",
+            "key": "key-901817556",
+            "label": "54",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:17\u002B00:00"
+          },
+          {
+            "etag": "hBabux2cYtEg4IfmxN98yGHMQnt",
+            "key": "key-901817556",
+            "label": "55",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "N6pJU8JpgqDvwWqsFeGzW8oUAYa",
+            "key": "key-901817556",
+            "label": "56",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "AYdc78T0ksPxwY8Hf0DvC1yBrGP",
+            "key": "key-901817556",
+            "label": "57",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "EuK1rnNADGLa9uYzz7I2A9jsfrs",
+            "key": "key-901817556",
+            "label": "58",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "KZz2r2IZ7zQTLcN9sDuf44fR6E8",
+            "key": "key-901817556",
+            "label": "59",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "SjKju83rMV65Moylr0vWJUhNHYM",
+            "key": "key-901817556",
+            "label": "6",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:14\u002B00:00"
+          },
+          {
+            "etag": "smF3RvvL5qmLw440H1Iu2ktf8DB",
+            "key": "key-901817556",
+            "label": "60",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "V4yJmeUuqlJ7HukwtJ8q2QK73qW",
+            "key": "key-901817556",
+            "label": "61",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "aBq8SOUjNlNArquWqhaqz1PCIp6",
+            "key": "key-901817556",
+            "label": "62",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "6MTgxZGQ6oB7BE2R2JxEzpUyBUx",
+            "key": "key-901817556",
+            "label": "63",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "NHnKOZGX9XLyfqNj1ldp9QifkK0",
+            "key": "key-901817556",
+            "label": "64",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "EPxvd3BZzmPBBqYnuWvLLbxakYA",
+            "key": "key-901817556",
+            "label": "65",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "2Jds23wbIhoKxZP7ZmIsXZRHS5J",
+            "key": "key-901817556",
+            "label": "66",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "OMV4443b5ponIT1uIySYijySGYO",
+            "key": "key-901817556",
+            "label": "67",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "Or5wb73uK4v64h33k88LycR1mPR",
+            "key": "key-901817556",
+            "label": "68",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:18\u002B00:00"
+          },
+          {
+            "etag": "qz4lc0GVowlThXViNJpRsialMqs",
+            "key": "key-901817556",
+            "label": "69",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "GiJT0gcD0spH0jDf7pMLiH6wdpp",
+            "key": "key-901817556",
+            "label": "7",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:14\u002B00:00"
+          },
+          {
+            "etag": "EOIKESN3P2mEKMrHBRQvlClofLW",
+            "key": "key-901817556",
+            "label": "70",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "haGvqOTzokYXsmlNWcGJJFORZnt",
+            "key": "key-901817556",
+            "label": "71",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "L9HfTs9HXmAQC7BCkkLG0JL5IWO",
+            "key": "key-901817556",
+            "label": "72",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "lw6owjc38BbJAuQdMdB6I9vV62Z",
+            "key": "key-901817556",
+            "label": "73",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "lX2nr2wcH9lZTfHlMzAuwJXz2NL",
+            "key": "key-901817556",
+            "label": "74",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "az93AsEMa8qxlNRva3Cwp4x4iEs",
+            "key": "key-901817556",
+            "label": "75",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "OhBf574X7lUXDI760GQzntCFx0O",
+            "key": "key-901817556",
+            "label": "76",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "uCrjjOBoEaLA6l4SFG1GHyglQNZ",
+            "key": "key-901817556",
+            "label": "77",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "Sxo178BVIG4vEcz1iz2l036EvJ3",
+            "key": "key-901817556",
+            "label": "78",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "EJ0hhS1Z3iI8sPs4GEr3ib690m5",
+            "key": "key-901817556",
+            "label": "79",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "6UHEWp9F1SeMCYGTe544NfP8FpM",
+            "key": "key-901817556",
+            "label": "8",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:14\u002B00:00"
+          },
+          {
+            "etag": "HljCOUnAztk7XdMEhkFLmd9mQWB",
+            "key": "key-901817556",
+            "label": "80",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "c3h37yYzivYvW9yHtyDnbIpuoPk",
+            "key": "key-901817556",
+            "label": "81",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "0d8V5UOD3Pt1KfUtNSLE2lPdx4N",
+            "key": "key-901817556",
+            "label": "82",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "i1T3w2up6ALM7kG50jkWa4ukikn",
+            "key": "key-901817556",
+            "label": "83",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:19\u002B00:00"
+          },
+          {
+            "etag": "qCcSjim0jbEJT36WAa5W46C9fBK",
+            "key": "key-901817556",
+            "label": "84",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "QuVl7Zhz4dgLc4SzLgGysRr5W7Q",
+            "key": "key-901817556",
+            "label": "85",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "YTiLTZ8clmQgCeEoPWFhYaNkvqP",
+            "key": "key-901817556",
+            "label": "86",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "AxMZeLdbGCxzk7LslKerYzjqfNc",
+            "key": "key-901817556",
+            "label": "87",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "EvwZPwhrmztB2du6EHpqYR7eDjb",
+            "key": "key-901817556",
+            "label": "88",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "Vwwo9VetM4wwiMXElElgvp5I0nX",
+            "key": "key-901817556",
+            "label": "89",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "T3rYgLNyPBQ4njDdZjoLHO9x158",
+            "key": "key-901817556",
+            "label": "9",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:14\u002B00:00"
+          },
+          {
+            "etag": "TqYeMaGB0lnij4ZCfhHSo3GNakv",
+            "key": "key-901817556",
+            "label": "90",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "lPWqzcGN4aVps8BEG7NSWDffDOq",
+            "key": "key-901817556",
+            "label": "91",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "rkOIHii3MFSNzKWdjB0xYUdteRu",
+            "key": "key-901817556",
+            "label": "92",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "zGCIDBV23iV94iDm6a1pfCnTwAx",
+            "key": "key-901817556",
+            "label": "93",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "BiXlR2dlQNZO7ppMhWIfaLWggtQ",
+            "key": "key-901817556",
+            "label": "94",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "h1xZKmnYBRsHckWJdWHVgcl3cpV",
+            "key": "key-901817556",
+            "label": "95",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "84kIDFXhZhFMua2sg1H7ndCO1CL",
+            "key": "key-901817556",
+            "label": "96",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "o5oFLJPc4MCyAlcleYXZsuKYRhE",
+            "key": "key-901817556",
+            "label": "97",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:20\u002B00:00"
+          },
+          {
+            "etag": "IQvpH9A7R4YRX1vX3XudhD2AjxG",
+            "key": "key-901817556",
+            "label": "98",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:21\u002B00:00"
+          },
+          {
+            "etag": "HA8Ji7FPmMSIHWNNN9dlKYmmR3G",
+            "key": "key-901817556",
+            "label": "99",
+            "content_type": null,
+            "value": "test_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T21:47:21\u002B00:00"
+          },
+          {
+            "etag": "swa9FtVZaFSMT2Smpp2uEEOVfc0",
+            "key": "key-906145651",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:15:11\u002B00:00"
+          },
+          {
+            "etag": "ZyRlG0DRH9wpcvCiJSD43HtGP2d",
+            "key": "key-909199832",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:05:26\u002B00:00"
+          },
+          {
             "etag": "8CyYkv9oFg0BAPHmThI4s60qrQY",
             "key": "key-924dfd3642cd49529ec6420627ccfbf3",
             "label": null,
@@ -353,6 +6153,19 @@
             "tags": {},
             "locked": false,
             "last_modified": "2019-04-10T23:18:13\u002B00:00"
+          },
+          {
+            "etag": "hFZ3qz7iVPHs5NFAkeirApwO2zH",
+            "key": "key-928916906",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
           },
           {
             "etag": "m8QLwhqsr8XTjnxCNNumh8AP1M7",
@@ -366,6 +6179,58 @@
             },
             "locked": false,
             "last_modified": "2019-04-10T23:18:12\u002B00:00"
+          },
+          {
+            "etag": "FI4NS8fjFxewlzANoG7VHFp16up",
+            "key": "key-964002372",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:31\u002B00:00"
+          },
+          {
+            "etag": "F5iaae3gfe6Ant9sWkKCPW1QnOu",
+            "key": "key-971667487",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value2",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:06\u002B00:00"
+          },
+          {
+            "etag": "ScRzoMvgTVRpQji2YvKKSg28ikS",
+            "key": "key-98057351",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:50\u002B00:00"
+          },
+          {
+            "etag": "2IAoU9zDlEkqezrn955i8jYmNlt",
+            "key": "key-989748038",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
           },
           {
             "etag": "Hkd41xJvSuXdYustHzporIKJ0wS",
@@ -778,7 +6643,48 @@
             "tags": {},
             "locked": false,
             "last_modified": "2019-04-08T20:02:34\u002B00:00"
-          },
+          }
+        ],
+        "@nextLink": "/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LWNmNGFjNjc2NDBmYzQ2ZjJiNjgyNTgzYzIxN2IyOGRhCjM2"
+      }
+    },
+    {
+      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=%2A\u0026label=%2A\u0026after=a2V5LWNmNGFjNjc2NDBmYzQ2ZjJiNjgyNTgzYzIxN2IyOGRhCjM2\u0026api-version=1.0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/vnd.microsoft.appconfig.kv\u002Bjson",
+        "Authorization": "Sanitized",
+        "Date": "Mon, 14 Oct 2019 21:27:08 GMT",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTg=",
+        "User-Agent": [
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
+        ],
+        "x-ms-client-request-id": "53a908e779f26c968ae7e0d4462a5836",
+        "x-ms-content-sha256": "47DEQpj8HBSa\u002B/TImW\u002B5JCeuQeRkm5NMpJWZG3hSuFU=",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Access-Control-Allow-Methods": "GET, PUT, POST, DELETE, PATCH, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Connection": "keep-alive",
+        "Content-Type": "application/vnd.microsoft.appconfig.kvset\u002Bjson; charset=utf-8",
+        "Date": "Mon, 14 Oct 2019 21:27:08 GMT",
+        "Server": "openresty/1.15.8.1",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTg=;sn=651098",
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "53a908e779f26c968ae7e0d4462a5836",
+        "x-ms-correlation-request-id": "ec17ed45-1929-4793-ac91-bf043ac61857",
+        "x-ms-request-id": "ec17ed45-1929-4793-ac91-bf043ac61857"
+      },
+      "ResponseBody": {
+        "items": [
           {
             "etag": "93AZxTGVH4THERefq0bS2lbdz2F",
             "key": "key-cf4ac67640fc46f2b682583c217b28da",
@@ -1148,48 +7054,7 @@
             "tags": {},
             "locked": false,
             "last_modified": "2019-04-08T20:02:33\u002B00:00"
-          }
-        ],
-        "@nextLink": "/kv/?key=*\u0026label=*\u0026api-version=1.0\u0026after=a2V5LWNmNGFjNjc2NDBmYzQ2ZjJiNjgyNTgzYzIxN2IyOGRhCjc%3D"
-      }
-    },
-    {
-      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=*\u0026label=*\u0026after=a2V5LWNmNGFjNjc2NDBmYzQ2ZjJiNjgyNTgzYzIxN2IyOGRhCjc%3D\u0026api-version=1.0",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/vnd.microsoft.appconfig.kv\u002Bjson",
-        "Authorization": "Sanitized",
-        "Date": "Wed, 18 Sep 2019 21:33:04 GMT",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg3MDc=",
-        "User-Agent": [
-          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20190918.1\u002B0c319f5fd30ac3e2e5bc2936122815be22444424",
-          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
-        ],
-        "x-ms-client-request-id": "da388f8719a6e73abbda5f29f8abea72",
-        "x-ms-content-sha256": "47DEQpj8HBSa\u002B/TImW\u002B5JCeuQeRkm5NMpJWZG3hSuFU=",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Access-Control-Allow-Credentials": "true",
-        "Access-Control-Allow-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
-        "Access-Control-Allow-Methods": "GET, PUT, POST, DELETE, PATCH, OPTIONS",
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
-        "Connection": "keep-alive",
-        "Content-Type": "application/vnd.microsoft.appconfig.kvset\u002Bjson; charset=utf-8",
-        "Date": "Wed, 18 Sep 2019 21:33:04 GMT",
-        "Server": "nginx/1.13.12",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg3MDc=;sn=538707",
-        "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "da388f8719a6e73abbda5f29f8abea72",
-        "x-ms-correlation-request-id": "b94e21ee-5af8-45d2-88cd-24e7b2622083",
-        "x-ms-request-id": "b94e21ee-5af8-45d2-88cd-24e7b2622083"
-      },
-      "ResponseBody": {
-        "items": [
+          },
           {
             "etag": "Q2Z5NQszD58WLtEsnI22eJuJADg",
             "key": "key-cf4ac67640fc46f2b682583c217b28da",
@@ -1557,6 +7422,76 @@
             "last_modified": "2019-04-10T23:18:12\u002B00:00"
           },
           {
+            "etag": "sJhXRMt0oFPmiRExBrT1OkoQao4",
+            "key": "keyFields-1371382479",
+            "label": "my_label",
+            "content_type": null,
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          },
+          {
+            "etag": "PpTompYZlgc2s52cMRfcVZK0ock",
+            "key": "keyFields-1540288930",
+            "label": "my_label",
+            "content_type": null,
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "VS47CSVQtEsSHC1HeSiJU9cyfL7",
+            "key": "keyFields-1640774616",
+            "label": "my_label",
+            "content_type": "content-type",
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "Z773tvtnqrQQcaYLNI8bzdZvV0n",
+            "key": "keyFields-1659776538",
+            "label": "my_label",
+            "content_type": "content-type",
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:11\u002B00:00"
+          },
+          {
+            "etag": "qErvzTBxCZXyAzR1l6D1GTSeesz",
+            "key": "keyFields-1877364315",
+            "label": "my_label",
+            "content_type": null,
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "1cclG3RoPU4Bk2sIwgauKRqH5d9",
+            "key": "keyFields-2097297878",
+            "label": "my_label",
+            "content_type": "content-type",
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          },
+          {
+            "etag": "9CeW4shpXV3sXcwndojGKwqlclH",
+            "key": "keyFields-318044282",
+            "label": "my_label",
+            "content_type": null,
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
             "etag": "xRncVWEnGCOgj3BcgbND0N4zq9M",
             "key": "keyFields-4090cd05582f4af7b4c0992cbfcff1cd",
             "label": "my_label",
@@ -1585,6 +7520,26 @@
             "tags": {},
             "locked": false,
             "last_modified": "2019-04-10T23:26:24\u002B00:00"
+          },
+          {
+            "etag": "KghQZTfl8QJTskbJULTUkbqz0el",
+            "key": "keyFields-866062596",
+            "label": "my_label",
+            "content_type": "content-type",
+            "value": "my_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "6AugBtdAacltSCC5Sj6RZVjqZa0",
+            "key": "some_key",
+            "label": null,
+            "content_type": null,
+            "value": "new_value",
+            "tags": {},
+            "locked": false,
+            "last_modified": "2019-10-11T21:03:44\u002B00:00"
           }
         ]
       }
@@ -1594,14 +7549,14 @@
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "Date": "Wed, 18 Sep 2019 21:33:04 GMT",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg3MDc=",
-        "traceparent": "00-bd351bf10efd30488f6565a9836d9ead-930920b60f12f948-00",
+        "Date": "Mon, 14 Oct 2019 21:27:08 GMT",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTg=",
+        "traceparent": "00-f26ff257efa5c344ba1720df79df4d6e-d52ab71c2128e14f-00",
         "User-Agent": [
-          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20190918.1\u002B0c319f5fd30ac3e2e5bc2936122815be22444424",
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
           "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
         ],
-        "x-ms-client-request-id": "bb7aad96b4534b2e54d5823a1ba11fc2",
+        "x-ms-client-request-id": "09ce82684710e98917e4f4a03da8bbba",
         "x-ms-content-sha256": "47DEQpj8HBSa\u002B/TImW\u002B5JCeuQeRkm5NMpJWZG3hSuFU=",
         "x-ms-return-client-request-id": "true"
       },
@@ -1615,19 +7570,19 @@
         "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
         "Connection": "keep-alive",
         "Content-Type": "application/vnd.microsoft.appconfig.kv\u002Bjson; charset=utf-8",
-        "Date": "Wed, 18 Sep 2019 21:33:04 GMT",
-        "ETag": "\u0022f0Y8fclWXSyMikdBTEd7JW7AJzM\u0022",
-        "Last-Modified": "Wed, 18 Sep 2019 21:33:04 GMT",
-        "Server": "nginx/1.13.12",
+        "Date": "Mon, 14 Oct 2019 21:27:08 GMT",
+        "ETag": "\u0022V05MJKSeZIfH79ayQILiflCQ1tB\u0022",
+        "Last-Modified": "Mon, 14 Oct 2019 21:27:08 GMT",
+        "Server": "openresty/1.15.8.1",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg3MDg=;sn=538708",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTk=;sn=651099",
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "bb7aad96b4534b2e54d5823a1ba11fc2",
-        "x-ms-correlation-request-id": "22a544bc-3aa6-4c44-9924-f8d8b7008901",
-        "x-ms-request-id": "22a544bc-3aa6-4c44-9924-f8d8b7008901"
+        "x-ms-client-request-id": "09ce82684710e98917e4f4a03da8bbba",
+        "x-ms-correlation-request-id": "4d8dcadd-2bfd-48a9-ab5f-6d08a64f84fd",
+        "x-ms-request-id": "4d8dcadd-2bfd-48a9-ab5f-6d08a64f84fd"
       },
       "ResponseBody": {
-        "etag": "f0Y8fclWXSyMikdBTEd7JW7AJzM",
+        "etag": "V05MJKSeZIfH79ayQILiflCQ1tB",
         "key": "key-1301486225",
         "label": "test_label",
         "content_type": "test_content_type",
@@ -1637,7 +7592,7 @@
           "tag2": "value2"
         },
         "locked": false,
-        "last_modified": "2019-09-18T21:33:04\u002B00:00"
+        "last_modified": "2019-10-14T21:27:08\u002B00:00"
       }
     }
   ],

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/SessionRecords/ConfigurationLiveTests/GetBatchSettingOnlyLabel.json
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/SessionRecords/ConfigurationLiveTests/GetBatchSettingOnlyLabel.json
@@ -8,10 +8,10 @@
         "Authorization": "Sanitized",
         "Content-Length": "98",
         "Content-Type": "application/json",
-        "Date": "Wed, 18 Sep 2019 21:33:01 GMT",
-        "traceparent": "00-dc36dacfc002c5489ea934e074cad536-60a93bf6bdbaae43-00",
+        "Date": "Mon, 14 Oct 2019 21:21:58 GMT",
+        "traceparent": "00-a9fc597579ad5d41b7cf4a1f57680aa5-be384f30a17ecb49-00",
         "User-Agent": [
-          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20190918.1\u002B0c319f5fd30ac3e2e5bc2936122815be22444424",
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
           "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
         ],
         "x-ms-client-request-id": "3b34655bb1e68bd9eeba66751a973b80",
@@ -35,19 +35,19 @@
         "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
         "Connection": "keep-alive",
         "Content-Type": "application/vnd.microsoft.appconfig.kv\u002Bjson; charset=utf-8",
-        "Date": "Wed, 18 Sep 2019 21:33:01 GMT",
-        "ETag": "\u0022uiMuUmUh2cT8Qxb5LLmmAKQt1xQ\u0022",
-        "Last-Modified": "Wed, 18 Sep 2019 21:33:02 GMT",
-        "Server": "nginx/1.13.12",
+        "Date": "Mon, 14 Oct 2019 21:21:59 GMT",
+        "ETag": "\u0022KN2kssZblmh0NDoGUHiD5CgVvuG\u0022",
+        "Last-Modified": "Mon, 14 Oct 2019 21:21:59 GMT",
+        "Server": "openresty/1.15.8.1",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg2NTg=;sn=538658",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTI=;sn=651092",
         "Transfer-Encoding": "chunked",
         "x-ms-client-request-id": "3b34655bb1e68bd9eeba66751a973b80",
-        "x-ms-correlation-request-id": "bd756698-e6d3-4b86-8f9b-208f5ad59ee8",
-        "x-ms-request-id": "bd756698-e6d3-4b86-8f9b-208f5ad59ee8"
+        "x-ms-correlation-request-id": "4d86a285-dfb6-408a-b6d6-ae458f23fad9",
+        "x-ms-request-id": "4d86a285-dfb6-408a-b6d6-ae458f23fad9"
       },
       "ResponseBody": {
-        "etag": "uiMuUmUh2cT8Qxb5LLmmAKQt1xQ",
+        "etag": "KN2kssZblmh0NDoGUHiD5CgVvuG",
         "key": "key-215294593",
         "label": "test_label",
         "content_type": "test_content_type",
@@ -57,19 +57,19 @@
           "tag2": "value2"
         },
         "locked": false,
-        "last_modified": "2019-09-18T21:33:02\u002B00:00"
+        "last_modified": "2019-10-14T21:21:59\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=*\u0026label=test_label\u0026api-version=1.0",
+      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=%2A\u0026label=test_label\u0026api-version=1.0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/vnd.microsoft.appconfig.kv\u002Bjson",
         "Authorization": "Sanitized",
-        "Date": "Wed, 18 Sep 2019 21:33:01 GMT",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg2NTg=",
+        "Date": "Mon, 14 Oct 2019 21:21:59 GMT",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTI=",
         "User-Agent": [
-          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20190918.1\u002B0c319f5fd30ac3e2e5bc2936122815be22444424",
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
           "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
         ],
         "x-ms-client-request-id": "72edca4c594a3fc58f8d9937bebcc338",
@@ -86,19 +86,657 @@
         "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
         "Connection": "keep-alive",
         "Content-Type": "application/vnd.microsoft.appconfig.kvset\u002Bjson; charset=utf-8",
-        "Date": "Wed, 18 Sep 2019 21:33:01 GMT",
-        "Server": "nginx/1.13.12",
+        "Date": "Mon, 14 Oct 2019 21:21:59 GMT",
+        "Link": "\u003C/kv/?key=*\u0026label=test_label\u0026api-version=1.0\u0026after=a2V5LTk4OTc0ODAzOAp0ZXN0X2xhYmVs\u003E; rel=\u0022next\u0022",
+        "Server": "openresty/1.15.8.1",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg2NTg=;sn=538658",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTI=;sn=651092",
         "Transfer-Encoding": "chunked",
         "x-ms-client-request-id": "72edca4c594a3fc58f8d9937bebcc338",
-        "x-ms-correlation-request-id": "25cae6a5-bccf-40c3-bf7f-42ff5e53dba6",
-        "x-ms-request-id": "25cae6a5-bccf-40c3-bf7f-42ff5e53dba6"
+        "x-ms-correlation-request-id": "be272e1c-05b8-455d-a1df-996a88950d64",
+        "x-ms-request-id": "be272e1c-05b8-455d-a1df-996a88950d64"
       },
       "ResponseBody": {
         "items": [
           {
-            "etag": "uiMuUmUh2cT8Qxb5LLmmAKQt1xQ",
+            "etag": "ra7jHrNYwGCAWoymb4IQ0vCf9Dc",
+            "key": "key-1163835415",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:05:25\u002B00:00"
+          },
+          {
+            "etag": "6xrBoXzeP89iBJRpf5T0we4QNyC",
+            "key": "key-1174564512",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-20T03:01:39\u002B00:00"
+          },
+          {
+            "etag": "kCagdhqBQFNcZIJ5TxAb3jEL49w",
+            "key": "key-1177019792",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          },
+          {
+            "etag": "dHSZTRqmOXNJyLJF5pufiU6dquK",
+            "key": "key-1200977498",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:05\u002B00:00"
+          },
+          {
+            "etag": "9TzQS7loYjGo2dBa7gI8avECM9s",
+            "key": "key-1231954601",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value2",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:05:25\u002B00:00"
+          },
+          {
+            "etag": "uDoIwJFA6EMimAymtZE1ZaSadeR",
+            "key": "key-1233529568",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "IhCaZZtjxhJZOT4kst86ivVrDM9",
+            "key": "key-1252062984",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "3SJLTRLYcKynZOamHZu0ojwaIyJ",
+            "key": "key-1252790990",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:55\u002B00:00"
+          },
+          {
+            "etag": "0O2xWLZV29ZqSe9JbQLXJQR3Sm5",
+            "key": "key-1277519220",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:55\u002B00:00"
+          },
+          {
+            "etag": "JURXg9Zala8Ujo5fYA9kW4Rf6hP",
+            "key": "key-1301486225",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-14T21:17:43\u002B00:00"
+          },
+          {
+            "etag": "hY8crHO0a8k74AawBFGHHlvjm7J",
+            "key": "key-1309283906",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:06:04\u002B00:00"
+          },
+          {
+            "etag": "YufLr1ND2auNin5dZJLuB96Gxpy",
+            "key": "key-1323592047",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:08:00\u002B00:00"
+          },
+          {
+            "etag": "SfxQW7xVa3XkOnp3SllRt84cWlR",
+            "key": "key-1353875726",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:05:26\u002B00:00"
+          },
+          {
+            "etag": "WHB977nXW2zZL8AFGNAI6FpKppK",
+            "key": "key-1364459659",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "LUbaTeaEo7iZWJqwMCEiwZ64N3K",
+            "key": "key-1369197868",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
+          },
+          {
+            "etag": "URTIJGQelXjQVWasVWsg4xe6rLb",
+            "key": "key-13811035",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:18:13\u002B00:00"
+          },
+          {
+            "etag": "JBdU4qVsF5gcgIe1n7zZ77B5eso",
+            "key": "key-1381219121",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
+          },
+          {
+            "etag": "HsSY9HTWZ6d2SkPOzAGuIph6zYt",
+            "key": "key-1420801322",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "sbSjAQthvnfDGiKWz8rQ5NCpKjb",
+            "key": "key-1484301245",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:24:27\u002B00:00"
+          },
+          {
+            "etag": "1tzcwKQvcWBBVv7p3m6uPLyyOa7",
+            "key": "key-1488498371",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
+          },
+          {
+            "etag": "4yCOmwht9r1upewN8Odsi0Bcg8M",
+            "key": "key-1551731413",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "UpMP4mKBUEBjqQRMlD2sXB7FJEs",
+            "key": "key-156242278",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "wYuNxWrI5TQozzYpAciVySHaU7B",
+            "key": "key-1577810526",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "OrmLOlXvKFr9x2E1acXclGZD263",
+            "key": "key-1587818169",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:24:13\u002B00:00"
+          },
+          {
+            "etag": "wdhs1dq8NYXHheyCbky9eyWIKL5",
+            "key": "key-1603266762",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          },
+          {
+            "etag": "YHGfktoslQCCSNSEVuOCb1hrZcM",
+            "key": "key-1633697425",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "NpP8VyFX5Q6wjrXMNR1ftttz5Py",
+            "key": "key-1661468793",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T18:12:29\u002B00:00"
+          },
+          {
+            "etag": "xd7St6F6CuBJ2ONJelveJ5xaBLH",
+            "key": "key-1715663437",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          },
+          {
+            "etag": "Pn80ku8RIkNrPEza9y1k0aIv4MZ",
+            "key": "key-1716559556",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value2",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:55\u002B00:00"
+          },
+          {
+            "etag": "h3yjTfKtljOrEqb96vZ7jEhGm0o",
+            "key": "key-1720810414",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "3VeGoyPFcP4iGC2ExNPF2fkPvAb",
+            "key": "key-17297920",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "AeSBit4ycm1QEa90sDjW8PlBLaM",
+            "key": "key-1765082280",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "1D0YfHmg2SJuD6zEfhd31o9FNWq",
+            "key": "key-1786217009",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:31\u002B00:00"
+          },
+          {
+            "etag": "1BrnR77JndxaL4ndtsKgAkwuyr5",
+            "key": "key-1809216229",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "51F1mjgR1BCXDZyEVIog5KkxsVJ",
+            "key": "key-1828956231",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:55\u002B00:00"
+          },
+          {
+            "etag": "FliZ8FwgQ3NS58dfRL0HZrd5SXr",
+            "key": "key-1844884626",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:05:25\u002B00:00"
+          },
+          {
+            "etag": "Gxaxf0awnjXtA4Bh1MZzONQ1mW2",
+            "key": "key-1875045571",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:09\u002B00:00"
+          },
+          {
+            "etag": "e9o6tiNAhuQngS6rYK436ODRDcO",
+            "key": "key-1910922243",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:55\u002B00:00"
+          },
+          {
+            "etag": "qenIfhBrk88QpsJTwxuSSxm4SzC",
+            "key": "key-1919238788",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:07:04\u002B00:00"
+          },
+          {
+            "etag": "CWNgk6O4YLFZ12jqhHOPnCEDE8m",
+            "key": "key-1922091484",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "2VEHu39Mt7780fVEqtoadyUfE8i",
+            "key": "key-1934649991",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
+          },
+          {
+            "etag": "R8U84YRp2frl9PI0g3F4YYgrRB4",
+            "key": "key-1937393334",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:31\u002B00:00"
+          },
+          {
+            "etag": "zmZ65hqvHu2FpIbbMVi2HSGYbvr",
+            "key": "key-1983768591",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "ROiZnOqdsnLVV0G5QdaNHcEKew3",
+            "key": "key-2010525552",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:54\u002B00:00"
+          },
+          {
+            "etag": "h9729v3p9GahZj27TlRlI1sUIw5",
+            "key": "key-204035620",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:31\u002B00:00"
+          },
+          {
+            "etag": "QfOPNXMqjEueWYCaEchCrvT5uLW",
+            "key": "key-2051178311",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value2",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:50\u002B00:00"
+          },
+          {
+            "etag": "5VG77jljuIJ8c2qvTmTzjP5hFFR",
+            "key": "key-2053619125",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:09\u002B00:00"
+          },
+          {
+            "etag": "rGWi2Wsg21RdGcnFOl3AZxz42vr",
+            "key": "key-2113787248",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "k3sYCiP0mYo8BNoIeSsk97OZIel",
+            "key": "key-212129177",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          },
+          {
+            "etag": "KN2kssZblmh0NDoGUHiD5CgVvuG",
             "key": "key-215294593",
             "label": "test_label",
             "content_type": "test_content_type",
@@ -108,7 +746,59 @@
               "tag2": "value2"
             },
             "locked": false,
-            "last_modified": "2019-09-18T21:33:02\u002B00:00"
+            "last_modified": "2019-10-14T21:21:59\u002B00:00"
+          },
+          {
+            "etag": "agLm7TEWFYKCcksi2UyBz7ZVmn8",
+            "key": "key-221701127",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-14T21:16:39\u002B00:00"
+          },
+          {
+            "etag": "UhZIRQfYWPQzWAELLBfa09ehUvx",
+            "key": "key-222881053",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:15:13\u002B00:00"
+          },
+          {
+            "etag": "pnlSyvJyVdbopuT5WFhpD9ULr3G",
+            "key": "key-277273344",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "slvXjRxhTVg3IcKeO12PuutFgOp",
+            "key": "key-291156113",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
           },
           {
             "etag": "QB6ZifyjGfUn17lEKZMAK6No3jf",
@@ -124,6 +814,110 @@
             "last_modified": "2019-05-01T19:08:03\u002B00:00"
           },
           {
+            "etag": "mj5yMpfkn1kdd1K3YhPt5AUqhEf",
+            "key": "key-337032567",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:49\u002B00:00"
+          },
+          {
+            "etag": "Do7twZpoyGpe56S9tjkYR7T6oug",
+            "key": "key-407324161",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "Bn8Qww33MB3xLGowUmh9BGJVO4F",
+            "key": "key-429238547",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:06\u002B00:00"
+          },
+          {
+            "etag": "vUvAGXytPKGN4EdsONAZB1ZloOr",
+            "key": "key-439891543",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "RfYfTS1obmR3cR4S9WROiH1FeIE",
+            "key": "key-442070586",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T18:11:33\u002B00:00"
+          },
+          {
+            "etag": "HKbYauu5cqJbjg5dDwq7n3FC4oD",
+            "key": "key-442352028",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "WgaViI04lj7TF2VbpHTkzk3kaXr",
+            "key": "key-451104393",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          },
+          {
+            "etag": "wiUqbDzZboQ4lQ8wFOtMUTWkZ8E",
+            "key": "key-469594127",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:08:00\u002B00:00"
+          },
+          {
             "etag": "JmFAJhlGhqYS9XzZN5ZfdktOK3L",
             "key": "key-4dc1baef29474d1ea11dbf3b5c9a690c",
             "label": "test_label",
@@ -137,6 +931,110 @@
             "last_modified": "2019-04-10T23:26:23\u002B00:00"
           },
           {
+            "etag": "Zvd8V3jfPSFrHYk3rhF4Uvjh7ny",
+            "key": "key-52254665",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "QGxPc999Q76X1lFLQIzwwhGQSfO",
+            "key": "key-545314302",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value2",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:09\u002B00:00"
+          },
+          {
+            "etag": "nY5ZGit7NiAiLWOfDYMvLAOS1F7",
+            "key": "key-581866371",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:54\u002B00:00"
+          },
+          {
+            "etag": "MCSdJnjGySUVPVOgGrdvZYlkkCO",
+            "key": "key-601022664",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "VvjuWikzA4tTZVv7WRJQAs6uHa4",
+            "key": "key-603485485",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:21:29\u002B00:00"
+          },
+          {
+            "etag": "08VxcTF7XOikUwUcjmIaSnf225F",
+            "key": "key-611503496",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-20T03:01:47\u002B00:00"
+          },
+          {
+            "etag": "Jm36tIYyH7m8bPvrifYkVT1ofQb",
+            "key": "key-618631428",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:05\u002B00:00"
+          },
+          {
+            "etag": "BPubg2Ay3ofpoe2DKXrZNAVnt5e",
+            "key": "key-619387967",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:55\u002B00:00"
+          },
+          {
             "etag": "NNkiTFfEo9LzydkJzQXKNJKTyII",
             "key": "key-6413b030f9384ec9875636ae4ef38210",
             "label": "test_label",
@@ -148,6 +1046,58 @@
             },
             "locked": false,
             "last_modified": "2019-04-08T22:57:05\u002B00:00"
+          },
+          {
+            "etag": "R7nE3UyC94U7dxErKbGYFaUo3DX",
+            "key": "key-646766163",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T18:45:22\u002B00:00"
+          },
+          {
+            "etag": "hnHYu0T2IXWrlVW4iEyIx19J5E8",
+            "key": "key-665260818",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:16:37\u002B00:00"
+          },
+          {
+            "etag": "DLkqNFvqZGvKCUuGqwDtbY2cW8S",
+            "key": "key-674427950",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "dxDyLomTd2b0f9JRmhYcNokTopp",
+            "key": "key-676034902",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
           },
           {
             "etag": "yOAsvJzz97wJK3rXYDNGKswPLfs",
@@ -189,6 +1139,84 @@
             "last_modified": "2019-04-10T23:14:47\u002B00:00"
           },
           {
+            "etag": "cClYgjDuYXVjCdLxK46hyhs1Wi0",
+            "key": "key-708276799",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:54\u002B00:00"
+          },
+          {
+            "etag": "biYITZyCRHSxnnemqwgBOrCPqHa",
+            "key": "key-715857320",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value2",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:05:26\u002B00:00"
+          },
+          {
+            "etag": "uJbsczfnXinqQkeSEXeZVbYkHEg",
+            "key": "key-719454961",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-28T17:38:17\u002B00:00"
+          },
+          {
+            "etag": "fCkWnHvdpPNuvsu9EirkwToLIfb",
+            "key": "key-719690246",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T18:47:40\u002B00:00"
+          },
+          {
+            "etag": "304RpDyEyDoUVc329BbDsv9XAZl",
+            "key": "key-72708449",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "yzHXnBTeRhzlbNUHWHXUm2UHfvF",
+            "key": "key-786619267",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:50\u002B00:00"
+          },
+          {
             "etag": "m7EFRi22ngO0wY2LWxzcDYgMx0G",
             "key": "key-7d4e0bd02b004cafa8f82538e0716c93",
             "label": "test_label",
@@ -201,6 +1229,216 @@
             "locked": false,
             "last_modified": "2019-04-10T23:26:25\u002B00:00"
           },
+          {
+            "etag": "ziFSi2LSr3sFCFWjVqKJMS1OjS7",
+            "key": "key-825816014",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "p7eYoTmth5EErf3XWFIC2nroaJO",
+            "key": "key-842155684",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:08:15\u002B00:00"
+          },
+          {
+            "etag": "A66N4W2YWHswFYaAJevwOD3bGKk",
+            "key": "key-844845286",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "wMe2GAHNWBGeiGImsphYsmWC1Sx",
+            "key": "key-850661731",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:19:22\u002B00:00"
+          },
+          {
+            "etag": "hJGep8R6IQISAYoQ9QAhPjqFoP6",
+            "key": "key-856544848",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:12:29\u002B00:00"
+          },
+          {
+            "etag": "xxK2VYXZ9lluVoV0RYZ5Nt7deCf",
+            "key": "key-888672085",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "swa9FtVZaFSMT2Smpp2uEEOVfc0",
+            "key": "key-906145651",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:15:11\u002B00:00"
+          },
+          {
+            "etag": "ZyRlG0DRH9wpcvCiJSD43HtGP2d",
+            "key": "key-909199832",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:05:26\u002B00:00"
+          },
+          {
+            "etag": "hFZ3qz7iVPHs5NFAkeirApwO2zH",
+            "key": "key-928916906",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
+          },
+          {
+            "etag": "FI4NS8fjFxewlzANoG7VHFp16up",
+            "key": "key-964002372",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:31\u002B00:00"
+          },
+          {
+            "etag": "F5iaae3gfe6Ant9sWkKCPW1QnOu",
+            "key": "key-971667487",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value2",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:06\u002B00:00"
+          },
+          {
+            "etag": "ScRzoMvgTVRpQji2YvKKSg28ikS",
+            "key": "key-98057351",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:50\u002B00:00"
+          },
+          {
+            "etag": "2IAoU9zDlEkqezrn955i8jYmNlt",
+            "key": "key-989748038",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          }
+        ],
+        "@nextLink": "/kv/?key=*\u0026label=test_label\u0026api-version=1.0\u0026after=a2V5LTk4OTc0ODAzOAp0ZXN0X2xhYmVs"
+      }
+    },
+    {
+      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=%2A\u0026label=test_label\u0026after=a2V5LTk4OTc0ODAzOAp0ZXN0X2xhYmVs\u0026api-version=1.0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/vnd.microsoft.appconfig.kv\u002Bjson",
+        "Authorization": "Sanitized",
+        "Date": "Mon, 14 Oct 2019 21:21:59 GMT",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTI=",
+        "User-Agent": [
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
+        ],
+        "x-ms-client-request-id": "0be8fed41ae03f9c15681687ad677fa8",
+        "x-ms-content-sha256": "47DEQpj8HBSa\u002B/TImW\u002B5JCeuQeRkm5NMpJWZG3hSuFU=",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Access-Control-Allow-Methods": "GET, PUT, POST, DELETE, PATCH, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Connection": "keep-alive",
+        "Content-Type": "application/vnd.microsoft.appconfig.kvset\u002Bjson; charset=utf-8",
+        "Date": "Mon, 14 Oct 2019 21:21:59 GMT",
+        "Server": "openresty/1.15.8.1",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTI=;sn=651092",
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "0be8fed41ae03f9c15681687ad677fa8",
+        "x-ms-correlation-request-id": "5d9e5d1d-b19c-47c6-9bd0-2caf30149c92",
+        "x-ms-request-id": "5d9e5d1d-b19c-47c6-9bd0-2caf30149c92"
+      },
+      "ResponseBody": {
+        "items": [
           {
             "etag": "Hkd41xJvSuXdYustHzporIKJ0wS",
             "key": "key-a238e8dd62644ae1af58516c98613bae",
@@ -274,14 +1512,14 @@
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "Date": "Wed, 18 Sep 2019 21:33:01 GMT",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg2NTg=",
-        "traceparent": "00-c1f76d181b9acb4291d6acf75eadcd51-6ad88d2cd9122f4d-00",
+        "Date": "Mon, 14 Oct 2019 21:21:59 GMT",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTI=",
+        "traceparent": "00-1c4dfd7186474b45af324777f209de93-56752e09f1c7d94c-00",
         "User-Agent": [
-          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20190918.1\u002B0c319f5fd30ac3e2e5bc2936122815be22444424",
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
           "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
         ],
-        "x-ms-client-request-id": "0be8fed41ae03f9c15681687ad677fa8",
+        "x-ms-client-request-id": "2b733c3391410237a0f5ab5817a2cc31",
         "x-ms-content-sha256": "47DEQpj8HBSa\u002B/TImW\u002B5JCeuQeRkm5NMpJWZG3hSuFU=",
         "x-ms-return-client-request-id": "true"
       },
@@ -295,19 +1533,19 @@
         "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
         "Connection": "keep-alive",
         "Content-Type": "application/vnd.microsoft.appconfig.kv\u002Bjson; charset=utf-8",
-        "Date": "Wed, 18 Sep 2019 21:33:01 GMT",
-        "ETag": "\u0022uiMuUmUh2cT8Qxb5LLmmAKQt1xQ\u0022",
-        "Last-Modified": "Wed, 18 Sep 2019 21:33:02 GMT",
-        "Server": "nginx/1.13.12",
+        "Date": "Mon, 14 Oct 2019 21:21:59 GMT",
+        "ETag": "\u0022KN2kssZblmh0NDoGUHiD5CgVvuG\u0022",
+        "Last-Modified": "Mon, 14 Oct 2019 21:21:59 GMT",
+        "Server": "openresty/1.15.8.1",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg2NTk=;sn=538659",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTM=;sn=651093",
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "0be8fed41ae03f9c15681687ad677fa8",
-        "x-ms-correlation-request-id": "c8095612-d242-4509-98a1-a846cb41f325",
-        "x-ms-request-id": "c8095612-d242-4509-98a1-a846cb41f325"
+        "x-ms-client-request-id": "2b733c3391410237a0f5ab5817a2cc31",
+        "x-ms-correlation-request-id": "84237142-8ca9-4b96-a260-5a34da814d65",
+        "x-ms-request-id": "84237142-8ca9-4b96-a260-5a34da814d65"
       },
       "ResponseBody": {
-        "etag": "uiMuUmUh2cT8Qxb5LLmmAKQt1xQ",
+        "etag": "KN2kssZblmh0NDoGUHiD5CgVvuG",
         "key": "key-215294593",
         "label": "test_label",
         "content_type": "test_content_type",
@@ -317,7 +1555,7 @@
           "tag2": "value2"
         },
         "locked": false,
-        "last_modified": "2019-09-18T21:33:02\u002B00:00"
+        "last_modified": "2019-10-14T21:21:59\u002B00:00"
       }
     }
   ],

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/SessionRecords/ConfigurationLiveTests/GetBatchSettingOnlyLabelAsync.json
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/SessionRecords/ConfigurationLiveTests/GetBatchSettingOnlyLabelAsync.json
@@ -8,10 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "98",
         "Content-Type": "application/json",
-        "Date": "Wed, 18 Sep 2019 21:33:04 GMT",
-        "traceparent": "00-d800811ef8e3e94b81884fc42c491073-efb217ca60ac3349-00",
+        "Date": "Mon, 14 Oct 2019 21:21:47 GMT",
+        "Request-Id": "00-879ac7077dbd564b939509cf7efb2a86-16cea62d53896741-00",
+        "traceparent": "00-879ac7077dbd564b939509cf7efb2a86-16cea62d53896741-00",
         "User-Agent": [
-          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20190918.1\u002B0c319f5fd30ac3e2e5bc2936122815be22444424",
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
           "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
         ],
         "x-ms-client-request-id": "0d6329012a47e675b37a2184d132ce28",
@@ -35,19 +36,19 @@
         "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
         "Connection": "keep-alive",
         "Content-Type": "application/vnd.microsoft.appconfig.kv\u002Bjson; charset=utf-8",
-        "Date": "Wed, 18 Sep 2019 21:33:04 GMT",
-        "ETag": "\u0022MqROoQrWOTzONp0avVOW7iXI8KY\u0022",
-        "Last-Modified": "Wed, 18 Sep 2019 21:33:04 GMT",
-        "Server": "nginx/1.13.12",
+        "Date": "Mon, 14 Oct 2019 21:21:48 GMT",
+        "ETag": "\u0022bxqJJS35OpDXmCezWGaNb1R1E5s\u0022",
+        "Last-Modified": "Mon, 14 Oct 2019 21:21:48 GMT",
+        "Server": "openresty/1.15.8.1",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg3MTM=;sn=538713",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTA=;sn=651090",
         "Transfer-Encoding": "chunked",
         "x-ms-client-request-id": "0d6329012a47e675b37a2184d132ce28",
-        "x-ms-correlation-request-id": "566bb5bb-e2cb-40e6-811c-5791ca34d821",
-        "x-ms-request-id": "566bb5bb-e2cb-40e6-811c-5791ca34d821"
+        "x-ms-correlation-request-id": "abffd5dd-58b8-4bba-9937-2c7f9f5f8f8a",
+        "x-ms-request-id": "abffd5dd-58b8-4bba-9937-2c7f9f5f8f8a"
       },
       "ResponseBody": {
-        "etag": "MqROoQrWOTzONp0avVOW7iXI8KY",
+        "etag": "bxqJJS35OpDXmCezWGaNb1R1E5s",
         "key": "key-1608512009",
         "label": "test_label",
         "content_type": "test_content_type",
@@ -57,19 +58,20 @@
           "tag2": "value2"
         },
         "locked": false,
-        "last_modified": "2019-09-18T21:33:04\u002B00:00"
+        "last_modified": "2019-10-14T21:21:48\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=*\u0026label=test_label\u0026api-version=1.0",
+      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=%2A\u0026label=test_label\u0026api-version=1.0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/vnd.microsoft.appconfig.kv\u002Bjson",
         "Authorization": "Sanitized",
-        "Date": "Wed, 18 Sep 2019 21:33:04 GMT",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg3MTM=",
+        "Date": "Mon, 14 Oct 2019 21:21:48 GMT",
+        "Request-Id": "|8fe09bc4-42b8d7a929b99d01.",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTA=",
         "User-Agent": [
-          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20190918.1\u002B0c319f5fd30ac3e2e5bc2936122815be22444424",
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
           "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
         ],
         "x-ms-client-request-id": "10c1c5ef57c46e20321bfa660ecc2504",
@@ -86,19 +88,345 @@
         "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
         "Connection": "keep-alive",
         "Content-Type": "application/vnd.microsoft.appconfig.kvset\u002Bjson; charset=utf-8",
-        "Date": "Wed, 18 Sep 2019 21:33:04 GMT",
-        "Server": "nginx/1.13.12",
+        "Date": "Mon, 14 Oct 2019 21:21:48 GMT",
+        "Link": "\u003C/kv/?key=*\u0026label=test_label\u0026api-version=1.0\u0026after=a2V5LTk4OTc0ODAzOAp0ZXN0X2xhYmVs\u003E; rel=\u0022next\u0022",
+        "Server": "openresty/1.15.8.1",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg3MTM=;sn=538713",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTA=;sn=651090",
         "Transfer-Encoding": "chunked",
         "x-ms-client-request-id": "10c1c5ef57c46e20321bfa660ecc2504",
-        "x-ms-correlation-request-id": "dc459101-c26c-4e9a-8751-314f8c0fa229",
-        "x-ms-request-id": "dc459101-c26c-4e9a-8751-314f8c0fa229"
+        "x-ms-correlation-request-id": "a12736c7-17a0-4f85-a46f-0ea6e4aaa763",
+        "x-ms-request-id": "a12736c7-17a0-4f85-a46f-0ea6e4aaa763"
       },
       "ResponseBody": {
         "items": [
           {
-            "etag": "MqROoQrWOTzONp0avVOW7iXI8KY",
+            "etag": "ra7jHrNYwGCAWoymb4IQ0vCf9Dc",
+            "key": "key-1163835415",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:05:25\u002B00:00"
+          },
+          {
+            "etag": "6xrBoXzeP89iBJRpf5T0we4QNyC",
+            "key": "key-1174564512",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-20T03:01:39\u002B00:00"
+          },
+          {
+            "etag": "kCagdhqBQFNcZIJ5TxAb3jEL49w",
+            "key": "key-1177019792",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          },
+          {
+            "etag": "dHSZTRqmOXNJyLJF5pufiU6dquK",
+            "key": "key-1200977498",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:05\u002B00:00"
+          },
+          {
+            "etag": "9TzQS7loYjGo2dBa7gI8avECM9s",
+            "key": "key-1231954601",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value2",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:05:25\u002B00:00"
+          },
+          {
+            "etag": "uDoIwJFA6EMimAymtZE1ZaSadeR",
+            "key": "key-1233529568",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "IhCaZZtjxhJZOT4kst86ivVrDM9",
+            "key": "key-1252062984",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "3SJLTRLYcKynZOamHZu0ojwaIyJ",
+            "key": "key-1252790990",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:55\u002B00:00"
+          },
+          {
+            "etag": "0O2xWLZV29ZqSe9JbQLXJQR3Sm5",
+            "key": "key-1277519220",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:55\u002B00:00"
+          },
+          {
+            "etag": "JURXg9Zala8Ujo5fYA9kW4Rf6hP",
+            "key": "key-1301486225",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-14T21:17:43\u002B00:00"
+          },
+          {
+            "etag": "hY8crHO0a8k74AawBFGHHlvjm7J",
+            "key": "key-1309283906",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:06:04\u002B00:00"
+          },
+          {
+            "etag": "YufLr1ND2auNin5dZJLuB96Gxpy",
+            "key": "key-1323592047",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:08:00\u002B00:00"
+          },
+          {
+            "etag": "SfxQW7xVa3XkOnp3SllRt84cWlR",
+            "key": "key-1353875726",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:05:26\u002B00:00"
+          },
+          {
+            "etag": "WHB977nXW2zZL8AFGNAI6FpKppK",
+            "key": "key-1364459659",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "LUbaTeaEo7iZWJqwMCEiwZ64N3K",
+            "key": "key-1369197868",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
+          },
+          {
+            "etag": "URTIJGQelXjQVWasVWsg4xe6rLb",
+            "key": "key-13811035",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:18:13\u002B00:00"
+          },
+          {
+            "etag": "JBdU4qVsF5gcgIe1n7zZ77B5eso",
+            "key": "key-1381219121",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
+          },
+          {
+            "etag": "HsSY9HTWZ6d2SkPOzAGuIph6zYt",
+            "key": "key-1420801322",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "sbSjAQthvnfDGiKWz8rQ5NCpKjb",
+            "key": "key-1484301245",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:24:27\u002B00:00"
+          },
+          {
+            "etag": "1tzcwKQvcWBBVv7p3m6uPLyyOa7",
+            "key": "key-1488498371",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
+          },
+          {
+            "etag": "4yCOmwht9r1upewN8Odsi0Bcg8M",
+            "key": "key-1551731413",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "UpMP4mKBUEBjqQRMlD2sXB7FJEs",
+            "key": "key-156242278",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "wYuNxWrI5TQozzYpAciVySHaU7B",
+            "key": "key-1577810526",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "OrmLOlXvKFr9x2E1acXclGZD263",
+            "key": "key-1587818169",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:24:13\u002B00:00"
+          },
+          {
+            "etag": "wdhs1dq8NYXHheyCbky9eyWIKL5",
+            "key": "key-1603266762",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          },
+          {
+            "etag": "bxqJJS35OpDXmCezWGaNb1R1E5s",
             "key": "key-1608512009",
             "label": "test_label",
             "content_type": "test_content_type",
@@ -108,7 +436,371 @@
               "tag2": "value2"
             },
             "locked": false,
-            "last_modified": "2019-09-18T21:33:04\u002B00:00"
+            "last_modified": "2019-10-14T21:21:48\u002B00:00"
+          },
+          {
+            "etag": "YHGfktoslQCCSNSEVuOCb1hrZcM",
+            "key": "key-1633697425",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "NpP8VyFX5Q6wjrXMNR1ftttz5Py",
+            "key": "key-1661468793",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T18:12:29\u002B00:00"
+          },
+          {
+            "etag": "xd7St6F6CuBJ2ONJelveJ5xaBLH",
+            "key": "key-1715663437",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          },
+          {
+            "etag": "Pn80ku8RIkNrPEza9y1k0aIv4MZ",
+            "key": "key-1716559556",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value2",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:55\u002B00:00"
+          },
+          {
+            "etag": "h3yjTfKtljOrEqb96vZ7jEhGm0o",
+            "key": "key-1720810414",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "3VeGoyPFcP4iGC2ExNPF2fkPvAb",
+            "key": "key-17297920",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "AeSBit4ycm1QEa90sDjW8PlBLaM",
+            "key": "key-1765082280",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "1D0YfHmg2SJuD6zEfhd31o9FNWq",
+            "key": "key-1786217009",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:31\u002B00:00"
+          },
+          {
+            "etag": "1BrnR77JndxaL4ndtsKgAkwuyr5",
+            "key": "key-1809216229",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "51F1mjgR1BCXDZyEVIog5KkxsVJ",
+            "key": "key-1828956231",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:55\u002B00:00"
+          },
+          {
+            "etag": "FliZ8FwgQ3NS58dfRL0HZrd5SXr",
+            "key": "key-1844884626",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:05:25\u002B00:00"
+          },
+          {
+            "etag": "Gxaxf0awnjXtA4Bh1MZzONQ1mW2",
+            "key": "key-1875045571",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:09\u002B00:00"
+          },
+          {
+            "etag": "e9o6tiNAhuQngS6rYK436ODRDcO",
+            "key": "key-1910922243",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:55\u002B00:00"
+          },
+          {
+            "etag": "qenIfhBrk88QpsJTwxuSSxm4SzC",
+            "key": "key-1919238788",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:07:04\u002B00:00"
+          },
+          {
+            "etag": "CWNgk6O4YLFZ12jqhHOPnCEDE8m",
+            "key": "key-1922091484",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:12\u002B00:00"
+          },
+          {
+            "etag": "2VEHu39Mt7780fVEqtoadyUfE8i",
+            "key": "key-1934649991",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
+          },
+          {
+            "etag": "R8U84YRp2frl9PI0g3F4YYgrRB4",
+            "key": "key-1937393334",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:31\u002B00:00"
+          },
+          {
+            "etag": "zmZ65hqvHu2FpIbbMVi2HSGYbvr",
+            "key": "key-1983768591",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "ROiZnOqdsnLVV0G5QdaNHcEKew3",
+            "key": "key-2010525552",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:54\u002B00:00"
+          },
+          {
+            "etag": "h9729v3p9GahZj27TlRlI1sUIw5",
+            "key": "key-204035620",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:31\u002B00:00"
+          },
+          {
+            "etag": "QfOPNXMqjEueWYCaEchCrvT5uLW",
+            "key": "key-2051178311",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value2",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:50\u002B00:00"
+          },
+          {
+            "etag": "5VG77jljuIJ8c2qvTmTzjP5hFFR",
+            "key": "key-2053619125",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:09\u002B00:00"
+          },
+          {
+            "etag": "rGWi2Wsg21RdGcnFOl3AZxz42vr",
+            "key": "key-2113787248",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "k3sYCiP0mYo8BNoIeSsk97OZIel",
+            "key": "key-212129177",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          },
+          {
+            "etag": "agLm7TEWFYKCcksi2UyBz7ZVmn8",
+            "key": "key-221701127",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-14T21:16:39\u002B00:00"
+          },
+          {
+            "etag": "UhZIRQfYWPQzWAELLBfa09ehUvx",
+            "key": "key-222881053",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:15:13\u002B00:00"
+          },
+          {
+            "etag": "pnlSyvJyVdbopuT5WFhpD9ULr3G",
+            "key": "key-277273344",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "slvXjRxhTVg3IcKeO12PuutFgOp",
+            "key": "key-291156113",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
           },
           {
             "etag": "QB6ZifyjGfUn17lEKZMAK6No3jf",
@@ -124,6 +816,110 @@
             "last_modified": "2019-05-01T19:08:03\u002B00:00"
           },
           {
+            "etag": "mj5yMpfkn1kdd1K3YhPt5AUqhEf",
+            "key": "key-337032567",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:49\u002B00:00"
+          },
+          {
+            "etag": "Do7twZpoyGpe56S9tjkYR7T6oug",
+            "key": "key-407324161",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "Bn8Qww33MB3xLGowUmh9BGJVO4F",
+            "key": "key-429238547",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:06\u002B00:00"
+          },
+          {
+            "etag": "vUvAGXytPKGN4EdsONAZB1ZloOr",
+            "key": "key-439891543",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "RfYfTS1obmR3cR4S9WROiH1FeIE",
+            "key": "key-442070586",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T18:11:33\u002B00:00"
+          },
+          {
+            "etag": "HKbYauu5cqJbjg5dDwq7n3FC4oD",
+            "key": "key-442352028",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "WgaViI04lj7TF2VbpHTkzk3kaXr",
+            "key": "key-451104393",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          },
+          {
+            "etag": "wiUqbDzZboQ4lQ8wFOtMUTWkZ8E",
+            "key": "key-469594127",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:08:00\u002B00:00"
+          },
+          {
             "etag": "JmFAJhlGhqYS9XzZN5ZfdktOK3L",
             "key": "key-4dc1baef29474d1ea11dbf3b5c9a690c",
             "label": "test_label",
@@ -137,6 +933,110 @@
             "last_modified": "2019-04-10T23:26:23\u002B00:00"
           },
           {
+            "etag": "Zvd8V3jfPSFrHYk3rhF4Uvjh7ny",
+            "key": "key-52254665",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "QGxPc999Q76X1lFLQIzwwhGQSfO",
+            "key": "key-545314302",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value2",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:09\u002B00:00"
+          },
+          {
+            "etag": "nY5ZGit7NiAiLWOfDYMvLAOS1F7",
+            "key": "key-581866371",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:54\u002B00:00"
+          },
+          {
+            "etag": "MCSdJnjGySUVPVOgGrdvZYlkkCO",
+            "key": "key-601022664",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "VvjuWikzA4tTZVv7WRJQAs6uHa4",
+            "key": "key-603485485",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:21:29\u002B00:00"
+          },
+          {
+            "etag": "08VxcTF7XOikUwUcjmIaSnf225F",
+            "key": "key-611503496",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-20T03:01:47\u002B00:00"
+          },
+          {
+            "etag": "Jm36tIYyH7m8bPvrifYkVT1ofQb",
+            "key": "key-618631428",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:05\u002B00:00"
+          },
+          {
+            "etag": "BPubg2Ay3ofpoe2DKXrZNAVnt5e",
+            "key": "key-619387967",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:55\u002B00:00"
+          },
+          {
             "etag": "NNkiTFfEo9LzydkJzQXKNJKTyII",
             "key": "key-6413b030f9384ec9875636ae4ef38210",
             "label": "test_label",
@@ -148,6 +1048,58 @@
             },
             "locked": false,
             "last_modified": "2019-04-08T22:57:05\u002B00:00"
+          },
+          {
+            "etag": "R7nE3UyC94U7dxErKbGYFaUo3DX",
+            "key": "key-646766163",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T18:45:22\u002B00:00"
+          },
+          {
+            "etag": "hnHYu0T2IXWrlVW4iEyIx19J5E8",
+            "key": "key-665260818",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:16:37\u002B00:00"
+          },
+          {
+            "etag": "DLkqNFvqZGvKCUuGqwDtbY2cW8S",
+            "key": "key-674427950",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "dxDyLomTd2b0f9JRmhYcNokTopp",
+            "key": "key-676034902",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
           },
           {
             "etag": "yOAsvJzz97wJK3rXYDNGKswPLfs",
@@ -189,6 +1141,84 @@
             "last_modified": "2019-04-10T23:14:47\u002B00:00"
           },
           {
+            "etag": "cClYgjDuYXVjCdLxK46hyhs1Wi0",
+            "key": "key-708276799",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:56:54\u002B00:00"
+          },
+          {
+            "etag": "biYITZyCRHSxnnemqwgBOrCPqHa",
+            "key": "key-715857320",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value2",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:05:26\u002B00:00"
+          },
+          {
+            "etag": "uJbsczfnXinqQkeSEXeZVbYkHEg",
+            "key": "key-719454961",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-28T17:38:17\u002B00:00"
+          },
+          {
+            "etag": "fCkWnHvdpPNuvsu9EirkwToLIfb",
+            "key": "key-719690246",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T18:47:40\u002B00:00"
+          },
+          {
+            "etag": "304RpDyEyDoUVc329BbDsv9XAZl",
+            "key": "key-72708449",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:30\u002B00:00"
+          },
+          {
+            "etag": "yzHXnBTeRhzlbNUHWHXUm2UHfvF",
+            "key": "key-786619267",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:50\u002B00:00"
+          },
+          {
             "etag": "m7EFRi22ngO0wY2LWxzcDYgMx0G",
             "key": "key-7d4e0bd02b004cafa8f82538e0716c93",
             "label": "test_label",
@@ -201,6 +1231,217 @@
             "locked": false,
             "last_modified": "2019-04-10T23:26:25\u002B00:00"
           },
+          {
+            "etag": "ziFSi2LSr3sFCFWjVqKJMS1OjS7",
+            "key": "key-825816014",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:04\u002B00:00"
+          },
+          {
+            "etag": "p7eYoTmth5EErf3XWFIC2nroaJO",
+            "key": "key-842155684",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:08:15\u002B00:00"
+          },
+          {
+            "etag": "A66N4W2YWHswFYaAJevwOD3bGKk",
+            "key": "key-844845286",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:25\u002B00:00"
+          },
+          {
+            "etag": "wMe2GAHNWBGeiGImsphYsmWC1Sx",
+            "key": "key-850661731",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:19:22\u002B00:00"
+          },
+          {
+            "etag": "hJGep8R6IQISAYoQ9QAhPjqFoP6",
+            "key": "key-856544848",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:12:29\u002B00:00"
+          },
+          {
+            "etag": "xxK2VYXZ9lluVoV0RYZ5Nt7deCf",
+            "key": "key-888672085",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:26\u002B00:00"
+          },
+          {
+            "etag": "swa9FtVZaFSMT2Smpp2uEEOVfc0",
+            "key": "key-906145651",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:15:11\u002B00:00"
+          },
+          {
+            "etag": "ZyRlG0DRH9wpcvCiJSD43HtGP2d",
+            "key": "key-909199832",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T19:05:26\u002B00:00"
+          },
+          {
+            "etag": "hFZ3qz7iVPHs5NFAkeirApwO2zH",
+            "key": "key-928916906",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:20\u002B00:00"
+          },
+          {
+            "etag": "FI4NS8fjFxewlzANoG7VHFp16up",
+            "key": "key-964002372",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:31\u002B00:00"
+          },
+          {
+            "etag": "F5iaae3gfe6Ant9sWkKCPW1QnOu",
+            "key": "key-971667487",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value2",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:14:06\u002B00:00"
+          },
+          {
+            "etag": "ScRzoMvgTVRpQji2YvKKSg28ikS",
+            "key": "key-98057351",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-09-22T20:13:50\u002B00:00"
+          },
+          {
+            "etag": "2IAoU9zDlEkqezrn955i8jYmNlt",
+            "key": "key-989748038",
+            "label": "test_label",
+            "content_type": "test_content_type",
+            "value": "test_value",
+            "tags": {
+              "tag1": "value1",
+              "tag2": "value2"
+            },
+            "locked": false,
+            "last_modified": "2019-10-02T20:57:03\u002B00:00"
+          }
+        ],
+        "@nextLink": "/kv/?key=*\u0026label=test_label\u0026api-version=1.0\u0026after=a2V5LTk4OTc0ODAzOAp0ZXN0X2xhYmVs"
+      }
+    },
+    {
+      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=%2A\u0026label=test_label\u0026after=a2V5LTk4OTc0ODAzOAp0ZXN0X2xhYmVs\u0026api-version=1.0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/vnd.microsoft.appconfig.kv\u002Bjson",
+        "Authorization": "Sanitized",
+        "Date": "Mon, 14 Oct 2019 21:21:48 GMT",
+        "Request-Id": "|8fe09bc5-42b8d7a929b99d01.",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTA=",
+        "User-Agent": [
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
+          "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
+        ],
+        "x-ms-client-request-id": "dd9e586ca59c73daf11f917e52c6d172",
+        "x-ms-content-sha256": "47DEQpj8HBSa\u002B/TImW\u002B5JCeuQeRkm5NMpJWZG3hSuFU=",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Access-Control-Allow-Methods": "GET, PUT, POST, DELETE, PATCH, OPTIONS",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
+        "Connection": "keep-alive",
+        "Content-Type": "application/vnd.microsoft.appconfig.kvset\u002Bjson; charset=utf-8",
+        "Date": "Mon, 14 Oct 2019 21:21:48 GMT",
+        "Server": "openresty/1.15.8.1",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTA=;sn=651090",
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "dd9e586ca59c73daf11f917e52c6d172",
+        "x-ms-correlation-request-id": "b592f7e6-f13e-432a-912e-918555ce7545",
+        "x-ms-request-id": "b592f7e6-f13e-432a-912e-918555ce7545"
+      },
+      "ResponseBody": {
+        "items": [
           {
             "etag": "Hkd41xJvSuXdYustHzporIKJ0wS",
             "key": "key-a238e8dd62644ae1af58516c98613bae",
@@ -274,14 +1515,15 @@
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "Date": "Wed, 18 Sep 2019 21:33:04 GMT",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg3MTM=",
-        "traceparent": "00-e906ee7928d34849855facf0fc067500-a35bd979a539bb4c-00",
+        "Date": "Mon, 14 Oct 2019 21:21:48 GMT",
+        "Request-Id": "00-5187dfcdc874a146b9691b05ba0c739a-c37cad142a72234f-00",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTA=",
+        "traceparent": "00-5187dfcdc874a146b9691b05ba0c739a-c37cad142a72234f-00",
         "User-Agent": [
-          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20190918.1\u002B0c319f5fd30ac3e2e5bc2936122815be22444424",
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
           "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
         ],
-        "x-ms-client-request-id": "dd9e586ca59c73daf11f917e52c6d172",
+        "x-ms-client-request-id": "f868ba20a62ba94509f4db2b300fd7e7",
         "x-ms-content-sha256": "47DEQpj8HBSa\u002B/TImW\u002B5JCeuQeRkm5NMpJWZG3hSuFU=",
         "x-ms-return-client-request-id": "true"
       },
@@ -295,19 +1537,19 @@
         "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
         "Connection": "keep-alive",
         "Content-Type": "application/vnd.microsoft.appconfig.kv\u002Bjson; charset=utf-8",
-        "Date": "Wed, 18 Sep 2019 21:33:04 GMT",
-        "ETag": "\u0022MqROoQrWOTzONp0avVOW7iXI8KY\u0022",
-        "Last-Modified": "Wed, 18 Sep 2019 21:33:04 GMT",
-        "Server": "nginx/1.13.12",
+        "Date": "Mon, 14 Oct 2019 21:21:48 GMT",
+        "ETag": "\u0022bxqJJS35OpDXmCezWGaNb1R1E5s\u0022",
+        "Last-Modified": "Mon, 14 Oct 2019 21:21:48 GMT",
+        "Server": "openresty/1.15.8.1",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg3MTQ=;sn=538714",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTE=;sn=651091",
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "dd9e586ca59c73daf11f917e52c6d172",
-        "x-ms-correlation-request-id": "a543dcc2-c573-4d85-b8ee-e4d901c708ca",
-        "x-ms-request-id": "a543dcc2-c573-4d85-b8ee-e4d901c708ca"
+        "x-ms-client-request-id": "f868ba20a62ba94509f4db2b300fd7e7",
+        "x-ms-correlation-request-id": "89102bc4-dc1a-4fed-b95c-cc5461a6f93f",
+        "x-ms-request-id": "89102bc4-dc1a-4fed-b95c-cc5461a6f93f"
       },
       "ResponseBody": {
-        "etag": "MqROoQrWOTzONp0avVOW7iXI8KY",
+        "etag": "bxqJJS35OpDXmCezWGaNb1R1E5s",
         "key": "key-1608512009",
         "label": "test_label",
         "content_type": "test_content_type",
@@ -317,7 +1559,7 @@
           "tag2": "value2"
         },
         "locked": false,
-        "last_modified": "2019-09-18T21:33:04\u002B00:00"
+        "last_modified": "2019-10-14T21:21:48\u002B00:00"
       }
     }
   ],

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/SessionRecords/ConfigurationLiveTests/GetBatchSettingWithFields.json
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/SessionRecords/ConfigurationLiveTests/GetBatchSettingWithFields.json
@@ -8,11 +8,11 @@
         "Authorization": "Sanitized",
         "Content-Length": "50",
         "Content-Type": "application/json",
-        "Date": "Wed, 18 Sep 2019 21:33:01 GMT",
+        "Date": "Mon, 14 Oct 2019 21:21:59 GMT",
         "If-None-Match": "*",
-        "traceparent": "00-917724a2a8cfbd4182033191e5f8fb47-548505e23c0f604f-00",
+        "traceparent": "00-c149450a4835a043a6f0678ba0540251-9f8b60f55cd46741-00",
         "User-Agent": [
-          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20190918.1\u002B0c319f5fd30ac3e2e5bc2936122815be22444424",
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
           "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
         ],
         "x-ms-client-request-id": "c2d73ddded16da8f8f48f97abb0746cc",
@@ -33,38 +33,38 @@
         "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
         "Connection": "keep-alive",
         "Content-Type": "application/vnd.microsoft.appconfig.kv\u002Bjson; charset=utf-8",
-        "Date": "Wed, 18 Sep 2019 21:33:01 GMT",
-        "ETag": "\u0022VAcb1yuR0Ph4RTIUQfTztUriCB6\u0022",
-        "Last-Modified": "Wed, 18 Sep 2019 21:33:02 GMT",
-        "Server": "nginx/1.13.12",
+        "Date": "Mon, 14 Oct 2019 21:21:59 GMT",
+        "ETag": "\u0022lLGCR62pqBY6VxVye8Y2vaHIyif\u0022",
+        "Last-Modified": "Mon, 14 Oct 2019 21:21:59 GMT",
+        "Server": "openresty/1.15.8.1",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg2NjI=;sn=538662",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTQ=;sn=651094",
         "Transfer-Encoding": "chunked",
         "x-ms-client-request-id": "c2d73ddded16da8f8f48f97abb0746cc",
-        "x-ms-correlation-request-id": "00303327-0ff4-4470-beab-33953272bfc7",
-        "x-ms-request-id": "00303327-0ff4-4470-beab-33953272bfc7"
+        "x-ms-correlation-request-id": "0022bfe2-519f-4b61-8bda-1c5d9e41fa48",
+        "x-ms-request-id": "0022bfe2-519f-4b61-8bda-1c5d9e41fa48"
       },
       "ResponseBody": {
-        "etag": "VAcb1yuR0Ph4RTIUQfTztUriCB6",
+        "etag": "lLGCR62pqBY6VxVye8Y2vaHIyif",
         "key": "keyFields-881848492",
         "label": "my_label",
         "content_type": null,
         "value": "my_value",
         "tags": {},
         "locked": false,
-        "last_modified": "2019-09-18T21:33:02\u002B00:00"
+        "last_modified": "2019-10-14T21:21:59\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=keyFields-881848492\u0026$select=key, label, etag\u0026api-version=1.0",
+      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=keyFields-881848492\u0026$select=key%2C%20label%2C%20etag\u0026api-version=1.0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/vnd.microsoft.appconfig.kv\u002Bjson",
         "Authorization": "Sanitized",
-        "Date": "Wed, 18 Sep 2019 21:33:01 GMT",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg2NjI=",
+        "Date": "Mon, 14 Oct 2019 21:21:59 GMT",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTQ=",
         "User-Agent": [
-          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20190918.1\u002B0c319f5fd30ac3e2e5bc2936122815be22444424",
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
           "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
         ],
         "x-ms-client-request-id": "b03496fa90d899008fd96f430f470488",
@@ -81,19 +81,19 @@
         "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
         "Connection": "keep-alive",
         "Content-Type": "application/vnd.microsoft.appconfig.kvset\u002Bjson; charset=utf-8",
-        "Date": "Wed, 18 Sep 2019 21:33:01 GMT",
-        "Server": "nginx/1.13.12",
+        "Date": "Mon, 14 Oct 2019 21:21:59 GMT",
+        "Server": "openresty/1.15.8.1",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg2NjI=;sn=538662",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTQ=;sn=651094",
         "Transfer-Encoding": "chunked",
         "x-ms-client-request-id": "b03496fa90d899008fd96f430f470488",
-        "x-ms-correlation-request-id": "5aef1614-aa3e-48e6-aab3-5024282ff1d8",
-        "x-ms-request-id": "5aef1614-aa3e-48e6-aab3-5024282ff1d8"
+        "x-ms-correlation-request-id": "168b8269-40e1-4d88-b142-c7fe11a9c399",
+        "x-ms-request-id": "168b8269-40e1-4d88-b142-c7fe11a9c399"
       },
       "ResponseBody": {
         "items": [
           {
-            "etag": "VAcb1yuR0Ph4RTIUQfTztUriCB6",
+            "etag": "lLGCR62pqBY6VxVye8Y2vaHIyif",
             "key": "keyFields-881848492",
             "label": "my_label"
           }
@@ -105,11 +105,11 @@
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "Date": "Wed, 18 Sep 2019 21:33:01 GMT",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg2NjI=",
-        "traceparent": "00-4bed3ae18378c44ab3d76f6188971c57-736053e7fdc3e748-00",
+        "Date": "Mon, 14 Oct 2019 21:21:59 GMT",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTQ=",
+        "traceparent": "00-72786c93b59ccd47953739dd23b74c03-7530d9b472a56642-00",
         "User-Agent": [
-          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20190918.1\u002B0c319f5fd30ac3e2e5bc2936122815be22444424",
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
           "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
         ],
         "x-ms-client-request-id": "a5039c95e58ce3bad1e94eae067fe3c7",
@@ -126,26 +126,26 @@
         "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
         "Connection": "keep-alive",
         "Content-Type": "application/vnd.microsoft.appconfig.kv\u002Bjson; charset=utf-8",
-        "Date": "Wed, 18 Sep 2019 21:33:02 GMT",
-        "ETag": "\u0022VAcb1yuR0Ph4RTIUQfTztUriCB6\u0022",
-        "Last-Modified": "Wed, 18 Sep 2019 21:33:02 GMT",
-        "Server": "nginx/1.13.12",
+        "Date": "Mon, 14 Oct 2019 21:21:59 GMT",
+        "ETag": "\u0022lLGCR62pqBY6VxVye8Y2vaHIyif\u0022",
+        "Last-Modified": "Mon, 14 Oct 2019 21:21:59 GMT",
+        "Server": "openresty/1.15.8.1",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg2NjM=;sn=538663",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwOTU=;sn=651095",
         "Transfer-Encoding": "chunked",
         "x-ms-client-request-id": "a5039c95e58ce3bad1e94eae067fe3c7",
-        "x-ms-correlation-request-id": "db89718b-b16b-492b-bfcb-aea1b98fb336",
-        "x-ms-request-id": "db89718b-b16b-492b-bfcb-aea1b98fb336"
+        "x-ms-correlation-request-id": "d3546c77-a37a-48a9-8ee4-84df4d75a8c6",
+        "x-ms-request-id": "d3546c77-a37a-48a9-8ee4-84df4d75a8c6"
       },
       "ResponseBody": {
-        "etag": "VAcb1yuR0Ph4RTIUQfTztUriCB6",
+        "etag": "lLGCR62pqBY6VxVye8Y2vaHIyif",
         "key": "keyFields-881848492",
         "label": "my_label",
         "content_type": null,
         "value": "my_value",
         "tags": {},
         "locked": false,
-        "last_modified": "2019-09-18T21:33:02\u002B00:00"
+        "last_modified": "2019-10-14T21:21:59\u002B00:00"
       }
     }
   ],

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/SessionRecords/ConfigurationLiveTests/GetBatchSettingWithFieldsAsync.json
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/SessionRecords/ConfigurationLiveTests/GetBatchSettingWithFieldsAsync.json
@@ -8,11 +8,12 @@
         "Authorization": "Sanitized",
         "Content-Length": "50",
         "Content-Type": "application/json",
-        "Date": "Wed, 18 Sep 2019 21:33:04 GMT",
+        "Date": "Mon, 14 Oct 2019 21:21:35 GMT",
         "If-None-Match": "*",
-        "traceparent": "00-bef2a91367c62e44b4cf383d4d876630-fb359dfee69c6d46-00",
+        "Request-Id": "00-d4f9f451b84b634aa9ec00c1f1567543-8935b1b38057c348-00",
+        "traceparent": "00-d4f9f451b84b634aa9ec00c1f1567543-8935b1b38057c348-00",
         "User-Agent": [
-          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20190918.1\u002B0c319f5fd30ac3e2e5bc2936122815be22444424",
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
           "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
         ],
         "x-ms-client-request-id": "0cbe5f4cc1460a91954f1254b808c103",
@@ -33,38 +34,39 @@
         "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
         "Connection": "keep-alive",
         "Content-Type": "application/vnd.microsoft.appconfig.kv\u002Bjson; charset=utf-8",
-        "Date": "Wed, 18 Sep 2019 21:33:04 GMT",
-        "ETag": "\u0022eGH7vPBEGpyYNwa0GABodpmwEmU\u0022",
-        "Last-Modified": "Wed, 18 Sep 2019 21:33:05 GMT",
-        "Server": "nginx/1.13.12",
+        "Date": "Mon, 14 Oct 2019 21:21:36 GMT",
+        "ETag": "\u002207y0rLGQREt28oBKV46zdNfHcIb\u0022",
+        "Last-Modified": "Mon, 14 Oct 2019 21:21:36 GMT",
+        "Server": "openresty/1.15.8.1",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg3MTc=;sn=538717",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwODg=;sn=651088",
         "Transfer-Encoding": "chunked",
         "x-ms-client-request-id": "0cbe5f4cc1460a91954f1254b808c103",
-        "x-ms-correlation-request-id": "27752332-6598-429c-b856-0707511741ff",
-        "x-ms-request-id": "27752332-6598-429c-b856-0707511741ff"
+        "x-ms-correlation-request-id": "603f93e2-e139-4fdb-b49f-06b879153b7b",
+        "x-ms-request-id": "603f93e2-e139-4fdb-b49f-06b879153b7b"
       },
       "ResponseBody": {
-        "etag": "eGH7vPBEGpyYNwa0GABodpmwEmU",
+        "etag": "07y0rLGQREt28oBKV46zdNfHcIb",
         "key": "keyFields-1967554874",
         "label": "my_label",
         "content_type": null,
         "value": "my_value",
         "tags": {},
         "locked": false,
-        "last_modified": "2019-09-18T21:33:05\u002B00:00"
+        "last_modified": "2019-10-14T21:21:36\u002B00:00"
       }
     },
     {
-      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=keyFields-1967554874\u0026$select=key, label, etag\u0026api-version=1.0",
+      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/?key=keyFields-1967554874\u0026$select=key%2C%20label%2C%20etag\u0026api-version=1.0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/vnd.microsoft.appconfig.kv\u002Bjson",
         "Authorization": "Sanitized",
-        "Date": "Wed, 18 Sep 2019 21:33:04 GMT",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg3MTc=",
+        "Date": "Mon, 14 Oct 2019 21:21:36 GMT",
+        "Request-Id": "|ce763ec9-4371bcdb347cac36.",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwODg=",
         "User-Agent": [
-          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20190918.1\u002B0c319f5fd30ac3e2e5bc2936122815be22444424",
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
           "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
         ],
         "x-ms-client-request-id": "4991d2ae941c31c6195a72f36c10d6fe",
@@ -81,19 +83,19 @@
         "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
         "Connection": "keep-alive",
         "Content-Type": "application/vnd.microsoft.appconfig.kvset\u002Bjson; charset=utf-8",
-        "Date": "Wed, 18 Sep 2019 21:33:04 GMT",
-        "Server": "nginx/1.13.12",
+        "Date": "Mon, 14 Oct 2019 21:21:36 GMT",
+        "Server": "openresty/1.15.8.1",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg3MTc=;sn=538717",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwODg=;sn=651088",
         "Transfer-Encoding": "chunked",
         "x-ms-client-request-id": "4991d2ae941c31c6195a72f36c10d6fe",
-        "x-ms-correlation-request-id": "1af03394-feb3-45c4-a67a-3801467fb1ff",
-        "x-ms-request-id": "1af03394-feb3-45c4-a67a-3801467fb1ff"
+        "x-ms-correlation-request-id": "5ee00163-f976-44f9-8efa-359016e75e72",
+        "x-ms-request-id": "5ee00163-f976-44f9-8efa-359016e75e72"
       },
       "ResponseBody": {
         "items": [
           {
-            "etag": "eGH7vPBEGpyYNwa0GABodpmwEmU",
+            "etag": "07y0rLGQREt28oBKV46zdNfHcIb",
             "key": "keyFields-1967554874",
             "label": "my_label"
           }
@@ -105,11 +107,12 @@
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
-        "Date": "Wed, 18 Sep 2019 21:33:04 GMT",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg3MTc=",
-        "traceparent": "00-bacd7f77ffb65e42a36b85e7c5732e81-b38b9bd293a9224c-00",
+        "Date": "Mon, 14 Oct 2019 21:21:36 GMT",
+        "Request-Id": "00-fe97bdfbe42db041a0235d82cb002034-991c71243535b84d-00",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwODg=",
+        "traceparent": "00-fe97bdfbe42db041a0235d82cb002034-991c71243535b84d-00",
         "User-Agent": [
-          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20190918.1\u002B0c319f5fd30ac3e2e5bc2936122815be22444424",
+          "azsdk-net-Data.AppConfiguration/1.0.0-dev.20191014.1\u002B95a72400de2f4df7f8112fba20eba4d84b37c218",
           "(.NET Core 4.6.27817.01; Microsoft Windows 10.0.16299 )"
         ],
         "x-ms-client-request-id": "5717192c80c1edb12428acc4816389e4",
@@ -126,26 +129,26 @@
         "Access-Control-Expose-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",
         "Connection": "keep-alive",
         "Content-Type": "application/vnd.microsoft.appconfig.kv\u002Bjson; charset=utf-8",
-        "Date": "Wed, 18 Sep 2019 21:33:04 GMT",
-        "ETag": "\u0022eGH7vPBEGpyYNwa0GABodpmwEmU\u0022",
-        "Last-Modified": "Wed, 18 Sep 2019 21:33:05 GMT",
-        "Server": "nginx/1.13.12",
+        "Date": "Mon, 14 Oct 2019 21:21:36 GMT",
+        "ETag": "\u002207y0rLGQREt28oBKV46zdNfHcIb\u0022",
+        "Last-Modified": "Mon, 14 Oct 2019 21:21:36 GMT",
+        "Server": "openresty/1.15.8.1",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "Sync-Token": "zAJw6V16=ODotMSM1Mzg3MTg=;sn=538718",
+        "Sync-Token": "zAJw6V16=ODotMSM2NTEwODk=;sn=651089",
         "Transfer-Encoding": "chunked",
         "x-ms-client-request-id": "5717192c80c1edb12428acc4816389e4",
-        "x-ms-correlation-request-id": "40245cd3-f388-4b2f-87f9-4325c75bc5c0",
-        "x-ms-request-id": "40245cd3-f388-4b2f-87f9-4325c75bc5c0"
+        "x-ms-correlation-request-id": "b734bdb9-8fa4-4297-a926-2a934c6accc2",
+        "x-ms-request-id": "b734bdb9-8fa4-4297-a926-2a934c6accc2"
       },
       "ResponseBody": {
-        "etag": "eGH7vPBEGpyYNwa0GABodpmwEmU",
+        "etag": "07y0rLGQREt28oBKV46zdNfHcIb",
         "key": "keyFields-1967554874",
         "label": "my_label",
         "content_type": null,
         "value": "my_value",
         "tags": {},
         "locked": false,
-        "last_modified": "2019-09-18T21:33:05\u002B00:00"
+        "last_modified": "2019-10-14T21:21:36\u002B00:00"
       }
     }
   ],

--- a/sdk/core/Azure.Core/tests/RequestUriBuilderTest.cs
+++ b/sdk/core/Azure.Core/tests/RequestUriBuilderTest.cs
@@ -203,7 +203,7 @@ namespace Azure.Core.Tests
             }
             else
             {
-                uriBuilder.AppendPath(append, false);
+                uriBuilder.AppendPath(append, escape: false);
             }
 
             Assert.AreEqual(expectedResult, uriBuilder.ToUri().OriginalString);

--- a/sdk/core/Azure.Core/tests/RequestUriBuilderTest.cs
+++ b/sdk/core/Azure.Core/tests/RequestUriBuilderTest.cs
@@ -16,6 +16,13 @@ namespace Azure.Core.Tests
             new Uri("https://localhost:443/"),
             new Uri("http://localhost:80/"),
             new Uri("http://localhost:80/ ? "),
+            new Uri("http://localhost:80/%25"),
+            new Uri("http://localhost:80/~!@#$%^&*()_+=-"),
+            new Uri("http://localhost:80/" + Uri.EscapeDataString("~!@#$%^&*()_+=-")),
+            new UriBuilder(new Uri("http://localhost:80/"))
+            {
+                Path = "~!@#$%^&*()_+=-"
+            }.Uri
         };
 
         [TestCaseSource(nameof(Uris))]
@@ -86,12 +93,12 @@ namespace Azure.Core.Tests
             Assert.AreEqual("http://localhost/", uriBuilder.ToUri().ToString());
         }
 
-        [TestCase("\u1234\u2345", "%E1%88%B4%E2%8D%85")]
-        [TestCase("\u1234", "%E1%88%B4")]
-        [TestCase("\u1234\u2345", "%E1%88%B4%E2%8D%85")]
-        [TestCase(" ", "%20")]
-        [TestCase("%#?&", "%25#?&")]
-        public void PathIsEscaped(string path, string expectedPath)
+        [TestCase("\u1234\u2345")]
+        [TestCase("\u1234")]
+        [TestCase("\u1234\u2345")]
+        [TestCase(" ")]
+        [TestCase("%#?&")]
+        public void PathIsNotEscaped(string path)
         {
             var uriBuilder = new RequestUriBuilder
             {
@@ -101,7 +108,26 @@ namespace Azure.Core.Tests
                 Path = path
             };
 
-            Assert.AreEqual("http://localhost/" + expectedPath, uriBuilder.ToUri().OriginalString);
+            Assert.AreEqual("http://localhost/" + path, uriBuilder.ToUri().OriginalString);
+        }
+
+        [TestCase("\u1234\u2345", "%E1%88%B4%E2%8D%85")]
+        [TestCase("\u1234", "%E1%88%B4")]
+        [TestCase("\u1234\u2345", "%E1%88%B4%E2%8D%85")]
+        [TestCase(" ", "%20")]
+        [TestCase("%#?&", "%25%23%3F%26")]
+        public void PathIsEscaped(string path, string expected)
+        {
+            var uriBuilder = new RequestUriBuilder
+            {
+                Scheme = "http",
+                Host = "localhost",
+                Port = 80
+            };
+
+            uriBuilder.AppendPath(path);
+
+            Assert.AreEqual("http://localhost/" + expected, uriBuilder.ToUri().OriginalString);
         }
 
         [Test]
@@ -157,8 +183,11 @@ namespace Azure.Core.Tests
         [TestCase(null, "p", "http://localhost/p")]
         [TestCase("/", "p", "http://localhost/p")]
         [TestCase("/", "/p", "http://localhost/p")]
-        [TestCase("", "\u1234", "http://localhost/%E1%88%B4")]
-        public void AppendPathWorks(string initialPath, string append, string expectedResult)
+        [TestCase("", "\u1234", "http://localhost/\u1234", false)]
+        [TestCase("", "%E1%88%B4", "http://localhost/%E1%88%B4", false)]
+        [TestCase("", "\u1234", "http://localhost/%E1%88%B4", true)]
+        [TestCase("", "%E1%88%B4", "http://localhost/%25E1%2588%25B4", true)]
+        public void AppendPathWorks(string initialPath, string append, string expectedResult, bool escape = false)
         {
             var uriBuilder = new RequestUriBuilder
             {
@@ -167,7 +196,15 @@ namespace Azure.Core.Tests
                 Port = 80,
                 Path = initialPath
             };
-            uriBuilder.AppendPath(append);
+
+            if (escape)
+            {
+                uriBuilder.AppendPath(append);
+            }
+            else
+            {
+                uriBuilder.AppendPath(append, false);
+            }
 
             Assert.AreEqual(expectedResult, uriBuilder.ToUri().OriginalString);
         }
@@ -203,6 +240,32 @@ namespace Azure.Core.Tests
             uriBuilder.AppendQuery("c", "d");
 
             Assert.AreEqual("http://localhost/ab?query=value&c=d", uriBuilder.ToUri().ToString());
+        }
+
+        [Test]
+        public void AppendingPathWithSpecialCharacters()
+        {
+            var uriBuilder = new RequestUriBuilder();
+            uriBuilder.Reset(new Uri("http://localhost/"));
+            uriBuilder.AppendPath("/");
+            uriBuilder.AppendPath("~!@#$%^&*()_+");
+            uriBuilder.AppendPath("b/");
+
+            Assert.AreEqual("http://localhost/~%21%40%23%24%25%5E%26%2A%28%29_%2Bb%2F", uriBuilder.ToString());
+            // Uri decodes some escaping
+            Assert.AreEqual("http://localhost/~!%40%23%24%25^%26*()_%2Bb%2F", uriBuilder.ToUri().ToString());
+        }
+
+        [Test]
+        public void AppendingQueryWithSpecialCharacters()
+        {
+            var uriBuilder = new RequestUriBuilder();
+            uriBuilder.Reset(new Uri("http://localhost/"));
+            uriBuilder.AppendQuery("a", "~!@#$%^&*()_+");
+
+            Assert.AreEqual("http://localhost/?a=~%21%40%23%24%25%5E%26%2A%28%29_%2B", uriBuilder.ToString());
+            // Uri decodes some escaping
+            Assert.AreEqual("http://localhost/?a=~!%40%23%24%25^%26*()_%2B", uriBuilder.ToUri().ToString());
         }
 
         [TestCase("?a", "?a")]

--- a/sdk/core/Azure.Core/tests/RequestUriBuilderTest.cs
+++ b/sdk/core/Azure.Core/tests/RequestUriBuilderTest.cs
@@ -16,6 +16,7 @@ namespace Azure.Core.Tests
             new Uri("https://localhost:443/"),
             new Uri("http://localhost:80/"),
             new Uri("http://localhost:80/ ? "),
+            new Uri("http://localhost:80/ prefix"),
             new Uri("http://localhost:80/%25"),
             new Uri("http://localhost:80/~!@#$%^&*()_+=-"),
             new Uri("http://localhost:80/" + Uri.EscapeDataString("~!@#$%^&*()_+=-")),
@@ -252,8 +253,11 @@ namespace Azure.Core.Tests
             uriBuilder.AppendPath("b/");
 
             Assert.AreEqual("http://localhost/~%21%40%23%24%25%5E%26%2A%28%29_%2Bb%2F", uriBuilder.ToString());
-            // Uri decodes some escaping
+#if NETCOREAPP
             Assert.AreEqual("http://localhost/~%21%40%23%24%25^%26%2A%28%29_%2Bb%2F", uriBuilder.ToUri().ToString());
+#else
+            Assert.AreEqual("http://localhost/~!%40%23%24%25^%26*()_%2Bb%2F", uriBuilder.ToUri().ToString());
+#endif
         }
 
         [Test]
@@ -264,8 +268,11 @@ namespace Azure.Core.Tests
             uriBuilder.AppendQuery("a", "~!@#$%^&*()_+");
 
             Assert.AreEqual("http://localhost/?a=~%21%40%23%24%25%5E%26%2A%28%29_%2B", uriBuilder.ToString());
-            // Uri decodes some escaping
+#if NETCOREAPP
             Assert.AreEqual("http://localhost/?a=~%21%40%23%24%25^%26%2A%28%29_%2B", uriBuilder.ToUri().ToString());
+#else
+            Assert.AreEqual("http://localhost/?a=~!%40%23%24%25^%26*()_%2B", uriBuilder.ToUri().ToString());
+#endif
         }
 
         [TestCase("?a", "?a")]

--- a/sdk/core/Azure.Core/tests/RequestUriBuilderTest.cs
+++ b/sdk/core/Azure.Core/tests/RequestUriBuilderTest.cs
@@ -253,7 +253,7 @@ namespace Azure.Core.Tests
 
             Assert.AreEqual("http://localhost/~%21%40%23%24%25%5E%26%2A%28%29_%2Bb%2F", uriBuilder.ToString());
             // Uri decodes some escaping
-            Assert.AreEqual("http://localhost/~!%40%23%24%25^%26*()_%2Bb%2F", uriBuilder.ToUri().ToString());
+            Assert.AreEqual("http://localhost/~%21%40%23%24%25^%26%2A%28%29_%2Bb%2F", uriBuilder.ToUri().ToString());
         }
 
         [Test]
@@ -265,7 +265,7 @@ namespace Azure.Core.Tests
 
             Assert.AreEqual("http://localhost/?a=~%21%40%23%24%25%5E%26%2A%28%29_%2B", uriBuilder.ToString());
             // Uri decodes some escaping
-            Assert.AreEqual("http://localhost/?a=~!%40%23%24%25^%26*()_%2B", uriBuilder.ToUri().ToString());
+            Assert.AreEqual("http://localhost/?a=~%21%40%23%24%25^%26%2A%28%29_%2B", uriBuilder.ToUri().ToString());
         }
 
         [TestCase("?a", "?a")]

--- a/sdk/identity/Azure.Identity/src/AadIdentityClient.cs
+++ b/sdk/identity/Azure.Identity/src/AadIdentityClient.cs
@@ -178,7 +178,7 @@ namespace Azure.Identity
 
             request.Uri.AppendPath(tenantId);
 
-            request.Uri.AppendPath("/oauth2/v2.0/token");
+            request.Uri.AppendPath("/oauth2/v2.0/token", escape: false);
 
             var bodyStr = $"response_type=token&grant_type=client_credentials&client_id={Uri.EscapeDataString(clientId)}&client_secret={Uri.EscapeDataString(clientSecret)}&scope={Uri.EscapeDataString(string.Join(" ", scopes))}";
 
@@ -201,7 +201,7 @@ namespace Azure.Identity
 
             request.Uri.AppendPath(tenantId);
 
-            request.Uri.AppendPath("/oauth2/v2.0/token");
+            request.Uri.AppendPath("/oauth2/v2.0/token", escape: false);
 
             string clientAssertion = CreateClientAssertionJWT(clientId, request.Uri.ToString(), clientCertficate);
 

--- a/sdk/identity/Azure.Identity/src/AadIdentityClient.cs
+++ b/sdk/identity/Azure.Identity/src/AadIdentityClient.cs
@@ -176,7 +176,7 @@ namespace Azure.Identity
 
             request.Uri.Reset(_options.AuthorityHost);
 
-            request.Uri.AppendPath(tenantId);
+            request.Uri.AppendPath(tenantId, true);
 
             request.Uri.AppendPath("/oauth2/v2.0/token");
 
@@ -199,7 +199,7 @@ namespace Azure.Identity
 
             request.Uri.Reset(_options.AuthorityHost);
 
-            request.Uri.AppendPath(tenantId);
+            request.Uri.AppendPath(tenantId, true);
 
             request.Uri.AppendPath("/oauth2/v2.0/token");
 

--- a/sdk/identity/Azure.Identity/src/AadIdentityClient.cs
+++ b/sdk/identity/Azure.Identity/src/AadIdentityClient.cs
@@ -176,7 +176,7 @@ namespace Azure.Identity
 
             request.Uri.Reset(_options.AuthorityHost);
 
-            request.Uri.AppendPath(tenantId, true);
+            request.Uri.AppendPath(tenantId);
 
             request.Uri.AppendPath("/oauth2/v2.0/token");
 
@@ -199,7 +199,7 @@ namespace Azure.Identity
 
             request.Uri.Reset(_options.AuthorityHost);
 
-            request.Uri.AppendPath(tenantId, true);
+            request.Uri.AppendPath(tenantId);
 
             request.Uri.AppendPath("/oauth2/v2.0/token");
 

--- a/sdk/identity/Azure.Identity/src/ManagedIdentityClient.cs
+++ b/sdk/identity/Azure.Identity/src/ManagedIdentityClient.cs
@@ -371,11 +371,11 @@ namespace Azure.Identity
 
             request.Uri.AppendQuery("api-version", ImdsApiVersion);
 
-            request.Uri.AppendQuery("resource", Uri.EscapeDataString(resource));
+            request.Uri.AppendQuery("resource", resource);
 
             if (!string.IsNullOrEmpty(clientId))
             {
-                request.Uri.AppendQuery("client_id", Uri.EscapeDataString(clientId));
+                request.Uri.AppendQuery("client_id", clientId);
             }
 
             return request;
@@ -396,11 +396,11 @@ namespace Azure.Identity
 
             request.Uri.AppendQuery("api-version", AppServiceMsiApiVersion);
 
-            request.Uri.AppendQuery("resource", Uri.EscapeDataString(resource));
+            request.Uri.AppendQuery("resource", resource);
 
             if (!string.IsNullOrEmpty(clientId))
             {
-                request.Uri.AppendQuery("client_id", Uri.EscapeDataString(clientId));
+                request.Uri.AppendQuery("client_id", clientId);
             }
 
             return request;

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyResolverLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyResolverLiveTests.cs
@@ -42,7 +42,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
 
             uriBuilder.Reset(VaultUri);
 
-            uriBuilder.AppendPath($"/keys/");
+            uriBuilder.AppendPath($"/keys/", escape: false);
 
             uriBuilder.AppendPath(Recording.GenerateId());
 
@@ -56,7 +56,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
 
             uriBuilder.Reset(VaultUri);
 
-            uriBuilder.AppendPath($"/secrets/");
+            uriBuilder.AppendPath($"/secrets/", escape: false);
 
             uriBuilder.AppendPath(Recording.GenerateId());
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/KeyVaultPipeline.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/KeyVaultPipeline.cs
@@ -33,7 +33,7 @@ namespace Azure.Security.KeyVault
             var firstPage = new RequestUriBuilder();
             firstPage.Reset(_vaultUri);
 
-            firstPage.AppendPath(path);
+            firstPage.AppendPath(path, false);
             firstPage.AppendQuery("api-version", ApiVersion);
 
             return firstPage.ToUri();
@@ -44,7 +44,7 @@ namespace Azure.Security.KeyVault
             var firstPage = new RequestUriBuilder();
             firstPage.Reset(_vaultUri);
 
-            firstPage.AppendPath(path);
+            firstPage.AppendPath(path, false);
             firstPage.AppendQuery("api-version", ApiVersion);
 
             foreach ((string, string) tuple in queryParams)
@@ -78,7 +78,7 @@ namespace Azure.Security.KeyVault
 
             foreach (var p in path)
             {
-                request.Uri.AppendPath(p);
+                request.Uri.AppendPath(p, escape: false);
             }
 
             request.Uri.AppendQuery("api-version", ApiVersion);

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/KeyVaultPipeline.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/KeyVaultPipeline.cs
@@ -33,7 +33,7 @@ namespace Azure.Security.KeyVault
             var firstPage = new RequestUriBuilder();
             firstPage.Reset(_vaultUri);
 
-            firstPage.AppendPath(path, false);
+            firstPage.AppendPath(path, escape: false);
             firstPage.AppendQuery("api-version", ApiVersion);
 
             return firstPage.ToUri();
@@ -44,7 +44,7 @@ namespace Azure.Security.KeyVault
             var firstPage = new RequestUriBuilder();
             firstPage.Reset(_vaultUri);
 
-            firstPage.AppendPath(path, false);
+            firstPage.AppendPath(path, escape: false);
             firstPage.AppendQuery("api-version", ApiVersion);
 
             foreach ((string, string) tuple in queryParams)

--- a/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
@@ -119,8 +119,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "service", encode: false);
-                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                _request.Uri.AppendQuery("restype", "service", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "properties", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -252,8 +252,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "service", encode: false);
-                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                _request.Uri.AppendQuery("restype", "service", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "properties", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -383,8 +383,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "service", encode: false);
-                _request.Uri.AppendQuery("comp", "stats", encode: false);
+                _request.Uri.AppendQuery("restype", "service", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "stats", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -534,7 +534,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "list", encode: false);
+                _request.Uri.AppendQuery("comp", "list", escapeValue: false);
                 if (prefix != null) { _request.Uri.AppendQuery("prefix", prefix); }
                 if (marker != null) { _request.Uri.AppendQuery("marker", marker); }
                 if (maxresults != null) { _request.Uri.AppendQuery("maxresults", maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
@@ -677,8 +677,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Post;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "service", encode: false);
-                _request.Uri.AppendQuery("comp", "userdelegationkey", encode: false);
+                _request.Uri.AppendQuery("restype", "service", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "userdelegationkey", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -805,8 +805,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "account", encode: false);
-                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                _request.Uri.AppendQuery("restype", "account", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "properties", escapeValue: false);
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -969,7 +969,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Post;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "batch", encode: false);
+                _request.Uri.AppendQuery("comp", "batch", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -1129,7 +1129,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "container", encode: false);
+                _request.Uri.AppendQuery("restype", "container", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -1281,7 +1281,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "container", encode: false);
+                _request.Uri.AppendQuery("restype", "container", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -1469,7 +1469,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Delete;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "container", encode: false);
+                _request.Uri.AppendQuery("restype", "container", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -1612,8 +1612,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "container", encode: false);
-                _request.Uri.AppendQuery("comp", "metadata", encode: false);
+                _request.Uri.AppendQuery("restype", "container", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "metadata", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -1766,8 +1766,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "container", encode: false);
-                _request.Uri.AppendQuery("comp", "acl", encode: false);
+                _request.Uri.AppendQuery("restype", "container", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "acl", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -1943,8 +1943,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "container", encode: false);
-                _request.Uri.AppendQuery("comp", "acl", encode: false);
+                _request.Uri.AppendQuery("restype", "container", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "acl", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -2122,8 +2122,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "lease", encode: false);
-                _request.Uri.AppendQuery("restype", "container", encode: false);
+                _request.Uri.AppendQuery("comp", "lease", escapeValue: false);
+                _request.Uri.AppendQuery("restype", "container", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -2291,8 +2291,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "lease", encode: false);
-                _request.Uri.AppendQuery("restype", "container", encode: false);
+                _request.Uri.AppendQuery("comp", "lease", escapeValue: false);
+                _request.Uri.AppendQuery("restype", "container", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -2455,8 +2455,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "lease", encode: false);
-                _request.Uri.AppendQuery("restype", "container", encode: false);
+                _request.Uri.AppendQuery("comp", "lease", escapeValue: false);
+                _request.Uri.AppendQuery("restype", "container", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -2619,8 +2619,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "lease", encode: false);
-                _request.Uri.AppendQuery("restype", "container", encode: false);
+                _request.Uri.AppendQuery("comp", "lease", escapeValue: false);
+                _request.Uri.AppendQuery("restype", "container", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -2796,8 +2796,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "lease", encode: false);
-                _request.Uri.AppendQuery("restype", "container", encode: false);
+                _request.Uri.AppendQuery("comp", "lease", escapeValue: false);
+                _request.Uri.AppendQuery("restype", "container", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -2966,8 +2966,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "container", encode: false);
-                _request.Uri.AppendQuery("comp", "list", encode: false);
+                _request.Uri.AppendQuery("restype", "container", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "list", escapeValue: false);
                 if (prefix != null) { _request.Uri.AppendQuery("prefix", prefix); }
                 if (marker != null) { _request.Uri.AppendQuery("marker", marker); }
                 if (maxresults != null) { _request.Uri.AppendQuery("maxresults", maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
@@ -3126,8 +3126,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "container", encode: false);
-                _request.Uri.AppendQuery("comp", "list", encode: false);
+                _request.Uri.AppendQuery("restype", "container", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "list", escapeValue: false);
                 if (prefix != null) { _request.Uri.AppendQuery("prefix", prefix); }
                 if (delimiter != null) { _request.Uri.AppendQuery("delimiter", delimiter); }
                 if (marker != null) { _request.Uri.AppendQuery("marker", marker); }
@@ -4286,7 +4286,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Patch;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("action", "setAccessControl", encode: false);
+                _request.Uri.AppendQuery("action", "setAccessControl", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -4465,7 +4465,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Head;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("action", "getAccessControl", encode: false);
+                _request.Uri.AppendQuery("action", "getAccessControl", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
                 if (upn != null) {
                 #pragma warning disable CA1308 // Normalize strings to uppercase
@@ -4898,7 +4898,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "undelete", encode: false);
+                _request.Uri.AppendQuery("comp", "undelete", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -5078,7 +5078,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                _request.Uri.AppendQuery("comp", "properties", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -5288,7 +5288,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "metadata", encode: false);
+                _request.Uri.AppendQuery("comp", "metadata", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -5480,7 +5480,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "lease", encode: false);
+                _request.Uri.AppendQuery("comp", "lease", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -5660,7 +5660,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "lease", encode: false);
+                _request.Uri.AppendQuery("comp", "lease", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -5835,7 +5835,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "lease", encode: false);
+                _request.Uri.AppendQuery("comp", "lease", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -6023,7 +6023,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "lease", encode: false);
+                _request.Uri.AppendQuery("comp", "lease", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -6199,7 +6199,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "lease", encode: false);
+                _request.Uri.AppendQuery("comp", "lease", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -6394,7 +6394,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "snapshot", encode: false);
+                _request.Uri.AppendQuery("comp", "snapshot", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -7033,7 +7033,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "copy", encode: false);
+                _request.Uri.AppendQuery("comp", "copy", escapeValue: false);
                 _request.Uri.AppendQuery("copyid", copyId);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
@@ -7176,7 +7176,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "tier", encode: false);
+                _request.Uri.AppendQuery("comp", "tier", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -7681,7 +7681,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "page", encode: false);
+                _request.Uri.AppendQuery("comp", "page", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -7927,7 +7927,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "page", encode: false);
+                _request.Uri.AppendQuery("comp", "page", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -8220,7 +8220,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "page", encode: false);
+                _request.Uri.AppendQuery("comp", "page", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -8453,7 +8453,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "pagelist", encode: false);
+                _request.Uri.AppendQuery("comp", "pagelist", escapeValue: false);
                 if (snapshot != null) { _request.Uri.AppendQuery("snapshot", snapshot); }
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
@@ -8660,7 +8660,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "pagelist", encode: false);
+                _request.Uri.AppendQuery("comp", "pagelist", escapeValue: false);
                 if (snapshot != null) { _request.Uri.AppendQuery("snapshot", snapshot); }
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
                 if (prevsnapshot != null) { _request.Uri.AppendQuery("prevsnapshot", prevsnapshot); }
@@ -8873,7 +8873,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                _request.Uri.AppendQuery("comp", "properties", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -9061,7 +9061,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                _request.Uri.AppendQuery("comp", "properties", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -9241,7 +9241,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "incrementalcopy", encode: false);
+                _request.Uri.AppendQuery("comp", "incrementalcopy", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -9739,7 +9739,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "appendblock", encode: false);
+                _request.Uri.AppendQuery("comp", "appendblock", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -10023,7 +10023,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "appendblock", encode: false);
+                _request.Uri.AppendQuery("comp", "appendblock", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -10563,7 +10563,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "block", encode: false);
+                _request.Uri.AppendQuery("comp", "block", escapeValue: false);
                 _request.Uri.AppendQuery("blockid", blockId);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
@@ -10796,7 +10796,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "block", encode: false);
+                _request.Uri.AppendQuery("comp", "block", escapeValue: false);
                 _request.Uri.AppendQuery("blockid", blockId);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
@@ -11067,7 +11067,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "blocklist", encode: false);
+                _request.Uri.AppendQuery("comp", "blocklist", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -11274,7 +11274,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "blocklist", encode: false);
+                _request.Uri.AppendQuery("comp", "blocklist", escapeValue: false);
                 _request.Uri.AppendQuery("blocklisttype", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(listType));
                 if (snapshot != null) { _request.Uri.AppendQuery("snapshot", snapshot); }
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
@@ -11500,7 +11500,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("resource", "directory", encode: false);
+                _request.Uri.AppendQuery("resource", "directory", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -12160,7 +12160,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Patch;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("action", "setAccessControl", encode: false);
+                _request.Uri.AppendQuery("action", "setAccessControl", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -12339,7 +12339,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Head;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("action", "getAccessControl", encode: false);
+                _request.Uri.AppendQuery("action", "getAccessControl", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
                 if (upn != null) {
                 #pragma warning disable CA1308 // Normalize strings to uppercase

--- a/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
@@ -119,9 +119,9 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "service");
-                _request.Uri.AppendQuery("comp", "properties");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "service", encode: false);
+                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -252,9 +252,9 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "service");
-                _request.Uri.AppendQuery("comp", "properties");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "service", encode: false);
+                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -383,9 +383,9 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "service");
-                _request.Uri.AppendQuery("comp", "stats");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "service", encode: false);
+                _request.Uri.AppendQuery("comp", "stats", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -534,12 +534,12 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "list");
-                if (prefix != null) { _request.Uri.AppendQuery("prefix", System.Uri.EscapeDataString(prefix)); }
-                if (marker != null) { _request.Uri.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
-                if (maxresults != null) { _request.Uri.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (include != null) { _request.Uri.AppendQuery("include", System.Uri.EscapeDataString(Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(include.Value))); }
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "list", encode: false);
+                if (prefix != null) { _request.Uri.AppendQuery("prefix", prefix); }
+                if (marker != null) { _request.Uri.AppendQuery("marker", marker); }
+                if (maxresults != null) { _request.Uri.AppendQuery("maxresults", maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (include != null) { _request.Uri.AppendQuery("include", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(include.Value)); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -677,9 +677,9 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Post;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "service");
-                _request.Uri.AppendQuery("comp", "userdelegationkey");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "service", encode: false);
+                _request.Uri.AppendQuery("comp", "userdelegationkey", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -805,8 +805,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "account");
-                _request.Uri.AppendQuery("comp", "properties");
+                _request.Uri.AppendQuery("restype", "account", encode: false);
+                _request.Uri.AppendQuery("comp", "properties", encode: false);
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -969,8 +969,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Post;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "batch");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "batch", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("Content-Length", contentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
@@ -1129,8 +1129,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "container");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "container", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 if (access != Azure.Storage.Blobs.Models.PublicAccessType.None) { _request.Headers.SetValue("x-ms-blob-public-access", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(access)); }
@@ -1281,8 +1281,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "container");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "container", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -1469,8 +1469,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Delete;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "container");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "container", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -1612,9 +1612,9 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "container");
-                _request.Uri.AppendQuery("comp", "metadata");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "container", encode: false);
+                _request.Uri.AppendQuery("comp", "metadata", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -1766,9 +1766,9 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "container");
-                _request.Uri.AppendQuery("comp", "acl");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "container", encode: false);
+                _request.Uri.AppendQuery("comp", "acl", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -1943,9 +1943,9 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "container");
-                _request.Uri.AppendQuery("comp", "acl");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "container", encode: false);
+                _request.Uri.AppendQuery("comp", "acl", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 if (access != Azure.Storage.Blobs.Models.PublicAccessType.None) { _request.Headers.SetValue("x-ms-blob-public-access", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(access)); }
@@ -2122,9 +2122,9 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "lease");
-                _request.Uri.AppendQuery("restype", "container");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "lease", encode: false);
+                _request.Uri.AppendQuery("restype", "container", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-lease-action", "acquire");
@@ -2291,9 +2291,9 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "lease");
-                _request.Uri.AppendQuery("restype", "container");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "lease", encode: false);
+                _request.Uri.AppendQuery("restype", "container", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-lease-action", "release");
@@ -2455,9 +2455,9 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "lease");
-                _request.Uri.AppendQuery("restype", "container");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "lease", encode: false);
+                _request.Uri.AppendQuery("restype", "container", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-lease-action", "renew");
@@ -2619,9 +2619,9 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "lease");
-                _request.Uri.AppendQuery("restype", "container");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "lease", encode: false);
+                _request.Uri.AppendQuery("restype", "container", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-lease-action", "break");
@@ -2796,9 +2796,9 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "lease");
-                _request.Uri.AppendQuery("restype", "container");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "lease", encode: false);
+                _request.Uri.AppendQuery("restype", "container", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-lease-action", "change");
@@ -2966,13 +2966,13 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "container");
-                _request.Uri.AppendQuery("comp", "list");
-                if (prefix != null) { _request.Uri.AppendQuery("prefix", System.Uri.EscapeDataString(prefix)); }
-                if (marker != null) { _request.Uri.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
-                if (maxresults != null) { _request.Uri.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (include != null) { _request.Uri.AppendQuery("include", System.Uri.EscapeDataString(string.Join(",", System.Linq.Enumerable.Select(include, item => Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(item))))); }
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "container", encode: false);
+                _request.Uri.AppendQuery("comp", "list", encode: false);
+                if (prefix != null) { _request.Uri.AppendQuery("prefix", prefix); }
+                if (marker != null) { _request.Uri.AppendQuery("marker", marker); }
+                if (maxresults != null) { _request.Uri.AppendQuery("maxresults", maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (include != null) { _request.Uri.AppendQuery("include", string.Join(",", System.Linq.Enumerable.Select(include, item => Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(item)))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -3126,14 +3126,14 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "container");
-                _request.Uri.AppendQuery("comp", "list");
-                if (prefix != null) { _request.Uri.AppendQuery("prefix", System.Uri.EscapeDataString(prefix)); }
-                if (delimiter != null) { _request.Uri.AppendQuery("delimiter", System.Uri.EscapeDataString(delimiter)); }
-                if (marker != null) { _request.Uri.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
-                if (maxresults != null) { _request.Uri.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (include != null) { _request.Uri.AppendQuery("include", System.Uri.EscapeDataString(string.Join(",", System.Linq.Enumerable.Select(include, item => Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(item))))); }
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "container", encode: false);
+                _request.Uri.AppendQuery("comp", "list", encode: false);
+                if (prefix != null) { _request.Uri.AppendQuery("prefix", prefix); }
+                if (delimiter != null) { _request.Uri.AppendQuery("delimiter", delimiter); }
+                if (marker != null) { _request.Uri.AppendQuery("marker", marker); }
+                if (maxresults != null) { _request.Uri.AppendQuery("maxresults", maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (include != null) { _request.Uri.AppendQuery("include", string.Join(",", System.Linq.Enumerable.Select(include, item => Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(item)))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -3332,8 +3332,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                if (snapshot != null) { _request.Uri.AppendQuery("snapshot", System.Uri.EscapeDataString(snapshot)); }
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (snapshot != null) { _request.Uri.AppendQuery("snapshot", snapshot); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -3783,8 +3783,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Head;
                 _request.Uri.Reset(resourceUri);
-                if (snapshot != null) { _request.Uri.AppendQuery("snapshot", System.Uri.EscapeDataString(snapshot)); }
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (snapshot != null) { _request.Uri.AppendQuery("snapshot", snapshot); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -4110,8 +4110,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Delete;
                 _request.Uri.Reset(resourceUri);
-                if (snapshot != null) { _request.Uri.AppendQuery("snapshot", System.Uri.EscapeDataString(snapshot)); }
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (snapshot != null) { _request.Uri.AppendQuery("snapshot", snapshot); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -4286,8 +4286,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Patch;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("action", "setAccessControl");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("action", "setAccessControl", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -4465,11 +4465,11 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Head;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("action", "getAccessControl");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("action", "getAccessControl", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
                 if (upn != null) {
                 #pragma warning disable CA1308 // Normalize strings to uppercase
-                _request.Uri.AppendQuery("upn", System.Uri.EscapeDataString(upn.Value.ToString(System.Globalization.CultureInfo.InvariantCulture).ToLowerInvariant()));
+                _request.Uri.AppendQuery("upn", upn.Value.ToString(System.Globalization.CultureInfo.InvariantCulture).ToLowerInvariant());
                 #pragma warning restore CA1308 // Normalize strings to uppercase
                 }
 
@@ -4735,8 +4735,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (pathRenameMode != null) { _request.Uri.AppendQuery("mode", System.Uri.EscapeDataString(Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(pathRenameMode.Value))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (pathRenameMode != null) { _request.Uri.AppendQuery("mode", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(pathRenameMode.Value)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-rename-source", renameSource);
@@ -4898,8 +4898,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "undelete");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "undelete", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -5078,8 +5078,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "properties");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -5288,8 +5288,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "metadata");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "metadata", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -5480,8 +5480,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "lease");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "lease", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-lease-action", "acquire");
@@ -5660,8 +5660,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "lease");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "lease", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-lease-action", "release");
@@ -5835,8 +5835,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "lease");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "lease", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-lease-action", "renew");
@@ -6023,8 +6023,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "lease");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "lease", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-lease-action", "change");
@@ -6199,8 +6199,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "lease");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "lease", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-lease-action", "break");
@@ -6394,8 +6394,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "snapshot");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "snapshot", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -6625,7 +6625,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-copy-source", copySource.ToString());
@@ -6854,7 +6854,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-requires-sync", "true");
@@ -7033,9 +7033,9 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "copy");
-                _request.Uri.AppendQuery("copyid", System.Uri.EscapeDataString(copyId));
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "copy", encode: false);
+                _request.Uri.AppendQuery("copyid", copyId);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-copy-action", "abort");
@@ -7176,8 +7176,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "tier");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "tier", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-access-tier", tier);
@@ -7411,7 +7411,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-blob-type", "PageBlob");
@@ -7681,8 +7681,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "page");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "page", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-page-write", "update");
@@ -7927,8 +7927,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "page");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "page", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-page-write", "clear");
@@ -8220,8 +8220,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "page");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "page", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-page-write", "update");
@@ -8453,9 +8453,9 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "pagelist");
-                if (snapshot != null) { _request.Uri.AppendQuery("snapshot", System.Uri.EscapeDataString(snapshot)); }
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "pagelist", encode: false);
+                if (snapshot != null) { _request.Uri.AppendQuery("snapshot", snapshot); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -8660,10 +8660,10 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "pagelist");
-                if (snapshot != null) { _request.Uri.AppendQuery("snapshot", System.Uri.EscapeDataString(snapshot)); }
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (prevsnapshot != null) { _request.Uri.AppendQuery("prevsnapshot", System.Uri.EscapeDataString(prevsnapshot)); }
+                _request.Uri.AppendQuery("comp", "pagelist", encode: false);
+                if (snapshot != null) { _request.Uri.AppendQuery("snapshot", snapshot); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (prevsnapshot != null) { _request.Uri.AppendQuery("prevsnapshot", prevsnapshot); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -8873,8 +8873,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "properties");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-blob-content-length", blobContentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
@@ -9061,8 +9061,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "properties");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-sequence-number-action", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(sequenceNumberAction));
@@ -9241,8 +9241,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "incrementalcopy");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "incrementalcopy", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-copy-source", copySource.ToString());
@@ -9482,7 +9482,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-blob-type", "AppendBlob");
@@ -9739,8 +9739,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "appendblock");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "appendblock", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("Content-Length", contentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
@@ -10023,8 +10023,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "appendblock");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "appendblock", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-copy-source", sourceUri.ToString());
@@ -10323,7 +10323,7 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-blob-type", "BlockBlob");
@@ -10563,9 +10563,9 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "block");
-                _request.Uri.AppendQuery("blockid", System.Uri.EscapeDataString(blockId));
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "block", encode: false);
+                _request.Uri.AppendQuery("blockid", blockId);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("Content-Length", contentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
@@ -10796,9 +10796,9 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "block");
-                _request.Uri.AppendQuery("blockid", System.Uri.EscapeDataString(blockId));
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "block", encode: false);
+                _request.Uri.AppendQuery("blockid", blockId);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("Content-Length", contentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
@@ -11067,8 +11067,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "blocklist");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "blocklist", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -11274,10 +11274,10 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "blocklist");
-                _request.Uri.AppendQuery("blocklisttype", System.Uri.EscapeDataString(Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(listType)));
-                if (snapshot != null) { _request.Uri.AppendQuery("snapshot", System.Uri.EscapeDataString(snapshot)); }
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "blocklist", encode: false);
+                _request.Uri.AppendQuery("blocklisttype", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(listType));
+                if (snapshot != null) { _request.Uri.AppendQuery("snapshot", snapshot); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -11500,8 +11500,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("resource", "directory");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("resource", "directory", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -11766,9 +11766,9 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (marker != null) { _request.Uri.AppendQuery("continuation", System.Uri.EscapeDataString(marker)); }
-                if (pathRenameMode != null) { _request.Uri.AppendQuery("mode", System.Uri.EscapeDataString(Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(pathRenameMode.Value))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (marker != null) { _request.Uri.AppendQuery("continuation", marker); }
+                if (pathRenameMode != null) { _request.Uri.AppendQuery("mode", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(pathRenameMode.Value)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-rename-source", renameSource);
@@ -11971,11 +11971,11 @@ namespace Azure.Storage.Blobs
                 _request.Uri.Reset(resourceUri);
 
                 #pragma warning disable CA1308 // Normalize strings to uppercase
-                _request.Uri.AppendQuery("recursive", System.Uri.EscapeDataString(recursiveDirectoryDelete.ToString(System.Globalization.CultureInfo.InvariantCulture).ToLowerInvariant()));
+                _request.Uri.AppendQuery("recursive", recursiveDirectoryDelete.ToString(System.Globalization.CultureInfo.InvariantCulture).ToLowerInvariant());
                 #pragma warning restore CA1308 // Normalize strings to uppercase
 
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (marker != null) { _request.Uri.AppendQuery("continuation", System.Uri.EscapeDataString(marker)); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (marker != null) { _request.Uri.AppendQuery("continuation", marker); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -12160,8 +12160,8 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Patch;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("action", "setAccessControl");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("action", "setAccessControl", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -12339,11 +12339,11 @@ namespace Azure.Storage.Blobs
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Head;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("action", "getAccessControl");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("action", "getAccessControl", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
                 if (upn != null) {
                 #pragma warning disable CA1308 // Normalize strings to uppercase
-                _request.Uri.AppendQuery("upn", System.Uri.EscapeDataString(upn.Value.ToString(System.Globalization.CultureInfo.InvariantCulture).ToLowerInvariant()));
+                _request.Uri.AppendQuery("upn", upn.Value.ToString(System.Globalization.CultureInfo.InvariantCulture).ToLowerInvariant());
                 #pragma warning restore CA1308 // Normalize strings to uppercase
                 }
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
@@ -1391,6 +1391,7 @@ namespace Azure.Storage.Blobs.Test
                 e => Assert.AreEqual("ContainerNotFound", e.ErrorCode.Split('\n')[0]));
         }
 
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/8113")]
         [Test]
         public async Task ListBlobsFlatSegmentAsync_PreservesWhitespace()
         {

--- a/sdk/storage/Azure.Storage.Common/swagger/Generator/src/generator.ts
+++ b/sdk/storage/Azure.Storage.Common/swagger/Generator/src/generator.ts
@@ -352,10 +352,12 @@ function generateOperation(w: IndentWriter, serviceModel: IServiceModel, group: 
             for (const query of operation.request.queries) {
                 const constant = isEnumType(query.model) && query.model.constant;
                 useParameter(query, value => {
-                    if (!query.skipUrlEncoding && !constant) {
-                        value = `System.Uri.EscapeDataString(${value})`
+                    w.write(`${requestName}.Uri.AppendQuery("${query.name}", ${value}`);
+                    if (query.skipUrlEncoding || constant) {
+                        w.write(`, encode: false`);
                     }
-                    w.write(`${requestName}.Uri.AppendQuery("${query.name}", ${value});`);
+
+                    w.write(`);`);
                 });
             }
         }

--- a/sdk/storage/Azure.Storage.Common/swagger/Generator/src/generator.ts
+++ b/sdk/storage/Azure.Storage.Common/swagger/Generator/src/generator.ts
@@ -354,7 +354,7 @@ function generateOperation(w: IndentWriter, serviceModel: IServiceModel, group: 
                 useParameter(query, value => {
                     w.write(`${requestName}.Uri.AppendQuery("${query.name}", ${value}`);
                     if (query.skipUrlEncoding || constant) {
-                        w.write(`, encode: false`);
+                        w.write(`, escapeValue: false`);
                     }
 
                     w.write(`);`);

--- a/sdk/storage/Azure.Storage.Files/src/Generated/FileRestClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Generated/FileRestClient.cs
@@ -114,8 +114,8 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "service", encode: false);
-                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                _request.Uri.AppendQuery("restype", "service", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "properties", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -241,8 +241,8 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "service", encode: false);
-                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                _request.Uri.AppendQuery("restype", "service", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "properties", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -386,7 +386,7 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "list", encode: false);
+                _request.Uri.AppendQuery("comp", "list", escapeValue: false);
                 if (prefix != null) { _request.Uri.AppendQuery("prefix", prefix); }
                 if (marker != null) { _request.Uri.AppendQuery("marker", marker); }
                 if (maxresults != null) { _request.Uri.AppendQuery("maxresults", maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
@@ -532,7 +532,7 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "share", encode: false);
+                _request.Uri.AppendQuery("restype", "share", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -678,7 +678,7 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "share", encode: false);
+                _request.Uri.AppendQuery("restype", "share", escapeValue: false);
                 if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", sharesnapshot); }
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
@@ -835,7 +835,7 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Delete;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "share", encode: false);
+                _request.Uri.AppendQuery("restype", "share", escapeValue: false);
                 if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", sharesnapshot); }
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
@@ -961,8 +961,8 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "share", encode: false);
-                _request.Uri.AppendQuery("comp", "snapshot", encode: false);
+                _request.Uri.AppendQuery("restype", "share", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "snapshot", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -1115,8 +1115,8 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "share", encode: false);
-                _request.Uri.AppendQuery("comp", "filepermission", encode: false);
+                _request.Uri.AppendQuery("restype", "share", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "filepermission", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -1261,8 +1261,8 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "share", encode: false);
-                _request.Uri.AppendQuery("comp", "filepermission", encode: false);
+                _request.Uri.AppendQuery("restype", "share", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "filepermission", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -1395,8 +1395,8 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "share", encode: false);
-                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                _request.Uri.AppendQuery("restype", "share", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "properties", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -1536,8 +1536,8 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "share", encode: false);
-                _request.Uri.AppendQuery("comp", "metadata", encode: false);
+                _request.Uri.AppendQuery("restype", "share", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "metadata", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -1677,8 +1677,8 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "share", encode: false);
-                _request.Uri.AppendQuery("comp", "acl", encode: false);
+                _request.Uri.AppendQuery("restype", "share", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "acl", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -1811,8 +1811,8 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "share", encode: false);
-                _request.Uri.AppendQuery("comp", "acl", encode: false);
+                _request.Uri.AppendQuery("restype", "share", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "acl", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -1960,8 +1960,8 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "share", encode: false);
-                _request.Uri.AppendQuery("comp", "stats", encode: false);
+                _request.Uri.AppendQuery("restype", "share", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "stats", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -2135,7 +2135,7 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "directory", encode: false);
+                _request.Uri.AppendQuery("restype", "directory", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -2313,7 +2313,7 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "directory", encode: false);
+                _request.Uri.AppendQuery("restype", "directory", escapeValue: false);
                 if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", sharesnapshot); }
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
@@ -2488,7 +2488,7 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Delete;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "directory", encode: false);
+                _request.Uri.AppendQuery("restype", "directory", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -2644,8 +2644,8 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "directory", encode: false);
-                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                _request.Uri.AppendQuery("restype", "directory", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "properties", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -2817,8 +2817,8 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "directory", encode: false);
-                _request.Uri.AppendQuery("comp", "metadata", encode: false);
+                _request.Uri.AppendQuery("restype", "directory", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "metadata", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -2978,8 +2978,8 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "directory", encode: false);
-                _request.Uri.AppendQuery("comp", "list", encode: false);
+                _request.Uri.AppendQuery("restype", "directory", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "list", escapeValue: false);
                 if (prefix != null) { _request.Uri.AppendQuery("prefix", prefix); }
                 if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", sharesnapshot); }
                 if (marker != null) { _request.Uri.AppendQuery("marker", marker); }
@@ -3127,7 +3127,7 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "listhandles", encode: false);
+                _request.Uri.AppendQuery("comp", "listhandles", escapeValue: false);
                 if (marker != null) { _request.Uri.AppendQuery("marker", marker); }
                 if (maxresults != null) { _request.Uri.AppendQuery("maxresults", maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
@@ -3283,7 +3283,7 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "forceclosehandles", encode: false);
+                _request.Uri.AppendQuery("comp", "forceclosehandles", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
                 if (marker != null) { _request.Uri.AppendQuery("marker", marker); }
                 if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", sharesnapshot); }
@@ -4515,7 +4515,7 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                _request.Uri.AppendQuery("comp", "properties", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -4708,7 +4708,7 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "metadata", encode: false);
+                _request.Uri.AppendQuery("comp", "metadata", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -4881,7 +4881,7 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "range", encode: false);
+                _request.Uri.AppendQuery("comp", "range", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -5073,7 +5073,7 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "range", encode: false);
+                _request.Uri.AppendQuery("comp", "range", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -5233,7 +5233,7 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "rangelist", encode: false);
+                _request.Uri.AppendQuery("comp", "rangelist", escapeValue: false);
                 if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", sharesnapshot); }
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
@@ -5550,7 +5550,7 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "copy", encode: false);
+                _request.Uri.AppendQuery("comp", "copy", escapeValue: false);
                 _request.Uri.AppendQuery("copyid", copyId);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
@@ -5686,7 +5686,7 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "listhandles", encode: false);
+                _request.Uri.AppendQuery("comp", "listhandles", escapeValue: false);
                 if (marker != null) { _request.Uri.AppendQuery("marker", marker); }
                 if (maxresults != null) { _request.Uri.AppendQuery("maxresults", maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
@@ -5832,7 +5832,7 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "forceclosehandles", encode: false);
+                _request.Uri.AppendQuery("comp", "forceclosehandles", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
                 if (marker != null) { _request.Uri.AppendQuery("marker", marker); }
                 if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", sharesnapshot); }

--- a/sdk/storage/Azure.Storage.Files/src/Generated/FileRestClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Generated/FileRestClient.cs
@@ -114,9 +114,9 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "service");
-                _request.Uri.AppendQuery("comp", "properties");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "service", encode: false);
+                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -241,9 +241,9 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "service");
-                _request.Uri.AppendQuery("comp", "properties");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "service", encode: false);
+                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -386,12 +386,12 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "list");
-                if (prefix != null) { _request.Uri.AppendQuery("prefix", System.Uri.EscapeDataString(prefix)); }
-                if (marker != null) { _request.Uri.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
-                if (maxresults != null) { _request.Uri.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (include != null) { _request.Uri.AppendQuery("include", System.Uri.EscapeDataString(string.Join(",", System.Linq.Enumerable.Select(include, item => Azure.Storage.Files.FileRestClient.Serialization.ToString(item))))); }
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "list", encode: false);
+                if (prefix != null) { _request.Uri.AppendQuery("prefix", prefix); }
+                if (marker != null) { _request.Uri.AppendQuery("marker", marker); }
+                if (maxresults != null) { _request.Uri.AppendQuery("maxresults", maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (include != null) { _request.Uri.AppendQuery("include", string.Join(",", System.Linq.Enumerable.Select(include, item => Azure.Storage.Files.FileRestClient.Serialization.ToString(item)))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -532,8 +532,8 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "share");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "share", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -678,9 +678,9 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "share");
-                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "share", encode: false);
+                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", sharesnapshot); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -835,9 +835,9 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Delete;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "share");
-                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "share", encode: false);
+                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", sharesnapshot); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -961,9 +961,9 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "share");
-                _request.Uri.AppendQuery("comp", "snapshot");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "share", encode: false);
+                _request.Uri.AppendQuery("comp", "snapshot", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -1115,9 +1115,9 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "share");
-                _request.Uri.AppendQuery("comp", "filepermission");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "share", encode: false);
+                _request.Uri.AppendQuery("comp", "filepermission", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -1261,9 +1261,9 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "share");
-                _request.Uri.AppendQuery("comp", "filepermission");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "share", encode: false);
+                _request.Uri.AppendQuery("comp", "filepermission", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-file-permission-key", filePermissionKey);
@@ -1395,9 +1395,9 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "share");
-                _request.Uri.AppendQuery("comp", "properties");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "share", encode: false);
+                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -1536,9 +1536,9 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "share");
-                _request.Uri.AppendQuery("comp", "metadata");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "share", encode: false);
+                _request.Uri.AppendQuery("comp", "metadata", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -1677,9 +1677,9 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "share");
-                _request.Uri.AppendQuery("comp", "acl");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "share", encode: false);
+                _request.Uri.AppendQuery("comp", "acl", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -1811,9 +1811,9 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "share");
-                _request.Uri.AppendQuery("comp", "acl");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "share", encode: false);
+                _request.Uri.AppendQuery("comp", "acl", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -1960,9 +1960,9 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "share");
-                _request.Uri.AppendQuery("comp", "stats");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "share", encode: false);
+                _request.Uri.AppendQuery("comp", "stats", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -2135,8 +2135,8 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "directory");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "directory", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -2313,9 +2313,9 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "directory");
-                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "directory", encode: false);
+                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", sharesnapshot); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -2488,8 +2488,8 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Delete;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "directory");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "directory", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -2644,9 +2644,9 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "directory");
-                _request.Uri.AppendQuery("comp", "properties");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "directory", encode: false);
+                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -2817,9 +2817,9 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "directory");
-                _request.Uri.AppendQuery("comp", "metadata");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "directory", encode: false);
+                _request.Uri.AppendQuery("comp", "metadata", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -2978,13 +2978,13 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "directory");
-                _request.Uri.AppendQuery("comp", "list");
-                if (prefix != null) { _request.Uri.AppendQuery("prefix", System.Uri.EscapeDataString(prefix)); }
-                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
-                if (marker != null) { _request.Uri.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
-                if (maxresults != null) { _request.Uri.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "directory", encode: false);
+                _request.Uri.AppendQuery("comp", "list", encode: false);
+                if (prefix != null) { _request.Uri.AppendQuery("prefix", prefix); }
+                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", sharesnapshot); }
+                if (marker != null) { _request.Uri.AppendQuery("marker", marker); }
+                if (maxresults != null) { _request.Uri.AppendQuery("maxresults", maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -3127,11 +3127,11 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "listhandles");
-                if (marker != null) { _request.Uri.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
-                if (maxresults != null) { _request.Uri.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
+                _request.Uri.AppendQuery("comp", "listhandles", encode: false);
+                if (marker != null) { _request.Uri.AppendQuery("marker", marker); }
+                if (maxresults != null) { _request.Uri.AppendQuery("maxresults", maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", sharesnapshot); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -3283,10 +3283,10 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "forceclosehandles");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (marker != null) { _request.Uri.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
-                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
+                _request.Uri.AppendQuery("comp", "forceclosehandles", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (marker != null) { _request.Uri.AppendQuery("marker", marker); }
+                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", sharesnapshot); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-handle-id", handleId);
@@ -3510,7 +3510,7 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -3716,7 +3716,7 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -4089,8 +4089,8 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Head;
                 _request.Uri.Reset(resourceUri);
-                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", sharesnapshot); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -4325,7 +4325,7 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Delete;
                 _request.Uri.Reset(resourceUri);
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -4515,8 +4515,8 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "properties");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -4708,8 +4708,8 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "metadata");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "metadata", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -4881,8 +4881,8 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "range");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "range", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-range", range);
@@ -5073,8 +5073,8 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "range");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "range", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-range", range);
@@ -5233,9 +5233,9 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "rangelist");
-                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "rangelist", encode: false);
+                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", sharesnapshot); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -5393,7 +5393,7 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -5550,9 +5550,9 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "copy");
-                _request.Uri.AppendQuery("copyid", System.Uri.EscapeDataString(copyId));
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "copy", encode: false);
+                _request.Uri.AppendQuery("copyid", copyId);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-copy-action", "abort");
@@ -5686,11 +5686,11 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "listhandles");
-                if (marker != null) { _request.Uri.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
-                if (maxresults != null) { _request.Uri.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
+                _request.Uri.AppendQuery("comp", "listhandles", encode: false);
+                if (marker != null) { _request.Uri.AppendQuery("marker", marker); }
+                if (maxresults != null) { _request.Uri.AppendQuery("maxresults", maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", sharesnapshot); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2019-02-02");
@@ -5832,10 +5832,10 @@ namespace Azure.Storage.Files
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "forceclosehandles");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (marker != null) { _request.Uri.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
-                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
+                _request.Uri.AppendQuery("comp", "forceclosehandles", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (marker != null) { _request.Uri.AppendQuery("marker", marker); }
+                if (sharesnapshot != null) { _request.Uri.AppendQuery("sharesnapshot", sharesnapshot); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-handle-id", handleId);

--- a/sdk/storage/Azure.Storage.Queues/src/Generated/QueueRestClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Generated/QueueRestClient.cs
@@ -119,8 +119,8 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "service", encode: false);
-                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                _request.Uri.AppendQuery("restype", "service", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "properties", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -252,8 +252,8 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "service", encode: false);
-                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                _request.Uri.AppendQuery("restype", "service", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "properties", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -383,8 +383,8 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "service", encode: false);
-                _request.Uri.AppendQuery("comp", "stats", encode: false);
+                _request.Uri.AppendQuery("restype", "service", escapeValue: false);
+                _request.Uri.AppendQuery("comp", "stats", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -534,7 +534,7 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "list", encode: false);
+                _request.Uri.AppendQuery("comp", "list", escapeValue: false);
                 if (prefix != null) { _request.Uri.AppendQuery("prefix", prefix); }
                 if (marker != null) { _request.Uri.AppendQuery("marker", marker); }
                 if (maxresults != null) { _request.Uri.AppendQuery("maxresults", maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
@@ -939,7 +939,7 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "metadata", encode: false);
+                _request.Uri.AppendQuery("comp", "metadata", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -1088,7 +1088,7 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "metadata", encode: false);
+                _request.Uri.AppendQuery("comp", "metadata", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -1219,7 +1219,7 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "acl", encode: false);
+                _request.Uri.AppendQuery("comp", "acl", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -1358,7 +1358,7 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "acl", encode: false);
+                _request.Uri.AppendQuery("comp", "acl", escapeValue: false);
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
@@ -1940,7 +1940,7 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("peekonly", "true", encode: false);
+                _request.Uri.AppendQuery("peekonly", "true", escapeValue: false);
                 if (numberOfMessages != null) { _request.Uri.AppendQuery("numofmessages", numberOfMessages.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 

--- a/sdk/storage/Azure.Storage.Queues/src/Generated/QueueRestClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Generated/QueueRestClient.cs
@@ -119,9 +119,9 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "service");
-                _request.Uri.AppendQuery("comp", "properties");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "service", encode: false);
+                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -252,9 +252,9 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "service");
-                _request.Uri.AppendQuery("comp", "properties");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "service", encode: false);
+                _request.Uri.AppendQuery("comp", "properties", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -383,9 +383,9 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("restype", "service");
-                _request.Uri.AppendQuery("comp", "stats");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("restype", "service", encode: false);
+                _request.Uri.AppendQuery("comp", "stats", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -534,12 +534,12 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "list");
-                if (prefix != null) { _request.Uri.AppendQuery("prefix", System.Uri.EscapeDataString(prefix)); }
-                if (marker != null) { _request.Uri.AppendQuery("marker", System.Uri.EscapeDataString(marker)); }
-                if (maxresults != null) { _request.Uri.AppendQuery("maxresults", System.Uri.EscapeDataString(maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (include != null) { _request.Uri.AppendQuery("include", System.Uri.EscapeDataString(string.Join(",", System.Linq.Enumerable.Select(include, item => Azure.Storage.Queues.QueueRestClient.Serialization.ToString(item))))); }
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "list", encode: false);
+                if (prefix != null) { _request.Uri.AppendQuery("prefix", prefix); }
+                if (marker != null) { _request.Uri.AppendQuery("marker", marker); }
+                if (maxresults != null) { _request.Uri.AppendQuery("maxresults", maxresults.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (include != null) { _request.Uri.AppendQuery("include", string.Join(",", System.Linq.Enumerable.Select(include, item => Azure.Storage.Queues.QueueRestClient.Serialization.ToString(item)))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -681,7 +681,7 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -815,7 +815,7 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Delete;
                 _request.Uri.Reset(resourceUri);
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -939,8 +939,8 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "metadata");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "metadata", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -1088,8 +1088,8 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "metadata");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "metadata", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -1219,8 +1219,8 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "acl");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "acl", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -1358,8 +1358,8 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("comp", "acl");
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("comp", "acl", encode: false);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -1515,9 +1515,9 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                if (numberOfMessages != null) { _request.Uri.AppendQuery("numofmessages", System.Uri.EscapeDataString(numberOfMessages.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (visibilitytimeout != null) { _request.Uri.AppendQuery("visibilitytimeout", System.Uri.EscapeDataString(visibilitytimeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (numberOfMessages != null) { _request.Uri.AppendQuery("numofmessages", numberOfMessages.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (visibilitytimeout != null) { _request.Uri.AppendQuery("visibilitytimeout", visibilitytimeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -1650,7 +1650,7 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Delete;
                 _request.Uri.Reset(resourceUri);
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -1793,9 +1793,9 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Post;
                 _request.Uri.Reset(resourceUri);
-                if (visibilitytimeout != null) { _request.Uri.AppendQuery("visibilitytimeout", System.Uri.EscapeDataString(visibilitytimeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (messageTimeToLive != null) { _request.Uri.AppendQuery("messagettl", System.Uri.EscapeDataString(messageTimeToLive.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                if (visibilitytimeout != null) { _request.Uri.AppendQuery("visibilitytimeout", visibilitytimeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (messageTimeToLive != null) { _request.Uri.AppendQuery("messagettl", messageTimeToLive.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -1940,9 +1940,9 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Get;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("peekonly", "true");
-                if (numberOfMessages != null) { _request.Uri.AppendQuery("numofmessages", System.Uri.EscapeDataString(numberOfMessages.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("peekonly", "true", encode: false);
+                if (numberOfMessages != null) { _request.Uri.AppendQuery("numofmessages", numberOfMessages.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -2106,9 +2106,9 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Put;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("popreceipt", System.Uri.EscapeDataString(popReceipt));
-                _request.Uri.AppendQuery("visibilitytimeout", System.Uri.EscapeDataString(visibilitytimeout.ToString(System.Globalization.CultureInfo.InvariantCulture)));
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("popreceipt", popReceipt);
+                _request.Uri.AppendQuery("visibilitytimeout", visibilitytimeout.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
@@ -2263,8 +2263,8 @@ namespace Azure.Storage.Queues
                 // Set the endpoint
                 _request.Method = Azure.Core.RequestMethod.Delete;
                 _request.Uri.Reset(resourceUri);
-                _request.Uri.AppendQuery("popreceipt", System.Uri.EscapeDataString(popReceipt));
-                if (timeout != null) { _request.Uri.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
+                _request.Uri.AppendQuery("popreceipt", popReceipt);
+                if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/8104

In the current implementation of UriBuilder we use Uri escaping that escapes some characters(`%`, `?`) but not the others (`#`). Doing escaping by default without the ability to disable it also makes it impossible for clients to have stricter escaping logic (i.e. also escape `#`) because doing so would cause double escaping.

This PR:
1. Adds overloads for AppenPath/AppendQuery that allow disabling escaping.
2. Switches default escaping to stricter EscapeDataString