### PR TITLE
[Event Hubs Client] Track Two: Fifth Preview (Event Data as Stream)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpEventHubProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpEventHubProducer.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -125,7 +124,7 @@ namespace Azure.Messaging.EventHubs.Amqp
             PartitionId = partitionId;
             ConnectionScope = connectionScope;
             MessageConverter = messageConverter;
-            SendLink = new FaultTolerantAmqpObject<SendingAmqpLink>(timeout => CreateLinkAndEnsureProducerStateAsync(partitionId, timeout, CancellationToken.None) , link => link.SafeClose());
+            SendLink = new FaultTolerantAmqpObject<SendingAmqpLink>(timeout => CreateLinkAndEnsureProducerStateAsync(partitionId, timeout, CancellationToken.None), link => link.SafeClose());
 
             _retryPolicy = retryPolicy;
             _tryTimeout = retryPolicy.CalculateTryTimeout(0);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
 
 namespace Azure.Messaging.EventHubs
 {
@@ -27,6 +28,29 @@ namespace Azure.Messaging.EventHubs
         /// <seealso cref="EventData.Properties" />
         ///
         public ReadOnlyMemory<byte> Body { get; }
+
+        /// <summary>
+        ///   The data associated with the event, in stream form.
+        /// </summary>
+        ///
+        /// <value>
+        ///   A <see cref="Stream" /> containing the raw data representing the <see cref="Body" />
+        ///   of the event.  The caller is assumed to have ownership of the stream, including responsibility
+        ///   for managing its lifespan and ensuring proper disposal.
+        /// </value>
+        ///
+        /// <remarks>
+        ///   If the means for deserializing the raw data is not apparent to consumers, a
+        ///   common technique is to make use of <see cref="EventData.Properties" /> to associate serialization hints
+        ///   as an aid to consumers who wish to deserialize the binary data.
+        /// </remarks>
+        ///
+        /// <seealso cref="EventData.Properties" />
+        ///
+        public Stream BodyAsStream
+        {
+            get => new MemoryStream(Body.ToArray());
+        }
 
         /// <summary>
         ///   The set of free-form event properties which may be used for passing metadata associated with the event with the event body

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubClient.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Messaging.EventHubs.Amqp;
 using Azure.Messaging.EventHubs.Authorization;
-using Azure.Messaging.EventHubs.Compatibility;
 using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Metadata;
 
@@ -442,7 +441,7 @@ namespace Azure.Messaging.EventHubs
             {
                 case TransportType.AmqpTcp:
                 case TransportType.AmqpWebSockets:
-                    return new AmqpEventHubClient(fullyQualifiedNamespace, eventHubName, credential, options, defaultRetryPolicy);
+                    return new AmqpEventHubClient(fullyQualifiedNamespace, eventHubName, credential, options, defaultRetryPolicy);
 
                 default:
                     throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.InvalidTransportType, options.TransportType.ToString()), nameof(options.TransportType));

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/PartitionContext.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/PartitionContext.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading.Tasks;
 using Azure.Core;
-using Azure.Core.Diagnostics;
 using Azure.Core.Pipeline;
 using Azure.Messaging.EventHubs.Diagnostics;
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/PartitionPump.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/PartitionPump.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Core.Diagnostics;
 using Azure.Core.Pipeline;
 using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Diagnostics;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.Designer.cs
