### PR TITLE
Fix issue where any retry will fail to AppConfig service.

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/AuthenticationPolicy.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/AuthenticationPolicy.cs
@@ -68,10 +68,9 @@ namespace Azure.Data.AppConfiguration
                 var signature = Convert.ToBase64String(hmac.ComputeHash(Encoding.ASCII.GetBytes(stringToSign))); // Calculate the signature
                 string signedHeaders = "date;host;x-ms-content-sha256"; // Semicolon separated header names
 
-                // TODO (pri 3): should date header writing be moved out from here?
-                message.Request.Headers.Add("Date", utcNowString);
-                message.Request.Headers.Add("x-ms-content-sha256", contentHash);
-                message.Request.Headers.Add("Authorization", $"HMAC-SHA256 Credential={_credential}&SignedHeaders={signedHeaders}&Signature={signature}");
+                message.Request.Headers.SetValue("Date", utcNowString);
+                message.Request.Headers.SetValue("x-ms-content-sha256", contentHash);
+                message.Request.Headers.SetValue("Authorization", $"HMAC-SHA256 Credential={_credential}&SignedHeaders={signedHeaders}&Signature={signature}");
             }
         }
 

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationMockTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationMockTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -819,6 +820,29 @@ namespace Azure.Data.AppConfiguration.Tests
             Assert.AreEqual(correlationContext, "CorrelationContextValue1,CorrelationContextValue2");
             Assert.IsFalse(request.Headers.TryGetValue("x-ms-random-id", out string randomId));
         }
+
+        [Test]
+        public async Task AuthorizationHeadersAddedOnceWithRetries()
+        {
+            var response = new MockResponse(200);
+            response.SetContent(SerializationHelpers.Serialize(s_testSetting, SerializeSetting));
+
+            var mockTransport = new MockTransport(new MockResponse(503), response);
+            ConfigurationClient service = CreateTestService(mockTransport);
+
+            ConfigurationSetting setting = await service.GetAsync(s_testSetting.Key, s_testSetting.Label);
+
+            var retriedRequest = mockTransport.Requests[1];
+
+            AssertRequestCommon(retriedRequest);
+            Assert.True(retriedRequest.Headers.TryGetValues("Date", out var dateHeaders));
+            Assert.True(retriedRequest.Headers.TryGetValues("x-ms-content-sha256", out var contentHashHeaders));
+            Assert.True(retriedRequest.Headers.TryGetValues("Authorization", out var authorizationHeaders));
+            Assert.AreEqual(1, dateHeaders.Count());
+            Assert.AreEqual(1, contentHashHeaders.Count());
+            Assert.AreEqual(1, authorizationHeaders.Count());
+        }
+
 
         private void AssertContent(byte[] expected, MockRequest request, bool compareAsString = true)
         {


### PR DESCRIPTION
Fix is to call SetValue for headers in AuthenticationPolicy rather than Add.