### PR TITLE
[Storage] Change ShareClient.SetQuotaInternal and ListSharesIncludeType from public to internal

### DIFF
--- a/sdk/storage/Azure.Storage.Files/src/Generated/FileRestClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Generated/FileRestClient.cs
@@ -7446,7 +7446,7 @@ namespace Azure.Storage.Files.Models
     /// <summary>
     /// ListSharesIncludeType values
     /// </summary>
-    public enum ListSharesIncludeType
+    internal enum ListSharesIncludeType
     {
         /// <summary>
         /// snapshots

--- a/sdk/storage/Azure.Storage.Files/src/ShareClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/ShareClient.cs
@@ -868,7 +868,7 @@ namespace Azure.Storage.Files
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<ShareInfo>> SetQuotaInternal(
+        internal virtual async Task<Response<ShareInfo>> SetQuotaInternal(
             int quotaInBytes,
             bool async,
             CancellationToken cancellationToken)

--- a/sdk/storage/Azure.Storage.Files/swagger/readme.md
+++ b/sdk/storage/Azure.Storage.Files/swagger/readme.md
@@ -148,6 +148,15 @@ directive:
     }
 ```
 
+### Hide ListSharesIncludeType
+``` yaml
+directive:
+- from: swagger-document
+  where: $.parameters.ListSharesInclude
+  transform: >
+    $.items["x-az-public"] = false;
+```
+
 ### /{shareName}?restype=share
 ``` yaml
 directive:


### PR DESCRIPTION
Change [ShareClient.SetQuotaInternal](https://apiview.azurewebsites.net/Assemblies/Review/47c9ebbff8c0458fa2e7904eae34656f#Azure.Storage.Files.ShareClient) and [ListSharesIncludeType](https://apiview.azurewebsites.net/Assemblies/Review/47c9ebbff8c0458fa2e7904eae34656f#0ab7be88f79f4198ac525c2e8f0751fe) from public to internal.