@@ -8,10 +8,8 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Azure.Messaging.EventHubs {
-    using System;
-    
-    
+namespace Azure.Messaging.EventHubs
+{
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -22,319 +20,388 @@ namespace Azure.Messaging.EventHubs {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources {
-        
+    internal class Resources
+    {
         private static global::System.Resources.ResourceManager resourceMan;
-        
+
         private static global::System.Globalization.CultureInfo resourceCulture;
-        
+
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Resources() {
+        internal Resources()
+        {
         }
-        
+
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
-            get {
-                if (object.ReferenceEquals(resourceMan, null)) {
+        internal static global::System.Resources.ResourceManager ResourceManager
+        {
+            get
+            {
+                if (object.ReferenceEquals(resourceMan, null))
+                {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Azure.Messaging.EventHubs.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-        
+
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
-            get {
+        internal static global::System.Globalization.CultureInfo Culture
+        {
+            get
+            {
                 return resourceCulture;
             }
-            set {
+            set
+            {
                 resourceCulture = value;
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The {0} value is expected to be a {1} bit signed integer. Actual value: &apos;{2}&apos;..
         /// </summary>
-        internal static string CannotParseIntegerType {
-            get {
+        internal static string CannotParseIntegerType
+        {
+            get
+            {
                 return ResourceManager.GetString("CannotParseIntegerType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to A producer created for a specific partition cannot send events using a partition key. This producer is associated with partition &apos;{0}&apos;..
         /// </summary>
-        internal static string CannotSendWithPartitionIdAndPartitionKey {
-            get {
+        internal static string CannotSendWithPartitionIdAndPartitionKey
+        {
+            get
+            {
                 return ResourceManager.GetString("CannotSendWithPartitionIdAndPartitionKey", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The &apos;identifier&apos; parameter exceeds the maximum allowed size of {0} characters..
         /// </summary>
-        internal static string ConsumerIdentifierOverMaxValue {
-            get {
+        internal static string ConsumerIdentifierOverMaxValue
+        {
+            get
+            {
                 return ResourceManager.GetString("ConsumerIdentifierOverMaxValue", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Unable to acquire an access token using the provided credential..
         /// </summary>
-        internal static string CouldNotAcquireAccessToken {
-            get {
+        internal static string CouldNotAcquireAccessToken
+        {
+            get
+            {
                 return ResourceManager.GetString("CouldNotAcquireAccessToken", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to {0} has already been disposed and cannot perform the requested operation..
         /// </summary>
-        internal static string DisposedInstanceCannotPerformOperation {
-            get {
+        internal static string DisposedInstanceCannotPerformOperation
+        {
+            get
+            {
                 return ResourceManager.GetString("DisposedInstanceCannotPerformOperation", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Could not create a subscription for events for Event Hub: &apos;{0}&apos;, partition: &apos;{1}&apos;, consumer group: &apos;{2}&apos;..
         /// </summary>
-        internal static string FailedToCreateEventSubscription {
-            get {
+        internal static string FailedToCreateEventSubscription
+        {
+            get
+            {
                 return ResourceManager.GetString("FailedToCreateEventSubscription", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Serialization failed due to an unsupported type, {0}..
         /// </summary>
-        internal static string FailedToSerializeUnsupportedType {
-            get {
+        internal static string FailedToSerializeUnsupportedType
+        {
+            get
+            {
                 return ResourceManager.GetString("FailedToSerializeUnsupportedType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The connection string could not be parsed; either it was malformed or contains no well-known tokens..
         /// </summary>
-        internal static string InvalidConnectionString {
-            get {
+        internal static string InvalidConnectionString
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidConnectionString", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The string has an invalid encoding format..
         /// </summary>
-        internal static string InvalidEncoding {
-            get {
+        internal static string InvalidEncoding
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidEncoding", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to An invalid message body was encountered.  Either the body was null or an incorrect type. Expected: {0}.
         /// </summary>
-        internal static string InvalidMessageBody {
-            get {
+        internal static string InvalidMessageBody
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidMessageBody", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The shared access signature could not be parsed; it was either malformed or incorrectly encoded..
         /// </summary>
-        internal static string InvalidSharedAccessSignature {
-            get {
+        internal static string InvalidSharedAccessSignature
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidSharedAccessSignature", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The time period may not be Zero or Infinite..
         /// </summary>
-        internal static string InvalidTimePeriod {
-            get {
+        internal static string InvalidTimePeriod
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidTimePeriod", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The requested transport type, &apos;{0}&apos; is not supported..
         /// </summary>
-        internal static string InvalidTransportType {
-            get {
+        internal static string InvalidTransportType
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidTransportType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The message (id:{0}, size:{1} bytes) is larger than is currently allowed ({2} bytes)..
         /// </summary>
-        internal static string MessageSizeExceeded {
-            get {
+        internal static string MessageSizeExceeded
+        {
+            get
+            {
                 return ResourceManager.GetString("MessageSizeExceeded", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The connection string used for an Event Hub client must specify the Event Hubs namespace host, and a Shared Access Signature (both the name and value) to be valid. The path to an Event Hub must be included in the connection string or specified separately..
         /// </summary>
-        internal static string MissingConnectionInformation {
-            get {
+        internal static string MissingConnectionInformation
+        {
+            get
+            {
                 return ResourceManager.GetString("MissingConnectionInformation", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The path to an Event Hub may be specified as part of the connection string or as a separate value, but not both..
         /// </summary>
-        internal static string OnlyOneEventHubNameMayBeSpecified {
-            get {
+        internal static string OnlyOneEventHubNameMayBeSpecified
+        {
+            get
+            {
                 return ResourceManager.GetString("OnlyOneEventHubNameMayBeSpecified", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to A proxy may only be used for a web sockets connection..
         /// </summary>
-        internal static string ProxyMustUseWebSockets {
-            get {
+        internal static string ProxyMustUseWebSockets
+        {
+            get
+            {
                 return ResourceManager.GetString("ProxyMustUseWebSockets", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The requested resource, &apos;{0}&apos;, does not match the resource of the shared access signature, &apos;{1}&apos;. A token cannot be issued..
         /// </summary>
-        internal static string ResourceMustMatchSharedAccessSignature {
-            get {
+        internal static string ResourceMustMatchSharedAccessSignature
+        {
+            get
+            {
                 return ResourceManager.GetString("ResourceMustMatchSharedAccessSignature", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Retry options must be specified; if no retry is desired, please set the maximum number of retries to 0. To provide a custom retry policy, please assign it on the client directly..
         /// </summary>
-        internal static string RetryOptionsMustBeSet {
-            get {
+        internal static string RetryOptionsMustBeSet
+        {
+            get
+            {
                 return ResourceManager.GetString("RetryOptionsMustBeSet", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to In order to update the signature, a shared access key must have been provided when the shared access signature was created..
         /// </summary>
-        internal static string SharedAccessKeyIsRequired {
-            get {
+        internal static string SharedAccessKeyIsRequired
+        {
+            get
+            {
                 return ResourceManager.GetString("SharedAccessKeyIsRequired", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to A shared key credential is unable to generate a token directly. Please use this credential when creating an Event Hub Client, for proper generation of shared key tokens..
         /// </summary>
-        internal static string SharedKeyCredentialCannotGenerateTokens {
-            get {
+        internal static string SharedKeyCredentialCannotGenerateTokens
+        {
+            get
+            {
                 return ResourceManager.GetString("SharedKeyCredentialCannotGenerateTokens", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to A timeout value must be positive. To request using the default timeout, please use TimeSpan.Zero or null..
         /// </summary>
-        internal static string TimeoutMustBePositive {
-            get {
+        internal static string TimeoutMustBePositive
+        {
+            get
+            {
                 return ResourceManager.GetString("TimeoutMustBePositive", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Argument {0} must be a non-negative timespan value. The provided value was {1}..
         /// </summary>
-        internal static string TimeSpanMustBeNonNegative {
-            get {
+        internal static string TimeSpanMustBeNonNegative
+        {
+            get
+            {
                 return ResourceManager.GetString("TimeSpanMustBeNonNegative", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to An unknown error was encountered while communicating with the Event Hubs service..
         /// </summary>
-        internal static string UnknownCommunicationException {
-            get {
+        internal static string UnknownCommunicationException
+        {
+            get
+            {
                 return ResourceManager.GetString("UnknownCommunicationException", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The specified connection type, &quot;{0}&quot;, is not recognized as valid in this context..
         /// </summary>
-        internal static string UnknownConnectionType {
-            get {
+        internal static string UnknownConnectionType
+        {
+            get
+            {
                 return ResourceManager.GetString("UnknownConnectionType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The requested retry mode, &apos;{0}&apos;, is not known; a retry delay canot be determined..
         /// </summary>
-        internal static string UnknownRetryMode {
-            get {
+        internal static string UnknownRetryMode
+        {
+            get
+            {
                 return ResourceManager.GetString("UnknownRetryMode", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to An unrecoverable exception was encountered that left the environment in a bad state..
         /// </summary>
-        internal static string UnrecoverableException {
-            get {
+        internal static string UnrecoverableException
+        {
+            get
+            {
                 return ResourceManager.GetString("UnrecoverableException", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The credential is not a known and supported credential type. Please use a JWT credential or shared key credential..
         /// </summary>
-        internal static string UnsupportedCredential {
-            get {
+        internal static string UnsupportedCredential
+        {
+            get
+            {
                 return ResourceManager.GetString("UnsupportedCredential", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The requested transport event type, &apos;{0}&apos;, is not supported by the active transport client..
         /// </summary>
-        internal static string UnsupportedTransportEventType {
-            get {
+        internal static string UnsupportedTransportEventType
+        {
+            get
+            {
                 return ResourceManager.GetString("UnsupportedTransportEventType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The value supplied must be greater than or equal to {0}..
         /// </summary>
-        internal static string ValueMustBeAtLeast {
-            get {
+        internal static string ValueMustBeAtLeast
+        {
+            get
+            {
                 return ResourceManager.GetString("ValueMustBeAtLeast", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The value supplied must be between {0} and {1}..
         /// </summary>
-        internal static string ValueOutOfRange {
-            get {
+        internal static string ValueOutOfRange
+        {
+            get
+            {
                 return ResourceManager.GetString("ValueOutOfRange", resourceCulture);
             }
         }
@@ -342,8 +409,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to The event position is not valid for filtering.  It must have an offset, sequence number, or enqueued time available to filter against..
         /// </summary>
-        internal static string InvalidEventPositionForFilter {
-            get {
+        internal static string InvalidEventPositionForFilter
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidEventPositionForFilter", resourceCulture);
             }
         }
@@ -351,8 +420,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to Unable to create the items needed to communicate with the Event Hubs service..
         /// </summary>
-        internal static string CouldNotCreateLink {
-            get {
+        internal static string CouldNotCreateLink
+        {
+            get
+            {
                 return ResourceManager.GetString("CouldNotCreateLink", resourceCulture);
             }
         }
@@ -360,8 +431,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to {0} has already been closed and cannot perform the requested operation..
         /// </summary>
-        internal static string ClosedConnectionCannotPerformOperation {
-            get {
+        internal static string ClosedConnectionCannotPerformOperation
+        {
+            get
+            {
                 return ResourceManager.GetString("ClosedConnectionCannotPerformOperation", resourceCulture);
             }
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventHubClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventHubClientTests.cs
@@ -31,8 +31,8 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         public static IEnumerable<object[]> RetryOptionTestCases()
         {
-            yield return new object[] { new RetryOptions { MaximumRetries = 3, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = RetryMode.Fixed }};
-            yield return new object[] { new RetryOptions { MaximumRetries = 0, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = RetryMode.Fixed }};
+            yield return new object[] { new RetryOptions { MaximumRetries = 3, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = RetryMode.Fixed } };
+            yield return new object[] { new RetryOptions { MaximumRetries = 0, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = RetryMode.Fixed } };
         }
 
         /// <summary>
@@ -402,9 +402,9 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(converter => converter.CreatePartitionPropertiesRequest(It.Is<string>(value => value == eventHubName), It.Is<string>(value => value == partitionId), It.Is<string>(value => value == tokenValue)))
                 .Returns(default(AmqpMessage));
 
-             mockScope
-                .Setup(scope => scope.OpenManagementLinkAsync(It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
-                .Throws(retriableException);
+            mockScope
+               .Setup(scope => scope.OpenManagementLinkAsync(It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+               .Throws(retriableException);
 
             var client = new InjectableMockClient("my.eventhub.com", eventHubName, mockCredential.Object, new EventHubClientOptions(), retryPolicy, mockScope.Object, mockConverter.Object);
             Assert.That(async () => await client.GetPartitionPropertiesAsync(partitionId, cancellationSource.Token), Throws.InstanceOf(retriableException.GetType()));

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventHubConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventHubConsumerTests.cs
@@ -30,8 +30,8 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         public static IEnumerable<object[]> RetryOptionTestCases()
         {
-            yield return new object[] { new RetryOptions { MaximumRetries = 3, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = RetryMode.Fixed }};
-            yield return new object[] { new RetryOptions { MaximumRetries = 0, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = RetryMode.Fixed }};
+            yield return new object[] { new RetryOptions { MaximumRetries = 3, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = RetryMode.Fixed } };
+            yield return new object[] { new RetryOptions { MaximumRetries = 0, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = RetryMode.Fixed } };
         }
 
         /// <summary>
@@ -273,15 +273,15 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(credential => credential.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.Is<CancellationToken>(value => value == cancellationSource.Token)))
                 .Returns(Task.FromResult(new AccessToken(tokenValue, DateTimeOffset.MaxValue)));
 
-             mockScope
-                .Setup(scope => scope.OpenConsumerLinkAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<EventPosition>(),
-                    It.IsAny<EventHubConsumerOptions>(),
-                    It.IsAny<TimeSpan>(),
-                    It.IsAny<CancellationToken>()))
-                .Throws(retriableException);
+            mockScope
+               .Setup(scope => scope.OpenConsumerLinkAsync(
+                   It.IsAny<string>(),
+                   It.IsAny<string>(),
+                   It.IsAny<EventPosition>(),
+                   It.IsAny<EventHubConsumerOptions>(),
+                   It.IsAny<TimeSpan>(),
+                   It.IsAny<CancellationToken>()))
+               .Throws(retriableException);
 
             var consumer = new AmqpEventHubConsumer(eventHub, consumerGroup, partition, eventPosition, options, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy, null);
             Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf(retriableException.GetType()));

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventHubProducerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventHubProducerTests.cs
@@ -7,11 +7,9 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Core;
 using Azure.Messaging.EventHubs.Amqp;
 using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Errors;
-using Azure.Messaging.EventHubs.Metadata;
 using Microsoft.Azure.Amqp;
 using Moq;
 using Moq.Protected;
@@ -33,8 +31,8 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         public static IEnumerable<object[]> RetryOptionTestCases()
         {
-            yield return new object[] { new RetryOptions { MaximumRetries = 3, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = RetryMode.Fixed }};
-            yield return new object[] { new RetryOptions { MaximumRetries = 0, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = RetryMode.Fixed }};
+            yield return new object[] { new RetryOptions { MaximumRetries = 3, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = RetryMode.Fixed } };
+            yield return new object[] { new RetryOptions { MaximumRetries = 0, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = RetryMode.Fixed } };
         }
 
         /// <summary>
@@ -396,7 +394,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     ItExpr.IsAny<Func<AmqpMessage>>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<CancellationToken>())
-                .Callback<Func<AmqpMessage>, string, CancellationToken>( (factory, key, token) => messageFactory = factory)
+                .Callback<Func<AmqpMessage>, string, CancellationToken>((factory, key, token) => messageFactory = factory)
                 .Returns(Task.CompletedTask);
 
             await producer.Object.SendAsync(events, new SendOptions { PartitionKey = partitonKey }, CancellationToken.None);
@@ -582,7 +580,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     ItExpr.IsAny<Func<AmqpMessage>>(),
                     ItExpr.IsAny<string>(),
                     ItExpr.IsAny<CancellationToken>())
-                .Callback<Func<AmqpMessage>, string, CancellationToken>( (factory, key, token) => messageFactory = factory)
+                .Callback<Func<AmqpMessage>, string, CancellationToken>((factory, key, token) => messageFactory = factory)
                 .Returns(Task.CompletedTask);
 
             using TransportEventBatch transportBatch = await producer.Object.CreateBatchAsync(options, default);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventDataTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventDataTests.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="EventData" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class EventDataTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventData.BodyAsStream "/>
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void BodyAsStreamReturnsTheBody()
+        {
+            var eventData = new EventData(new byte[] { 0x11, 0x22, 0x65, 0x78 });
+
+            using var eventDataStream = eventData.BodyAsStream;
+            using var bodyStream = new MemoryStream();
+            eventDataStream.CopyTo(bodyStream);
+
+            var streamData = bodyStream.ToArray();
+            Assert.That(streamData, Is.Not.Null, "There should have been data in the stream.");
+            Assert.That(streamData, Is.EqualTo(eventData.Body.ToArray()), "The body data and the data read from the stream should agree.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventData.BodyAsStream "/>
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void BodyAsStreamAllowsAnEmptyBody()
+        {
+            var eventData = new EventData(Array.Empty<byte>());
+
+            using var eventDataStream = eventData.BodyAsStream;
+            using var bodyStream = new MemoryStream();
+            eventDataStream.CopyTo(bodyStream);
+
+            var streamData = bodyStream.ToArray();
+            Assert.That(streamData, Is.Not.Null, "There should have been data in the stream.");
+            Assert.That(streamData.Length, Is.EqualTo(0), "The stream should have contained no data.");
+        }
+    }
+}


### PR DESCRIPTION
# Summary

The focus of these changes is the addition of a convenience property for retrieving the body of an event as a stream.  Additionally, a code formatting pass across the source and tests was performed.

# Last Upstream Rebase

Friday, October 18, 11:34am (EDT)

# Related and Follow-Up Issues

- [Allow the EventData body to be retrieved as a Stream](https://github.com/Azure/azure-sdk-for-net/issues/7589) (#7589) 