### PR TITLE
Expand default header allow-list

### DIFF
--- a/sdk/core/Azure.Core/src/DiagnosticsOptions.cs
+++ b/sdk/core/Azure.Core/src/DiagnosticsOptions.cs
@@ -20,6 +20,7 @@ namespace Azure.Core
             {
                 "x-ms-client-request-id",
                 "x-ms-return-client-request-id",
+                "traceparent",
 
                 "Accept",
                 "Cache-Control",

--- a/sdk/core/Azure.Core/src/DiagnosticsOptions.cs
+++ b/sdk/core/Azure.Core/src/DiagnosticsOptions.cs
@@ -18,10 +18,28 @@ namespace Azure.Core
             ApplicationId = DefaultApplicationId;
             LoggedHeaderNames = new List<string>()
             {
-                "Date",
-                "traceparent",
                 "x-ms-client-request-id",
-                "x-ms-request-id"
+                "x-ms-return-client-request-id",
+
+                "Accept",
+                "Cache-Control",
+                "Connection",
+                "Content-Length",
+                "Content-Type",
+                "Date",
+                "ETag",
+                "Expires",
+                "If-Match",
+                "If-Modified-Since",
+                "If-None-Match",
+                "If-Unmodified-Since",
+                "Last-Modified",
+                "Pragma",
+                "Request-Id",
+                "Retry-After",
+                "Server",
+                "Transfer-Encoding",
+                "User-Agent"
             };
             LoggedQueryParameters = new List<string>();
         }


### PR DESCRIPTION
I've added HTTP headers commonly used across services that do not contain PII.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/8140

