### PR TITLE
[Storage] Rename `StorageHandle` to `StorageFileHandle`

### DIFF
--- a/sdk/storage/Azure.Storage.Files/src/DirectoryClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/DirectoryClient.cs
@@ -1119,7 +1119,7 @@ namespace Azure.Storage.Files
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual Pageable<StorageHandle> GetHandles(
+        public virtual Pageable<StorageFileHandle> GetHandles(
             bool? recursive = default,
             CancellationToken cancellationToken = default) =>
             new GetDirectoryHandlesAsyncCollection(this, recursive).ToSyncCollection(cancellationToken);
@@ -1147,7 +1147,7 @@ namespace Azure.Storage.Files
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual AsyncPageable<StorageHandle> GetHandlesAsync(
+        public virtual AsyncPageable<StorageFileHandle> GetHandlesAsync(
             bool? recursive = default,
             CancellationToken cancellationToken = default) =>
             new GetDirectoryHandlesAsyncCollection(this, recursive).ToAsyncCollection(cancellationToken);

--- a/sdk/storage/Azure.Storage.Files/src/FileClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/FileClient.cs
@@ -2266,7 +2266,7 @@ namespace Azure.Storage.Files
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual Pageable<StorageHandle> GetHandles(
+        public virtual Pageable<StorageFileHandle> GetHandles(
             CancellationToken cancellationToken = default) =>
             new GetFileHandlesAsyncCollection(this).ToSyncCollection(cancellationToken);
 
@@ -2290,7 +2290,7 @@ namespace Azure.Storage.Files
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual AsyncPageable<StorageHandle> GetHandlesAsync(
+        public virtual AsyncPageable<StorageFileHandle> GetHandlesAsync(
             CancellationToken cancellationToken = default) =>
             new GetFileHandlesAsyncCollection(this).ToAsyncCollection(cancellationToken);
 

--- a/sdk/storage/Azure.Storage.Files/src/Generated/FileRestClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Generated/FileRestClient.cs
@@ -8822,6 +8822,151 @@ namespace Azure.Storage.Files.Models
 }
 #endregion class StorageFileCopyInfo
 
+#region class StorageFileHandle
+namespace Azure.Storage.Files.Models
+{
+    /// <summary>
+    /// A listed Azure Storage handle item.
+    /// </summary>
+    public partial class StorageFileHandle
+    {
+        /// <summary>
+        /// XSMB service handle ID
+        /// </summary>
+        public string HandleId { get; internal set; }
+
+        /// <summary>
+        /// File or directory name including full path starting from share root
+        /// </summary>
+        public string Path { get; internal set; }
+
+        /// <summary>
+        /// FileId uniquely identifies the file or directory.
+        /// </summary>
+        public string FileId { get; internal set; }
+
+        /// <summary>
+        /// ParentId uniquely identifies the parent directory of the object.
+        /// </summary>
+        public string ParentId { get; internal set; }
+
+        /// <summary>
+        /// SMB session ID in context of which the file handle was opened
+        /// </summary>
+        public string SessionId { get; internal set; }
+
+        /// <summary>
+        /// Client IP that opened the handle
+        /// </summary>
+        public string ClientIp { get; internal set; }
+
+        /// <summary>
+        /// Time when the session that previously opened the handle has last been reconnected. (UTC)
+        /// </summary>
+        public System.DateTimeOffset OpenTime { get; internal set; }
+
+        /// <summary>
+        /// Time handle was last connected to (UTC)
+        /// </summary>
+        public System.DateTimeOffset? LastReconnectTime { get; internal set; }
+
+        /// <summary>
+        /// Prevent direct instantiation of StorageFileHandle instances.
+        /// You can use FilesModelFactory.StorageFileHandle instead.
+        /// </summary>
+        internal StorageFileHandle() { }
+
+        /// <summary>
+        /// Deserializes XML into a new StorageFileHandle instance.
+        /// </summary>
+        /// <param name="element">The XML element to deserialize.</param>
+        /// <returns>A deserialized StorageFileHandle instance.</returns>
+        internal static Azure.Storage.Files.Models.StorageFileHandle FromXml(System.Xml.Linq.XElement element)
+        {
+            System.Diagnostics.Debug.Assert(element != null);
+            System.Xml.Linq.XElement _child;
+            Azure.Storage.Files.Models.StorageFileHandle _value = new Azure.Storage.Files.Models.StorageFileHandle();
+            _child = element.Element(System.Xml.Linq.XName.Get("HandleId", ""));
+            if (_child != null)
+            {
+                _value.HandleId = _child.Value;
+            }
+            _child = element.Element(System.Xml.Linq.XName.Get("Path", ""));
+            if (_child != null)
+            {
+                _value.Path = _child.Value;
+            }
+            _child = element.Element(System.Xml.Linq.XName.Get("FileId", ""));
+            if (_child != null)
+            {
+                _value.FileId = _child.Value;
+            }
+            _child = element.Element(System.Xml.Linq.XName.Get("ParentId", ""));
+            if (_child != null)
+            {
+                _value.ParentId = _child.Value;
+            }
+            _child = element.Element(System.Xml.Linq.XName.Get("SessionId", ""));
+            if (_child != null)
+            {
+                _value.SessionId = _child.Value;
+            }
+            _child = element.Element(System.Xml.Linq.XName.Get("ClientIp", ""));
+            if (_child != null)
+            {
+                _value.ClientIp = _child.Value;
+            }
+            _child = element.Element(System.Xml.Linq.XName.Get("OpenTime", ""));
+            if (_child != null)
+            {
+                _value.OpenTime = System.DateTimeOffset.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
+            }
+            _child = element.Element(System.Xml.Linq.XName.Get("LastReconnectTime", ""));
+            if (_child != null)
+            {
+                _value.LastReconnectTime = System.DateTimeOffset.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
+            }
+            CustomizeFromXml(element, _value);
+            return _value;
+        }
+
+        static partial void CustomizeFromXml(System.Xml.Linq.XElement element, Azure.Storage.Files.Models.StorageFileHandle value);
+    }
+
+    /// <summary>
+    /// FilesModelFactory provides utilities for mocking.
+    /// </summary>
+    public static partial class FilesModelFactory
+    {
+        /// <summary>
+        /// Creates a new StorageFileHandle instance for mocking.
+        /// </summary>
+        public static StorageFileHandle StorageFileHandle(
+            string handleId,
+            string path,
+            string fileId,
+            string sessionId,
+            string clientIp,
+            System.DateTimeOffset openTime,
+            string parentId = default,
+            System.DateTimeOffset? lastReconnectTime = default)
+        {
+            return new StorageFileHandle()
+            {
+                HandleId = handleId,
+                Path = path,
+                FileId = fileId,
+                SessionId = sessionId,
+                ClientIp = clientIp,
+                OpenTime = openTime,
+                ParentId = parentId,
+                LastReconnectTime = lastReconnectTime,
+            };
+        }
+    }
+}
+#endregion class StorageFileHandle
+
 #region class StorageFileRangeInfo
 namespace Azure.Storage.Files.Models
 {
@@ -8948,151 +9093,6 @@ namespace Azure.Storage.Files.Models
 }
 #endregion class StorageFileUploadInfo
 
-#region class StorageHandle
-namespace Azure.Storage.Files.Models
-{
-    /// <summary>
-    /// A listed Azure Storage handle item.
-    /// </summary>
-    public partial class StorageHandle
-    {
-        /// <summary>
-        /// XSMB service handle ID
-        /// </summary>
-        public string HandleId { get; internal set; }
-
-        /// <summary>
-        /// File or directory name including full path starting from share root
-        /// </summary>
-        public string Path { get; internal set; }
-
-        /// <summary>
-        /// FileId uniquely identifies the file or directory.
-        /// </summary>
-        public string FileId { get; internal set; }
-
-        /// <summary>
-        /// ParentId uniquely identifies the parent directory of the object.
-        /// </summary>
-        public string ParentId { get; internal set; }
-
-        /// <summary>
-        /// SMB session ID in context of which the file handle was opened
-        /// </summary>
-        public string SessionId { get; internal set; }
-
-        /// <summary>
-        /// Client IP that opened the handle
-        /// </summary>
-        public string ClientIp { get; internal set; }
-
-        /// <summary>
-        /// Time when the session that previously opened the handle has last been reconnected. (UTC)
-        /// </summary>
-        public System.DateTimeOffset OpenTime { get; internal set; }
-
-        /// <summary>
-        /// Time handle was last connected to (UTC)
-        /// </summary>
-        public System.DateTimeOffset? LastReconnectTime { get; internal set; }
-
-        /// <summary>
-        /// Prevent direct instantiation of StorageHandle instances.
-        /// You can use FilesModelFactory.StorageHandle instead.
-        /// </summary>
-        internal StorageHandle() { }
-
-        /// <summary>
-        /// Deserializes XML into a new StorageHandle instance.
-        /// </summary>
-        /// <param name="element">The XML element to deserialize.</param>
-        /// <returns>A deserialized StorageHandle instance.</returns>
-        internal static Azure.Storage.Files.Models.StorageHandle FromXml(System.Xml.Linq.XElement element)
-        {
-            System.Diagnostics.Debug.Assert(element != null);
-            System.Xml.Linq.XElement _child;
-            Azure.Storage.Files.Models.StorageHandle _value = new Azure.Storage.Files.Models.StorageHandle();
-            _child = element.Element(System.Xml.Linq.XName.Get("HandleId", ""));
-            if (_child != null)
-            {
-                _value.HandleId = _child.Value;
-            }
-            _child = element.Element(System.Xml.Linq.XName.Get("Path", ""));
-            if (_child != null)
-            {
-                _value.Path = _child.Value;
-            }
-            _child = element.Element(System.Xml.Linq.XName.Get("FileId", ""));
-            if (_child != null)
-            {
-                _value.FileId = _child.Value;
-            }
-            _child = element.Element(System.Xml.Linq.XName.Get("ParentId", ""));
-            if (_child != null)
-            {
-                _value.ParentId = _child.Value;
-            }
-            _child = element.Element(System.Xml.Linq.XName.Get("SessionId", ""));
-            if (_child != null)
-            {
-                _value.SessionId = _child.Value;
-            }
-            _child = element.Element(System.Xml.Linq.XName.Get("ClientIp", ""));
-            if (_child != null)
-            {
-                _value.ClientIp = _child.Value;
-            }
-            _child = element.Element(System.Xml.Linq.XName.Get("OpenTime", ""));
-            if (_child != null)
-            {
-                _value.OpenTime = System.DateTimeOffset.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
-            }
-            _child = element.Element(System.Xml.Linq.XName.Get("LastReconnectTime", ""));
-            if (_child != null)
-            {
-                _value.LastReconnectTime = System.DateTimeOffset.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
-            }
-            CustomizeFromXml(element, _value);
-            return _value;
-        }
-
-        static partial void CustomizeFromXml(System.Xml.Linq.XElement element, Azure.Storage.Files.Models.StorageHandle value);
-    }
-
-    /// <summary>
-    /// FilesModelFactory provides utilities for mocking.
-    /// </summary>
-    public static partial class FilesModelFactory
-    {
-        /// <summary>
-        /// Creates a new StorageHandle instance for mocking.
-        /// </summary>
-        public static StorageHandle StorageHandle(
-            string handleId,
-            string path,
-            string fileId,
-            string sessionId,
-            string clientIp,
-            System.DateTimeOffset openTime,
-            string parentId = default,
-            System.DateTimeOffset? lastReconnectTime = default)
-        {
-            return new StorageHandle()
-            {
-                HandleId = handleId,
-                Path = path,
-                FileId = fileId,
-                SessionId = sessionId,
-                ClientIp = clientIp,
-                OpenTime = openTime,
-                ParentId = parentId,
-                LastReconnectTime = lastReconnectTime,
-            };
-        }
-    }
-}
-#endregion class StorageHandle
-
 #region class StorageHandlesSegment
 namespace Azure.Storage.Files.Models
 {
@@ -9109,7 +9109,7 @@ namespace Azure.Storage.Files.Models
         /// <summary>
         /// Handles
         /// </summary>
-        public System.Collections.Generic.IEnumerable<Azure.Storage.Files.Models.StorageHandle> Handles { get; internal set; }
+        public System.Collections.Generic.IEnumerable<Azure.Storage.Files.Models.StorageFileHandle> Handles { get; internal set; }
 
         /// <summary>
         /// Creates a new StorageHandlesSegment instance
@@ -9127,7 +9127,7 @@ namespace Azure.Storage.Files.Models
         {
             if (!skipInitialization)
             {
-                Handles = new System.Collections.Generic.List<Azure.Storage.Files.Models.StorageHandle>();
+                Handles = new System.Collections.Generic.List<Azure.Storage.Files.Models.StorageFileHandle>();
             }
         }
 
@@ -9152,11 +9152,11 @@ namespace Azure.Storage.Files.Models
                 _value.Handles = System.Linq.Enumerable.ToList(
                     System.Linq.Enumerable.Select(
                         _child.Elements(System.Xml.Linq.XName.Get("Handle", "")),
-                        e => Azure.Storage.Files.Models.StorageHandle.FromXml(e)));
+                        e => Azure.Storage.Files.Models.StorageFileHandle.FromXml(e)));
             }
             else
             {
-                _value.Handles = new System.Collections.Generic.List<Azure.Storage.Files.Models.StorageHandle>();
+                _value.Handles = new System.Collections.Generic.List<Azure.Storage.Files.Models.StorageFileHandle>();
             }
             CustomizeFromXml(element, _value);
             return _value;

--- a/sdk/storage/Azure.Storage.Files/src/Models/GetDirectoryHandlesAsyncCollection.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Models/GetDirectoryHandlesAsyncCollection.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Azure.Storage.Files.Models
 {
-    internal class GetDirectoryHandlesAsyncCollection : StorageCollectionEnumerator<StorageHandle>
+    internal class GetDirectoryHandlesAsyncCollection : StorageCollectionEnumerator<StorageFileHandle>
     {
         private readonly DirectoryClient _client;
         private readonly bool? _recursive;
@@ -20,7 +20,7 @@ namespace Azure.Storage.Files.Models
             _recursive = recursive;
         }
 
-        public override async ValueTask<Page<StorageHandle>> GetNextPageAsync(
+        public override async ValueTask<Page<StorageFileHandle>> GetNextPageAsync(
             string continuationToken,
             int? pageSizeHint,
             bool isAsync,
@@ -35,7 +35,7 @@ namespace Azure.Storage.Files.Models
             Response<StorageHandlesSegment> response = isAsync ?
                 await task.ConfigureAwait(false) :
                 task.EnsureCompleted();
-            return new Page<StorageHandle>(
+            return new Page<StorageFileHandle>(
                 response.Value.Handles.ToArray(),
                 response.Value.NextMarker,
                 response.GetRawResponse());

--- a/sdk/storage/Azure.Storage.Files/src/Models/GetFileHandlesAsyncCollection.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Models/GetFileHandlesAsyncCollection.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Azure.Storage.Files.Models
 {
-    internal class GetFileHandlesAsyncCollection : StorageCollectionEnumerator<StorageHandle>
+    internal class GetFileHandlesAsyncCollection : StorageCollectionEnumerator<StorageFileHandle>
     {
         private readonly FileClient _client;
 
@@ -17,7 +17,7 @@ namespace Azure.Storage.Files.Models
             _client = client;
         }
 
-        public override async ValueTask<Page<StorageHandle>> GetNextPageAsync(
+        public override async ValueTask<Page<StorageFileHandle>> GetNextPageAsync(
             string continuationToken,
             int? pageSizeHint,
             bool isAsync,
@@ -31,7 +31,7 @@ namespace Azure.Storage.Files.Models
             Response<StorageHandlesSegment> response = isAsync ?
                 await task.ConfigureAwait(false) :
                 task.EnsureCompleted();
-            return new Page<StorageHandle>(
+            return new Page<StorageFileHandle>(
                 response.Value.Handles.ToArray(),
                 response.Value.NextMarker,
                 response.GetRawResponse());

--- a/sdk/storage/Azure.Storage.Files/swagger/readme.md
+++ b/sdk/storage/Azure.Storage.Files/swagger/readme.md
@@ -320,8 +320,8 @@ directive:
 - from: swagger-document
   where: $.definitions
   transform: >
-    if (!$.StorageHandle) {
-        $.StorageHandle = $.HandleItem;
+    if (!$.StorageFileHandle) {
+        $.StorageFileHandle = $.HandleItem;
         delete $.HandleItem;
     }
     if (!$.StorageHandlesSegment) {
@@ -331,7 +331,7 @@ directive:
         const path = $.StorageHandlesSegment.properties.HandleList.items.$ref.replace(/[#].*$/, "#/definitions/");
         $.StorageHandlesSegment.properties.Handles = {
             "type": "array",
-            "items": { "$ref": path + "StorageHandle" },
+            "items": { "$ref": path + "StorageFileHandle" },
             "xml": { "name": "Entries", "wrapped": true }
         };
         delete $.StorageHandlesSegment.properties.HandleList;

--- a/sdk/storage/Azure.Storage.Files/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files/tests/DirectoryClientTests.cs
@@ -501,7 +501,7 @@ namespace Azure.Storage.Files.Test
             using (GetNewDirectory(out DirectoryClient directory))
             {
                 // Act
-                IList<StorageHandle> handles = await directory.GetHandlesAsync().ToListAsync();
+                IList<StorageFileHandle> handles = await directory.GetHandlesAsync().ToListAsync();
 
                 // Assert
                 Assert.AreEqual(0, handles.Count);

--- a/sdk/storage/Azure.Storage.Files/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files/tests/FileClientTests.cs
@@ -1108,7 +1108,7 @@ namespace Azure.Storage.Files.Test
             using (GetNewFile(out FileClient file))
             {
                 // Act
-                IList<StorageHandle> handles = await file.GetHandlesAsync().ToListAsync();
+                IList<StorageFileHandle> handles = await file.GetHandlesAsync().ToListAsync();
 
                 // Assert
                 Assert.AreEqual(0, handles.Count);
@@ -1122,7 +1122,7 @@ namespace Azure.Storage.Files.Test
             using (GetNewFile(out FileClient file))
             {
                 // Act
-                IList<StorageHandle> handles = await file.GetHandlesAsync().ToListAsync();
+                IList<StorageFileHandle> handles = await file.GetHandlesAsync().ToListAsync();
 
                 // Assert
                 Assert.AreEqual(0, handles.Count);


### PR DESCRIPTION
[As per API review](https://apiview.azurewebsites.net/Assemblies/Review/c52f059a-6d57-4d40-b7d2-a5816565a660#Azure.Storage.Blobs.BlobClientOptions.ServiceVersion), rename `StorageHandle` to `StorageFileHandle`.