### PR TITLE
[Event Hubs Client] Track Two: Fifth Preview (Immutable LastEnqueuedEventProperties)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpEventHubClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpEventHubClient.cs
@@ -429,10 +429,6 @@ namespace Azure.Messaging.EventHubs.Amqp
         {
             Argument.AssertNotClosed(_closed, nameof(AmqpEventHubClient));
 
-            LastEnqueuedEventProperties lastEnqueuedEventProperties = consumerOptions.TrackLastEnqueuedEventInformation
-                ? new LastEnqueuedEventProperties(EventHubName, partitionId)
-                : null;
-
             EventHubRetryPolicy retryPolicy = defaultRetryPolicy ?? _retryPolicy;
 
             var transportConsumer = new AmqpEventHubConsumer
@@ -444,8 +440,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                 consumerOptions,
                 ConnectionScope,
                 MessageConverter,
-                retryPolicy,
-                lastEnqueuedEventProperties
+                retryPolicy
             );
 
             return new EventHubConsumer(transportConsumer, EventHubName, consumerGroup, partitionId, eventPosition, consumerOptions, retryPolicy);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpMessageConverter.cs
@@ -373,7 +373,8 @@ namespace Azure.Messaging.EventHubs.Amqp
                 partitionKey: systemAnnotations.PartitionKey,
                 lastPartitionSequenceNumber: systemAnnotations.LastSequenceNumber,
                 lastPartitionOffset: systemAnnotations.LastOffset,
-                lastPartitionEnqueuedTime: systemAnnotations.LastEnqueuedTime);
+                lastPartitionEnqueuedTime: systemAnnotations.LastEnqueuedTime,
+                lastPartitionInformationRetrievalTime: systemAnnotations.LastReceivedTime);
         }
 
         /// <summary>
@@ -478,6 +479,17 @@ namespace Azure.Messaging.EventHubs.Amqp
                     && (long.TryParse((string)propertyValue, out var offset)))
                 {
                     systemProperties.LastOffset = offset;
+                }
+
+                if ((source.DeliveryAnnotations.Map.TryGetValue(AmqpProperty.LastPartitionInformationRetrievalTimeUtc, out amqpValue))
+                    && (TryCreateEventPropertyForAmqpProperty(amqpValue, out propertyValue)))
+                {
+                    systemProperties.LastReceivedTime = propertyValue switch
+                    {
+                        DateTime dateValue => new DateTimeOffset(dateValue, TimeSpan.Zero),
+                        long longValue => new DateTimeOffset(longValue, TimeSpan.Zero),
+                        _ => (DateTimeOffset)propertyValue
+                    };
                 }
             }
 
@@ -782,6 +794,9 @@ namespace Azure.Messaging.EventHubs.Amqp
 
             /// <summary>The date and time, in UTC, that an event was last enqueued in the partition.</summary>
             public DateTimeOffset? LastEnqueuedTime;
+
+            /// <summary>The date and time, in UTC, that the last enqueued event information was retrieved from the service.</summary>
+            public DateTimeOffset? LastReceivedTime;
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProperty.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProperty.cs
@@ -86,6 +86,13 @@ namespace Azure.Messaging.EventHubs
         public static AmqpSymbol PartitionLastEnqueuedTimeUtc { get; } = "last_enqueued_time_utc";
 
         /// <summary>
+        ///   The message property that identifies the time that the last enqueued event information was
+        ///   received from the service.
+        /// </summary>
+        ///
+        public static AmqpSymbol LastPartitionInformationRetrievalTimeUtc { get; } = "runtime_info_retrieval_time_utc";
+
+        /// <summary>
         ///   The set of descriptors for well-known <see cref="DescribedType" />
         ///   property types.
         /// </summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubClient.cs
@@ -387,16 +387,12 @@ namespace Azure.Messaging.EventHubs.Compatibility
                 ? new BasicRetryPolicy(consumerOptions.RetryOptions)
                 : defaultRetryPolicy;
 
