### PR TITLE
Fix nullable annotation for Headers.TryGetValues

### DIFF
--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
@@ -79,7 +79,7 @@ namespace Azure.Core.Pipeline
 
         internal static bool TryGetHeader(HttpHeaders headers, HttpContent? content, string name, [NotNullWhen(true)] out string? value)
         {
-            if (TryGetHeader(headers, content, name, out IEnumerable<string> values))
+            if (TryGetHeader(headers, content, name, out IEnumerable<string>? values))
             {
                 value = JoinHeaderValues(values);
                 return true;
@@ -89,7 +89,7 @@ namespace Azure.Core.Pipeline
             return false;
         }
 
-        internal static bool TryGetHeader(HttpHeaders headers, HttpContent? content, string name, out IEnumerable<string> values)
+        internal static bool TryGetHeader(HttpHeaders headers, HttpContent? content, string name, [NotNullWhen(true)] out IEnumerable<string>? values)
         {
             return headers.TryGetValues(name, out values) || content?.Headers.TryGetValues(name, out values) == true;
         }
@@ -187,7 +187,7 @@ namespace Azure.Core.Pipeline
 
             protected internal override bool TryGetHeader(string name, [NotNullWhen(true)] out string? value) => HttpClientTransport.TryGetHeader(_requestMessage.Headers, _requestContent, name, out value);
 
-            protected internal override bool TryGetHeaderValues(string name, out IEnumerable<string> values) => HttpClientTransport.TryGetHeader(_requestMessage.Headers, _requestContent, name, out values);
+            protected internal override bool TryGetHeaderValues(string name, [NotNullWhen(true)] out IEnumerable<string>? values) => HttpClientTransport.TryGetHeader(_requestMessage.Headers, _requestContent, name, out values);
 
             protected internal override bool ContainsHeader(string name) => HttpClientTransport.ContainsHeader(_requestMessage.Headers, _requestContent, name);
 
@@ -377,7 +377,7 @@ namespace Azure.Core.Pipeline
 
             protected internal override bool TryGetHeader(string name, [NotNullWhen(true)] out string? value) => HttpClientTransport.TryGetHeader(_responseMessage.Headers, _responseContent, name, out value);
 
-            protected internal override bool TryGetHeaderValues(string name, out IEnumerable<string> values) => HttpClientTransport.TryGetHeader(_responseMessage.Headers, _responseContent, name, out values);
+            protected internal override bool TryGetHeaderValues(string name, [NotNullWhen(true)] out IEnumerable<string>? values) => HttpClientTransport.TryGetHeader(_responseMessage.Headers, _responseContent, name, out values);
 
             protected internal override bool ContainsHeader(string name) => HttpClientTransport.ContainsHeader(_responseMessage.Headers, _responseContent, name);
 

--- a/sdk/core/Azure.Core/src/Request.cs
+++ b/sdk/core/Azure.Core/src/Request.cs
@@ -19,7 +19,7 @@ namespace Azure.Core
 
         protected internal abstract bool TryGetHeader(string name, [NotNullWhen(true)] out string? value);
 
-        protected internal abstract bool TryGetHeaderValues(string name, out IEnumerable<string> values);
+        protected internal abstract bool TryGetHeaderValues(string name, [NotNullWhen(true)] out IEnumerable<string>? values);
 
         protected internal abstract bool ContainsHeader(string name);
 

--- a/sdk/core/Azure.Core/src/RequestFailedException.cs
+++ b/sdk/core/Azure.Core/src/RequestFailedException.cs
@@ -7,14 +7,13 @@ namespace Azure
 {
     public class RequestFailedException : Exception
     {
-        public const int NoStatusCode = 0;
         public int Status { get; }
 
-        public RequestFailedException(string message) : this(NoStatusCode, message)
+        public RequestFailedException(string message) : this(0, message)
         {
         }
 
-        public RequestFailedException(string message, Exception? innerException) : this(NoStatusCode, message, innerException)
+        public RequestFailedException(string message, Exception? innerException) : this(0, message, innerException)
         {
         }
 

--- a/sdk/core/Azure.Core/src/RequestHeaders.cs
+++ b/sdk/core/Azure.Core/src/RequestHeaders.cs
@@ -41,7 +41,7 @@ namespace Azure.Core
             return _request.TryGetHeader(name, out value);
         }
 
-        public bool TryGetValues(string name, out IEnumerable<string> values)
+        public bool TryGetValues(string name, [NotNullWhen(true)] out IEnumerable<string>? values)
         {
             return _request.TryGetHeaderValues(name, out values);
         }

--- a/sdk/core/Azure.Core/src/Response.cs
+++ b/sdk/core/Azure.Core/src/Response.cs
@@ -25,7 +25,7 @@ namespace Azure
 
         protected internal abstract bool TryGetHeader(string name, [NotNullWhen(true)] out string? value);
 
-        protected internal abstract bool TryGetHeaderValues(string name, out IEnumerable<string> values);
+        protected internal abstract bool TryGetHeaderValues(string name, [NotNullWhen(true)] out IEnumerable<string>? values);
 
         protected internal abstract bool ContainsHeader(string name);
 

--- a/sdk/core/Azure.Core/src/ResponseHeaders.cs
+++ b/sdk/core/Azure.Core/src/ResponseHeaders.cs
@@ -47,7 +47,7 @@ namespace Azure.Core
             return _response.TryGetHeader(name, out value);
         }
 
-        public bool TryGetValues(string name, out IEnumerable<string> values)
+        public bool TryGetValues(string name, [NotNullWhen(true)] out IEnumerable<string>? values)
         {
             return _response.TryGetHeaderValues(name, out values);
         }

--- a/sdk/core/Azure.Core/tests/HttpClientTransportTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpClientTransportTests.cs
@@ -369,6 +369,19 @@ namespace Azure.Core.Tests
         }
 
         [TestCaseSource(nameof(HeadersWithValuesAndType))]
+        public void TryGetReturnsCorrectValuesWhenNotFound(string headerName, string headerValue, bool contentHeader)
+        {
+            var transport = new HttpClientTransport();
+            Request request = CreateRequest(transport);
+
+            Assert.False(request.Headers.TryGetValue(headerName, out string value));
+            Assert.IsNull(value);
+
+            Assert.False(request.Headers.TryGetValues(headerName, out IEnumerable<string> values));
+            Assert.IsNull(values);
+        }
+
+        [TestCaseSource(nameof(HeadersWithValuesAndType))]
         public async Task SettingContentHeaderDoesNotSetContent(string headerName, string headerValue, bool contentHeader)
         {
             HttpContent httpMessageContent = null;


### PR DESCRIPTION
The implementation was correct but the annotation was wrong.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/8092

I also sneaked in https://github.com/Azure/azure-sdk-for-net/issues/8093 as it's extra minor.