### PR TITLE
Tracing: Add client kind on Azure.Core.Http.Request Activity

### DIFF
--- a/sdk/core/Azure.Core/src/Pipeline/Internal/RequestActivityPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/RequestActivityPolicy.cs
@@ -61,7 +61,7 @@ namespace Azure.Core.Pipeline
             activity.AddTag("http.url", message.Request.Uri.ToString());
             activity.AddTag("requestId", message.Request.ClientRequestId);
             activity.AddTag("kind", "client");
-            
+
             if (message.Request.Headers.TryGetValue("User-Agent", out string? userAgent))
             {
                 activity.AddTag("http.user_agent", userAgent);

--- a/sdk/core/Azure.Core/src/Pipeline/Internal/RequestActivityPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/RequestActivityPolicy.cs
@@ -60,7 +60,8 @@ namespace Azure.Core.Pipeline
             activity.AddTag("http.method", message.Request.Method.Method);
             activity.AddTag("http.url", message.Request.Uri.ToString());
             activity.AddTag("requestId", message.Request.ClientRequestId);
-
+            activity.AddTag("kind", "client");
+            
             if (message.Request.Headers.TryGetValue("User-Agent", out string? userAgent))
             {
                 activity.AddTag("http.user_agent", userAgent);

--- a/sdk/core/Azure.Core/tests/RequestActivityPolicyTests.cs
+++ b/sdk/core/Azure.Core/tests/RequestActivityPolicyTests.cs
@@ -60,6 +60,7 @@ namespace Azure.Core.Tests
             CollectionAssert.Contains(activity.Tags, new KeyValuePair<string, string>("http.user_agent", "agent"));
             CollectionAssert.Contains(activity.Tags, new KeyValuePair<string, string>("requestId", clientRequestId));
             CollectionAssert.Contains(activity.Tags, new KeyValuePair<string, string>("serviceRequestId", "server request id"));
+            CollectionAssert.Contains(activity.Tags, new KeyValuePair<string, string>("kind", "client"));
         }
 
 


### PR DESCRIPTION
RequestActivityPolicy does not set SpanKind on the Activity. Other (Event Hubs) instrumentations do this.  This field helps visualize call graphs and service maps.

It seems there are `DiagnosticProperty` constants including span kinds are defined in eventhubs where, but not in Core.

cc @pakrym 