### PR TITLE
[Event Hubs Client] Track Two: Fifth Preview (Telemetry Properties)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/ClientLibraryInformation.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/ClientLibraryInformation.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using System.Globalization;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Versioning;
@@ -48,6 +48,14 @@ namespace Azure.Messaging.EventHubs.Core
         public string Platform { get; }
 
         /// <summary>
+        ///  The client library information, formatted in the standard form used by SDK
+        ///  user agents when interacting with Azure services.
+        /// </summary>
+        ///
+        [Description("User-Agent")]
+        public string UserAgent => $"azsdk-net-{ Product }/{ Version } ({ Framework }; { Platform })";
+
+        /// <summary>
         ///   Prevents a default instance of the <see cref="ClientLibraryInformation"/> class from being created.
         /// </summary>
         ///
@@ -55,7 +63,7 @@ namespace Azure.Messaging.EventHubs.Core
         {
             Assembly assembly = typeof(ClientLibraryInformation).Assembly;
 
-            Product = assembly.GetCustomAttribute<AssemblyProductAttribute>()?.Product;
+            Product = $"{ nameof(Messaging) }.{ nameof(EventHubs) }";
             Version = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version;
             Framework = assembly.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName;
 
@@ -75,7 +83,21 @@ namespace Azure.Messaging.EventHubs.Core
         public IEnumerable<KeyValuePair<string, string>> EnumerateProperties() =>
             typeof(ClientLibraryInformation)
                 .GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                .Select(property => new KeyValuePair<string, string>(property.Name.ToLower(CultureInfo.InvariantCulture), (string)property.GetValue(this, null)));
+                .Select(property => new KeyValuePair<string, string>(GetTelemetryName(property), (string)property.GetValue(this, null)));
 
+        /// <summary>
+        ///   Gets the name of the property, as it should appear in telemetry
+        ///   information.
+        /// </summary>
+        ///
+        /// <param name="property">The property to consider.</param>
+        ///
+        /// <returns>The name of the property for use as telemetry for the client library.</returns>
+        ///
+        private static string GetTelemetryName(PropertyInfo property)
+        {
+            string name = property.GetCustomAttribute<DescriptionAttribute>(false)?.Description;
+            return (string.IsNullOrEmpty(name)) ? property.Name : name;
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ClientLibraryInformationTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ClientLibraryInformationTests.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using Azure.Messaging.EventHubs.Core;
 using NUnit.Framework;
 
@@ -72,6 +74,17 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
+        ///   Validates functionality of the <see cref="ClientLibraryInformation.Current" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void UserAgentCanBeAccessed()
+        {
+            Assert.That(() => ClientLibraryInformation.Current.UserAgent, Throws.Nothing);
+        }
+
+        /// <summary>
         ///   Validates functionality of the <see cref="ClientLibraryInformation.EnumerateProperties" />
         ///   property.
         /// </summary>
@@ -79,12 +92,54 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void PropertiesCanBeEnumerated()
         {
+            Dictionary<string, string> expectedNames = typeof(ClientLibraryInformation)
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .ToDictionary(property => property.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(false)?.Description ?? property.Name, property => property.Name);
+
             foreach (KeyValuePair<string, string> property in ClientLibraryInformation.Current.EnumerateProperties())
             {
-                PropertyInfo matchingProperty = typeof(ClientLibraryInformation).GetProperty(property.Key, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+                Assert.That(expectedNames.ContainsKey(property.Key), Is.True, $"The property, { property.Key }, was not expected.");
+
+                PropertyInfo matchingProperty = typeof(ClientLibraryInformation)
+                    .GetProperty(expectedNames[property.Key], BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
 
                 Assert.That(matchingProperty, Is.Not.Null, $"The property, { property.Key }, was not found.");
                 Assert.That((string)matchingProperty.GetValue(ClientLibraryInformation.Current, null), Is.EqualTo(property.Value), $"The value for { property.Key } should match.");
+            }
+        }
+
+        /// <summary>
+        ///   Validates functionality of the <see cref="ClientLibraryInformation.EnumerateProperties" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void EnumeratedPropertiesUseDescriptionsWhenPresent()
+        {
+            ClientLibraryInformation instance = ClientLibraryInformation.Current;
+
+            HashSet<string> expectedNames = new HashSet<string>(
+                typeof(ClientLibraryInformation)
+                    .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                    .Select(property => property.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(false)?.Description ?? property.Name));
+
+            foreach (KeyValuePair<string, string> property in ClientLibraryInformation.Current.EnumerateProperties())
+            {
+                Assert.That(expectedNames.Contains(property.Key), Is.True, $"The property, { property.Key }, was not found.");
+            }
+        }
+
+        /// <summary>
+        ///   Validates functionality of the <see cref="ClientLibraryInformation.EnumerateProperties" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void PropertiesArePopulated()
+        {
+            foreach (KeyValuePair<string, string> property in ClientLibraryInformation.Current.EnumerateProperties())
+            {
+                Assert.That(property.Value, Is.Not.Null.And.Not.Empty, $"The property, { property.Key }, was not populated.");
             }
         }
     }


### PR DESCRIPTION
# Summary

The focus of these changes is to ensure that we are properly populating the `Product` information and to add the standard SDK user agent property.

# Last Upstream Rebase

Monday, October 21, 12:26pm (EDT)

# Related and Follow-Up Issues

- [User Agent not being sent with telemetry properties](https://github.com/Azure/azure-sdk-for-net/issues/8017) (#8017) 