### PR TITLE
[Storage] Change first ServiceVersion value to 1 and throw for everything else

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClientOptions.cs
@@ -17,7 +17,7 @@ namespace Azure.Storage.Blobs
         /// <summary>
         /// The Latest service version supported by this client library.
         /// </summary>
-        internal const ServiceVersion LatestVersion = ServiceVersion.V2018_11_09;
+        internal const ServiceVersion LatestVersion = ServiceVersion.V2019_02_02;
 
         /// <summary>
         /// The versions of Azure Blob Storage supported by this client
@@ -28,10 +28,10 @@ namespace Azure.Storage.Blobs
         {
 #pragma warning disable CA1707 // Identifiers should not contain underscores
             /// <summary>
-            /// The 2018-11-09 service version described at
-            /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/version-2018-11-09" />
+            /// The 2019-02-02 service version described at
+            /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services#version-2019-02-02" />
             /// </summary>
-            V2018_11_09 = 1
+            V2019_02_02 = 1
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
@@ -62,7 +62,7 @@ namespace Azure.Storage.Blobs
             ServiceVersion version = LatestVersion,
             CustomerProvidedKey? customerProvidedKey = default)
         {
-            Version = version == ServiceVersion.V2018_11_09 ? version: throw Errors.VersionNotSupported(nameof(version));
+            Version = version == ServiceVersion.V2019_02_02 ? version: throw Errors.VersionNotSupported(nameof(version));
             CustomerProvidedKey = customerProvidedKey;
             this.Initialize();
         }

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClientOptions.cs
@@ -31,7 +31,7 @@ namespace Azure.Storage.Blobs
             /// The 2018-11-09 service version described at
             /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/version-2018-11-09" />
             /// </summary>
-            V2018_11_09 = 0
+            V2018_11_09 = 1
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
@@ -62,7 +62,7 @@ namespace Azure.Storage.Blobs
             ServiceVersion version = LatestVersion,
             CustomerProvidedKey? customerProvidedKey = default)
         {
-            Version = version;
+            Version = (int)version == 1? version: throw Errors.ArgumentNotSupported(nameof(version));
             CustomerProvidedKey = customerProvidedKey;
             this.Initialize();
         }

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClientOptions.cs
@@ -62,7 +62,7 @@ namespace Azure.Storage.Blobs
             ServiceVersion version = LatestVersion,
             CustomerProvidedKey? customerProvidedKey = default)
         {
-            Version = (int)version == 1? version: throw Errors.ArgumentNotSupported(nameof(version));
+            Version = version == ServiceVersion.V2018_11_09 ? version: throw Errors.VersionNotSupported(nameof(version));
             CustomerProvidedKey = customerProvidedKey;
             this.Initialize();
         }

--- a/sdk/storage/Azure.Storage.Common/src/Errors.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Errors.cs
@@ -60,8 +60,8 @@ namespace Azure.Storage
         public static ArgumentException InvalidResourceType(char s)
             => new ArgumentException($"Invalid resource type: '{s}'");
 