-            LastEnqueuedEventProperties partitionMetrics = (consumerOptions.TrackLastEnqueuedEventInformation)
-                ? new LastEnqueuedEventProperties(EventHubName, partitionId)
-                : null;
-
             return new EventHubConsumer
             (
-                new TrackOneEventHubConsumer(CreateReceiverFactory, initialRetryPolicy, partitionMetrics),
+                new TrackOneEventHubConsumer(CreateReceiverFactory, initialRetryPolicy),
                 TrackOneClient.EventHubName,
-                partitionId,
                 consumerGroup,
+                partitionId,
                 eventPosition,
                 consumerOptions,
                 initialRetryPolicy

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubConsumer.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Messaging.EventHubs.Core;
-using Azure.Messaging.EventHubs.Metadata;
 
 namespace Azure.Messaging.EventHubs.Compatibility
 {
@@ -50,7 +49,6 @@ namespace Azure.Messaging.EventHubs.Compatibility
         ///
         /// <param name="trackOneReceiverFactory">A delegate that can be used for creation of the <see cref="TrackOne.PartitionReceiver" /> to which operations are delegated to.</param>
         /// <param name="retryPolicy">The retry policy to use when creating the <see cref="TrackOne.PartitionReceiver" />.</param>
-        /// <param name="lastEnqueuedEventProperties">The set of properties for the last event enqueued in a partition; if not requested in the consumer options, it is expected that this is <c>null</c>.</param>
         ///
         /// <remarks>
         ///   As an internal type, this class performs only basic sanity checks against its arguments.  It
@@ -62,8 +60,7 @@ namespace Azure.Messaging.EventHubs.Compatibility
         /// </remarks>
         ///
         public TrackOneEventHubConsumer(Func<EventHubRetryPolicy, TrackOne.PartitionReceiver> trackOneReceiverFactory,
-                                        EventHubRetryPolicy retryPolicy,
-                                        LastEnqueuedEventProperties lastEnqueuedEventProperties) : base(lastEnqueuedEventProperties)
+                                        EventHubRetryPolicy retryPolicy)
         {
             Argument.AssertNotNull(trackOneReceiverFactory, nameof(trackOneReceiverFactory));
             Argument.AssertNotNull(retryPolicy, nameof(retryPolicy));
@@ -118,27 +115,20 @@ namespace Azure.Messaging.EventHubs.Compatibility
                                      eventData.SystemProperties.PartitionKey,
                                      (eventData.LastSequenceNumber != default ? eventData.LastSequenceNumber : default(long?)),
                                      (parsedLastOffset >= 0 ? parsedLastOffset : default(long?)),
-                                     (eventData.LastEnqueuedTime != default ? new DateTimeOffset(eventData.LastEnqueuedTime) : default(DateTimeOffset?)));
+                                     (eventData.LastEnqueuedTime != default ? new DateTimeOffset(eventData.LastEnqueuedTime) : default(DateTimeOffset?)),
+                                     (eventData.RetrievalTime != default ? new DateTimeOffset(eventData.RetrievalTime) : default(DateTimeOffset?)));
             }
 
             try
             {
-                IEnumerable<EventData> events = ((await TrackOneReceiver.ReceiveAsync(maximumMessageCount, maximumWaitTime).ConfigureAwait(false))
+                List<EventData> events = ((await TrackOneReceiver.ReceiveAsync(maximumMessageCount, maximumWaitTime).ConfigureAwait(false))
                         ?? Enumerable.Empty<TrackOne.EventData>())
-                    .Select(TransformEvent);
+                    .Select(TransformEvent)
+                    .ToList();
 
-                if ((TrackOneReceiver.ReceiverRuntimeMetricEnabled) && (LastEnqueuedEventInformation != null))
+                if ((TrackOneReceiver.ReceiverRuntimeMetricEnabled) && (events.Count > 0))
                 {
-                    if (!long.TryParse(TrackOneReceiver.RuntimeInfo.LastEnqueuedOffset, out var parsedOffset))
-                    {
-                        parsedOffset = -1;
-                    }
-
-                    LastEnqueuedEventInformation.UpdateMetrics(
-                        TrackOneReceiver.RuntimeInfo.LastSequenceNumber,
-                        ((parsedOffset >= 0) ? parsedOffset : default(long?)),
-                        ((TrackOneReceiver.RuntimeInfo.LastEnqueuedTimeUtc == DateTime.MinValue) ? default(DateTimeOffset?) : new DateTimeOffset(TrackOneReceiver.RuntimeInfo.LastEnqueuedTimeUtc)),
-                        ((TrackOneReceiver.RuntimeInfo.RetrievalTime == DateTime.MinValue) ? default(DateTimeOffset?) : new DateTimeOffset(TrackOneReceiver.RuntimeInfo.RetrievalTime)));
+                    LastReceivedEvent = events[events.Count - 1];
                 }
 
                 return events;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventHubConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventHubConsumer.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Messaging.EventHubs.Metadata;
 
 namespace Azure.Messaging.EventHubs.Core
 {
@@ -29,24 +28,15 @@ namespace Azure.Messaging.EventHubs.Core
         public virtual bool Closed { get; }
 
         /// <summary>
-        ///   A set of information about the enqueued state of a partition, as observed by the consumer as
-        ///   events are received from the Event Hubs service.
+        ///   The most recent event received from the Event Hubs service by this consumer instance.
         /// </summary>
         ///
-        /// <value><c>null</c>, if the information was not requested; otherwise, the last observed set of partition metrics.</value>
+        /// <value>
+        ///   <c>null</c>, if the <see cref="EventHubConsumerOptions.TrackLastEnqueuedEventInformation" /> was not requested; otherwise,
+        ///   the most recently received event.
+        /// </value>
         ///
-        public LastEnqueuedEventProperties LastEnqueuedEventInformation { get; }
-
-        /// <summary>
-        ///   Initializes a new instance of the <see cref="TransportEventHubConsumer"/> class.
-        /// </summary>
-        ///
-        /// <param name="lastEnqueuedEventProperties">The set of properties for the last event enqueued in a partition.</param>
-        ///
-        protected TransportEventHubConsumer(LastEnqueuedEventProperties lastEnqueuedEventProperties = null)
-        {
-            LastEnqueuedEventInformation = lastEnqueuedEventProperties;
-        }
+        public EventData LastReceivedEvent { get;  protected set; }
 
         /// <summary>
         ///   Updates the active retry policy for the consumer.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -160,6 +160,18 @@ namespace Azure.Messaging.EventHubs
         protected internal DateTimeOffset? LastPartitionEnqueuedTime { get; }
 
         /// <summary>
+        ///   The date and time, in UTC, that the last event information for the Event Hub partition was retrieved
+        ///   from the Event Hubs service.
+        /// </summary>
+        ///
+        /// <remarks>
+        ///   This property is only populated for events received using an <see cref="EventHubConsumer" /> which was created when
+        ///   <see cref="EventHubConsumerOptions.TrackLastEnqueuedEventInformation" /> is enabled.
+        /// </remarks>
+        ///
+        protected internal DateTimeOffset? LastPartitionInformationRetrievalTime { get; }
+
+        /// <summary>
         ///   Initializes a new instance of the <see cref="EventData"/> class.
         /// </summary>
         ///
@@ -184,6 +196,7 @@ namespace Azure.Messaging.EventHubs
         /// <param name="lastPartitionSequenceNumber">The sequence number that was last enqueued into the Event Hub partition.</param>
         /// <param name="lastPartitionOffset">The offset that was last enqueued into the Event Hub partition.</param>
         /// <param name="lastPartitionEnqueuedTime">The date and time, in UTC, of the event that was last enqueued into the Event Hub partition.</param>
+        /// <param name="lastPartitionInformationRetrievalTime">The date and time, in UTC, that the last event information for the Event Hub partition was retrieved from the serivce.</param>
         ///
         protected internal EventData(ReadOnlyMemory<byte> eventBody,
                                      IDictionary<string, object> properties = null,
@@ -194,7 +207,8 @@ namespace Azure.Messaging.EventHubs
                                      string partitionKey = null,
                                      long? lastPartitionSequenceNumber = null,
                                      long? lastPartitionOffset = null,
-                                     DateTimeOffset? lastPartitionEnqueuedTime = null)
+                                     DateTimeOffset? lastPartitionEnqueuedTime = null,
+                                     DateTimeOffset? lastPartitionInformationRetrievalTime = null)
         {
             Body = eventBody;
             Properties = properties ?? new Dictionary<string, object>();
@@ -206,6 +220,7 @@ namespace Azure.Messaging.EventHubs
             LastPartitionSequenceNumber = lastPartitionSequenceNumber;
             LastPartitionOffset = lastPartitionOffset;
             LastPartitionEnqueuedTime = lastPartitionEnqueuedTime;
+            LastPartitionInformationRetrievalTime = lastPartitionInformationRetrievalTime;
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumer.cs
@@ -108,25 +108,6 @@ namespace Azure.Messaging.EventHubs
         public string Identifier => Options?.Identifier;
 
         /// <summary>
-        ///   A set of information about the last enqueued event of a partition, as observed by the consumer as
-        ///   events are received from the Event Hubs service.
-        /// </summary>
-        ///
-        /// <value>
-        ///   <c>null</c>, if the information was not requested by setting <see cref="EventHubConsumerOptions.TrackLastEnqueuedEventInformation" />;
-        ///   otherwise, the properties describing the most recently enqueued event in the partition.
-        /// </value>
-        ///
-        /// <remarks>
-        ///   When information about the partition's last enqueued event is being tracked, each event received from the Event Hubs
-        ///   service will carry metadata about the partition that it otherwise would not. This results in a small amount of
-        ///   additional network bandwidth consumption that is generally a favorable trade-off when considered
-        ///   against periodically making requests for partition properties using the Event Hub client.
-        /// </remarks>
-        ///
-        public LastEnqueuedEventProperties LastEnqueuedEventInformation => InnerConsumer.LastEnqueuedEventInformation;
-
-        /// <summary>
         ///   The policy to use for determining retry behavior for when an operation fails.
         /// </summary>
         ///
@@ -214,6 +195,31 @@ namespace Azure.Messaging.EventHubs
         ///
         protected EventHubConsumer()
         {
+        }
+
+        /// <summary>
+        ///   A set of information about the last enqueued event of a partition, as observed by the consumer as
+        ///   events are received from the Event Hubs service.  This is only available if the consumer was
+        ///   created with <see cref="EventHubConsumerOptions.TrackLastEnqueuedEventInformation" /> set.
+        /// </summary>
+        ///
+        /// <remarks>
+        ///   When information about the partition's last enqueued event is being tracked, each event received from the Event Hubs
+        ///   service will carry metadata about the partition that it otherwise would not. This results in a small amount of
+        ///   additional network bandwidth consumption that is generally a favorable trade-off when considered
+        ///   against periodically making requests for partition properties using the Event Hub client.
+        /// </remarks>
+        ///
+        /// <exception cref="InvalidOperationException">Occurs when this method is invoked without <see cref="EventHubConsumerOptions.TrackLastEnqueuedEventInformation" /> set.</exception>
+        ///
+        public virtual LastEnqueuedEventProperties ReadLastEnqueuedEventInformation()
+        {
+            if (!Options.TrackLastEnqueuedEventInformation)
+            {
+                throw new InvalidOperationException(Resources.TrackLastEnqueuedEventInformationNotSet);
+            }
+
+            return new LastEnqueuedEventProperties(EventHubName, PartitionId, InnerConsumer.LastReceivedEvent);
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Metadata/LastEnqueuedEventProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Metadata/LastEnqueuedEventProperties.cs
@@ -28,38 +28,25 @@ namespace Azure.Messaging.EventHubs.Metadata
         ///   The sequence number of the last observed event to be enqueued in the partition.
         /// </summary>
         ///
-        public long? LastEnqueuedSequenceNumber { get; private set; }
+        public long? LastEnqueuedSequenceNumber { get; }
 
         /// <summary>
         ///   The offset of the last observed event to be enqueued in the partition.
         /// </summary>
         ///
-        public long? LastEnqueuedOffset { get; private set; }
+        public long? LastEnqueuedOffset { get; }
 
         /// <summary>
         ///   The date and time, in UTC, that the last observed event was enqueued in the partition.
         /// </summary>
         ///
-        public DateTimeOffset? LastEnqueuedTime { get; private set; }
+        public DateTimeOffset? LastEnqueuedTime { get; }
 
         /// <summary>
         ///   The date and time, in UTC, that the information about the last enqueued event was received.
         /// </summary>
-        public DateTimeOffset? InformationReceived { get; private set; }
-
-        /// <summary>
-        ///   Initializes a new instance of the <see cref="LastEnqueuedEventProperties"/> class.
-        /// </summary>
         ///
-        /// <param name="eventHubName">The name of the Event Hub that contains the partitions.</param>
-        /// <param name="partitionId">The identifier of the partition.</param>
-        ///
-        protected internal LastEnqueuedEventProperties(string eventHubName,
-                                                       string partitionId)
-        {
-            EventHubName = eventHubName;
-            PartitionId = partitionId;
-        }
+        public DateTimeOffset? InformationReceived { get; }
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="LastEnqueuedEventProperties"/> class.
@@ -70,39 +57,41 @@ namespace Azure.Messaging.EventHubs.Metadata
         /// <param name="lastSequenceNumber">The sequence number observed the last event to be enqueued in the partition.</param>
         /// <param name="lastOffset">The offset of the last event to be enqueued in the partition.</param>
         /// <param name="lastEnqueuedTime">The date and time, in UTC, that the last event was enqueued in the partition.</param>
-        /// <param name="lastUpdatedTime">The date and time, in UTC, that the metrics were last updated.</param>
+        /// <param name="lastReceivedTime">The date and time, in UTC, that the information was last received.</param>
         ///
         protected internal LastEnqueuedEventProperties(string eventHubName,
                                                        string partitionId,
                                                        long? lastSequenceNumber,
                                                        long? lastOffset,
                                                        DateTimeOffset? lastEnqueuedTime,
-                                                       DateTimeOffset? lastUpdatedTime)
+                                                       DateTimeOffset? lastReceivedTime)
         {
             EventHubName = eventHubName;
             PartitionId = partitionId;
-
-            UpdateMetrics(lastSequenceNumber, lastOffset, lastEnqueuedTime, lastUpdatedTime);
-        }
-
-        /// <summary>
-        ///   Updates the current set of metrics for the partition.
-        /// </summary>
-        ///
-        /// <param name="lastSequenceNumber">The sequence number observed the last event to be enqueued in the partition.</param>
-        /// <param name="lastOffset">The offset of the last event to be enqueued in the partition.</param>
-        /// <param name="lastEnqueuedTime">The date and time, in UTC, that the last event was enqueued in the partition.</param>
-        /// <param name="lastReceivedTime">The date and time, in UTC, that the metrics were last updated.</param>
-        ///
-        protected internal void UpdateMetrics(long? lastSequenceNumber,
-                                              long? lastOffset,
-                                              DateTimeOffset? lastEnqueuedTime,
-                                              DateTimeOffset? lastReceivedTime)
-        {
             LastEnqueuedSequenceNumber = lastSequenceNumber;
             LastEnqueuedOffset = lastOffset;
             LastEnqueuedTime = lastEnqueuedTime;
             InformationReceived = lastReceivedTime;
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="LastEnqueuedEventProperties"/> class.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the Event Hub that contains the partitions.</param>
+        /// <param name="partitionId">The identifier of the partition.</param>
+        /// <param name="sourceEvent">The event to use as the source for the partition information.</param>
+        ///
+        internal LastEnqueuedEventProperties(string eventHubName,
+                                             string partitionId,
+                                             EventData sourceEvent) :
+            this(eventHubName,
+                 partitionId,
+                 sourceEvent?.LastPartitionSequenceNumber,
+                 sourceEvent?.LastPartitionOffset,
+                 sourceEvent?.LastPartitionEnqueuedTime,
+                 sourceEvent?.LastPartitionInformationRetrievalTime)
+        {
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.Designer.cs
@@ -438,5 +438,16 @@ namespace Azure.Messaging.EventHubs
                 return ResourceManager.GetString("ClosedConnectionCannotPerformOperation", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to This information is only available when TrackLastEnqueuedEventInformation is set on the Event Hub consumer options..
+        /// </summary>
+        internal static string TrackLastEnqueuedEventInformationNotSet
+        {
+            get
+            {
+                return ResourceManager.GetString("TrackLastEnqueuedEventInformationNotSet", resourceCulture);
+            }
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -218,5 +218,8 @@
   </data>
   <data name="ClosedConnectionCannotPerformOperation" xml:space="preserve">
     <value>{0} has already been closed and cannot perform the requested operation.</value>
+  </data>
+  <data name="TrackLastEnqueuedEventInformationNotSet" xml:space="preserve">
+    <value>This information is only available when TrackLastEnqueuedEventInformation is set on the Event Hub consumer options.</value>
   </data>
 </root>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventHubConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventHubConsumerTests.cs
@@ -43,7 +43,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorRequiresTheEventHubName(string eventHub)
         {
-            Assert.That(() => new AmqpEventHubConsumer(eventHub, "$DEFAULT", "0", EventPosition.Earliest, new EventHubConsumerOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>(), null), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new AmqpEventHubConsumer(eventHub, "$DEFAULT", "0", EventPosition.Earliest, new EventHubConsumerOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorRequiresTheConsumerGroup(string group)
         {
-            Assert.That(() => new AmqpEventHubConsumer("myHub", group, "0", EventPosition.Earliest, new EventHubConsumerOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>(), new LastEnqueuedEventProperties("hub", "0")), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new AmqpEventHubConsumer("myHub", group, "0", EventPosition.Earliest, new EventHubConsumerOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorRequiresThePartition(string partition)
         {
-            Assert.That(() => new AmqpEventHubConsumer("aHub", "$DEFAULT", partition, EventPosition.Earliest, new EventHubConsumerOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>(), null), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new AmqpEventHubConsumer("aHub", "$DEFAULT", partition, EventPosition.Earliest, new EventHubConsumerOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorRequiresTheEventPosition()
         {
-            Assert.That(() => new AmqpEventHubConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", null, new EventHubConsumerOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>(), null), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpEventHubConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", null, new EventHubConsumerOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>()), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -87,7 +87,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorRequiresTheOptions()
         {
-            Assert.That(() => new AmqpEventHubConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.FromOffset(1), null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>(), new LastEnqueuedEventProperties("hub", "0")), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpEventHubConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.FromOffset(1), null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>()), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorRequiresTheConnectionScope()
         {
-            Assert.That(() => new AmqpEventHubConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.FromSequenceNumber(123), new EventHubConsumerOptions(), null, Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>(), null), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpEventHubConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.FromSequenceNumber(123), new EventHubConsumerOptions(), null, Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>()), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -107,7 +107,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorRequiresTheRetryPolicy()
         {
-            Assert.That(() => new AmqpEventHubConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.Latest, new EventHubConsumerOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), null, new LastEnqueuedEventProperties("hub", "0")), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpEventHubConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.Latest, new EventHubConsumerOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), null), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task CloseMarksTheConsumerAsClosed()
         {
-            var consumer = new AmqpEventHubConsumer("aHub", "$DEFAULT", "0", EventPosition.Earliest, new EventHubConsumerOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>(), null);
+            var consumer = new AmqpEventHubConsumer("aHub", "$DEFAULT", "0", EventPosition.Earliest, new EventHubConsumerOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>());
             Assert.That(consumer.Closed, Is.False, "The consumer should not be closed on creation");
 
             await consumer.CloseAsync(CancellationToken.None);
@@ -133,7 +133,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void CloseRespectsTheCancellationToken()
         {
-            var consumer = new AmqpEventHubConsumer("aHub", "$DEFAULT", "0", EventPosition.Earliest, new EventHubConsumerOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>(), null);
+            var consumer = new AmqpEventHubConsumer("aHub", "$DEFAULT", "0", EventPosition.Earliest, new EventHubConsumerOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>());
             using var cancellationSource = new CancellationTokenSource();
 
             cancellationSource.Cancel();
@@ -149,7 +149,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void UpdateRetryPolicyValidatesTheRetryPolicy()
         {
-            var consumer = new AmqpEventHubConsumer("aHub", "$DEFAULT", "0", EventPosition.Earliest, new EventHubConsumerOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>(), null);
+            var consumer = new AmqpEventHubConsumer("aHub", "$DEFAULT", "0", EventPosition.Earliest, new EventHubConsumerOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>());
             Assert.That(() => consumer.UpdateRetryPolicy(null), Throws.ArgumentNullException);
         }
 
@@ -162,7 +162,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void UpdateRetryPolicyUpdatesTheRetryPolicy()
         {
             var newPolicy = new BasicRetryPolicy(new RetryOptions { Delay = TimeSpan.FromMilliseconds(50) });
-            var consumer = new AmqpEventHubConsumer("aHub", "$DEFAULT", "0", EventPosition.Earliest, new EventHubConsumerOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>(), null);
+            var consumer = new AmqpEventHubConsumer("aHub", "$DEFAULT", "0", EventPosition.Earliest, new EventHubConsumerOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>());
 
             Assert.That(GetActiveRetryPolicy(consumer), Is.Not.SameAs(newPolicy), "The initial policy should be a unique instance");
 
@@ -180,7 +180,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var initialPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
             var initialTimeout = initialPolicy.CalculateTryTimeout(0);
-            var consumer = new AmqpEventHubConsumer("aHub", "$DEFAULT", "0", EventPosition.Earliest, new EventHubConsumerOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), initialPolicy, null);
+            var consumer = new AmqpEventHubConsumer("aHub", "$DEFAULT", "0", EventPosition.Earliest, new EventHubConsumerOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), initialPolicy);
 
             Assert.That(GetTimeout(consumer), Is.EqualTo(initialTimeout), "The initial timeout should match");
 
@@ -215,7 +215,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             using var cancellationSource = new CancellationTokenSource();
 
-            var consumer = new AmqpEventHubConsumer(eventHub, consumerGroup, partition, eventPosition, options, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy, null);
+            var consumer = new AmqpEventHubConsumer(eventHub, consumerGroup, partition, eventPosition, options, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             Assert.That(async () => await consumer.ReceiveAsync(count, null, cancellationSource.Token), Throws.InstanceOf<ArgumentException>());
         }
 
@@ -241,7 +241,7 @@ namespace Azure.Messaging.EventHubs.Tests
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();
 
-            var consumer = new AmqpEventHubConsumer(eventHub, consumerGroup, partition, eventPosition, options, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy, null);
+            var consumer = new AmqpEventHubConsumer(eventHub, consumerGroup, partition, eventPosition, options, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
         }
 
@@ -283,7 +283,7 @@ namespace Azure.Messaging.EventHubs.Tests
                    It.IsAny<CancellationToken>()))
                .Throws(retriableException);
 
-            var consumer = new AmqpEventHubConsumer(eventHub, consumerGroup, partition, eventPosition, options, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy, null);
+            var consumer = new AmqpEventHubConsumer(eventHub, consumerGroup, partition, eventPosition, options, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf(retriableException.GetType()));
 
             mockScope
@@ -318,7 +318,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             using var cancellationSource = new CancellationTokenSource();
 
-            var consumer = new AmqpEventHubConsumer(eventHub, consumerGroup, partition, eventPosition, options, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy, null);
+            var consumer = new AmqpEventHubConsumer(eventHub, consumerGroup, partition, eventPosition, options, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             await consumer.CloseAsync(cancellationSource.Token);
 
             Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf<EventHubsClientClosedException>());

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubClientTests.cs
@@ -823,17 +823,19 @@ namespace Azure.Messaging.EventHubs.Tests
 
                 if (!metricsEnabled)
                 {
-                    Assert.That(consumer.LastEnqueuedEventInformation, Is.Null, "No metrics should have been created when not requested.");
+                    Assert.That(() => consumer.ReadLastEnqueuedEventInformation(), Throws.TypeOf<InvalidOperationException>(), "No metrics should be available when not requested.");
                 }
                 else
                 {
-                    Assert.That(consumer.LastEnqueuedEventInformation, Is.Not.Null, "Metrics should have been created when requested.");
-                    Assert.That(consumer.LastEnqueuedEventInformation.EventHubName, Is.EqualTo(eventHubName), "The metrics event hub should match");
-                    Assert.That(consumer.LastEnqueuedEventInformation.PartitionId, Is.EqualTo(partitionId), "The metrics partition should match");
-                    Assert.That(consumer.LastEnqueuedEventInformation.LastEnqueuedOffset.HasValue, Is.False, "The metrics partition should have no initial offset");
-                    Assert.That(consumer.LastEnqueuedEventInformation.LastEnqueuedSequenceNumber.HasValue, Is.False, "The metrics partition should have no initial sequence number");
-                    Assert.That(consumer.LastEnqueuedEventInformation.LastEnqueuedTime.HasValue, Is.False, "The metrics partition should have no initial enqueue time");
-                    Assert.That(consumer.LastEnqueuedEventInformation.InformationReceived.HasValue, Is.False, "The metrics partition should have no initial update time");
+                    var lastEnqueuedEventInformation = consumer.ReadLastEnqueuedEventInformation();
+
+                    Assert.That(lastEnqueuedEventInformation, Is.Not.Null, "Metrics should have been created when requested.");
+                    Assert.That(lastEnqueuedEventInformation.EventHubName, Is.EqualTo(eventHubName), "The metrics event hub should match");
+                    Assert.That(lastEnqueuedEventInformation.PartitionId, Is.EqualTo(partitionId), "The metrics partition should match");
+                    Assert.That(lastEnqueuedEventInformation.LastEnqueuedOffset.HasValue, Is.False, "The metrics partition should have no initial offset");
+                    Assert.That(lastEnqueuedEventInformation.LastEnqueuedSequenceNumber.HasValue, Is.False, "The metrics partition should have no initial sequence number");
+                    Assert.That(lastEnqueuedEventInformation.LastEnqueuedTime.HasValue, Is.False, "The metrics partition should have no initial enqueue time");
+                    Assert.That(lastEnqueuedEventInformation.InformationReceived.HasValue, Is.False, "The metrics partition should have no initial update time");
                 }
 
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerLiveTests.cs
@@ -1004,23 +1004,25 @@ namespace Azure.Messaging.EventHubs.Tests
                         // Validate the partition metrics were received and populated.
 
                         Assert.That(receivedEvents, Is.Not.Empty, "There should have been a set of events received.");
-                        Assert.That(consumer.LastEnqueuedEventInformation, Is.Not.Null, "There should be a partition metrics instance.");
-                        Assert.That(consumer.LastEnqueuedEventInformation.LastEnqueuedSequenceNumber.HasValue, Is.True, "There should be a last sequence number populated.");
-                        Assert.That(consumer.LastEnqueuedEventInformation.LastEnqueuedOffset.HasValue, Is.True, "There should be a last offset populated.");
-                        Assert.That(consumer.LastEnqueuedEventInformation.LastEnqueuedTime.HasValue, Is.True, "There should be a last enqueued time populated.");
-                        Assert.That(consumer.LastEnqueuedEventInformation.InformationReceived.HasValue, Is.True, "There should be a last update time populated.");
+
+                        var currentMetrics = consumer.ReadLastEnqueuedEventInformation();
+                        Assert.That(currentMetrics, Is.Not.Null, "There should be a partition metrics instance.");
+                        Assert.That(currentMetrics.LastEnqueuedSequenceNumber.HasValue, Is.True, "There should be a last sequence number populated.");
+                        Assert.That(currentMetrics.LastEnqueuedOffset.HasValue, Is.True, "There should be a last offset populated.");
+                        Assert.That(currentMetrics.LastEnqueuedTime.HasValue, Is.True, "There should be a last enqueued time populated.");
+                        Assert.That(currentMetrics.InformationReceived.HasValue, Is.True, "There should be a last update time populated.");
 
                         // Capture the metrics update time for comparison against the second batch in order to
                         // ensure that metrics are updated each time events are received.  Pause for a moment to
                         // be sure that receiving has some delta in time stamp.
 
                         var previousMetrics = new LastEnqueuedEventProperties(
-                            consumer.LastEnqueuedEventInformation.EventHubName,
-                            consumer.LastEnqueuedEventInformation.PartitionId,
-                            consumer.LastEnqueuedEventInformation.LastEnqueuedSequenceNumber,
-                            consumer.LastEnqueuedEventInformation.LastEnqueuedOffset,
-                            consumer.LastEnqueuedEventInformation.LastEnqueuedTime,
-                            consumer.LastEnqueuedEventInformation.InformationReceived);
+                            currentMetrics.EventHubName,
+                            currentMetrics.PartitionId,
+                            currentMetrics.LastEnqueuedSequenceNumber,
+                            currentMetrics.LastEnqueuedOffset,
+                            currentMetrics.LastEnqueuedTime,
+                            currentMetrics.InformationReceived);
 
                         await Task.Delay(TimeSpan.FromSeconds(15));
 
@@ -1039,11 +1041,13 @@ namespace Azure.Messaging.EventHubs.Tests
                         // Validate that metrics have been updated or remain stable.
 
                         Assert.That(receivedEvents, Is.Not.Empty, "There should have been a set of events received.");
-                        Assert.That(consumer.LastEnqueuedEventInformation, Is.Not.Null, "There should be a partition metrics instance.");
-                        Assert.That(consumer.LastEnqueuedEventInformation.LastEnqueuedSequenceNumber.Value, Is.Not.EqualTo(previousMetrics.LastEnqueuedSequenceNumber), "The last sequence number should have been updated.");
-                        Assert.That(consumer.LastEnqueuedEventInformation.LastEnqueuedOffset.Value, Is.Not.EqualTo(previousMetrics.LastEnqueuedOffset), "The last offset should have been updated.");
-                        Assert.That(consumer.LastEnqueuedEventInformation.LastEnqueuedTime.Value, Is.Not.EqualTo(previousMetrics.LastEnqueuedTime), "The last enqueue time should have been updated.");
-                        Assert.That(consumer.LastEnqueuedEventInformation.InformationReceived.Value, Is.GreaterThan(previousMetrics.InformationReceived), "The last update time should have been incremented.");
+
+                        currentMetrics = consumer.ReadLastEnqueuedEventInformation();
+                        Assert.That(currentMetrics, Is.Not.Null, "There should be a partition metrics instance.");
+                        Assert.That(currentMetrics.LastEnqueuedSequenceNumber.Value, Is.Not.EqualTo(previousMetrics.LastEnqueuedSequenceNumber), "The last sequence number should have been updated.");
+                        Assert.That(currentMetrics.LastEnqueuedOffset.Value, Is.Not.EqualTo(previousMetrics.LastEnqueuedOffset), "The last offset should have been updated.");
+                        Assert.That(currentMetrics.LastEnqueuedTime.Value, Is.Not.EqualTo(previousMetrics.LastEnqueuedTime), "The last enqueue time should have been updated.");
+                        Assert.That(currentMetrics.InformationReceived.Value, Is.GreaterThan(previousMetrics.InformationReceived), "The last update time should have been incremented.");
                     }
                 }
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerTests.cs
@@ -260,6 +260,72 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubConsumer.ReadLastEnqueuedEventInformation" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void ReadLastEnqueuedEventInformationRespectsTheTrackingEnabledFlag(bool trackingEnabled)
+        {
+            var retryOptions = new RetryOptions
+            {
+                Delay = TimeSpan.FromSeconds(1),
+                MaximumDelay = TimeSpan.FromSeconds(2),
+                TryTimeout = TimeSpan.FromSeconds(3),
+                MaximumRetries = 4,
+                Mode = RetryMode.Fixed
+            };
+
+            var consumerOptions = new EventHubConsumerOptions { TrackLastEnqueuedEventInformation = trackingEnabled };
+            var consumer = new EventHubConsumer(new ObservableTransportConsumerMock(), "dummy", "consumerGroup", "0", EventPosition.Latest, consumerOptions, new BasicRetryPolicy(retryOptions));
+
+            if (trackingEnabled)
+            {
+                var metrics = consumer.ReadLastEnqueuedEventInformation();
+                Assert.That(metrics.EventHubName, Is.Not.Null.And.Not.Empty, "The Event Hub name should be present.");
+                Assert.That(metrics.PartitionId, Is.Not.Null.And.Not.Empty, "The partition id should be present.");
+            }
+            else
+            {
+                Assert.That(() => consumer.ReadLastEnqueuedEventInformation(), Throws.TypeOf<InvalidOperationException>(), "Last enqueued event information cannot be read if tracking is not enabled.");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubConsumer.ReadLastEnqueuedEventInformation" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void ReadLastEnqueuedEventInformationPopulatesFromTheLastReceivedEvent()
+        {
+            var lastEvent = new EventData
+            (
+                eventBody: Array.Empty<byte>(),
+                lastPartitionSequenceNumber: 12345,
+                lastPartitionOffset: 89101,
+                lastPartitionEnqueuedTime: DateTimeOffset.Parse("2015-10-27T00:00:00Z"),
+                lastPartitionInformationRetrievalTime: DateTimeOffset.Parse("2012-03-04T08:49:00Z")
+            );
+
+            var eventHub = "someHub";
+            var partition = "PART";
+            var consumerOptions = new EventHubConsumerOptions { TrackLastEnqueuedEventInformation = true };
+            var transportMock = new ObservableTransportConsumerMock { LastReceivedEvent = lastEvent };
+            var consumer = new EventHubConsumer(transportMock, eventHub, "consumerGroup", partition, EventPosition.Latest, consumerOptions, Mock.Of<EventHubRetryPolicy>());
+            var metrics = consumer.ReadLastEnqueuedEventInformation();
+
+            Assert.That(metrics.EventHubName, Is.EqualTo(eventHub), "The Event Hub name should match.");
+            Assert.That(metrics.PartitionId, Is.EqualTo(partition), "The partition id should match.");
+            Assert.That(metrics.LastEnqueuedSequenceNumber, Is.EqualTo(lastEvent.LastPartitionSequenceNumber), "The sequence number should match.");
+            Assert.That(metrics.LastEnqueuedOffset, Is.EqualTo(lastEvent.LastPartitionOffset), "The offset should match.");
+            Assert.That(metrics.LastEnqueuedTime, Is.EqualTo(lastEvent.LastPartitionEnqueuedTime), "The enqueue time should match.");
+            Assert.That(metrics.InformationReceived, Is.EqualTo(lastEvent.LastPartitionInformationRetrievalTime), "The retrieval time should match.");
+        }
+
+        /// <summary>
         ///   Verifies functionality of the <see cref="EventHubConsumer.CloseAsync" />
         ///   method.
         /// </summary>
@@ -1200,6 +1266,12 @@ namespace Azure.Messaging.EventHubs.Tests
             public bool WasCloseCalled = false;
             public EventHubRetryPolicy UpdateRetryPolicyCalledWith;
             public (int, TimeSpan?) ReceiveCalledWith;
+
+            public new EventData LastReceivedEvent
+            {
+                get => base.LastReceivedEvent;
+                set => base.LastReceivedEvent = value;
+            }
 
             public override Task<IEnumerable<EventData>> ReceiveAsync(int maximumMessageCount,
                                                                       TimeSpan? maximumWaitTime,


### PR DESCRIPTION
# Summary

The focus of these changes is  to make the last enqueued event properties an atomic read and remove the race condition from in-place updates.  To better reflect this behavior, the existing property was changed to a method in an attempt to discourage consumers from accessing it's properties directly.

# Last Upstream Rebase

Monday, October 21, 2:58pm (EDT)

# Related and Follow-Up Issues

- [EventHubConsumer.LastEnqueuedEventInformation should return an immutable object](https://github.com/Azure/azure-sdk-for-net/issues/7862) (#7862) 