### PR TITLE
Storage: Rename date properties to *On naming convention

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
@@ -3823,7 +3823,7 @@ namespace Azure.Storage.Blobs
                         }
                         if (response.Headers.TryGetValue("x-ms-creation-time", out _header))
                         {
-                            _value.CreationTime = System.DateTimeOffset.Parse(_header, System.Globalization.CultureInfo.InvariantCulture);
+                            _value.CreatedOn = System.DateTimeOffset.Parse(_header, System.Globalization.CultureInfo.InvariantCulture);
                         }
                         _value.Metadata = new System.Collections.Generic.Dictionary<string, string>(System.StringComparer.OrdinalIgnoreCase);
                         foreach (Azure.Core.HttpHeader _headerPair in response.Headers)
@@ -3839,7 +3839,7 @@ namespace Azure.Storage.Blobs
                         }
                         if (response.Headers.TryGetValue("x-ms-copy-completion-time", out _header))
                         {
-                            _value.CopyCompletionTime = System.DateTimeOffset.Parse(_header, System.Globalization.CultureInfo.InvariantCulture);
+                            _value.CopyCompletedOn = System.DateTimeOffset.Parse(_header, System.Globalization.CultureInfo.InvariantCulture);
                         }
                         if (response.Headers.TryGetValue("x-ms-copy-status-description", out _header))
                         {
@@ -3947,7 +3947,7 @@ namespace Azure.Storage.Blobs
                         }
                         if (response.Headers.TryGetValue("x-ms-access-tier-change-time", out _header))
                         {
-                            _value.AccessTierChangeTime = System.DateTimeOffset.Parse(_header, System.Globalization.CultureInfo.InvariantCulture);
+                            _value.AccessTierChangedOn = System.DateTimeOffset.Parse(_header, System.Globalization.CultureInfo.InvariantCulture);
                         }
 
                         // Create the response
@@ -14590,7 +14590,7 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// A GMT date/time value, to the second. All primary writes preceding this value are guaranteed to be available for read operations at the secondary. Primary writes after this point in time may or may not be available for reads.
         /// </summary>
-        public System.DateTimeOffset LastSyncTime { get; internal set; }
+        public System.DateTimeOffset? LastSyncedOn { get; internal set; }
 
         /// <summary>
         /// Prevent direct instantiation of BlobGeoReplication instances.
@@ -14616,7 +14616,7 @@ namespace Azure.Storage.Blobs.Models
             _child = element.Element(System.Xml.Linq.XName.Get("LastSyncTime", ""));
             if (_child != null)
             {
-                _value.LastSyncTime = System.DateTimeOffset.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
+                _value.LastSyncedOn = System.DateTimeOffset.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
             }
             CustomizeFromXml(element, _value);
             return _value;
@@ -14635,12 +14635,12 @@ namespace Azure.Storage.Blobs.Models
         /// </summary>
         public static BlobGeoReplication BlobGeoReplication(
             Azure.Storage.Blobs.Models.BlobGeoReplicationStatus status,
-            System.DateTimeOffset lastSyncTime)
+            System.DateTimeOffset? lastSyncedOn = default)
         {
             return new BlobGeoReplication()
             {
                 Status = status,
-                LastSyncTime = lastSyncTime,
+                LastSyncedOn = lastSyncedOn,
             };
         }
     }
@@ -15039,7 +15039,7 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// AccessTierChangeTime
         /// </summary>
-        public System.DateTimeOffset? AccessTierChangeTime { get; internal set; }
+        public System.DateTimeOffset? AccessTierChangedOn { get; internal set; }
 
         /// <summary>
         /// ETag
@@ -15210,7 +15210,7 @@ namespace Azure.Storage.Blobs.Models
             _child = element.Element(System.Xml.Linq.XName.Get("AccessTierChangeTime", ""));
             if (_child != null)
             {
-                _value.AccessTierChangeTime = System.DateTimeOffset.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
+                _value.AccessTierChangedOn = System.DateTimeOffset.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
             }
             _child = element.Element(System.Xml.Linq.XName.Get("Etag", ""));
             if (_child != null)
@@ -15296,7 +15296,7 @@ namespace Azure.Storage.Blobs.Models
                 CreationTime = creationTime,
                 ArchiveStatus = archiveStatus,
                 CustomerProvidedKeySha256 = customerProvidedKeySha256,
-                AccessTierChangeTime = accessTierChangeTime,
+                AccessTierChangedOn = accessTierChangeTime,
                 ETag = eTag,
             };
         }
@@ -15541,7 +15541,7 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// Returns the date and time the blob was created.
         /// </summary>
-        public System.DateTimeOffset CreationTime { get; internal set; }
+        public System.DateTimeOffset CreatedOn { get; internal set; }
 
         /// <summary>
         /// x-ms-meta
@@ -15556,7 +15556,7 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// Conclusion time of the last attempted Copy Blob operation where this blob was the destination blob. This value can specify the time of a completed, aborted, or failed copy attempt. This header does not appear if a copy is pending, if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List.
         /// </summary>
-        public System.DateTimeOffset CopyCompletionTime { get; internal set; }
+        public System.DateTimeOffset CopyCompletedOn { get; internal set; }
 
         /// <summary>
         /// Only appears when x-ms-copy-status is failed or pending. Describes the cause of the last fatal or non-fatal copy operation failure. This header does not appear if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List
@@ -15693,7 +15693,7 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// The time the tier was changed on the object. This is only returned if the tier on the block blob was ever set.
         /// </summary>
-        public System.DateTimeOffset AccessTierChangeTime { get; internal set; }
+        public System.DateTimeOffset AccessTierChangedOn { get; internal set; }
 
         /// <summary>
         /// Creates a new BlobProperties instance
@@ -15773,14 +15773,14 @@ namespace Azure.Storage.Blobs.Models
                 IsServerEncrypted = isServerEncrypted,
                 CopyStatusDescription = copyStatusDescription,
                 EncryptionKeySha256 = encryptionKeySha256,
-                CopyCompletionTime = copyCompletionTime,
+                CopyCompletedOn = copyCompletionTime,
                 AccessTier = accessTier,
                 BlobType = blobType,
                 AccessTierInferred = accessTierInferred,
                 Metadata = metadata,
                 ArchiveStatus = archiveStatus,
-                CreationTime = creationTime,
-                AccessTierChangeTime = accessTierChangeTime,
+                CreatedOn = creationTime,
+                AccessTierChangedOn = accessTierChangeTime,
                 ContentType = contentType,
             };
         }

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/BlobInfo.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/BlobInfo.cs
@@ -142,7 +142,7 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// Conclusion time of the last attempted Copy Blob operation where this blob was the destination blob. This value can specify the time of a completed, aborted, or failed copy attempt. This header does not appear if a copy is pending, if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List.
         /// </summary>
-        public DateTimeOffset CopyCompletionTime => _flattened.CopyCompletionTime;
+        public DateTimeOffset CopyCompletedOn => _flattened.CopyCompletionTime;
 
         /// <summary>
         /// Only appears when x-ms-copy-status is failed or pending. Describes the cause of the last fatal or non-fatal copy operation failure. This header does not appear if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List

--- a/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasQueryParameters.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasQueryParameters.cs
@@ -28,12 +28,12 @@ namespace Azure.Storage.Sas
         /// <summary>
         /// Gets the time at which the key becomes valid.
         /// </summary>
-        public DateTimeOffset KeyStart => _keyStart;
+        public DateTimeOffset KeyStartsOn => _keyStart;
 
         /// <summary>
         /// Gets the time at which the key becomes expires.
         /// </summary>
