### PR TITLE
[Event Hubs Client] Track Two: Fifth Preview (AMQP Producer)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
@@ -39,7 +39,10 @@ namespace Azure.Messaging.EventHubs.Amqp
         private const string WebSocketsUriScheme = "wss";
 
         /// <summary>The string formatting mask to apply to the service endpoint to consume events for a given consumer group and partition.</summary>
-        private const string ConsumerPathSuffixMask = "/ConsumerGroups/{0}/Partitions/{1}";
+        private const string ConsumerPathSuffixMask = "{0}/ConsumerGroups/{1}/Partitions/{2}";
+
+        /// <summary>The string formatting mask to apply to the service endpoint to publish events for a given partition.</summary>
+        private const string PartitionProducerPathSuffixMask = "{0}/Partitions/{1}";
 
         /// <summary>
         ///   The version of AMQP to use within the scope.
@@ -241,12 +244,45 @@ namespace Azure.Messaging.EventHubs.Amqp
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
             var stopWatch = Stopwatch.StartNew();
-            var consumerEndpoint = new Uri(ServiceEndpoint, string.Format(ConsumerPathSuffixMask, consumerGroup, partitionId));
+            var consumerEndpoint = new Uri(ServiceEndpoint, string.Format(ConsumerPathSuffixMask, EventHubName, consumerGroup, partitionId));
 
             var connection = await ActiveConnection.GetOrCreateAsync(timeout).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
             var link = await CreateReceivingLinkAsync(connection, consumerEndpoint, eventPosition, consumerOptions, timeout.CalculateRemaining(stopWatch.Elapsed), cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+
+            await OpenAmqpObjectAsync(link, timeout.CalculateRemaining(stopWatch.Elapsed)).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+
+            stopWatch.Stop();
+            return link;
+        }
+
+        /// <summary>
+        ///   Opens an AMQP link for use with producer operations.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the Event Hub partition to which the link should be bound; if unbound, <c>null</c>.</param>
+        /// <param name="timeout">The timeout to apply when creating the link.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        /// <returns>A link for use with producer operations.</returns>
+        ///
+        public virtual async Task<SendingAmqpLink> OpenProducerLinkAsync(string partitionId,
+                                                                         TimeSpan timeout,
+                                                                         CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+
+            var stopWatch = Stopwatch.StartNew();
+            var path = (string.IsNullOrEmpty(partitionId)) ? EventHubName : string.Format(PartitionProducerPathSuffixMask, EventHubName, partitionId);
+            var producerEndpoint = new Uri(ServiceEndpoint, path);
+
+            var connection = await ActiveConnection.GetOrCreateAsync(timeout).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+
+            var link = await CreateSendingLinkAsync(connection, producerEndpoint, timeout.CalculateRemaining(stopWatch.Elapsed), cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
             await OpenAmqpObjectAsync(link, timeout.CalculateRemaining(stopWatch.Elapsed)).ConfigureAwait(false);
@@ -470,7 +506,98 @@ namespace Azure.Messaging.EventHubs.Amqp
                 }
 
                 var link = new ReceivingAmqpLink(linkSettings);
-                linkSettings.LinkName = $"{ Id };{ connection.Identifier };{ session.Identifier };{ link.Identifier }";
+                linkSettings.LinkName = $"{ Id };{ connection.Identifier }:{ session.Identifier }:{ link.Identifier }";
+                link.AttachTo(session);
+
+                stopWatch.Stop();
+
+                // Configure refresh for authorization of the link.
+
+                var refreshTimer = default(Timer);
+
+                var refreshHandler = CreateAuthorizationRefreshHandler
+                (
+                    connection,
+                    link,
+                    TokenProvider,
+                    endpoint,
+                    endpoint.AbsoluteUri,
+                    endpoint.AbsoluteUri,
+                    authClaims,
+                    AuthorizationRefreshTimeout,
+                    () => refreshTimer
+                );
+
+                refreshTimer = new Timer(refreshHandler, null, CalculateLinkAuthorizationRefreshInterval(authExpirationUtc), Timeout.InfiniteTimeSpan);
+
+                // Track the link before returning it, so that it can be managed with the scope.
+
+                BeginTrackingLinkAsActive(link, refreshTimer);
+                return link;
+            }
+            catch
+            {
+                // Aborting the session will perform any necessary cleanup of
+                // the associated link as well.
+
+                session?.Abort();
+                throw;
+            }
+        }
+
+        /// <summary>
+        ///   Creates an AMQP link for use with publishing operations.
+        /// </summary>
+        ///
+        /// <param name="connection">The active and opened AMQP connection to use for this link.</param>
+        /// <param name="endpoint">The fully qualified endpoint to open the link for.</param>
+        /// <param name="timeout">The timeout to apply when creating the link.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        /// <returns>A link for use for operations related to receiving events.</returns>
+        ///
+        protected virtual async Task<SendingAmqpLink> CreateSendingLinkAsync(AmqpConnection connection,
+                                                                             Uri endpoint,
+                                                                             TimeSpan timeout,
+                                                                             CancellationToken cancellationToken)
+        {
+            Argument.AssertNotDisposed(IsDisposed, nameof(AmqpConnectionScope));
+            cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+
+            var session = default(AmqpSession);
+            var stopWatch = Stopwatch.StartNew();
+
+            try
+            {
+                // Perform the initial authorization for the link.
+
+                var authClaims = new[] { EventHubsClaim.Send };
+                var authExpirationUtc = await RequestAuthorizationUsingCbsAsync(connection, TokenProvider, endpoint, endpoint.AbsoluteUri, endpoint.AbsoluteUri, authClaims, timeout.CalculateRemaining(stopWatch.Elapsed)).ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+
+                // Create and open the AMQP session associated with the link.
+
+                var sessionSettings = new AmqpSessionSettings { Properties = new Fields() };
+                session = connection.CreateSession(sessionSettings);
+
+                await OpenAmqpObjectAsync(session, timeout).ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+
+                // Create and open the link.
+
+                var linkSettings = new AmqpLinkSettings
+                {
+                    Role = false,
+                    InitialDeliveryCount = 0,
+                    Source = new Source { Address = Guid.NewGuid().ToString() },
+                    Target = new Target { Address = endpoint.AbsolutePath }
+                };
+
+                linkSettings.AddProperty(AmqpProperty.Timeout, (uint)timeout.CalculateRemaining(stopWatch.Elapsed).TotalMilliseconds);
+                linkSettings.AddProperty(AmqpProperty.EntityType, (int)AmqpProperty.Entity.EventHub);
+
+                var link = new SendingAmqpLink(linkSettings);
+                linkSettings.LinkName = $"{ Id };{ connection.Identifier }:{ session.Identifier }:{ link.Identifier }";
                 link.AttachTo(session);
 
                 stopWatch.Stop();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpEventBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpEventBatch.cs
@@ -83,11 +83,11 @@ namespace Azure.Messaging.EventHubs.Amqp
         {
             Argument.AssertNotNull(messageConverter, nameof(messageConverter));
             Argument.AssertNotNull(options, nameof(options));
-            Argument.AssertNotNull(options.MaximumizeInBytes, nameof(options.MaximumizeInBytes));
+            Argument.AssertNotNull(options.MaximumSizeInBytes, nameof(options.MaximumSizeInBytes));
 
             MessageConverter = messageConverter;
             Options = options;
-            MaximumSizeInBytes = options.MaximumizeInBytes.Value;
+            MaximumSizeInBytes = options.MaximumSizeInBytes.Value;
 
             // Initialize the size by reserving space for the batch envelope.
 
@@ -130,6 +130,7 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                 _sizeBytes = size;
                 BatchMessages.Add(eventMessage);
+
                 return true;
             }
             catch

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpEventHubProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpEventHubProducer.cs
@@ -1,0 +1,417 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Messaging.EventHubs.Core;
+using Azure.Messaging.EventHubs.Diagnostics;
+using Azure.Messaging.EventHubs.Errors;
+using Microsoft.Azure.Amqp;
+using Microsoft.Azure.Amqp.Framing;
+
+namespace Azure.Messaging.EventHubs.Amqp
+{
+    /// <summary>
+    ///   A transport client abstraction responsible for brokering operations for AMQP-based connections.
+    ///   It is intended that the public <see cref="EventHubProducer" /> make use of an instance
+    ///   via containment and delegate operations to it.
+    /// </summary>
+    ///
+    /// <seealso cref="Azure.Messaging.EventHubs.Core.TransportEventHubProducer" />
+    ///
+    internal class AmqpEventHubProducer : TransportEventHubProducer
+    {
+        /// <summary>The active retry policy for the producer.</summary>
+        private EventHubRetryPolicy _retryPolicy;
+
+        /// <summary>The amount of time to allow for an operation to complete before considering it to have timed out.</summary>
+        private TimeSpan _tryTimeout;
+
+        /// <summary>Indicates whether or not this instance has been closed.</summary>
+        private bool _closed = false;
+
+        /// <summary>The count of send operations performed by this instance; this is used to tag deliveries for the AMQP link.</summary>
+        private int _deliveryCount = 0;
+
+        /// <summary>
+        ///   Indicates whether or not this consumer has been closed.
+        /// </summary>
+        ///
+        /// <value>
+        ///   <c>true</c> if the consumer is closed; otherwise, <c>false</c>.
+        /// </value>
+        ///
+        public override bool Closed => _closed;
+
+        /// <summary>
+        ///   The name of the Event Hub to which the producer is bound.
+        /// </summary>
+        ///
+        private string EventHubName { get; }
+
+        /// <summary>
+        ///   The identifier of the Event Hub partition that this producer is bound to, if any.  If bound, events will
+        ///   be published only to this partition.
+        /// </summary>
+        ///
+        /// <value>The partition to which the producer is bound; if unbound, <c>null</c>.</value>
+        ///
+        private string PartitionId { get; }
+
+        /// <summary>
+        ///   The maximum size of an AMQP message allowed by the associated
+        ///   producer link.
+        /// </summary>
+        ///
+        /// <value>The maximum message size, in bytes.</value>
+        ///
+        private long? MaximumMessageSize { get; set; }
+
+        /// <summary>
+        ///   The converter to use for translating between AMQP messages and client library
+        ///   types.
+        /// </summary>
+        ///
+        private AmqpMessageConverter MessageConverter { get; }
+
+        /// <summary>
+        ///   The AMQP connection scope responsible for managing transport constructs for this instance.
+        /// </summary>
+        ///
+        private AmqpConnectionScope ConnectionScope { get; }
+
+        /// <summary>
+        ///   The AMQP link intended for use with publishing operations.
+        /// </summary>
+        ///
+        private FaultTolerantAmqpObject<SendingAmqpLink> SendLink { get; }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="AmqpEventHubProducer"/> class.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the Event Hub to which events will be published.</param>
+        /// <param name="partitionId">The identifier of the Event Hub partition to which it is bound; if unbound, <c>null</c>.</param>
+        /// <param name="connectionScope">The AMQP connection context for operations.</param>
+        /// <param name="messageConverter">The converter to use for translating between AMQP messages and client types.</param>
+        /// <param name="retryPolicy">The retry policy to consider when an operation fails.</param>
+        ///
+        /// <remarks>
+        ///   As an internal type, this class performs only basic sanity checks against its arguments.  It
+        ///   is assumed that callers are trusted and have performed deep validation.
+        ///
+        ///   Any parameters passed are assumed to be owned by this instance and safe to mutate or dispose;
+        ///   creation of clones or otherwise protecting the parameters is assumed to be the purview of the
+        ///   caller.
+        /// </remarks>
+        ///
+        public AmqpEventHubProducer(string eventHubName,
+                                    string partitionId,
+                                    AmqpConnectionScope connectionScope,
+                                    AmqpMessageConverter messageConverter,
+                                    EventHubRetryPolicy retryPolicy)
+        {
+            Argument.AssertNotNullOrEmpty(eventHubName, nameof(eventHubName));
+            Argument.AssertNotNull(connectionScope, nameof(connectionScope));
+            Argument.AssertNotNull(messageConverter, nameof(messageConverter));
+            Argument.AssertNotNull(retryPolicy, nameof(retryPolicy));
+
+            EventHubName = eventHubName;
+            PartitionId = partitionId;
+            ConnectionScope = connectionScope;
+            MessageConverter = messageConverter;
+            SendLink = new FaultTolerantAmqpObject<SendingAmqpLink>(timeout => CreateLinkAndEnsureProducerStateAsync(partitionId, timeout, CancellationToken.None) , link => link.SafeClose());
+
+            _retryPolicy = retryPolicy;
+            _tryTimeout = retryPolicy.CalculateTryTimeout(0);
+        }
+
+        /// <summary>
+        ///   Updates the active retry policy for the producer.
+        /// </summary>
+        ///
+        /// <param name="newRetryPolicy">The retry policy to set as active.</param>
+        ///
+        public override void UpdateRetryPolicy(EventHubRetryPolicy newRetryPolicy)
+        {
+            Argument.AssertNotNull(newRetryPolicy, nameof(newRetryPolicy));
+
+            _retryPolicy = newRetryPolicy;
+            _tryTimeout = _retryPolicy.CalculateTryTimeout(0);
+        }
+
+        /// <summary>
+        ///   Sends a set of events to the associated Event Hub using a batched approach.  If the size of events exceed the
+        ///   maximum size of a single batch, an exception will be triggered and the send will fail.
+        /// </summary>
+        ///
+        /// <param name="events">The set of event data to send.</param>
+        /// <param name="sendOptions">The set of options to consider when sending this batch.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        public override async Task SendAsync(IEnumerable<EventData> events,
+                                             SendOptions sendOptions,
+                                             CancellationToken cancellationToken)
+        {
+            Argument.AssertNotNull(events, nameof(events));
+            Argument.AssertNotClosed(_closed, nameof(AmqpEventHubProducer));
+
+            AmqpMessage messageFactory() => MessageConverter.CreateBatchFromEvents(events, sendOptions?.PartitionKey);
+            await SendAsync(messageFactory, sendOptions?.PartitionKey, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   Sends a set of events to the associated Event Hub using a batched approach.
+        /// </summary>
+        ///
+        /// <param name="eventBatch">The event batch to send.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        ///
+        /// <remarks>
+        ///   The caller is assumed to retain ownership of the <paramref name="eventBatch" /> and
+        ///   is responsible for managing its lifespan, including disposal.
+        /// </remarks>
+        ///
+        public override async Task SendAsync(EventDataBatch eventBatch,
+                                             CancellationToken cancellationToken)
+        {
+            Argument.AssertNotNull(eventBatch, nameof(eventBatch));
+            Argument.AssertNotClosed(_closed, nameof(AmqpEventHubProducer));
+
+            AmqpMessage messageFactory() => MessageConverter.CreateBatchFromMessages(
+                eventBatch.AsEnumerable<AmqpMessage>(),
+                eventBatch.SendOptions?.PartitionKey);
+
+            await SendAsync(messageFactory, eventBatch.SendOptions?.PartitionKey, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   Creates a size-constraint batch to which <see cref="EventData" /> may be added using a try-based pattern.  If an event would
+        ///   exceed the maximum allowable size of the batch, the batch will not allow adding the event and signal that scenario using its
+        ///   return value.
+        ///
+        ///   Because events that would violate the size constraint cannot be added, publishing a batch will not trigger an exception when
+        ///   attempting to send the events to the Event Hubs service.
+        /// </summary>
+        ///
+        /// <param name="options">The set of options to consider when creating this batch.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        /// <returns>An <see cref="EventDataBatch" /> with the requested <paramref name="options"/>.</returns>
+        ///
+        public override async ValueTask<TransportEventBatch> CreateBatchAsync(BatchOptions options,
+                                                                              CancellationToken cancellationToken)
+        {
+            Argument.AssertNotNull(options, nameof(options));
+
+            // Ensure that maximum message size has been determined; this depends on the underlying
+            // AMQP link, so if not set, requesting the link will ensure that it is populated.
+
+            if (!MaximumMessageSize.HasValue)
+            {
+                await SendLink.GetOrCreateAsync(_tryTimeout).ConfigureAwait(false);
+            }
+
+            // Ensure that there was a maximum size populated; if none was provided,
+            // default to the maximum size allowed by the link.
+
+            options.MaximumSizeInBytes ??= MaximumMessageSize;
+
+            Argument.AssertInRange(options.MaximumSizeInBytes.Value, EventHubProducer.MinimumBatchSizeLimit, MaximumMessageSize.Value, nameof(options.MaximumSizeInBytes));
+            return new AmqpEventBatch(MessageConverter, options);
+        }
+
+        /// <summary>
+        ///   Closes the connection to the transport producer instance.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        public override async Task CloseAsync(CancellationToken cancellationToken)
+        {
+            if (_closed)
+            {
+                return;
+            }
+
+            var clientId = GetHashCode().ToString();
+            var clientType = GetType();
+
+            try
+            {
+                EventHubsEventSource.Log.ClientCloseStart(clientType, EventHubName, clientId);
+                cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+
+                if (SendLink?.TryGetOpenedObject(out var _) == true)
+                {
+                    await SendLink.CloseAsync().ConfigureAwait(false);
+                }
+
+                SendLink.Dispose();
+
+                _closed = true;
+            }
+            catch (Exception ex)
+            {
+                EventHubsEventSource.Log.ClientCloseError(clientType, EventHubName, clientId, ex.Message);
+                throw;
+            }
+            finally
+            {
+                EventHubsEventSource.Log.ClientCloseComplete(clientType, EventHubName, clientId);
+            }
+        }
+
+        /// <summary>
+        ///   Sends an AMQP message that contains a batch of events to the associated Event Hub. If the size of events exceed the
+        ///   maximum size of a single batch, an exception will be triggered and the send will fail.
+        /// </summary>
+        ///
+        /// <param name="messageFactory">A factory which can be used to produce an AMQP message containing the batch of events to be sent.</param>
+        /// <param name="partitionKey">The hashing key to use for influencing the partition to which events should be routed.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        protected virtual async Task SendAsync(Func<AmqpMessage> messageFactory,
+                                               string partitionKey,
+                                               CancellationToken cancellationToken)
+        {
+            var failedAttemptCount = 0;
+            var logPartition = PartitionId ?? partitionKey;
+            var retryDelay = default(TimeSpan?);
+            var messageHash = default(string);
+            var stopWatch = Stopwatch.StartNew();
+
+            SendingAmqpLink link;
+
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    try
+                    {
+                        using AmqpMessage batchMessage = messageFactory();
+                        messageHash = batchMessage.GetHashCode().ToString();
+
+                        EventHubsEventSource.Log.EventPublishStart(EventHubName, logPartition, messageHash);
+
+                        link = await SendLink.GetOrCreateAsync(UseMinimum(ConnectionScope.SessionTimeout, _tryTimeout)).ConfigureAwait(false);
+                        cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+
+                        // Validate that the batch of messages is not too large to send.  This is done after the link is created to ensure
+                        // that the maximum message size is known, as it is dictated by the service using the link.
+
+                        if (batchMessage.SerializedMessageSize > MaximumMessageSize)
+                        {
+                            throw new MessageSizeExceededException(EventHubName, string.Format(Resources.MessageSizeExceeded, messageHash, batchMessage.SerializedMessageSize, MaximumMessageSize));
+                        }
+
+                        // Attempt to send the message batch.
+
+                        var deliveryTag = new ArraySegment<byte>(BitConverter.GetBytes(Interlocked.Increment(ref _deliveryCount)));
+                        var outcome = await link.SendMessageAsync(batchMessage, deliveryTag, AmqpConstants.NullBinary, _tryTimeout.CalculateRemaining(stopWatch.Elapsed)).ConfigureAwait(false);
+                        cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+
+                        if (outcome.DescriptorCode != Accepted.Code)
+                        {
+                            throw AmqpError.CreateExceptionForError((outcome as Rejected)?.Error, EventHubName);
+                        }
+
+                        // The send operation should be considered successful; return to
+                        // exit the retry loop.
+
+                        return;
+                    }
+                    catch (AmqpException amqpException)
+                    {
+                        throw AmqpError.CreateExceptionForError(amqpException.Error, EventHubName);
+                    }
+                    catch (Exception ex)
+                    {
+                        EventHubsEventSource.Log.EventPublishError(EventHubName, logPartition, messageHash, ex.Message);
+
+                        // Determine if there should be a retry for the next attempt; if so enforce the delay but do not quit the loop.
+                        // Otherwise, bubble the exception.
+
+                        ++failedAttemptCount;
+                        retryDelay = _retryPolicy.CalculateRetryDelay(ex, failedAttemptCount);
+
+                        if ((retryDelay.HasValue) && (!ConnectionScope.IsDisposed))
+                        {
+                            cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+
+                            await Task.Delay(retryDelay.Value, cancellationToken).ConfigureAwait(false);
+                            stopWatch.Reset();
+                        }
+                        else
+                        {
+                            throw;
+                        }
+                    }
+                }
+
+                // If no value has been returned nor exception thrown by this point,
+                // then cancellation has been requested.
+
+                throw new TaskCanceledException();
+            }
+            finally
+            {
+                stopWatch.Stop();
+                EventHubsEventSource.Log.EventPublishComplete(EventHubName, logPartition, messageHash);
+            }
+        }
+
+        /// <summary>
+        ///   Creates the AMQP link to be used for producer-related operations and ensures
+        ///   that the corresponding state for the producer has been updated based on the link
+        ///   configuration.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the Event Hub partition to which it is bound; if unbound, <c>null</c>.</param>
+        /// <param name="timeout">The timeout to apply when creating the link.</param>
+        /// <param name="cancellationToken">The cancellation token to consider when creating the link.</param>
+        ///
+        /// <returns>The AMQP link to use for producer-related operations.</returns>
+        ///
+        /// <remarks>
+        ///   This method will modify class-level state, setting those attributes that depend on the AMQP
+        ///   link configuration.  There exists a benign race condition in doing so, as there may be multiple
+        ///   concurrent callers.  In this case, the attributes may be set multiple times but the resulting
+        ///   value will be the same.
+        /// </remarks>
+        ///
+        protected virtual async Task<SendingAmqpLink> CreateLinkAndEnsureProducerStateAsync(string partitionId,
+                                                                                            TimeSpan timeout,
+                                                                                            CancellationToken cancellationToken)
+        {
+            SendingAmqpLink link = await ConnectionScope.OpenProducerLinkAsync(partitionId, timeout, cancellationToken).ConfigureAwait(false);
+
+            if (!MaximumMessageSize.HasValue)
+            {
+                await Task.Delay(15, cancellationToken).ConfigureAwait(false);
+                MaximumMessageSize = (long)link.Settings.MaxMessageSize;
+            }
+
+            return link;
+        }
+
+        /// <summary>
+        ///   Uses the minimum value of the two specified <see cref="TimeSpan" /> instances.
+        /// </summary>
+        ///
+        /// <param name="firstOption">The first option to consider.</param>
+        /// <param name="secondOption">The second option to consider.</param>
+        ///
+        /// <returns>The smaller of the two specified intervals.</returns>
+        ///
+        private static TimeSpan UseMinimum(TimeSpan firstOption,
+                                           TimeSpan secondOption) => (firstOption < secondOption) ? firstOption : secondOption;
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpMessageConverter.cs
@@ -282,6 +282,8 @@ namespace Azure.Messaging.EventHubs.Amqp
                     using var messageStream = message.ToStream();
                     return new Data { Value = ReadStreamToArraySegment(messageStream) };
                 }));
+
+                batchEnvelope.MessageFormat = AmqpConstants.AmqpBatchedMessageFormat;
             }
 
             if (!string.IsNullOrEmpty(partitionKey))
