### PR TITLE
Exclude shared types from Azure.Core by default

### DIFF
--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -29,4 +29,15 @@
     <PackageReference Include="System.Numerics.Vectors" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Shared\*.cs"/>
+    <Compile Include="Shared\Argument.cs"/>
+    <Compile Include="Shared\EventSourceEventFormatting.cs"/>
+    <Compile Include="Shared\HashCodeBuilder.cs"/>
+    <Compile Include="Shared\NullableAttributes.cs"/>
+    <Compile Include="Shared\ContentTypeUtilities.cs"/>
+    <Compile Include="Shared\ClientDiagnostics.cs"/>
+    <Compile Include="Shared\DiagnosticScope.cs"/>
+  </ItemGroup>
 </Project>

--- a/sdk/core/Azure.Core/tests/Azure.Core.Tests.csproj
+++ b/sdk/core/Azure.Core/tests/Azure.Core.Tests.csproj
@@ -22,7 +22,12 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\src\Shared\ArrayBufferWriter.cs" />
     <Compile Include="..\src\Shared\ContentTypeUtilities.cs" />
+    <Compile Include="..\src\Shared\ForwardsClientCallsAttribute.cs" />
+    <Compile Include="..\src\Shared\RetriableStream.cs" />
+    <Compile Include="..\src\Shared\NoBodyResponse{T}.cs" />
+    <Compile Include="..\src\Shared\ResponseExceptionExtensions.cs" />
   </ItemGroup>
 
 </Project>

--- a/sdk/core/Azure.Core/tests/Azure.Core.Tests.csproj
+++ b/sdk/core/Azure.Core/tests/Azure.Core.Tests.csproj
@@ -28,6 +28,7 @@
     <Compile Include="..\src\Shared\RetriableStream.cs" />
     <Compile Include="..\src\Shared\NoBodyResponse{T}.cs" />
     <Compile Include="..\src\Shared\ResponseExceptionExtensions.cs" />
+    <Compile Include="..\src\Shared\OperationHelpers.cs"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/8106