-        public DateTimeOffset KeyExpiry => _keyExpiry;
+        public DateTimeOffset KeyExpiresOn => _keyExpiry;
 
         /// <summary>
         /// Gets the Storage service that accepts the key.

--- a/sdk/storage/Azure.Storage.Blobs/swagger/readme.md
+++ b/sdk/storage/Azure.Storage.Blobs/swagger/readme.md
@@ -463,6 +463,22 @@ directive:
         $.BlobItemProperties.required = ["AccessTierInferred"];
         const path = $.BlobItem.properties.Properties.$ref.replace(/[#].*$/, "#/definitions/BlobItemProperties");
         $.BlobItem.properties.Properties = { "$ref": path };
+
+        $.BlobItemProperties.properties.CreatedOn = $.BlobItemProperties.properties.CreationTime;
+        $.BlobItemProperties.properties.CreatedOn.xml = {"name": "CreationTime"};
+        delete $.BlobItemProperties.properties.CreationTime;
+
+        $.BlobItemProperties.properties.CopyCompletedOn = $.BlobItemProperties.properties.CopyCompletionTime;
+        $.BlobItemProperties.properties.CopyCompletedOn.xml = {"name": "CopyCompletionTime"};
+        delete $.BlobItemProperties.properties.CopyCompletionTime;
+
+        $.BlobItemProperties.properties.DeletedOn = $.BlobItemProperties.properties.DeletedTime;
+        $.BlobItemProperties.properties.DeletedOn.xml = {"name": "DeletedTime"};
+        delete $.BlobItemProperties.properties.DeletedTime;
+
+        $.BlobItemProperties.properties.AccessTierChangedOn = $.BlobItemProperties.properties.AccessTierChangeTime;
+        $.BlobItemProperties.properties.AccessTierChangedOn.xml = {"name": "AccessTierChangeTime"};
+        delete $.BlobItemProperties.properties.AccessTierChangeTime;
     }
 - from: swagger-document
   where: $["x-ms-paths"]["/{containerName}/{blob}"]
@@ -503,6 +519,9 @@ directive:
     $.head.responses["200"].headers["Content-Language"].type = "array";
     $.head.responses["200"].headers["Content-Language"].collectionFormat = "csv";
     $.head.responses["200"].headers["Content-Language"].items = { "type": "string" };
+    $.head.responses["200"].headers["Content-MD5"]["x-ms-copy-completion-time"] = "CopyCompletedOn";
+    $.head.responses["200"].headers["Content-MD5"]["x-ms-creation-time"] = "CreatedOn";
+    $.head.responses["200"].headers["Content-MD5"]["x-ms-access-tier-change-time"] = "AccessTierChangedOn";
     $.head.responses["304"] = {
         "description": "The condition specified using HTTP conditional header(s) is not met.",
         "x-az-response-name": "ConditionNotMetError",
@@ -564,6 +583,9 @@ directive:
             const path = def["$ref"].replace(/[#].*$/, "#/definitions/BlobGeoReplication");
             $.BlobServiceStatistics.properties.GeoReplication = {"$ref": path};
         }
+        $.BlobGeoReplication.properties.LastSyncedOn = $.BlobGeoReplication.properties.LastSyncTime;
+        delete $.BlobGeoReplication.properties.LastSyncTime;
+        $.BlobGeoReplication.properties.LastSyncedOn.xml = { "name": "LastSyncTime" };
     }
 ```
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
@@ -86,8 +86,8 @@ namespace Azure.Storage.Blobs.Test
             Assert.AreEqual(String.Empty, sasQueryParameters.Identifier);
             Assert.AreEqual(constants.Sas.KeyObjectId, sasQueryParameters.KeyObjectId);
             Assert.AreEqual(constants.Sas.KeyTenantId, sasQueryParameters.KeyTenantId);
-            Assert.AreEqual(constants.Sas.KeyStart, sasQueryParameters.KeyStart);
-            Assert.AreEqual(constants.Sas.KeyExpiry, sasQueryParameters.KeyExpiry);
+            Assert.AreEqual(constants.Sas.KeyStart, sasQueryParameters.KeyStartsOn);
+            Assert.AreEqual(constants.Sas.KeyExpiry, sasQueryParameters.KeyExpiresOn);
             Assert.AreEqual(constants.Sas.KeyService, sasQueryParameters.KeyService);
             Assert.AreEqual(constants.Sas.KeyVersion, sasQueryParameters.KeyVersion);
             Assert.AreEqual(Constants.Sas.Resource.Container, sasQueryParameters.Resource);
@@ -148,8 +148,8 @@ namespace Azure.Storage.Blobs.Test
             Assert.AreEqual(String.Empty, sasQueryParameters.Identifier);
             Assert.AreEqual(constants.Sas.KeyObjectId, sasQueryParameters.KeyObjectId);
             Assert.AreEqual(constants.Sas.KeyTenantId, sasQueryParameters.KeyTenantId);
-            Assert.AreEqual(constants.Sas.KeyStart, sasQueryParameters.KeyStart);
-            Assert.AreEqual(constants.Sas.KeyExpiry, sasQueryParameters.KeyExpiry);
+            Assert.AreEqual(constants.Sas.KeyStart, sasQueryParameters.KeyStartsOn);
+            Assert.AreEqual(constants.Sas.KeyExpiry, sasQueryParameters.KeyExpiresOn);
             Assert.AreEqual(constants.Sas.KeyService, sasQueryParameters.KeyService);
             Assert.AreEqual(constants.Sas.KeyVersion, sasQueryParameters.KeyVersion);
             Assert.AreEqual(Constants.Sas.Resource.Blob, sasQueryParameters.Resource);
@@ -210,8 +210,8 @@ namespace Azure.Storage.Blobs.Test
             Assert.AreEqual(String.Empty, sasQueryParameters.Identifier);
             Assert.AreEqual(constants.Sas.KeyObjectId, sasQueryParameters.KeyObjectId);
             Assert.AreEqual(constants.Sas.KeyTenantId, sasQueryParameters.KeyTenantId);
-            Assert.AreEqual(constants.Sas.KeyStart, sasQueryParameters.KeyStart);
-            Assert.AreEqual(constants.Sas.KeyExpiry, sasQueryParameters.KeyExpiry);
+            Assert.AreEqual(constants.Sas.KeyStart, sasQueryParameters.KeyStartsOn);
+            Assert.AreEqual(constants.Sas.KeyExpiry, sasQueryParameters.KeyExpiresOn);
             Assert.AreEqual(constants.Sas.KeyService, sasQueryParameters.KeyService);
             Assert.AreEqual(constants.Sas.KeyVersion, sasQueryParameters.KeyVersion);
             Assert.AreEqual(Constants.Sas.Resource.BlobSnapshot, sasQueryParameters.Resource);

--- a/sdk/storage/Azure.Storage.Files/src/Generated/FileRestClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Generated/FileRestClient.cs
@@ -8845,12 +8845,12 @@ namespace Azure.Storage.Files.Models
         /// <summary>
         /// Time when the session that previously opened the handle has last been reconnected. (UTC)
         /// </summary>
-        public System.DateTimeOffset OpenTime { get; internal set; }
+        public System.DateTimeOffset? OpenedOn { get; internal set; }
 
         /// <summary>
         /// Time handle was last connected to (UTC)
         /// </summary>
-        public System.DateTimeOffset? LastReconnectTime { get; internal set; }
+        public System.DateTimeOffset? LastReconnectedOn { get; internal set; }
 
         /// <summary>
         /// Prevent direct instantiation of StorageFileHandle instances.
@@ -8901,12 +8901,12 @@ namespace Azure.Storage.Files.Models
             _child = element.Element(System.Xml.Linq.XName.Get("OpenTime", ""));
             if (_child != null)
             {
-                _value.OpenTime = System.DateTimeOffset.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
+                _value.OpenedOn = System.DateTimeOffset.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
             }
             _child = element.Element(System.Xml.Linq.XName.Get("LastReconnectTime", ""));
             if (_child != null)
             {
-                _value.LastReconnectTime = System.DateTimeOffset.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
+                _value.LastReconnectedOn = System.DateTimeOffset.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
             }
             CustomizeFromXml(element, _value);
             return _value;
@@ -8929,9 +8929,9 @@ namespace Azure.Storage.Files.Models
             string fileId,
             string sessionId,
             string clientIp,
-            System.DateTimeOffset openTime,
             string parentId = default,
-            System.DateTimeOffset? lastReconnectTime = default)
+            System.DateTimeOffset? openedOn = default,
+            System.DateTimeOffset? lastReconnectedOn = default)
         {
             return new StorageFileHandle()
             {
@@ -8940,9 +8940,9 @@ namespace Azure.Storage.Files.Models
                 FileId = fileId,
                 SessionId = sessionId,
                 ClientIp = clientIp,
-                OpenTime = openTime,
                 ParentId = parentId,
-                LastReconnectTime = lastReconnectTime,
+                OpenedOn = openedOn,
+                LastReconnectedOn = lastReconnectedOn,
             };
         }
     }

--- a/sdk/storage/Azure.Storage.Files/src/Models/FileSmbProperties.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Models/FileSmbProperties.cs
@@ -30,17 +30,17 @@ namespace Azure.Storage.Files.Models
         /// <summary>
         /// The creation time of the file.
         /// </summary>
-        public DateTimeOffset? FileCreationTime { get; set; }
+        public DateTimeOffset? FileCreatedOn { get; set; }
 
         /// <summary>
         /// The last write time of the file.
         /// </summary>
-        public DateTimeOffset? FileLastWriteTime { get; set; }
+        public DateTimeOffset? FileLastWrittenOn { get; set; }
 
         /// <summary>
         /// The change time of the file.
         /// </summary>
-        public DateTimeOffset? FileChangeTime { get; internal set; }
+        public DateTimeOffset? FileChangedOn { get; internal set; }
 
         /// <summary>
         /// The fileId of the file.
@@ -60,9 +60,9 @@ namespace Azure.Storage.Files.Models
         {
             FileAttributes = FileExtensions.ToFileAttributes(rawStorageFileInfo.FileAttributes);
             FilePermissionKey = rawStorageFileInfo.FilePermissionKey;
-            FileCreationTime = rawStorageFileInfo.FileCreationTime;
-            FileLastWriteTime = rawStorageFileInfo.FileLastWriteTime;
-            FileChangeTime = rawStorageFileInfo.FileChangeTime;
+            FileCreatedOn = rawStorageFileInfo.FileCreationTime;
+            FileLastWrittenOn = rawStorageFileInfo.FileLastWriteTime;
+            FileChangedOn = rawStorageFileInfo.FileChangeTime;
             FileId = rawStorageFileInfo.FileId;
             ParentId = rawStorageFileInfo.FileParentId;
 
@@ -72,9 +72,9 @@ namespace Azure.Storage.Files.Models
         {
             FileAttributes = FileExtensions.ToFileAttributes(rawStorageFileProperties.FileAttributes);
             FilePermissionKey = rawStorageFileProperties.FilePermissionKey;
-            FileCreationTime = rawStorageFileProperties.FileCreationTime;
-            FileLastWriteTime = rawStorageFileProperties.FileLastWriteTime;
-            FileChangeTime = rawStorageFileProperties.FileChangeTime;
+            FileCreatedOn = rawStorageFileProperties.FileCreationTime;
+            FileLastWrittenOn = rawStorageFileProperties.FileLastWriteTime;
+            FileChangedOn = rawStorageFileProperties.FileChangeTime;
             FileId = rawStorageFileProperties.FileId;
             ParentId = rawStorageFileProperties.FileParentId;
         }
@@ -83,9 +83,9 @@ namespace Azure.Storage.Files.Models
         {
             FileAttributes = FileExtensions.ToFileAttributes(flattenedStorageFileProperties.FileAttributes);
             FilePermissionKey = flattenedStorageFileProperties.FilePermissionKey;
-            FileCreationTime = flattenedStorageFileProperties.FileCreationTime;
-            FileLastWriteTime = flattenedStorageFileProperties.FileLastWriteTime;
-            FileChangeTime = flattenedStorageFileProperties.FileChangeTime;
+            FileCreatedOn = flattenedStorageFileProperties.FileCreationTime;
+            FileLastWrittenOn = flattenedStorageFileProperties.FileLastWriteTime;
+            FileChangedOn = flattenedStorageFileProperties.FileChangeTime;
             FileId = flattenedStorageFileProperties.FileId;
             ParentId = flattenedStorageFileProperties.FileParentId;
         }
@@ -94,9 +94,9 @@ namespace Azure.Storage.Files.Models
         {
             FileAttributes = FileExtensions.ToFileAttributes(rawStorageDirectoryInfo.FileAttributes);
             FilePermissionKey = rawStorageDirectoryInfo.FilePermissionKey;
-            FileCreationTime = rawStorageDirectoryInfo.FileCreationTime;
-            FileLastWriteTime = rawStorageDirectoryInfo.FileLastWriteTime;
-            FileChangeTime = rawStorageDirectoryInfo.FileChangeTime;
+            FileCreatedOn = rawStorageDirectoryInfo.FileCreationTime;
+            FileLastWrittenOn = rawStorageDirectoryInfo.FileLastWriteTime;
+            FileChangedOn = rawStorageDirectoryInfo.FileChangeTime;
             FileId = rawStorageDirectoryInfo.FileId;
             ParentId = rawStorageDirectoryInfo.FileParentId;
         }
@@ -105,9 +105,9 @@ namespace Azure.Storage.Files.Models
         {
             FileAttributes = FileExtensions.ToFileAttributes(rawStorageDirectoryProperties.FileAttributes);
             FilePermissionKey = rawStorageDirectoryProperties.FilePermissionKey;
-            FileCreationTime = rawStorageDirectoryProperties.FileCreationTime;
-            FileLastWriteTime = rawStorageDirectoryProperties.FileLastWriteTime;
-            FileChangeTime = rawStorageDirectoryProperties.FileChangeTime;
+            FileCreatedOn = rawStorageDirectoryProperties.FileCreationTime;
+            FileLastWrittenOn = rawStorageDirectoryProperties.FileLastWriteTime;
+            FileChangedOn = rawStorageDirectoryProperties.FileChangeTime;
             FileId = rawStorageDirectoryProperties.FileId;
             ParentId = rawStorageDirectoryProperties.FileParentId;
         }
@@ -129,10 +129,10 @@ namespace Azure.Storage.Files.Models
         public override int GetHashCode() => base.GetHashCode();
 
         internal string FileCreationTimeToString()
-            => NullableDateTimeOffsetToString(FileCreationTime);
+            => NullableDateTimeOffsetToString(FileCreatedOn);
 
         internal string FileLastWriteTimeToString()
-            => NullableDateTimeOffsetToString(FileLastWriteTime);
+            => NullableDateTimeOffsetToString(FileLastWrittenOn);
 
         private static string NullableDateTimeOffsetToString(DateTimeOffset? dateTimeOffset)
             => dateTimeOffset.HasValue ? DateTimeOffSetToString(dateTimeOffset.Value) : null;
@@ -149,11 +149,11 @@ namespace Azure.Storage.Files.Models
         /// Creates a new FileSmbProperties instance for mocking.
         /// </summary>
         public static FileSmbProperties FileSmbProperties(
-            DateTimeOffset? fileChangeTime,
+            DateTimeOffset? fileChangedOn,
             string fileId,
             string parentId) => new FileSmbProperties
             {
-                FileChangeTime = fileChangeTime,
+                FileChangedOn = fileChangedOn,
                 FileId = fileId,
                 ParentId = parentId
             };

--- a/sdk/storage/Azure.Storage.Files/src/Models/StorageFileDownloadDetails.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Models/StorageFileDownloadDetails.cs
@@ -66,7 +66,7 @@ namespace Azure.Storage.Files.Models
         /// <summary>
         /// Conclusion time of the last attempted Copy File operation where this file was the destination file. This value can specify the time of a completed, aborted, or failed copy attempt.
         /// </summary>
-        public DateTimeOffset CopyCompletionTime => _flattened.CopyCompletionTime;
+        public DateTimeOffset CopyCompletedOn => _flattened.CopyCompletionTime;
 
         /// <summary>
         /// Only appears when x-ms-copy-status is failed or pending. Describes cause of fatal or non-fatal copy operation failure.
@@ -136,7 +136,7 @@ namespace Azure.Storage.Files.Models
             string contentDisposition,
             IEnumerable<string> contentLanguage,
             string acceptRanges,
-            DateTimeOffset copyCompletionTime,
+            DateTimeOffset copyCompletedOn,
             string copyStatusDescription,
             string copyId,
             string copyProgress,
@@ -157,7 +157,7 @@ namespace Azure.Storage.Files.Models
                 ContentDisposition = contentDisposition,
                 ContentLanguage = contentLanguage,
                 AcceptRanges = acceptRanges,
-                CopyCompletionTime = copyCompletionTime,
+                CopyCompletionTime = copyCompletedOn,
                 CopyStatusDescription = copyStatusDescription,
                 CopyId = copyId,
                 CopyProgress = copyProgress,

--- a/sdk/storage/Azure.Storage.Files/src/Models/StorageFileProperties.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Models/StorageFileProperties.cs
@@ -73,7 +73,7 @@ namespace Azure.Storage.Files.Models
         /// <summary>
         /// Conclusion time of the last attempted Copy File operation where this file was the destination file. This value can specify the time of a completed, aborted, or failed copy attempt.
         /// </summary>
-        public DateTimeOffset CopyCompletionTime => _rawStorageFileProperties.CopyCompletionTime;
+        public DateTimeOffset CopyCompletedOn => _rawStorageFileProperties.CopyCompletionTime;
 
         /// <summary>
         /// Only appears when x-ms-copy-status is failed or pending. Describes cause of fatal or non-fatal copy operation failure.
@@ -136,7 +136,7 @@ namespace Azure.Storage.Files.Models
             string cacheControl,
             string contentDisposition,
             IEnumerable<string> contentLanguage,
-            DateTimeOffset copyCompletionTime,
+            DateTimeOffset copyCompletedOn,
             string copyStatusDescription,
             string copyId,
             string copyProgress,
@@ -162,7 +162,7 @@ namespace Azure.Storage.Files.Models
                 CacheControl = cacheControl,
                 ContentDisposition = contentDisposition,
                 ContentLanguage = contentLanguage,
-                CopyCompletionTime = copyCompletionTime,
+                CopyCompletionTime = copyCompletedOn,
                 CopyStatusDescription = copyStatusDescription,
                 CopyId = copyId,
                 CopyProgress = copyProgress,

--- a/sdk/storage/Azure.Storage.Files/swagger/readme.md
+++ b/sdk/storage/Azure.Storage.Files/swagger/readme.md
@@ -333,6 +333,12 @@ directive:
     if (!$.StorageFileHandle) {
         $.StorageFileHandle = $.HandleItem;
         delete $.HandleItem;
+        $.StorageFileHandle.properties.OpenedOn = $.StorageFileHandle.properties.OpenTime;
+        $.StorageFileHandle.properties.OpenedOn.xml = { "name": "OpenTime" };
+        delete $.StorageFileHandle.properties.OpenTime;
+        $.StorageFileHandle.properties.LastReconnectedOn = $.StorageFileHandle.properties.LastReconnectTime;
+        $.StorageFileHandle.properties.LastReconnectedOn.xml = { "name": "LastReconnectTime" };
+        delete $.StorageFileHandle.properties.LastReconnectTime;
     }
     if (!$.StorageHandlesSegment) {
         $.StorageHandlesSegment = $.ListHandlesResponse;

--- a/sdk/storage/Azure.Storage.Files/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files/tests/DirectoryClientTests.cs
@@ -175,8 +175,8 @@ namespace Azure.Storage.Files.Test
                 {
                     FilePermissionKey = createPermissionResponse.Value.FilePermissionKey,
                     FileAttributes = FileExtensions.ToFileAttributes("Directory|ReadOnly"),
-                    FileCreationTime = new DateTimeOffset(2019, 8, 15, 5, 15, 25, 60, TimeSpan.Zero),
-                    FileLastWriteTime = new DateTimeOffset(2019, 8, 26, 5, 15, 25, 60, TimeSpan.Zero),
+                    FileCreatedOn = new DateTimeOffset(2019, 8, 15, 5, 15, 25, 60, TimeSpan.Zero),
+                    FileLastWrittenOn = new DateTimeOffset(2019, 8, 26, 5, 15, 25, 60, TimeSpan.Zero),
                 };
 
                 // Act
@@ -185,8 +185,8 @@ namespace Azure.Storage.Files.Test
                 // Assert
                 AssertValidStorageDirectoryInfo(response);
                 //Assert.AreEqual(smbProperties.FileAttributes, response.Value.SmbProperties.Value.FileAttributes);
-                Assert.AreEqual(smbProperties.FileCreationTime, response.Value.SmbProperties.FileCreationTime);
-                Assert.AreEqual(smbProperties.FileLastWriteTime, response.Value.SmbProperties.FileLastWriteTime);
+                Assert.AreEqual(smbProperties.FileCreatedOn, response.Value.SmbProperties.FileCreatedOn);
+                Assert.AreEqual(smbProperties.FileLastWrittenOn, response.Value.SmbProperties.FileLastWrittenOn);
             }
         }
 
@@ -319,8 +319,8 @@ namespace Azure.Storage.Files.Test
                 {
                     FilePermissionKey = createPermissionResponse.Value.FilePermissionKey,
                     FileAttributes = FileExtensions.ToFileAttributes("Directory|ReadOnly"),
-                    FileCreationTime = new DateTimeOffset(2019, 8, 15, 5, 15, 25, 60, TimeSpan.Zero),
-                    FileLastWriteTime = new DateTimeOffset(2019, 8, 26, 5, 15, 25, 60, TimeSpan.Zero),
+                    FileCreatedOn = new DateTimeOffset(2019, 8, 15, 5, 15, 25, 60, TimeSpan.Zero),
+                    FileLastWrittenOn = new DateTimeOffset(2019, 8, 26, 5, 15, 25, 60, TimeSpan.Zero),
                 };
 
 
@@ -332,8 +332,8 @@ namespace Azure.Storage.Files.Test
                 // Assert
                 AssertValidStorageDirectoryInfo(response);
                 Assert.AreEqual(smbProperties.FileAttributes, response.Value.SmbProperties.FileAttributes);
-                Assert.AreEqual(smbProperties.FileCreationTime, response.Value.SmbProperties.FileCreationTime);
-                Assert.AreEqual(smbProperties.FileLastWriteTime, response.Value.SmbProperties.FileLastWriteTime);
+                Assert.AreEqual(smbProperties.FileCreatedOn, response.Value.SmbProperties.FileCreatedOn);
+                Assert.AreEqual(smbProperties.FileLastWrittenOn, response.Value.SmbProperties.FileLastWrittenOn);
             }
         }
 

--- a/sdk/storage/Azure.Storage.Files/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files/tests/FileClientTests.cs
@@ -194,8 +194,8 @@ namespace Azure.Storage.Files.Test
                 {
                     FilePermissionKey = createPermissionResponse.Value.FilePermissionKey,
                     FileAttributes = FileExtensions.ToFileAttributes("Archive|ReadOnly"),
-                    FileCreationTime = new DateTimeOffset(2019, 8, 15, 5, 15, 25, 60, TimeSpan.Zero),
-                    FileLastWriteTime = new DateTimeOffset(2019, 8, 26, 5, 15, 25, 60, TimeSpan.Zero),
+                    FileCreatedOn = new DateTimeOffset(2019, 8, 15, 5, 15, 25, 60, TimeSpan.Zero),
+                    FileLastWrittenOn = new DateTimeOffset(2019, 8, 26, 5, 15, 25, 60, TimeSpan.Zero),
                 };
 
                 // Act
@@ -206,8 +206,8 @@ namespace Azure.Storage.Files.Test
                 // Assert
                 AssertValidStorageFileInfo(response);
                 Assert.AreEqual(smbProperties.FileAttributes, response.Value.SmbProperties.FileAttributes);
-                Assert.AreEqual(smbProperties.FileCreationTime, response.Value.SmbProperties.FileCreationTime);
-                Assert.AreEqual(smbProperties.FileLastWriteTime, response.Value.SmbProperties.FileLastWriteTime);
+                Assert.AreEqual(smbProperties.FileCreatedOn, response.Value.SmbProperties.FileCreatedOn);
+                Assert.AreEqual(smbProperties.FileLastWrittenOn, response.Value.SmbProperties.FileLastWrittenOn);
             }
         }
 
@@ -471,8 +471,8 @@ namespace Azure.Storage.Files.Test
                 {
                     FilePermissionKey = createPermissionResponse.Value.FilePermissionKey,
                     FileAttributes = FileExtensions.ToFileAttributes("Archive|ReadOnly"),
-                    FileCreationTime = new DateTimeOffset(2019, 8, 15, 5, 15, 25, 60, TimeSpan.Zero),
-                    FileLastWriteTime = new DateTimeOffset(2019, 8, 26, 5, 15, 25, 60, TimeSpan.Zero),
+                    FileCreatedOn = new DateTimeOffset(2019, 8, 15, 5, 15, 25, 60, TimeSpan.Zero),
+                    FileLastWrittenOn = new DateTimeOffset(2019, 8, 26, 5, 15, 25, 60, TimeSpan.Zero),
                 };
 
 
@@ -484,8 +484,8 @@ namespace Azure.Storage.Files.Test
                 // Assert
                 AssertValidStorageFileInfo(response);
                 Assert.AreEqual(smbProperties.FileAttributes, response.Value.SmbProperties.FileAttributes);
-                Assert.AreEqual(smbProperties.FileCreationTime, response.Value.SmbProperties.FileCreationTime);
-                Assert.AreEqual(smbProperties.FileLastWriteTime, response.Value.SmbProperties.FileLastWriteTime);
+                Assert.AreEqual(smbProperties.FileCreatedOn, response.Value.SmbProperties.FileCreatedOn);
+                Assert.AreEqual(smbProperties.FileLastWrittenOn, response.Value.SmbProperties.FileLastWrittenOn);
             }
         }
 
@@ -777,7 +777,7 @@ namespace Azure.Storage.Files.Test
                 Assert.AreEqual(getPropertiesResponse.Value.CacheControl, downloadResponse.Value.Details.CacheControl);
                 Assert.AreEqual(getPropertiesResponse.Value.ContentDisposition, downloadResponse.Value.Details.ContentDisposition);
                 Assert.AreEqual(getPropertiesResponse.Value.ContentLanguage, downloadResponse.Value.Details.ContentLanguage);
-                Assert.AreEqual(getPropertiesResponse.Value.CopyCompletionTime, downloadResponse.Value.Details.CopyCompletionTime);
+                Assert.AreEqual(getPropertiesResponse.Value.CopyCompletedOn, downloadResponse.Value.Details.CopyCompletedOn);
                 Assert.AreEqual(getPropertiesResponse.Value.CopyStatusDescription, downloadResponse.Value.Details.CopyStatusDescription);
                 Assert.AreEqual(getPropertiesResponse.Value.CopyId, downloadResponse.Value.Details.CopyId);
                 Assert.AreEqual(getPropertiesResponse.Value.CopyProgress, downloadResponse.Value.Details.CopyProgress);

--- a/sdk/storage/Azure.Storage.Files/tests/FileTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files/tests/FileTestBase.cs
@@ -203,9 +203,9 @@ namespace Azure.Storage.Files.Tests
         {
             Assert.IsNotNull(fileSmbProperties.FileAttributes);
             Assert.IsNotNull(fileSmbProperties.FilePermissionKey);
-            Assert.IsNotNull(fileSmbProperties.FileCreationTime);
-            Assert.IsNotNull(fileSmbProperties.FileLastWriteTime);
-            Assert.IsNotNull(fileSmbProperties.FileChangeTime);
+            Assert.IsNotNull(fileSmbProperties.FileCreatedOn);
+            Assert.IsNotNull(fileSmbProperties.FileLastWrittenOn);
+            Assert.IsNotNull(fileSmbProperties.FileChangedOn);
             Assert.IsNotNull(fileSmbProperties.FileId);
             Assert.IsNotNull(fileSmbProperties.ParentId);
         }
@@ -213,10 +213,10 @@ namespace Azure.Storage.Files.Tests
         internal static void AssertPropertiesEqual(FileSmbProperties left, FileSmbProperties right)
         {
             Assert.AreEqual(left.FileAttributes, right.FileAttributes);
-            Assert.AreEqual(left.FileCreationTime, right.FileCreationTime);
-            Assert.AreEqual(left.FileChangeTime, right.FileChangeTime);
+            Assert.AreEqual(left.FileCreatedOn, right.FileCreatedOn);
+            Assert.AreEqual(left.FileChangedOn, right.FileChangedOn);
             Assert.AreEqual(left.FileId, right.FileId);
-            Assert.AreEqual(left.FileLastWriteTime, right.FileLastWriteTime);
+            Assert.AreEqual(left.FileLastWrittenOn, right.FileLastWrittenOn);
             Assert.AreEqual(left.FilePermissionKey, right.FilePermissionKey);
             Assert.AreEqual(left.ParentId, right.ParentId);
         }

--- a/sdk/storage/Azure.Storage.Queues/src/Generated/QueueRestClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Generated/QueueRestClient.cs
@@ -2148,7 +2148,7 @@ namespace Azure.Storage.Queues
                         }
                         if (response.Headers.TryGetValue("x-ms-time-next-visible", out _header))
                         {
-                            _value.TimeNextVisible = System.DateTimeOffset.Parse(_header, System.Globalization.CultureInfo.InvariantCulture);
+                            _value.NextVisibleOn = System.DateTimeOffset.Parse(_header, System.Globalization.CultureInfo.InvariantCulture);
                         }
 
                         // Create the response
@@ -2363,24 +2363,24 @@ namespace Azure.Storage.Queues.Models
         public string MessageId { get; internal set; }
 
         /// <summary>
+        /// The content of the Message.
+        /// </summary>
+        public string MessageText { get; internal set; }
+
+        /// <summary>
         /// The time the Message was inserted into the Queue.
         /// </summary>
-        public System.DateTimeOffset InsertionTime { get; internal set; }
+        public System.DateTimeOffset? InsertedOn { get; internal set; }
 
         /// <summary>
         /// The time that the Message will expire and be automatically deleted.
         /// </summary>
-        public System.DateTimeOffset ExpirationTime { get; internal set; }
+        public System.DateTimeOffset? ExpiresOn { get; internal set; }
 
         /// <summary>
         /// The number of times the message has been dequeued.
         /// </summary>
         public long DequeueCount { get; internal set; }
-
-        /// <summary>
-        /// The content of the Message.
-        /// </summary>
-        public string MessageText { get; internal set; }
 
         /// <summary>
         /// Prevent direct instantiation of PeekedMessage instances.
@@ -2403,25 +2403,25 @@ namespace Azure.Storage.Queues.Models
             {
                 _value.MessageId = _child.Value;
             }
+            _child = element.Element(System.Xml.Linq.XName.Get("MessageText", ""));
+            if (_child != null)
+            {
+                _value.MessageText = _child.Value;
+            }
             _child = element.Element(System.Xml.Linq.XName.Get("InsertionTime", ""));
             if (_child != null)
             {
-                _value.InsertionTime = System.DateTimeOffset.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
+                _value.InsertedOn = System.DateTimeOffset.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
             }
             _child = element.Element(System.Xml.Linq.XName.Get("ExpirationTime", ""));
             if (_child != null)
             {
-                _value.ExpirationTime = System.DateTimeOffset.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
+                _value.ExpiresOn = System.DateTimeOffset.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
             }
             _child = element.Element(System.Xml.Linq.XName.Get("DequeueCount", ""));
             if (_child != null)
             {
                 _value.DequeueCount = long.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
-            }
-            _child = element.Element(System.Xml.Linq.XName.Get("MessageText", ""));
-            if (_child != null)
-            {
-                _value.MessageText = _child.Value;
             }
             CustomizeFromXml(element, _value);
             return _value;
@@ -2440,18 +2440,18 @@ namespace Azure.Storage.Queues.Models
         /// </summary>
         public static PeekedMessage PeekedMessage(
             string messageId,
-            System.DateTimeOffset insertionTime,
-            System.DateTimeOffset expirationTime,
+            string messageText,
             long dequeueCount,
-            string messageText)
+            System.DateTimeOffset? insertedOn = default,
+            System.DateTimeOffset? expiresOn = default)
         {
             return new PeekedMessage()
             {
                 MessageId = messageId,
-                InsertionTime = insertionTime,
-                ExpirationTime = expirationTime,
-                DequeueCount = dequeueCount,
                 MessageText = messageText,
+                DequeueCount = dequeueCount,
+                InsertedOn = insertedOn,
+                ExpiresOn = expiresOn,
             };
         }
     }
@@ -3169,7 +3169,7 @@ namespace Azure.Storage.Queues.Models
         /// <summary>
         /// A GMT date/time value, to the second. All primary writes preceding this value are guaranteed to be available for read operations at the secondary. Primary writes after this point in time may or may not be available for reads.
         /// </summary>
-        public System.DateTimeOffset LastSyncTime { get; internal set; }
+        public System.DateTimeOffset? LastSyncedOn { get; internal set; }
 
         /// <summary>
         /// Prevent direct instantiation of QueueGeoReplication instances.
@@ -3195,7 +3195,7 @@ namespace Azure.Storage.Queues.Models
             _child = element.Element(System.Xml.Linq.XName.Get("LastSyncTime", ""));
             if (_child != null)
             {
-                _value.LastSyncTime = System.DateTimeOffset.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
+                _value.LastSyncedOn = System.DateTimeOffset.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
             }
             CustomizeFromXml(element, _value);
             return _value;
@@ -3214,12 +3214,12 @@ namespace Azure.Storage.Queues.Models
         /// </summary>
         public static QueueGeoReplication QueueGeoReplication(
             Azure.Storage.Queues.Models.QueueGeoReplicationStatus status,
-            System.DateTimeOffset lastSyncTime)
+            System.DateTimeOffset? lastSyncedOn = default)
         {
             return new QueueGeoReplication()
             {
                 Status = status,
-                LastSyncTime = lastSyncTime,
+                LastSyncedOn = lastSyncedOn,
             };
         }
     }
@@ -3390,34 +3390,34 @@ namespace Azure.Storage.Queues.Models
         public string MessageId { get; internal set; }
 
         /// <summary>
-        /// The time the Message was inserted into the Queue.
-        /// </summary>
-        public System.DateTimeOffset InsertionTime { get; internal set; }
-
-        /// <summary>
-        /// The time that the Message will expire and be automatically deleted.
-        /// </summary>
-        public System.DateTimeOffset ExpirationTime { get; internal set; }
-
-        /// <summary>
         /// This value is required to delete the Message. If deletion fails using this popreceipt then the message has been dequeued by another client.
         /// </summary>
         public string PopReceipt { get; internal set; }
 
         /// <summary>
+        /// The content of the Message.
+        /// </summary>
+        public string MessageText { get; internal set; }
+
+        /// <summary>
         /// The time that the message will again become visible in the Queue.
         /// </summary>
-        public System.DateTimeOffset TimeNextVisible { get; internal set; }
+        public System.DateTimeOffset? NextVisibleOn { get; internal set; }
+
+        /// <summary>
+        /// The time the Message was inserted into the Queue.
+        /// </summary>
+        public System.DateTimeOffset? InsertedOn { get; internal set; }
+
+        /// <summary>
+        /// The time that the Message will expire and be automatically deleted.
+        /// </summary>
+        public System.DateTimeOffset? ExpiresOn { get; internal set; }
 
         /// <summary>
         /// The number of times the message has been dequeued.
         /// </summary>
         public long DequeueCount { get; internal set; }
-
-        /// <summary>
-        /// The content of the Message.
-        /// </summary>
-        public string MessageText { get; internal set; }
 
         /// <summary>
         /// Prevent direct instantiation of QueueMessage instances.
@@ -3440,35 +3440,35 @@ namespace Azure.Storage.Queues.Models
             {
                 _value.MessageId = _child.Value;
             }
-            _child = element.Element(System.Xml.Linq.XName.Get("InsertionTime", ""));
-            if (_child != null)
-            {
-                _value.InsertionTime = System.DateTimeOffset.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
-            }
-            _child = element.Element(System.Xml.Linq.XName.Get("ExpirationTime", ""));
-            if (_child != null)
-            {
-                _value.ExpirationTime = System.DateTimeOffset.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
-            }
             _child = element.Element(System.Xml.Linq.XName.Get("PopReceipt", ""));
             if (_child != null)
             {
                 _value.PopReceipt = _child.Value;
             }
+            _child = element.Element(System.Xml.Linq.XName.Get("MessageText", ""));
+            if (_child != null)
+            {
+                _value.MessageText = _child.Value;
+            }
             _child = element.Element(System.Xml.Linq.XName.Get("TimeNextVisible", ""));
             if (_child != null)
             {
-                _value.TimeNextVisible = System.DateTimeOffset.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
+                _value.NextVisibleOn = System.DateTimeOffset.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
+            }
+            _child = element.Element(System.Xml.Linq.XName.Get("InsertionTime", ""));
+            if (_child != null)
+            {
+                _value.InsertedOn = System.DateTimeOffset.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
+            }
+            _child = element.Element(System.Xml.Linq.XName.Get("ExpirationTime", ""));
+            if (_child != null)
+            {
+                _value.ExpiresOn = System.DateTimeOffset.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
             }
             _child = element.Element(System.Xml.Linq.XName.Get("DequeueCount", ""));
             if (_child != null)
             {
                 _value.DequeueCount = long.Parse(_child.Value, System.Globalization.CultureInfo.InvariantCulture);
-            }
-            _child = element.Element(System.Xml.Linq.XName.Get("MessageText", ""));
-            if (_child != null)
-            {
-                _value.MessageText = _child.Value;
             }
             CustomizeFromXml(element, _value);
             return _value;
@@ -3487,22 +3487,22 @@ namespace Azure.Storage.Queues.Models
         /// </summary>
         public static QueueMessage QueueMessage(
             string messageId,
-            System.DateTimeOffset insertionTime,
-            System.DateTimeOffset expirationTime,
             string popReceipt,
-            System.DateTimeOffset timeNextVisible,
+            string messageText,
             long dequeueCount,
-            string messageText)
+            System.DateTimeOffset? nextVisibleOn = default,
+            System.DateTimeOffset? insertedOn = default,
+            System.DateTimeOffset? expiresOn = default)
         {
             return new QueueMessage()
             {
                 MessageId = messageId,
-                InsertionTime = insertionTime,
-                ExpirationTime = expirationTime,
                 PopReceipt = popReceipt,
-                TimeNextVisible = timeNextVisible,
-                DequeueCount = dequeueCount,
                 MessageText = messageText,
+                DequeueCount = dequeueCount,
+                NextVisibleOn = nextVisibleOn,
+                InsertedOn = insertedOn,
+                ExpiresOn = expiresOn,
             };
         }
     }
@@ -4383,7 +4383,7 @@ namespace Azure.Storage.Queues.Models
         /// <summary>
         /// A UTC date/time value that represents when the message will be visible on the queue.
         /// </summary>
-        public System.DateTimeOffset TimeNextVisible { get; internal set; }
+        public System.DateTimeOffset NextVisibleOn { get; internal set; }
 
         /// <summary>
         /// Prevent direct instantiation of UpdateReceipt instances.
@@ -4402,12 +4402,12 @@ namespace Azure.Storage.Queues.Models
         /// </summary>
         public static UpdateReceipt UpdateReceipt(
             string popReceipt,
-            System.DateTimeOffset timeNextVisible)
+            System.DateTimeOffset nextVisibleOn)
         {
             return new UpdateReceipt()
             {
                 PopReceipt = popReceipt,
-                TimeNextVisible = timeNextVisible,
+                NextVisibleOn = nextVisibleOn,
             };
         }
     }

--- a/sdk/storage/Azure.Storage.Queues/src/Models/QueueMessage.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Models/QueueMessage.cs
@@ -25,11 +25,11 @@ namespace Azure.Storage.Queues.Models
         public QueueMessage Update(UpdateReceipt updated) =>
             QueuesModelFactory.QueueMessage(
                 MessageId,
-                InsertionTime,
-                ExpirationTime,
                 updated.PopReceipt,
-                updated.TimeNextVisible,
+                MessageText,
                 DequeueCount,
-                MessageText);
+                updated.NextVisibleOn,
+                InsertedOn,
+                ExpiresOn);
     }
 }

--- a/sdk/storage/Azure.Storage.Queues/swagger/readme.md
+++ b/sdk/storage/Azure.Storage.Queues/swagger/readme.md
@@ -167,6 +167,7 @@ directive:
   where: $["x-ms-paths"]["/{queueName}/messages/{messageid}?popreceipt={popReceipt}&visibilitytimeout={visibilityTimeout}"]
   transform: >
     $.put.responses["204"]["x-az-response-name"] = "UpdateReceipt";
+    $.put.responses["204"].headers["x-ms-time-next-visible"]["x-ms-client-name"] = "NextVisibleOn";
 ```
 
 ### QueueErrorCode
@@ -195,6 +196,9 @@ directive:
             const path = def["$ref"].replace(/[#].*$/, "#/definitions/QueueGeoReplication");
             $.QueueServiceStatistics.properties.GeoReplication = {"$ref": path};
         }
+        $.QueueGeoReplication.properties.LastSyncedOn = $.QueueGeoReplication.properties.LastSyncTime;
+        delete $.QueueGeoReplication.properties.LastSyncTime;
+        $.QueueGeoReplication.properties.LastSyncedOn.xml = { "name": "LastSyncTime" };
     }
 ```
 
@@ -245,6 +249,22 @@ directive:
     if (!$.QueueMessage) {
         $.QueueMessage = $.DequeuedMessageItem;
         delete $.DequeuedMessageItem;
+
+        $.QueueMessage.properties.NextVisibleOn = $.QueueMessage.properties.TimeNextVisible;
+        $.QueueMessage.properties.NextVisibleOn.xml = {"name": "TimeNextVisible"};
+        delete $.QueueMessage.properties.TimeNextVisible;
+
+        $.QueueMessage.properties.InsertedOn = $.QueueMessage.properties.InsertionTime;
+        $.QueueMessage.properties.InsertedOn.xml = {"name": "InsertionTime"};
+        delete $.QueueMessage.properties.InsertionTime;
+
+        $.QueueMessage.properties.ExpiresOn = $.QueueMessage.properties.ExpirationTime;
+        $.QueueMessage.properties.ExpiresOn.xml = {"name": "ExpirationTime"};
+        delete $.QueueMessage.properties.ExpirationTime;
+
+        const count = $.QueueMessage.properties.DequeueCount;
+        delete $.QueueMessage.properties.DequeueCount;
+        $.QueueMessage.properties.DequeueCount = count;
     }
 - from: swagger-document
   where: $.definitions.DequeuedMessagesList
@@ -276,6 +296,25 @@ directive:
     }
 ```
 
+### EnqueuedMessage
+``` yaml
+directive:
+- from: swagger-document
+  where: $.definitions.EnqueuedMessage
+  transform: >
+    $.properties.NextVisibleOn = $.properties.TimeNextVisible;
+    $.properties.NextVisibleOn.xml = {"name": "TimeNextVisible"};
+    delete $.properties.TimeNextVisible;
+
+    $.properties.InsertedOn = $.properties.InsertionTime;
+    $.properties.InsertedOn.xml = {"name": "InsertionTime"};
+    delete $.properties.InsertionTime;
+
+    $.properties.ExpiresOn = $.properties.ExpirationTime;
+    $.properties.ExpiresOn.xml = {"name": "ExpirationTime"};
+    delete $.properties.ExpirationTime;
+```
+
 ### PeekedMessage
 ``` yaml
 directive:
@@ -285,6 +324,18 @@ directive:
     if (!$.PeekedMessage) {
         $.PeekedMessage = $.PeekedMessageItem;
         delete $.PeekedMessageItem;
+
+        $.PeekedMessage.properties.InsertedOn = $.PeekedMessage.properties.InsertionTime;
+        $.PeekedMessage.properties.InsertedOn.xml = {"name": "InsertionTime"};
+        delete $.PeekedMessage.properties.InsertionTime;
+
+        $.PeekedMessage.properties.ExpiresOn = $.PeekedMessage.properties.ExpirationTime;
+        $.PeekedMessage.properties.ExpiresOn.xml = {"name": "ExpirationTime"};
+        delete $.PeekedMessage.properties.ExpirationTime;
+
+        const count = $.PeekedMessage.properties.DequeueCount;
+        delete $.PeekedMessage.properties.DequeueCount;
+        $.PeekedMessage.properties.DequeueCount = count;
     }
 - from: swagger-document
   where: $.definitions.PeekedMessagesList

--- a/sdk/storage/Azure.Storage.Queues/tests/MessageIdClientTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/MessageIdClientTests.cs
@@ -1,0 +1,181 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Azure.Core.Testing;
+using Azure.Storage.Queues.Tests;
+using Azure.Storage.Test;
+using NUnit.Framework;
+
+namespace Azure.Storage.Queues.Test
+{
+    public class MessageIdClientTests : QueueTestBase
+    {
+        public MessageIdClientTests(bool async)
+            : base(async, null /* RecordedTestMode.Record /* to re-record */)
+        {
+        }
+
+        [Test]
+        public async Task DeleteAsync()
+        {
+            // Arrange
+            using (GetNewQueue(out QueueClient queue))
+            {
+                Models.SendReceipt enqueuedMessage = (await queue.SendMessageAsync(string.Empty)).Value;
+
+                // Act
+                Response result = await queue.DeleteMessageAsync(enqueuedMessage.MessageId, enqueuedMessage.PopReceipt);
+
+                // Assert
+                Assert.IsNotNull(result.Headers.RequestId);
+            }
+        }
+
+        [Test]
+        public async Task DeleteAsync_Error()
+        {
+            // Arrange
+            using (GetNewQueue(out QueueClient queue))
+            {
+                // Act
+                await TestHelper.AssertExpectedExceptionAsync<RequestFailedException>(
+                    queue.DeleteMessageAsync(GetNewMessageId(), GetNewString()),
+                    actualException => Assert.AreEqual("MessageNotFound", actualException.ErrorCode));
+            }
+        }
+
+        [Test]
+        public async Task DeleteAsync_DeletePeek()
+        {
+            // Arrange
+            using (GetNewQueue(out QueueClient queue))
+            {
+                Models.SendReceipt enqueuedMessage = (await queue.SendMessageAsync(string.Empty)).Value;
+
+                // Act
+                Response result = await queue.DeleteMessageAsync(enqueuedMessage.MessageId, enqueuedMessage.PopReceipt);
+
+                // Assert
+                await queue.PeekMessagesAsync();
+                Assert.IsNotNull(result.Headers.RequestId);
+            }
+        }
+
+        [Test]
+        public async Task UpdateAsync_Update()
+        {
+            // Arrange
+            using (GetNewQueue(out QueueClient queue))
+            {
+                var message0 = "foo";
+                var message1 = "bar";
+
+                Models.SendReceipt enqueuedMessage = (await queue.SendMessageAsync(message0)).Value;
+
+                // Act
+                Response<Models.UpdateReceipt> result = await queue.UpdateMessageAsync(
+                    enqueuedMessage.MessageId,
+                    enqueuedMessage.PopReceipt,
+                    message1,
+                    new TimeSpan(100));
+
+                // Assert
+                Assert.IsNotNull(result.GetRawResponse().Headers.RequestId);
+            }
+        }
+
+        [Test]
+        public async Task UpdateAsync_Min()
+        {
+            // Arrange
+            using (GetNewQueue(out QueueClient queue))
+            {
+                var message0 = "foo";
+                var message1 = "bar";
+
+                Models.SendReceipt enqueuedMessage = (await queue.SendMessageAsync(message0)).Value;
+
+                // Act
+                Response<Models.UpdateReceipt> result = await queue.UpdateMessageAsync(
+                    enqueuedMessage.MessageId,
+                    enqueuedMessage.PopReceipt,
+                    message1);
+
+                // Assert
+                Assert.IsNotNull(result.GetRawResponse().Headers.RequestId);
+            }
+        }
+
+        [Test]
+        public async Task UpdateAsync_UpdateDequeuedMessage()
+        {
+            using (GetNewQueue(out QueueClient queue))
+            {
+                var message0 = "foo";
+                var message1 = "bar";
+
+                await queue.SendMessageAsync(message0);
+                Models.QueueMessage message = (await queue.ReceiveMessagesAsync(1)).Value.First();
+
+                Response<Models.UpdateReceipt> update = await queue.UpdateMessageAsync(
+                    message.MessageId,
+                    message.PopReceipt,
+                    message1);
+
+                Assert.AreNotEqual(update.Value.PopReceipt, message.PopReceipt);
+                Assert.AreNotEqual(update.Value.NextVisibleOn, message.NextVisibleOn);
+
+                Models.QueueMessage newMessage = message.Update(update);
+                Assert.AreEqual(message.MessageId, newMessage.MessageId);
+                Assert.AreEqual(message.MessageText, newMessage.MessageText);
+                Assert.AreEqual(message.InsertedOn, newMessage.InsertedOn);
+                Assert.AreEqual(message.ExpiresOn, newMessage.ExpiresOn);
+                Assert.AreEqual(message.DequeueCount, newMessage.DequeueCount);
+                Assert.AreNotEqual(message.PopReceipt, newMessage.PopReceipt);
+                Assert.AreNotEqual(message.NextVisibleOn, newMessage.NextVisibleOn);
+                Assert.AreEqual(update.Value.PopReceipt, newMessage.PopReceipt);
+                Assert.AreEqual(update.Value.NextVisibleOn, newMessage.NextVisibleOn);
+            }
+        }
+
+        [Test]
+        public async Task UpdateAsync_UpdatePeek()
+        {
+            // Arrange
+            using (GetNewQueue(out QueueClient queue))
+            {
+                var message0 = "foo";
+                var message1 = "bar";
+
+                Models.SendReceipt enqueuedMessage = (await queue.SendMessageAsync(message0)).Value;
+
+                // Act
+                await queue.UpdateMessageAsync(enqueuedMessage.MessageId, enqueuedMessage.PopReceipt, message1);
+
+                // Assert
+                Response<Models.PeekedMessage[]> peekedMessages = await queue.PeekMessagesAsync(1);
+                Models.PeekedMessage peekedMessage = peekedMessages.Value.First();
+
+                Assert.AreEqual(1, peekedMessages.Value.Count());
+                Assert.AreEqual(message1, peekedMessage.MessageText);
+            }
+        }
+
+        [Test]
+        public async Task UpdateAsync_Error()
+        {
+            // Arrange
+            using (GetNewQueue(out QueueClient queue))
+            {
+                // Act
+                await TestHelper.AssertExpectedExceptionAsync<RequestFailedException>(
+                    queue.UpdateMessageAsync(GetNewMessageId(), GetNewString(), string.Empty),
+                    actualException => Assert.AreEqual("MessageNotFound", actualException.ErrorCode));
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #8155 to change `Expiry` to `ExpiresOn`, etc.