### PR TITLE
Use correct suffix for lockfile

### DIFF
--- a/sdk/identity/Azure.Identity/src/MsalCacheReader.cs
+++ b/sdk/identity/Azure.Identity/src/MsalCacheReader.cs
@@ -21,7 +21,7 @@ namespace Azure.Identity
         {
             _cachePath = cachePath;
 
-            _cacheLockPath = cachePath + ".lock";
+            _cacheLockPath = cachePath + ".lockfile";
 
             _cacheRetryCount = cacheRetryCount;
 


### PR DESCRIPTION
I noticed a discrepancy between our Java and .NET SDKs around what file we used for our file-based locking to ensure mutual exclusion around the shared cache.  We are using `.lock` here whereas the Java SDK was using [`.lockfile`](https://github.com/Azure/azure-sdk-for-java/blob/8cf736e7e8d9904ffb9336da1d14e6062a70a518/sdk/identity/azure-identity/src/main/java/com/azure/identity/implementation/msalextensions/cachepersister/CachePersister.java#L61-L71)

Looking into this (I was unable to find any authoritive documentation which is right) it seems like the convention is to use ".lockfile" and not ".lock" when accessing the
shared MSAL cache.

See: https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/f6409abcd173f159eb381195f6935182e1f90d11/src/extensions.msal/Microsoft.Identity.Client.Extensions.Msal/MsalCacheHelper.cs#L291 as another example.  I also ran Process Explorer and filtered to paths for the msal.cache file, and it looked like other apps were using `.lockfile` as well.

If this turns out to be "wrong" for some reason, let me know and I will fix the Java version.
