### PR TITLE
remove all remnants of common namespace

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Azure.Core.Testing;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
-using Azure.Storage.Common;
 using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using NUnit.Framework;

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Testing;
 using Azure.Storage.Blobs.Models;
-using Azure.Storage.Common;
 using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using NUnit.Framework;

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Azure.Core.Testing;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
-using Azure.Storage.Common;
 using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using NUnit.Framework;

--- a/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
@@ -12,7 +12,6 @@ using System.Threading.Tasks;
 using Azure.Core.Testing;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
-using Azure.Storage.Common;
 using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using NUnit.Framework;

--- a/sdk/storage/Azure.Storage.Blobs/tests/UnitTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/UnitTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Storage.Blobs.Models;
-using Azure.Storage.Common.Tests.Shared;
+using Azure.Storage.Tests.Shared;
 using NUnit.Framework;
 
 namespace Azure.Storage.Blobs.Tests

--- a/sdk/storage/Azure.Storage.Common/tests/ConsistencyTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/ConsistencyTests.cs
@@ -8,7 +8,7 @@ using Azure.Storage.Queues;
 using Azure.Storage.Test;
 using NUnit.Framework;
 
-namespace Azure.Storage.Common.Test
+namespace Azure.Storage.Test
 {
     [TestFixture]
     public class ConsistencyTests

--- a/sdk/storage/Azure.Storage.Common/tests/GeoRedundantReadPolicyTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/GeoRedundantReadPolicyTests.cs
@@ -8,7 +8,7 @@ using Azure.Core.Pipeline;
 using Azure.Core.Testing;
 using NUnit.Framework;
 
-namespace Azure.Storage.Common.Tests
+namespace Azure.Storage.Tests
 {
     public class GeoRedundantReadPolicyTests
     {

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/MockStream.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/MockStream.cs
@@ -4,7 +4,7 @@
 using System;
 using System.IO;
 
-namespace Azure.Storage.Common.Tests.Shared
+namespace Azure.Storage.Tests.Shared
 {
     /// <summary>
     /// Stream class that can be used for mocking. Properties can be implemented

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/TenantConfiguration.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/TenantConfiguration.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Text;
 using System.Xml.Linq;
-using Azure.Storage.Common;
 
 namespace Azure.Storage.Test
 {

--- a/sdk/storage/Azure.Storage.Common/tests/UtilityTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/UtilityTests.cs
@@ -14,7 +14,7 @@ using Azure.Storage.Queues.Models;
 using Azure.Storage.Test;
 using NUnit.Framework;
 
-namespace Azure.Storage.Common.Test
+namespace Azure.Storage.Test
 {
     [TestFixture]
     public class UtilityTests

--- a/sdk/storage/Azure.Storage.Files/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files/tests/DirectoryClientTests.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Azure.Core.Testing;
-using Azure.Storage.Common;
 using Azure.Storage.Files.Models;
 using Azure.Storage.Files.Tests;
 using Azure.Storage.Test;

--- a/sdk/storage/Azure.Storage.Files/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files/tests/FileClientTests.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Testing;
-using Azure.Storage.Common;
 using Azure.Storage.Files.Models;
 using Azure.Storage.Files.Tests;
 using Azure.Storage.Test;

--- a/sdk/storage/Azure.Storage.Files/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files/tests/ServiceClientTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Azure.Storage.Common;
 using Azure.Storage.Files.Models;
 using Azure.Storage.Files.Tests;
 using Azure.Storage.Test;

--- a/sdk/storage/Azure.Storage.Files/tests/ShareClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files/tests/ShareClientTests.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Azure.Core.Testing;
-using Azure.Storage.Common;
 using Azure.Storage.Files.Models;
 using Azure.Storage.Files.Tests;
 using Azure.Storage.Test;

--- a/sdk/storage/Azure.Storage.Files/tests/UnitTests.cs
+++ b/sdk/storage/Azure.Storage.Files/tests/UnitTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Storage.Common.Tests.Shared;
+using Azure.Storage.Tests.Shared;
 using Azure.Storage.Files.Models;
 using NUnit.Framework;
 


### PR DESCRIPTION
There were a few remaining namespace references to Common in test files. I removed those and then removed all other remaining Usings. I know that I got them all because the Usings started causing compilation errors.