-        public static ArgumentException ArgumentNotSupported(string paramName)
-           => new ArgumentException("Argument not supported", paramName);
+        public static ArgumentException VersionNotSupported(string paramName)
+           => new ArgumentException("The service version is not supported", paramName);
 
         public static ArgumentException AccountMismatch(string accountNameCredential, string accountNameValue)
             => new ArgumentException(string.Format(

--- a/sdk/storage/Azure.Storage.Common/src/Errors.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Errors.cs
@@ -61,7 +61,7 @@ namespace Azure.Storage
             => new ArgumentException($"Invalid resource type: '{s}'");
 
         public static ArgumentException VersionNotSupported(string paramName)
-           => new ArgumentException("The service version is not supported", paramName);
+           => new ArgumentException($"The version specified by {paramName} is not supported by this library.");
 
         public static ArgumentException AccountMismatch(string accountNameCredential, string accountNameValue)
             => new ArgumentException(string.Format(

--- a/sdk/storage/Azure.Storage.Common/src/Errors.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Errors.cs
@@ -60,6 +60,9 @@ namespace Azure.Storage
         public static ArgumentException InvalidResourceType(char s)
             => new ArgumentException($"Invalid resource type: '{s}'");
 
+        public static ArgumentException ArgumentNotSupported(string paramName)
+           => new ArgumentException("Argument not supported", paramName);
+
         public static ArgumentException AccountMismatch(string accountNameCredential, string accountNameValue)
             => new ArgumentException(string.Format(
                 CultureInfo.CurrentCulture,

--- a/sdk/storage/Azure.Storage.Files/src/FileClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Files/src/FileClientOptions.cs
@@ -50,7 +50,7 @@ namespace Azure.Storage.Files
         /// </param>
         public FileClientOptions(ServiceVersion version = LatestVersion)
         {
-            Version = (int)version == 1 ? version : throw Errors.ArgumentNotSupported(nameof(version));
+            Version = version == ServiceVersion.V2018_11_09 ? version : throw Errors.VersionNotSupported(nameof(version));
             this.Initialize();
         }
     }

--- a/sdk/storage/Azure.Storage.Files/src/FileClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Files/src/FileClientOptions.cs
@@ -15,7 +15,7 @@ namespace Azure.Storage.Files
         /// <summary>
         /// The Latest service version supported by this client library.
         /// </summary>
-        internal const ServiceVersion LatestVersion = ServiceVersion.V2018_11_09;
+        internal const ServiceVersion LatestVersion = ServiceVersion.V2019_02_02;
 
         /// <summary>
         /// The versions of Azure File Storage supported by this client
@@ -26,10 +26,10 @@ namespace Azure.Storage.Files
         {
 #pragma warning disable CA1707 // Identifiers should not contain underscores
             /// <summary>
-            /// The 2018-11-09 service version described at
-            /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/version-2018-11-09" />
+            /// The 2019-02-02 service version described at
+            /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services#version-2019-02-02" />
             /// </summary>
-            V2018_11_09 = 1
+            V2019_02_02 = 1
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
@@ -50,7 +50,7 @@ namespace Azure.Storage.Files
         /// </param>
         public FileClientOptions(ServiceVersion version = LatestVersion)
         {
-            Version = version == ServiceVersion.V2018_11_09 ? version : throw Errors.VersionNotSupported(nameof(version));
+            Version = version == ServiceVersion.V2019_02_02 ? version : throw Errors.VersionNotSupported(nameof(version));
             this.Initialize();
         }
     }

--- a/sdk/storage/Azure.Storage.Files/src/FileClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Files/src/FileClientOptions.cs
@@ -29,7 +29,7 @@ namespace Azure.Storage.Files
             /// The 2018-11-09 service version described at
             /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/version-2018-11-09" />
             /// </summary>
-            V2018_11_09 = 0
+            V2018_11_09 = 1
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
@@ -50,7 +50,7 @@ namespace Azure.Storage.Files
         /// </param>
         public FileClientOptions(ServiceVersion version = LatestVersion)
         {
-            Version = version;
+            Version = (int)version == 1 ? version : throw Errors.ArgumentNotSupported(nameof(version));
             this.Initialize();
         }
     }

--- a/sdk/storage/Azure.Storage.Queues/src/QueueClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueClientOptions.cs
@@ -16,7 +16,7 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// The Latest service version supported by this client library.
         /// </summary>
-        internal const ServiceVersion LatestVersion = ServiceVersion.V2018_11_09;
+        internal const ServiceVersion LatestVersion = ServiceVersion.V2019_02_02;
 
         /// <summary>
         /// The versions of Azure Queue Storage supported by this client
@@ -27,10 +27,10 @@ namespace Azure.Storage.Queues
         {
 #pragma warning disable CA1707 // Identifiers should not contain underscores
             /// <summary>
-            /// The 2018-11-09 service version described at
-            /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/version-2018-11-09" />
+            /// The 2019-02-02 service version described at
+            /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services#version-2019-02-02" />
             /// </summary>
-            V2018_11_09 = 1
+            V2019_02_02 = 1
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
@@ -51,7 +51,7 @@ namespace Azure.Storage.Queues
         /// </param>
         public QueueClientOptions(ServiceVersion version = LatestVersion)
         {
-            Version = version == ServiceVersion.V2018_11_09 ? version : throw Errors.VersionNotSupported(nameof(version));
+            Version = version == ServiceVersion.V2019_02_02 ? version : throw Errors.VersionNotSupported(nameof(version));
             this.Initialize();
         }
 

--- a/sdk/storage/Azure.Storage.Queues/src/QueueClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueClientOptions.cs
@@ -30,7 +30,7 @@ namespace Azure.Storage.Queues
             /// The 2018-11-09 service version described at
             /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/version-2018-11-09" />
             /// </summary>
-            V2018_11_09 = 0
+            V2018_11_09 = 1
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
@@ -51,7 +51,7 @@ namespace Azure.Storage.Queues
         /// </param>
         public QueueClientOptions(ServiceVersion version = LatestVersion)
         {
-            Version = version;
+            Version = (int)version == 1 ? version : throw Errors.ArgumentNotSupported(nameof(version));
             this.Initialize();
         }
 

--- a/sdk/storage/Azure.Storage.Queues/src/QueueClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueClientOptions.cs
@@ -51,7 +51,7 @@ namespace Azure.Storage.Queues
         /// </param>
         public QueueClientOptions(ServiceVersion version = LatestVersion)
         {
-            Version = (int)version == 1 ? version : throw Errors.ArgumentNotSupported(nameof(version));
+            Version = version == ServiceVersion.V2018_11_09 ? version : throw Errors.VersionNotSupported(nameof(version));
             this.Initialize();
         }
 


### PR DESCRIPTION
[As per API review](https://apiview.azurewebsites.net/Assemblies/Review/c52f059a-6d57-4d40-b7d2-a5816565a660#Azure.Storage.Blobs.BlobClientOptions.ServiceVersion) Change  ServiceVersion value to  `1` and throw exception for everything else.