@@ -290,8 +292,6 @@ namespace Azure.Messaging.EventHubs.Amqp
             }
 
             batchEnvelope.Batchable = true;
-            batchEnvelope.MessageFormat = AmqpConstants.AmqpBatchedMessageFormat;
-
             return batchEnvelope;
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/BatchOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/BatchOptions.cs
@@ -25,7 +25,7 @@ namespace Azure.Messaging.EventHubs
         ///   the maximum size allowed by the active transport will be used.
         /// </value>
         ///
-        public long? MaximumizeInBytes
+        public long? MaximumSizeInBytes
         {
             get => _maximumSizeInBytes;
 
@@ -33,7 +33,7 @@ namespace Azure.Messaging.EventHubs
             {
                 if (value.HasValue)
                 {
-                    Argument.AssertAtLeast(value.Value, EventHubProducer.MinimumBatchSizeLimit, nameof(MaximumizeInBytes));
+                    Argument.AssertAtLeast(value.Value, EventHubProducer.MinimumBatchSizeLimit, nameof(MaximumSizeInBytes));
                 }
 
                 _maximumSizeInBytes = value;
@@ -50,7 +50,7 @@ namespace Azure.Messaging.EventHubs
             new BatchOptions
             {
                 PartitionKey = PartitionKey,
-                _maximumSizeInBytes = MaximumizeInBytes
+                _maximumSizeInBytes = MaximumSizeInBytes
             };
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubProducer.cs
@@ -27,7 +27,7 @@ namespace Azure.Messaging.EventHubs.Compatibility
         private EventHubRetryPolicy _retryPolicy;
 
         /// <summary>A lazy instantiation of the producer instance to delegate operation to.</summary>
-        private Lazy<TrackOne.EventDataSender> _trackOneSender;
+        private readonly Lazy<TrackOne.EventDataSender> _trackOneSender;
 
         /// <summary>
         ///   The track one <see cref="TrackOne.EventDataSender" /> for use with this transport producer.
@@ -164,9 +164,9 @@ namespace Azure.Messaging.EventHubs.Compatibility
             // Ensure that there was a maximum size populated; if none was provided,
             // default to the maximum size allowed by the link.
 
-            options.MaximumizeInBytes ??= TrackOneSender.MaxMessageSize;
+            options.MaximumSizeInBytes ??= TrackOneSender.MaxMessageSize;
 
-            Argument.AssertInRange(options.MaximumizeInBytes.Value, EventHubProducer.MinimumBatchSizeLimit, TrackOneSender.MaxMessageSize, nameof(options.MaximumizeInBytes));
+            Argument.AssertInRange(options.MaximumSizeInBytes.Value, EventHubProducer.MinimumBatchSizeLimit, TrackOneSender.MaxMessageSize, nameof(options.MaximumSizeInBytes));
 
             return new AmqpEventBatch(new AmqpMessageConverter(), options);
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/BasicRetryPolicy.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/BasicRetryPolicy.cs
@@ -90,9 +90,7 @@ namespace Azure.Messaging.EventHubs.Core
             TimeSpan retryDelay = Options.Mode switch
             {
                 RetryMode.Fixed => CalculateFixedDelay(Options.Delay.TotalSeconds, baseJitterSeconds, s_randomNumberGenerator.Value),
-
                 RetryMode.Exponential => CalculateExponentialDelay(attemptCount, Options.Delay.TotalSeconds, baseJitterSeconds, s_randomNumberGenerator.Value),
-
                 _ => throw new NotSupportedException(string.Format(CultureInfo.CurrentCulture, Resources.UnknownRetryMode, Options.Mode.ToString())),
             };
 
@@ -117,7 +115,7 @@ namespace Azure.Messaging.EventHubs.Core
         ///
         private static bool ShouldRetryException(Exception exception)
         {
-            if (exception is TaskCanceledException)
+            if ((exception is TaskCanceledException) || (exception is OperationCanceledException))
             {
                 exception = exception?.InnerException;
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventHubProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventHubProducer.cs
@@ -17,6 +17,16 @@ namespace Azure.Messaging.EventHubs.Core
     internal abstract class TransportEventHubProducer
     {
         /// <summary>
+        ///   Indicates whether or not this producer has been closed.
+        /// </summary>
+        ///
+        /// <value>
+        ///   <c>true</c> if the producer is closed; otherwise, <c>false</c>.
+        /// </value>
+        ///
+        public virtual bool Closed { get; }
+
+        /// <summary>
         ///   Updates the active retry policy for the client.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventDataInstrumentation.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventDataInstrumentation.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics;
-using Azure.Core.Diagnostics;
 using Azure.Core.Pipeline;
 
 namespace Azure.Messaging.EventHubs.Diagnostics
@@ -30,7 +29,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
             if (!eventData.Properties.ContainsKey(DiagnosticProperty.DiagnosticIdAttribute))
             {
                 using DiagnosticScope messageScope = ClientDiagnostics.CreateScope(DiagnosticProperty.EventActivityName);
-                messageScope.AddAttribute("kind", "internal");
+                messageScope.AddAttribute(DiagnosticProperty.KindAttribute, DiagnosticProperty.InternalKind);
                 messageScope.Start();
 
                 Activity activity = Activity.Current;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubClient.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
+using Azure.Messaging.EventHubs.Amqp;
 using Azure.Messaging.EventHubs.Authorization;
 using Azure.Messaging.EventHubs.Compatibility;
 using Azure.Messaging.EventHubs.Core;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducer.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
-using Azure.Core.Diagnostics;
 using Azure.Core.Pipeline;
 using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Diagnostics;
@@ -39,7 +38,7 @@ namespace Azure.Messaging.EventHubs
         internal const int MinimumBatchSizeLimit = 24;
 
         /// <summary>The set of default publishing options to use when no specific options are requested.</summary>
-        private static readonly SendOptions s_defaultSendOptions = new SendOptions();
+        private static readonly SendOptions DefaultSendOptions = new SendOptions();
 
         /// <summary>The fully-qualified location of the Event Hub instance to which events will be sent.</summary>
         private readonly Uri _endpoint;
@@ -225,7 +224,7 @@ namespace Azure.Messaging.EventHubs
                                             SendOptions options,
                                             CancellationToken cancellationToken = default)
         {
-            options ??= s_defaultSendOptions;
+            options ??= DefaultSendOptions;
 
             Argument.AssertNotNull(events, nameof(events));
             AssertSinglePartitionReference(PartitionId, options.PartitionKey);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventBatchTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventBatchTests.cs
@@ -26,7 +26,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorValidatesTheMessageConverter()
         {
-            Assert.That(() => new AmqpEventBatch(null, new BatchOptions { MaximumizeInBytes = 31 }), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpEventBatch(null, new BatchOptions { MaximumSizeInBytes = 31 }), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 CreateBatchFromEventsHandler = (_e, _p) => Mock.Of<AmqpMessage>()
             };
 
-            Assert.That(() => new AmqpEventBatch(mockConverter, new BatchOptions { MaximumizeInBytes = null }), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpEventBatch(mockConverter, new BatchOptions { MaximumSizeInBytes = null }), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ConstructorSetsTheMaximumSize()
         {
             var maximumSize = 9943;
-            var options = new BatchOptions { MaximumizeInBytes = maximumSize };
+            var options = new BatchOptions { MaximumSizeInBytes = maximumSize };
 
             var mockConverter = new InjectableMockConverter
             {
@@ -96,7 +96,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(message => message.SerializedMessageSize)
                 .Returns(batchEnvelopeSize);
 
-            var batch = new AmqpEventBatch(mockConverter, new BatchOptions { MaximumizeInBytes = 27 });
+            var batch = new AmqpEventBatch(mockConverter, new BatchOptions { MaximumSizeInBytes = 27 });
             Assert.That(batch.SizeInBytes, Is.EqualTo(batchEnvelopeSize));
         }
 
@@ -113,7 +113,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 CreateBatchFromEventsHandler = (_e, _p) => Mock.Of<AmqpMessage>()
             };
 
-            var batch = new AmqpEventBatch(mockConverter, new BatchOptions { MaximumizeInBytes = 25 });
+            var batch = new AmqpEventBatch(mockConverter, new BatchOptions { MaximumSizeInBytes = 25 });
             Assert.That(() => batch.TryAdd(null), Throws.ArgumentNullException);
         }
 
@@ -130,7 +130,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 CreateBatchFromEventsHandler = (_e, _p) => Mock.Of<AmqpMessage>()
             };
 
-            var batch = new AmqpEventBatch(mockConverter, new BatchOptions { MaximumizeInBytes = 25 });
+            var batch = new AmqpEventBatch(mockConverter, new BatchOptions { MaximumSizeInBytes = 25 });
             batch.Dispose();
 
             Assert.That(() => batch.TryAdd(new EventData(new byte[0])), Throws.InstanceOf<ObjectDisposedException>());
@@ -146,7 +146,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var maximumSize = 50;
             var batchEnvelopeSize = 0;
-            var options = new BatchOptions { MaximumizeInBytes = maximumSize };
+            var options = new BatchOptions { MaximumSizeInBytes = maximumSize };
             var mockEnvelope = new Mock<AmqpMessage>();
             var mockEvent = new Mock<AmqpMessage>();
             var mockConverter = new InjectableMockConverter
@@ -178,7 +178,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var maximumSize = 50;
             var eventMessageSize = 40;
-            var options = new BatchOptions { MaximumizeInBytes = maximumSize };
+            var options = new BatchOptions { MaximumSizeInBytes = maximumSize };
             var mockEnvelope = new Mock<AmqpMessage>();
             var mockEvent = new Mock<AmqpMessage>();
             var mockConverter = new InjectableMockConverter
@@ -210,7 +210,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var currentIndex = -1;
             var maximumSize = 50;
-            var options = new BatchOptions { MaximumizeInBytes = maximumSize };
+            var options = new BatchOptions { MaximumSizeInBytes = maximumSize };
             var eventMessages = new AmqpMessage[5];
             var mockEnvelope = new Mock<AmqpMessage>();
             var mockConverter = new InjectableMockConverter
@@ -261,7 +261,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void TryAddSetsTheCount()
         {
             var currentIndex = -1;
-            var options = new BatchOptions { MaximumizeInBytes = 5000 };
+            var options = new BatchOptions { MaximumSizeInBytes = 5000 };
             var eventMessages = new AmqpMessage[5];
             var mockEnvelope = new Mock<AmqpMessage>();
             var mockConverter = new InjectableMockConverter
@@ -299,7 +299,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void AsEnumerableValidatesTheTypeParameter()
         {
-            var options = new BatchOptions { MaximumizeInBytes = 5000 };
+            var options = new BatchOptions { MaximumSizeInBytes = 5000 };
             var mockEnvelope = new Mock<AmqpMessage>();
             var mockConverter = new InjectableMockConverter
             {
@@ -324,7 +324,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var currentIndex = -1;
             var maximumSize = 5000;
-            var options = new BatchOptions { MaximumizeInBytes = maximumSize };
+            var options = new BatchOptions { MaximumSizeInBytes = maximumSize };
             var eventMessages = new AmqpMessage[5];
             var mockEnvelope = new Mock<AmqpMessage>();
             var mockConverter = new InjectableMockConverter
@@ -372,7 +372,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void DisposeCleansUpBatchMessages()
         {
             var currentIndex = -1;
-            var options = new BatchOptions { MaximumizeInBytes = 5000 };
+            var options = new BatchOptions { MaximumSizeInBytes = 5000 };
             var eventMessages = new AmqpMessage[5];
             var mockEnvelope = new Mock<AmqpMessage>();
             var mockConverter = new InjectableMockConverter
@@ -418,7 +418,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void DisposeClearsTheCount()
         {
             var currentIndex = -1;
-            var options = new BatchOptions { MaximumizeInBytes = 5000 };
+            var options = new BatchOptions { MaximumSizeInBytes = 5000 };
             var eventMessages = new AmqpMessage[5];
             var mockEnvelope = new Mock<AmqpMessage>();
             var mockConverter = new InjectableMockConverter
@@ -469,7 +469,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(message => message.SerializedMessageSize)
                 .Returns(9959);
 
-            var batch = new AmqpEventBatch(mockConverter, new BatchOptions { MaximumizeInBytes = 99 });
+            var batch = new AmqpEventBatch(mockConverter, new BatchOptions { MaximumSizeInBytes = 99 });
             batch.Dispose();
 
             Assert.That(batch.SizeInBytes, Is.EqualTo(0));

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventHubClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventHubClientTests.cs
@@ -430,6 +430,23 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubClient.CreateProducer" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreateProducerValidatesClosed()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+
+            var mockRetryPolicy = Mock.Of<EventHubRetryPolicy>();
+            var client = new AmqpEventHubClient("my.eventhub.com", "somePath", Mock.Of<TokenCredential>(), new EventHubClientOptions(), mockRetryPolicy);
+            await client.CloseAsync(cancellationSource.Token);
+
+            Assert.That(() => client.CreateProducer(new EventHubProducerOptions(), mockRetryPolicy), Throws.InstanceOf<EventHubsObjectClosedException>());
+        }
+
+        /// <summary>
         ///   Gets the active retry policy for the given client, using the
         ///   private field.
         /// </summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventHubConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventHubConsumerTests.cs
@@ -246,32 +246,6 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="AmqpEventHubConsumer.ReceiveAsync" />
-        ///   method.
-        /// </summary>
-        ///
-        [Test]
-        public async Task ReceiveAsyncValidatesClosed()
-        {
-            var eventHub = "eventHubName";
-            var consumerGroup = "$DEFAULT";
-            var partition = "3";
-            var eventPosition = EventPosition.FromOffset(123);
-            var options = new EventHubConsumerOptions { Identifier = "OMG!" };
-            var retryPolicy = new BasicRetryPolicy(new RetryOptions());
-            var retriableException = new EventHubsException(true, "Test");
-            var mockConverter = new Mock<AmqpMessageConverter>();
-            var mockCredential = new Mock<TokenCredential>();
-            var mockScope = new Mock<AmqpConnectionScope>();
-
-            using var cancellationSource = new CancellationTokenSource();
-
-            var consumer = new AmqpEventHubConsumer(eventHub, consumerGroup, partition, eventPosition, options, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy, null);
-            await consumer.CloseAsync(cancellationSource.Token);
-
-            Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf<EventHubsObjectClosedException>());
-        }
-
         /// <summary>
         ///   Verifies functionality of the <see cref="AmqpEventHubConsumer.ReceiveAsync" />
         ///   method.
@@ -324,7 +298,34 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Gets the active retry policy for the given client, using the
+        ///   Verifies functionality of the <see cref="AmqpEventHubConsumer.ReceiveAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ReceiveAsyncValidatesClosed()
+        {
+            var eventHub = "eventHubName";
+            var consumerGroup = "$DEFAULT";
+            var partition = "3";
+            var eventPosition = EventPosition.FromOffset(123);
+            var options = new EventHubConsumerOptions { Identifier = "OMG!" };
+            var retryPolicy = new BasicRetryPolicy(new RetryOptions());
+            var retriableException = new EventHubsException(true, "Test");
+            var mockConverter = new Mock<AmqpMessageConverter>();
+            var mockCredential = new Mock<TokenCredential>();
+            var mockScope = new Mock<AmqpConnectionScope>();
+
+            using var cancellationSource = new CancellationTokenSource();
+
+            var consumer = new AmqpEventHubConsumer(eventHub, consumerGroup, partition, eventPosition, options, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy, null);
+            await consumer.CloseAsync(cancellationSource.Token);
+
+            Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf<EventHubsObjectClosedException>());
+        }
+
+        /// <summary>
+        ///   Gets the active retry policy for the given consumer, using the
         ///   private field.
         /// </summary>
         ///
@@ -335,7 +336,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     .GetValue(target);
 
         /// <summary>
-        ///   Gets the active operation timeout for the given client, using the
+        ///   Gets the active operation timeout for the given consumer, using the
         ///   private field.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventHubProducerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventHubProducerTests.cs
@@ -1,0 +1,813 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Messaging.EventHubs.Amqp;
+using Azure.Messaging.EventHubs.Core;
+using Azure.Messaging.EventHubs.Errors;
+using Azure.Messaging.EventHubs.Metadata;
+using Microsoft.Azure.Amqp;
+using Moq;
+using Moq.Protected;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="AmqpEventHubProducer" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class AmqpEventHubProducerTests
+    {
+        /// <summary>
+        ///   The set of test cases for respecting basic retry configuration.
+        /// </summary>
+        ///
+        public static IEnumerable<object[]> RetryOptionTestCases()
+        {
+            yield return new object[] { new RetryOptions { MaximumRetries = 3, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = RetryMode.Fixed }};
+            yield return new object[] { new RetryOptions { MaximumRetries = 0, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = RetryMode.Fixed }};
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void ConstructorRequiresTheEventHubName(string eventHub)
+        {
+            Assert.That(() => new AmqpEventHubProducer(eventHub, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorRequiresTheConnectionScope()
+        {
+            Assert.That(() => new AmqpEventHubProducer("theMostAwesomeHubEvar", "0", null, Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>()), Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorRequiresTheRetryPolicy()
+        {
+            Assert.That(() => new AmqpEventHubProducer("theMostAwesomeHubEvar", null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), null), Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.CloseAsync"/>
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CloseMarksTheProducerAsClosed()
+        {
+            var producer = new AmqpEventHubProducer("aHub", "0", Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>());
+            Assert.That(producer.Closed, Is.False, "The producer should not be closed on creation");
+
+            await producer.CloseAsync(CancellationToken.None);
+            Assert.That(producer.Closed, Is.True, "The producer should be marked as closed after closing");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.CloseAsync"/>
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CloseRespectsTheCancellationToken()
+        {
+            var producer = new AmqpEventHubProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>());
+            using var cancellationSource = new CancellationTokenSource();
+
+            cancellationSource.Cancel();
+            Assert.That(async () => await producer.CloseAsync(cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>(), "Cancellation should trigger the appropriate exception.");
+            Assert.That(producer.Closed, Is.False, "Cancellation should have interrupted closing and left the producer in an open state.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.UpdateRetryPolicy" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void UpdateRetryPolicyValidatesTheRetryPolicy()
+        {
+            var producer = new AmqpEventHubProducer("aHub", "0", Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>());
+            Assert.That(() => producer.UpdateRetryPolicy(null), Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.UpdateRetryPolicy" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void UpdateRetryPolicyUpdatesTheRetryPolicy()
+        {
+            var newPolicy = new BasicRetryPolicy(new RetryOptions { Delay = TimeSpan.FromMilliseconds(50) });
+            var producer = new AmqpEventHubProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>());
+
+            Assert.That(GetActiveRetryPolicy(producer), Is.Not.SameAs(newPolicy), "The initial policy should be a unique instance");
+
+            producer.UpdateRetryPolicy(newPolicy);
+            Assert.That(GetActiveRetryPolicy(producer), Is.SameAs(newPolicy), "The updated policy should match");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.UpdateRetryPolicy" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void UpdateRetryPolicyUpdatesTheOperationTimeout()
+        {
+            var initialPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+            var initialTimeout = initialPolicy.CalculateTryTimeout(0);
+            var producer = new AmqpEventHubProducer("aHub", "0", Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), initialPolicy);
+
+            Assert.That(GetTimeout(producer), Is.EqualTo(initialTimeout), "The initial timeout should match");
+
+            var newPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromMilliseconds(50) });
+            TimeSpan newTimeout = newPolicy.CalculateTryTimeout(0);
+
+            producer.UpdateRetryPolicy(newPolicy);
+            Assert.That(GetTimeout(producer), Is.EqualTo(newTimeout), "The updated timeout should match");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.CreateBatchAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CreateBatchAsyncValidatesTheOptions()
+        {
+            var producer = new AmqpEventHubProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>());
+            Assert.That(async () => await producer.CreateBatchAsync(null, CancellationToken.None), Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.CreateBatchAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreateBatchAsyncEnsuresMaximumMessageSizeIsPopulated()
+        {
+            var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+            var producer = new Mock<AmqpEventHubProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
+            {
+                CallBase = true
+            };
+
+            producer
+                .Protected()
+                .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback(() => SetMaximumMessageSize(producer.Object, 512))
+                .Returns(Task.FromResult(new SendingAmqpLink(new AmqpLinkSettings())))
+                .Verifiable();
+
+            using TransportEventBatch batch = await producer.Object.CreateBatchAsync(new BatchOptions(), default);
+            producer.VerifyAll();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.CreateBatchAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreateBatchAsyncDefaultsTheMaximumSizeWhenNotProvided()
+        {
+            var expectedMaximumSize = 512;
+            var options = new BatchOptions { MaximumSizeInBytes = null };
+            var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+
+            var producer = new Mock<AmqpEventHubProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
+            {
+                CallBase = true
+            };
+
+            producer
+                .Protected()
+                .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback(() => SetMaximumMessageSize(producer.Object, expectedMaximumSize))
+                .Returns(Task.FromResult(new SendingAmqpLink(new AmqpLinkSettings())))
+                .Verifiable();
+
+            using TransportEventBatch batch = await producer.Object.CreateBatchAsync(options, default);
+            Assert.That(options.MaximumSizeInBytes, Is.EqualTo(expectedMaximumSize));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.CreateBatchAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreateBatchAsyncRespectsTheMaximumSizeWhenProvided()
+        {
+            var expectedMaximumSize = 512;
+            var options = new BatchOptions { MaximumSizeInBytes = expectedMaximumSize };
+            var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+
+            var producer = new Mock<AmqpEventHubProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
+            {
+                CallBase = true
+            };
+
+            producer
+                .Protected()
+                .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback(() => SetMaximumMessageSize(producer.Object, expectedMaximumSize + 27))
+                .Returns(Task.FromResult(new SendingAmqpLink(new AmqpLinkSettings())))
+                .Verifiable();
+
+            using TransportEventBatch batch = await producer.Object.CreateBatchAsync(options, default);
+            Assert.That(options.MaximumSizeInBytes, Is.EqualTo(expectedMaximumSize));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.CreateBatchAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CreateBatchAsyncVerifiesTheMaximumSize()
+        {
+            var linkMaximumSize = 512;
+            var options = new BatchOptions { MaximumSizeInBytes = 1024 };
+            var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+
+            var producer = new Mock<AmqpEventHubProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
+            {
+                CallBase = true
+            };
+
+            producer
+                .Protected()
+                .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback(() => SetMaximumMessageSize(producer.Object, linkMaximumSize))
+                .Returns(Task.FromResult(new SendingAmqpLink(new AmqpLinkSettings())))
+                .Verifiable();
+
+            Assert.That(async () => await producer.Object.CreateBatchAsync(options, default), Throws.InstanceOf<ArgumentOutOfRangeException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.CreateBatchAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreateBatchAsyncBuildsAnAmqpEventBatchWithTheOptions()
+        {
+            var options = new BatchOptions { MaximumSizeInBytes = 512 };
+            var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+
+            var producer = new Mock<AmqpEventHubProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
+            {
+                CallBase = true
+            };
+
+            producer
+                .Protected()
+                .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback(() => SetMaximumMessageSize(producer.Object, options.MaximumSizeInBytes.Value + 982))
+                .Returns(Task.FromResult(new SendingAmqpLink(new AmqpLinkSettings())))
+                .Verifiable();
+
+            using TransportEventBatch batch = await producer.Object.CreateBatchAsync(options, default);
+
+            Assert.That(batch, Is.Not.Null, "The created batch should be populated.");
+            Assert.That(batch, Is.InstanceOf<AmqpEventBatch>(), $"The created batch should be an { nameof(AmqpEventBatch) }.");
+            Assert.That(GetEventBatchOptions((AmqpEventBatch)batch), Is.SameAs(options), "The provided options should have been used.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void SendEnumerableValidatesTheEvents()
+        {
+            var producer = new AmqpEventHubProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubRetryPolicy>());
+            Assert.That(async () => await producer.SendAsync(null, new SendOptions(), CancellationToken.None), Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SendEnumerableEnsuresNotClosed()
+        {
+            var producer = new AmqpEventHubProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubRetryPolicy>());
+            await producer.CloseAsync(CancellationToken.None);
+
+            Assert.That(async () => await producer.SendAsync(Enumerable.Empty<EventData>(), new SendOptions(), CancellationToken.None), Throws.InstanceOf<EventHubsObjectClosedException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SendEnumerableUsesThePartitionKey()
+        {
+            var expectedPartitionKey = "some key";
+            var options = new BatchOptions { PartitionKey = expectedPartitionKey };
+            var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+
+            var producer = new Mock<AmqpEventHubProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
+            {
+                CallBase = true
+            };
+
+            producer
+                .Protected()
+                .Setup<Task>("SendAsync",
+                    ItExpr.IsAny<Func<AmqpMessage>>(),
+                    ItExpr.Is<string>(value => value == expectedPartitionKey),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+
+            await producer.Object.SendAsync(new[] { new EventData(new byte[] { 0x15 }) }, options, CancellationToken.None);
+            producer.VerifyAll();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("somekEy")]
+        public async Task SendEnumerableCreatesTheAmqpMessageFromTheEnumerable(string partitonKey)
+        {
+            var messageFactory = default(Func<AmqpMessage>);
+            var events = new[] { new EventData(new byte[] { 0x15 }) };
+
+            var producer = new Mock<AmqpEventHubProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubRetryPolicy>())
+            {
+                CallBase = true
+            };
+
+            producer
+                .Protected()
+                .Setup<Task>("SendAsync",
+                    ItExpr.IsAny<Func<AmqpMessage>>(),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<Func<AmqpMessage>, string, CancellationToken>( (factory, key, token) => messageFactory = factory)
+                .Returns(Task.CompletedTask);
+
+            await producer.Object.SendAsync(events, new SendOptions { PartitionKey = partitonKey }, CancellationToken.None);
+            Assert.That(messageFactory, Is.Not.Null, "The batch message factory should have been set.");
+
+            using var batchMessage = new AmqpMessageConverter().CreateBatchFromEvents(events, partitonKey);
+            using var factoryMessage = messageFactory();
+
+            Assert.That(factoryMessage.SerializedMessageSize, Is.EqualTo(batchMessage.SerializedMessageSize), "The serialized size of the messages should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void SendEnumerableRespectsTheCancellationTokenIfSetWhenCalled()
+        {
+            using CancellationTokenSource cancellationSource = new CancellationTokenSource();
+            cancellationSource.Cancel();
+
+            var producer = new AmqpEventHubProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubRetryPolicy>());
+            Assert.That(async () => await producer.SendAsync(new[] { new EventData(new byte[] { 0x15 }) }, new SendOptions(), cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(RetryOptionTestCases))]
+        public void SendEnumerableRespectsTheRetryPolicy(RetryOptions retryOptions)
+        {
+            var partitionId = "testMe";
+            var retriableException = new EventHubsException(true, "Test");
+            var retryPolicy = new BasicRetryPolicy(retryOptions);
+
+            var producer = new Mock<AmqpEventHubProducer>("aHub", partitionId, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
+            {
+                CallBase = true
+            };
+
+            producer
+                .Protected()
+                .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<CancellationToken>())
+                 .Throws(retriableException);
+
+            using CancellationTokenSource cancellationSource = new CancellationTokenSource();
+            Assert.That(async () => await producer.Object.SendAsync(new[] { new EventData(new byte[] { 0x65 }) }, new SendOptions(), cancellationSource.Token), Throws.InstanceOf(retriableException.GetType()));
+
+            producer
+                .Protected()
+                .Verify("CreateLinkAndEnsureProducerStateAsync", Times.Exactly(1 + retryOptions.MaximumRetries),
+                    ItExpr.Is<string>(value => value == partitionId),
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<CancellationToken>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void SendBatchValidatesTheBatch()
+        {
+            var producer = new AmqpEventHubProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubRetryPolicy>());
+            Assert.That(async () => await producer.SendAsync(null, CancellationToken.None), Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SendBatchEnsuresNotClosed()
+        {
+            var expectedMaximumSize = 512;
+            var options = new BatchOptions { MaximumSizeInBytes = null };
+            var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+
+            var producer = new Mock<AmqpEventHubProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
+            {
+                CallBase = true
+            };
+
+            producer
+                .Protected()
+                .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback(() => SetMaximumMessageSize(producer.Object, expectedMaximumSize))
+                .Returns(Task.FromResult(new SendingAmqpLink(new AmqpLinkSettings())));
+
+            using TransportEventBatch batch = await producer.Object.CreateBatchAsync(options, default);
+
+            await producer.Object.CloseAsync(CancellationToken.None);
+            Assert.That(async () => await producer.Object.SendAsync(new EventDataBatch(batch, new SendOptions()), CancellationToken.None), Throws.InstanceOf<EventHubsObjectClosedException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SendBatchUsesThePartitionKey()
+        {
+            var expectedMaximumSize = 512;
+            var expectedPartitionKey = "some key";
+            var options = new BatchOptions { PartitionKey = expectedPartitionKey };
+            var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+
+            var producer = new Mock<AmqpEventHubProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
+            {
+                CallBase = true
+            };
+
+            producer
+                .Protected()
+                .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback(() => SetMaximumMessageSize(producer.Object, expectedMaximumSize))
+                .Returns(Task.FromResult(new SendingAmqpLink(new AmqpLinkSettings())));
+
+            producer
+                .Protected()
+                .Setup<Task>("SendAsync",
+                    ItExpr.IsAny<Func<AmqpMessage>>(),
+                    ItExpr.Is<string>(value => value == expectedPartitionKey),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+
+            using TransportEventBatch batch = await producer.Object.CreateBatchAsync(options, default);
+            await producer.Object.SendAsync(new EventDataBatch(batch, options), CancellationToken.None);
+
+            producer.VerifyAll();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("somekEy")]
+        public async Task SendBatchCreatesTheAmqpMessageFromTheBatch(string partitonKey)
+        {
+            var messageFactory = default(Func<AmqpMessage>);
+            var expectedMaximumSize = 512;
+            var options = new BatchOptions { PartitionKey = partitonKey };
+            var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+
+            var producer = new Mock<AmqpEventHubProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
+            {
+                CallBase = true
+            };
+
+            producer
+                .Protected()
+                .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback(() => SetMaximumMessageSize(producer.Object, expectedMaximumSize))
+                .Returns(Task.FromResult(new SendingAmqpLink(new AmqpLinkSettings())));
+
+            producer
+                .Protected()
+                .Setup<Task>("SendAsync",
+                    ItExpr.IsAny<Func<AmqpMessage>>(),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<Func<AmqpMessage>, string, CancellationToken>( (factory, key, token) => messageFactory = factory)
+                .Returns(Task.CompletedTask);
+
+            using TransportEventBatch transportBatch = await producer.Object.CreateBatchAsync(options, default);
+
+            using var batch = new EventDataBatch(transportBatch, options);
+            batch.TryAdd(new EventData(new byte[] { 0x15 }));
+
+            await producer.Object.SendAsync(batch, CancellationToken.None);
+            Assert.That(messageFactory, Is.Not.Null, "The batch message factory should have been set.");
+
+            using var batchMessage = new AmqpMessageConverter().CreateBatchFromMessages(batch.AsEnumerable<AmqpMessage>(), partitonKey);
+            using var factoryMessage = messageFactory();
+
+            Assert.That(factoryMessage.SerializedMessageSize, Is.EqualTo(batchMessage.SerializedMessageSize), "The serialized size of the messages should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SendBatchDoesNotDisposeTheEventDataBatch()
+        {
+            var expectedMaximumSize = 512;
+            var options = new BatchOptions { MaximumSizeInBytes = null };
+            var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+
+            var producer = new Mock<AmqpEventHubProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
+            {
+                CallBase = true
+            };
+
+            producer
+                .Protected()
+                .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback(() => SetMaximumMessageSize(producer.Object, expectedMaximumSize))
+                .Returns(Task.FromResult(new SendingAmqpLink(new AmqpLinkSettings())));
+
+            producer
+                .Protected()
+                .Setup<Task>("SendAsync",
+                    ItExpr.IsAny<Func<AmqpMessage>>(),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns(Task.CompletedTask);
+
+            using TransportEventBatch transportBatch = await producer.Object.CreateBatchAsync(options, default);
+
+            using var batch = new EventDataBatch(transportBatch, options);
+            batch.TryAdd(new EventData(new byte[] { 0x15 }));
+
+            await producer.Object.SendAsync(batch, CancellationToken.None);
+
+            Assert.That(batch, Is.Not.Null, "The batch should not have been set to null.");
+            Assert.That(() => batch.TryAdd(new EventData(new byte[] { 0x23 })), Throws.Nothing, "The batch should not have been disposed.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SendBatchDoesNotDisposeTheEventsInTheSourceBatch()
+        {
+            var expectedMaximumSize = 512;
+            var options = new BatchOptions { MaximumSizeInBytes = null };
+            var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+
+            var producer = new Mock<AmqpEventHubProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
+            {
+                CallBase = true
+            };
+
+            producer
+                .Protected()
+                .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback(() => SetMaximumMessageSize(producer.Object, expectedMaximumSize))
+                .Returns(Task.FromResult(new SendingAmqpLink(new AmqpLinkSettings())));
+
+            producer
+                .Protected()
+                .Setup<Task>("SendAsync",
+                    ItExpr.IsAny<Func<AmqpMessage>>(),
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns(Task.CompletedTask);
+
+            using TransportEventBatch transportBatch = await producer.Object.CreateBatchAsync(options, default);
+
+            using var batch = new EventDataBatch(transportBatch, options);
+            batch.TryAdd(new EventData(new byte[] { 0x15 }));
+
+            await producer.Object.SendAsync(batch, CancellationToken.None);
+
+            Assert.That(batch, Is.Not.Null, "The batch should not have been set to null.");
+            Assert.That(() => batch.AsEnumerable<AmqpMessage>().Single().ThrowIfDisposed(), Throws.Nothing, "The events within the source batch should not have been disposed.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SendBatchRespectsTheCancellationTokenIfSetWhenCalled()
+        {
+            var expectedMaximumSize = 512;
+            var options = new BatchOptions();
+            var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+
+            var producer = new Mock<AmqpEventHubProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
+            {
+                CallBase = true
+            };
+
+            producer
+                .Protected()
+                .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback(() => SetMaximumMessageSize(producer.Object, expectedMaximumSize))
+                .Returns(Task.FromResult(new SendingAmqpLink(new AmqpLinkSettings())));
+
+            using TransportEventBatch batch = await producer.Object.CreateBatchAsync(options, default);
+            using CancellationTokenSource cancellationSource = new CancellationTokenSource();
+
+            cancellationSource.Cancel();
+            Assert.That(async () => await producer.Object.SendAsync(new EventDataBatch(batch, options), cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpEventHubProducer.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(RetryOptionTestCases))]
+        public void SendBatchRespectsTheRetryPolicy(RetryOptions retryOptions)
+        {
+            var partitionKey = "testMe";
+            var options = new BatchOptions { PartitionKey = partitionKey };
+            var retriableException = new EventHubsException(true, "Test");
+            var retryPolicy = new BasicRetryPolicy(retryOptions);
+            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), options);
+
+            var producer = new Mock<AmqpEventHubProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
+            {
+                CallBase = true
+            };
+
+            producer
+                .Protected()
+                .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureProducerStateAsync",
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<CancellationToken>())
+                 .Throws(retriableException);
+
+            using CancellationTokenSource cancellationSource = new CancellationTokenSource();
+            Assert.That(async () => await producer.Object.SendAsync(batch, cancellationSource.Token), Throws.InstanceOf(retriableException.GetType()));
+
+            producer
+                .Protected()
+                .Verify("CreateLinkAndEnsureProducerStateAsync", Times.Exactly(1 + retryOptions.MaximumRetries),
+                    ItExpr.Is<string>(value => value == null),
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<CancellationToken>());
+        }
+
+        /// <summary>
+        ///   Gets set of batch options that a <see cref="AmqpEventBatch" /> is using
+        ///   by accessing its private field.
+        /// </summary>
+        ///
+        /// <param name="batch">The batch to retrieve the source policy from.</param>
+        ///
+        /// <returns>The batch options.</returns>
+        ///
+        private static BatchOptions GetEventBatchOptions(AmqpEventBatch batch) =>
+            (BatchOptions)
+                typeof(AmqpEventBatch)
+                    .GetProperty("Options", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .GetValue(batch);
+
+        /// <summary>
+        ///   Gets the active retry policy for the given producer, using the
+        ///   private field.
+        /// </summary>
+        ///
+        private static EventHubRetryPolicy GetActiveRetryPolicy(AmqpEventHubProducer target) =>
+            (EventHubRetryPolicy)
+                typeof(AmqpEventHubProducer)
+                    .GetField("_retryPolicy", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .GetValue(target);
+
+        /// <summary>
+        ///   Gets the active operation timeout for the given producer, using the
+        ///   private field.
+        /// </summary>
+        ///
+        private static TimeSpan GetTimeout(AmqpEventHubProducer target) =>
+            (TimeSpan)
+                typeof(AmqpEventHubProducer)
+                    .GetField("_tryTimeout", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .GetValue(target);
+
+        /// <summary>
+        ///   Sets the maximum message size for the given producer, using its
+        ///   private accessor.
+        /// </summary>
+        ///
+        private static void SetMaximumMessageSize(AmqpEventHubProducer target, long value)
+        {
+            typeof(AmqpEventHubProducer)
+                .GetProperty("MaximumMessageSize", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.SetProperty)
+                .SetValue(target, value);
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpMessageConverterTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpMessageConverterTests.cs
@@ -337,7 +337,7 @@ namespace Azure.Messaging.EventHubs.Tests
             using AmqpMessage message = converter.CreateBatchFromEvents(new[] { eventData }, partitionKey);
             Assert.That(message, Is.Not.Null, "The batch envelope should have been created.");
             Assert.That(message.Batchable, Is.True, "The batch envelope should be set to batchable.");
-            Assert.That(message.MessageFormat, Is.EqualTo(AmqpConstants.AmqpBatchedMessageFormat), "The batch envelope should have a batchable format.");
+            Assert.That(message.MessageFormat, Is.Null, "The batch envelope should be not be marked with a batchable format when created from one event.");
             Assert.That(message.DataBody, Is.Not.Null, "The batch envelope should a body.");
             Assert.That(message.DataBody.ToList().Count, Is.EqualTo(1), "The batch envelope should contain a single event in the body.");
             Assert.That(message.MessageAnnotations.Map.TryGetValue(AmqpAnnotation.PartitionKey, out string partitionKeyAnnotation), Is.EqualTo(!string.IsNullOrEmpty(partitionKey)), "There should be an annotation if a partition key was present.");
@@ -538,7 +538,7 @@ namespace Azure.Messaging.EventHubs.Tests
             using AmqpMessage batchEnvelope = converter.CreateBatchFromMessages(new[] { source }, partitionKey);
             Assert.That(batchEnvelope, Is.Not.Null, "The batch envelope should have been created.");
             Assert.That(batchEnvelope.Batchable, Is.True, "The batch envelope should be set to batchable.");
-            Assert.That(batchEnvelope.MessageFormat, Is.EqualTo(AmqpConstants.AmqpBatchedMessageFormat), "The batch envelope should have a batchable format.");
+            Assert.That(batchEnvelope.MessageFormat, Is.Null, "The batch envelope should be not be marked with a batchable format when created from one event.");
             Assert.That(batchEnvelope.DataBody, Is.Not.Null, "The batch envelope should a body.");
             Assert.That(batchEnvelope.DataBody.ToList().Count, Is.EqualTo(1), "The batch envelope should contain a single event in the body.");
             Assert.That(batchEnvelope.MessageAnnotations.Map.TryGetValue(AmqpAnnotation.PartitionKey, out string partitionKeyAnnotation), Is.EqualTo(!string.IsNullOrEmpty(partitionKey)), "There should be an annotation if a partition key was present.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubProducerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubProducerTests.cs
@@ -189,7 +189,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 AmqpMessage.Create(new Data { Value = new ArraySegment<byte>(new byte[] { 0x33 }) }),
             };
 
-            var options = new BatchOptions { MaximumizeInBytes = 30 };
+            var options = new BatchOptions { MaximumSizeInBytes = 30 };
             var transportBatch = new TransportBatchMock { Messages = messages };
             var batch = new EventDataBatch(transportBatch, options);
             var mock = new ObservableSenderMock(new ClientMock(), null);
@@ -231,7 +231,7 @@ namespace Azure.Messaging.EventHubs.Tests
             };
 
             var expectedHashKey = "TestKEy";
-            var options = new BatchOptions { MaximumizeInBytes = 30, PartitionKey = expectedHashKey };
+            var options = new BatchOptions { MaximumSizeInBytes = 30, PartitionKey = expectedHashKey };
             var transportBatch = new TransportBatchMock { Messages = messages };
             var batch = new EventDataBatch(transportBatch, options);
             var mock = new ObservableSenderMock(new ClientMock(), null);
@@ -366,12 +366,12 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task CreateBatchAsyncDefaultsTheMaximumSizeWhenNotProvided()
         {
             var expectedMaximumSize = 512;
-            var options = new BatchOptions { MaximumizeInBytes = null };
+            var options = new BatchOptions { MaximumSizeInBytes = null };
             var mock = new ObservableSenderMock(new ClientMock(), null, expectedMaximumSize);
             var producer = new TrackOneEventHubProducer(_ => mock, Mock.Of<EventHubRetryPolicy>());
 
             await producer.CreateBatchAsync(options, default);
-            Assert.That(options.MaximumizeInBytes, Is.EqualTo(expectedMaximumSize));
+            Assert.That(options.MaximumSizeInBytes, Is.EqualTo(expectedMaximumSize));
         }
 
         /// <summary>
@@ -383,12 +383,12 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task CreateBatchAsyncRespectsTheMaximumSizeWhenProvided()
         {
             var expectedMaximumSize = 512;
-            var options = new BatchOptions { MaximumizeInBytes = 512 };
+            var options = new BatchOptions { MaximumSizeInBytes = 512 };
             var mock = new ObservableSenderMock(new ClientMock(), null);
             var producer = new TrackOneEventHubProducer(_ => mock, Mock.Of<EventHubRetryPolicy>());
 
             await producer.CreateBatchAsync(options, default);
-            Assert.That(options.MaximumizeInBytes, Is.EqualTo(expectedMaximumSize));
+            Assert.That(options.MaximumSizeInBytes, Is.EqualTo(expectedMaximumSize));
         }
 
         /// <summary>
@@ -400,7 +400,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CreateBatchAsyncVerifiesTheMaximumSize()
         {
             var linkMaximumSize = 512;
-            var options = new BatchOptions { MaximumizeInBytes = 1024 };
+            var options = new BatchOptions { MaximumSizeInBytes = 1024 };
             var mock = new ObservableSenderMock(new ClientMock(), null, linkMaximumSize);
             var producer = new TrackOneEventHubProducer(_ => mock, Mock.Of<EventHubRetryPolicy>());
 
@@ -415,7 +415,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task CreateBatchAsyncBuildsAnAmqpEventBatchWithTheOptions()
         {
-            var options = new BatchOptions { MaximumizeInBytes = 512 };
+            var options = new BatchOptions { MaximumSizeInBytes = 512 };
             var mock = new ObservableSenderMock(new ClientMock(), null);
             var producer = new TrackOneEventHubProducer(_ => mock, Mock.Of<EventHubRetryPolicy>());
             TransportEventBatch batch = await producer.CreateBatchAsync(options, default);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientLiveTests.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Authorization;
 using Azure.Messaging.EventHubs.Core;
+using Azure.Messaging.EventHubs.Errors;
 using Azure.Messaging.EventHubs.Metadata;
 using Azure.Messaging.EventHubs.Tests.Infrastructure;
 using NUnit.Framework;
@@ -253,9 +254,9 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     await Task.Delay(TimeSpan.FromSeconds(5));
 
-                    Assert.That(async () => await client.GetPartitionIdsAsync(), Throws.TypeOf<ObjectDisposedException>());
-                    Assert.That(async () => await client.GetPropertiesAsync(), Throws.TypeOf<ObjectDisposedException>());
-                    Assert.That(async () => await client.GetPartitionPropertiesAsync(partition), Throws.TypeOf<ObjectDisposedException>());
+                    Assert.That(async () => await client.GetPartitionIdsAsync(), Throws.TypeOf<EventHubsObjectClosedException>().Or.TypeOf<ObjectDisposedException>());
+                    Assert.That(async () => await client.GetPropertiesAsync(), Throws.TypeOf<EventHubsObjectClosedException>().Or.TypeOf<ObjectDisposedException>());
+                    Assert.That(async () => await client.GetPartitionPropertiesAsync(partition), Throws.TypeOf<EventHubsObjectClosedException>().Or.TypeOf<ObjectDisposedException>());
                 }
             }
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/BatchOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/BatchOptionsTests.cs
@@ -25,7 +25,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new BatchOptions
             {
                 PartitionKey = "some_partition_123",
-                MaximumizeInBytes = (int.MaxValue + 122L)
+                MaximumSizeInBytes = (int.MaxValue + 122L)
             };
 
             BatchOptions clone = options.Clone();
@@ -33,11 +33,11 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(clone, Is.Not.Null, "The clone should not be null.");
             Assert.That(clone, Is.Not.SameAs(options), "The clone should not the same reference as the options.");
             Assert.That(clone.PartitionKey, Is.EqualTo(options.PartitionKey), "The partition key of the clone should match.");
-            Assert.That(clone.MaximumizeInBytes, Is.EqualTo(options.MaximumizeInBytes), "The maximum size should match.");
+            Assert.That(clone.MaximumSizeInBytes, Is.EqualTo(options.MaximumSizeInBytes), "The maximum size should match.");
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="BatchOptions.MaximumizeInBytes" />
+        ///   Verifies functionality of the <see cref="BatchOptions.MaximumSizeInBytes" />
         ///   method.
         /// </summary>
         ///
@@ -45,11 +45,11 @@ namespace Azure.Messaging.EventHubs.Tests
         public void MaximumBatchSizeInBytesEnforcesMinimum()
         {
             var options = new BatchOptions();
-            Assert.That(() => options.MaximumizeInBytes = (EventHubProducer.MinimumBatchSizeLimit - 1), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => options.MaximumSizeInBytes = (EventHubProducer.MinimumBatchSizeLimit - 1), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="BatchOptions.MaximumizeInBytes" />
+        ///   Verifies functionality of the <see cref="BatchOptions.MaximumSizeInBytes" />
         ///   method.
         /// </summary>
         ///
@@ -57,11 +57,11 @@ namespace Azure.Messaging.EventHubs.Tests
         public void MaximumBatchSizeInBytesDoesNotLimitMaximum()
         {
             var options = new BatchOptions();
-            Assert.That(() => options.MaximumizeInBytes = int.MaxValue, Throws.Nothing);
+            Assert.That(() => options.MaximumSizeInBytes = int.MaxValue, Throws.Nothing);
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="BatchOptions.MaximumizeInBytes" />
+        ///   Verifies functionality of the <see cref="BatchOptions.MaximumSizeInBytes" />
         ///   method.
         /// </summary>
         ///
@@ -69,7 +69,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void MaximumBatchSizeInBytesAllowsNull()
         {
             var options = new BatchOptions();
-            Assert.That(() => options.MaximumizeInBytes = null, Throws.Nothing);
+            Assert.That(() => options.MaximumSizeInBytes = null, Throws.Nothing);
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerLiveTests.cs
@@ -242,10 +242,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 await using (EventHubProducer producer = client.CreateProducer())
                 {
                     var singleEvent = new EventData(Array.Empty<byte>());
-                    EventData[] eventSet = new[] { new EventData(new byte[0]) };
-
                     Assert.That(async () => await producer.SendAsync(singleEvent), Throws.Nothing);
-                    Assert.That(async () => await producer.SendAsync(eventSet), Throws.Nothing);
                 }
             }
         }
@@ -446,7 +443,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 await using (EventHubProducer producer = client.CreateProducer())
                 {
                     using EventDataBatch batch = await producer.CreateBatchAsync();
-                    batch.TryAdd(new EventData(new byte[0]));
+                    batch.TryAdd(new EventData(Array.Empty<byte>()));
 
                     Assert.That(batch.Count, Is.EqualTo(1), "The batch should contain a single event.");
                     Assert.That(async () => await producer.SendAsync(batch), Throws.Nothing);
@@ -596,7 +593,7 @@ namespace Azure.Messaging.EventHubs.Tests
                         await producer.CloseAsync();
                     }
 
-                    Assert.That(async () => await producer.SendAsync(events), Throws.TypeOf<ObjectDisposedException>());
+                    Assert.That(async () => await producer.SendAsync(events), Throws.TypeOf<EventHubsObjectClosedException>().Or.TypeOf<ObjectDisposedException>());
                 }
             }
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerTests.cs
@@ -153,6 +153,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
         /// <summary>
         ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   method.
         /// </summary>
         ///
         [Test]
@@ -166,6 +167,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
         /// <summary>
         ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   method.
         /// </summary>
         ///
         [Test]
@@ -179,6 +181,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
         /// <summary>
         ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   method.
         /// </summary>
         ///
         [Test]
@@ -197,6 +200,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
         /// <summary>
         ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   method.
         /// </summary>
         ///
         [Test]
@@ -215,6 +219,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
         /// <summary>
         ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   method.
         /// </summary>
         ///
         [Test]
@@ -228,6 +233,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
         /// <summary>
         ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   method.
         /// </summary>
         ///
         [Test]
@@ -241,6 +247,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
         /// <summary>
         ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   method.
         /// </summary>
         ///
         [Test]
@@ -254,6 +261,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
         /// <summary>
         ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   method.
         /// </summary>
         ///
         [Test]
@@ -269,6 +277,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
         /// <summary>
         ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   method.
         /// </summary>
         ///
         [Test]
@@ -284,6 +293,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
         /// <summary>
         ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   method.
         /// </summary>
         ///
         [Test]
@@ -299,6 +309,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
         /// <summary>
         ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   method.
         /// </summary>
         ///
         [Test]
@@ -314,6 +325,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
         /// <summary>
         ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   method.
         /// </summary>
         ///
         [Test]
@@ -333,6 +345,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
         /// <summary>
         ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   method.
         /// </summary>
         ///
         [Test]
@@ -353,6 +366,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
         /// <summary>
         ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   method.
         /// </summary>
         ///
         [Test]
@@ -369,6 +383,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
         /// <summary>
         ///   Verifies functionality of the <see cref="EventHubProducer.CreateBatchAsync"/>
+        ///   method.
         /// </summary>
         ///
         [Test]
@@ -383,12 +398,13 @@ namespace Azure.Messaging.EventHubs.Tests
 
         /// <summary>
         ///   Verifies functionality of the <see cref="EventHubProducer.CreateBatchAsync"/>
+        ///   method.
         /// </summary>
         ///
         [Test]
         public async Task CreateBatchInvokesTheTransportProducer()
         {
-            var batchOptions = new BatchOptions { PartitionKey = "Hi", MaximumizeInBytes = 9999 };
+            var batchOptions = new BatchOptions { PartitionKey = "Hi", MaximumSizeInBytes = 9999 };
             var transportProducer = new ObservableTransportProducerMock();
             var producer = new EventHubProducer(transportProducer, new Uri("amqp://some.endpoint.com/path"), "dummy", new EventHubProducerOptions(), Mock.Of<EventHubRetryPolicy>());
 
@@ -397,11 +413,12 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(transportProducer.CreateBatchCalledWith, Is.Not.Null, "The batch creation should have passed options.");
             Assert.That(transportProducer.CreateBatchCalledWith, Is.Not.SameAs(batchOptions), "The options should have been cloned.");
             Assert.That(transportProducer.CreateBatchCalledWith.PartitionKey, Is.EqualTo(batchOptions.PartitionKey), "The partition key should match.");
-            Assert.That(transportProducer.CreateBatchCalledWith.MaximumizeInBytes, Is.EqualTo(batchOptions.MaximumizeInBytes), "The maximum size should match.");
+            Assert.That(transportProducer.CreateBatchCalledWith.MaximumSizeInBytes, Is.EqualTo(batchOptions.MaximumSizeInBytes), "The maximum size should match.");
         }
 
         /// <summary>
         ///   Verifies functionality of the <see cref="EventHubProducer.CreateBatchAsync"/>
+        ///   method.
         /// </summary>
         ///
         [Test]
@@ -416,17 +433,18 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(transportProducer.CreateBatchCalledWith, Is.Not.Null, "The batch creation should have passed options.");
             Assert.That(transportProducer.CreateBatchCalledWith, Is.Not.SameAs(expectedOptions), "The options should have been cloned.");
             Assert.That(transportProducer.CreateBatchCalledWith.PartitionKey, Is.EqualTo(expectedOptions.PartitionKey), "The partition key should match.");
-            Assert.That(transportProducer.CreateBatchCalledWith.MaximumizeInBytes, Is.EqualTo(expectedOptions.MaximumizeInBytes), "The maximum size should match.");
+            Assert.That(transportProducer.CreateBatchCalledWith.MaximumSizeInBytes, Is.EqualTo(expectedOptions.MaximumSizeInBytes), "The maximum size should match.");
         }
 
         /// <summary>
         ///   Verifies functionality of the <see cref="EventHubProducer.CreateBatchAsync"/>
+        ///   method.
         /// </summary>
         ///
         [Test]
         public async Task CreateBatchSetsTheSendOptionsForTheEventBatch()
         {
-            var batchOptions = new BatchOptions { PartitionKey = "Hi", MaximumizeInBytes = 9999 };
+            var batchOptions = new BatchOptions { PartitionKey = "Hi", MaximumSizeInBytes = 9999 };
             var transportProducer = new ObservableTransportProducerMock();
             var producer = new EventHubProducer(transportProducer, new Uri("amqp://some.endpoint.com/path"), "dummy", new EventHubProducerOptions(), Mock.Of<EventHubRetryPolicy>());
             EventDataBatch eventBatch = await producer.CreateBatchAsync(batchOptions);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/LiveResourceManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/LiveResourceManager.cs
@@ -31,7 +31,7 @@ namespace Azure.Messaging.EventHubs.Tests.Infrastructure
         private const double RetryExponentialBackoffSeconds = 2.5;
 
         /// <summary>The number of seconds to use as the basis for applying jitter to retry back-off calculations.</summary>
-        private const double RetryBaseJitterSeconds = 15.0;
+        private const double RetryBaseJitterSeconds = 18.0;
 
         /// <summary>The buffer to apply when considering refreshing; credentials that expire less than this duration will be refreshed.</summary>
         private static readonly TimeSpan CredentialRefreshBuffer = TimeSpan.FromMinutes(5);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/RetryPolicies/BasicRetryPolicyTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/RetryPolicies/BasicRetryPolicyTests.cs
@@ -29,9 +29,10 @@ namespace Azure.Messaging.EventHubs.Tests
             yield return new object[] { new TimeoutException() };
             yield return new object[] { new SocketException(500) };
 
-            // Task Canceled should use the inner exception as the decision point.
+            // Task/Operation Canceled should use the inner exception as the decision point.
 
             yield return new object[] { new TaskCanceledException("dummy", new EventHubsException(true, null)) };
+            yield return new object[] { new OperationCanceledException("dummy", new EventHubsException(true, null)) };
 
             // Aggregate should use the first inner exception as the decision point.
 
@@ -58,9 +59,10 @@ namespace Azure.Messaging.EventHubs.Tests
             yield return new object[] { new OutOfMemoryException() };
             yield return new object[] { new ObjectDisposedException("dummy") };
 
-            // Task Canceled should use the inner exception as the decision point.
+            // Task/Operation Canceled should use the inner exception as the decision point.
 
             yield return new object[] { new TaskCanceledException("dummy", new EventHubsException(false, null)) };
+            yield return new object[] { new OperationCanceledException("dummy", new EventHubsException(false, null)) };
 
             // Null is not retriable, even if it is a blessed type.
 


### PR DESCRIPTION
# Summary

The focus of these changes is to implement the AMQP producer type.  In addition, the AMQP foundation and AMQP client have received some extension, tuning, and refactoring to apply learnings and keep consistent between the internal implementation and track one feature set.

# Last Upstream Rebase

Wednesday, October 16, 11:57am (EDT)

# Related and Follow-Up Issues

- [[Epic] Release Event Hubs Track 2 Library Preview 4 for .Net](https://github.com/Azure/azure-sdk-for-net/issues/7562) (#7562) 
- [AmqpEventHubProducer](https://github.com/Azure/azure-sdk-for-net/issues/7191) (#7191) 
- [Integrate Logging](https://github.com/Azure/azure-sdk-for-net/issues/7129) (#7129)