### PR TITLE
Make Response[<T>] easier to use in debugger

### DIFF
--- a/sdk/core/Azure.Core/src/Internal/ResponseDebugView.cs
+++ b/sdk/core/Azure.Core/src/Internal/ResponseDebugView.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Diagnostics;
+
 namespace Azure
 {
     internal class ResponseDebugView<T>

--- a/sdk/core/Azure.Core/src/Internal/ResponseDebugView.cs
+++ b/sdk/core/Azure.Core/src/Internal/ResponseDebugView.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure
+{
+    internal class ResponseDebugView<T>
+    {
+        private readonly Response<T> _response;
+
+        public ResponseDebugView(Response<T> response)
+        {
+            _response = response;
+        }
+
+        public Response GetRawResponse => _response.GetRawResponse();
+
+        public T Value => _response.Value;
+    }
+}

--- a/sdk/core/Azure.Core/src/Response.cs
+++ b/sdk/core/Azure.Core/src/Response.cs
@@ -35,5 +35,10 @@ namespace Azure
         {
             return new ValueResponse<T>(response, value);
         }
+
+        public override string ToString()
+        {
+            return $"Status: {Status}, ReasonPhrase: {ReasonPhrase}";
+        }
     }
 }

--- a/sdk/core/Azure.Core/src/Response{T}.cs
+++ b/sdk/core/Azure.Core/src/Response{T}.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.ComponentModel;
+using System.Diagnostics;
 
 namespace Azure
 {
@@ -9,6 +10,7 @@ namespace Azure
     /// Represents a result of Azure operation.
     /// </summary>
     /// <typeparam name="T">The type of returned value.</typeparam>
+    [DebuggerTypeProxy(typeof(ResponseDebugView<>))]
     public abstract class Response<T>
     {
         /// <summary>
@@ -37,7 +39,9 @@ namespace Azure
         public override int GetHashCode() => base.GetHashCode();
 
         /// <inheritdoc />
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public override string ToString() => base.ToString();
+        public override string ToString()
+        {
+            return $"Status: {GetRawResponse().Status}, Value: {Value}";
+        }
     }
 }

--- a/sdk/core/Azure.Core/src/Shared/NoBodyResponse{T}.cs
+++ b/sdk/core/Azure.Core/src/Shared/NoBodyResponse{T}.cs
@@ -24,6 +24,11 @@ namespace Azure
 
         public override Response GetRawResponse() => _response;
 
+        public override string ToString()
+        {
+            return $"Status: {GetRawResponse().Status}, Service returned no content";
+        }
+
 #pragma warning disable CA1064 // Exceptions should be public
         private class ResponseBodyNotFoundException : Exception
 #pragma warning restore CA1064 // Exceptions should be public

--- a/sdk/core/Azure.Core/tests/ResponseTests.cs
+++ b/sdk/core/Azure.Core/tests/ResponseTests.cs
@@ -29,6 +29,22 @@ namespace Azure.Core.Tests
         }
 
         [Test]
+        public void ToStringsFormatsStatusAndValue()
+        {
+            var response = Response.FromValue(new TestPayload("test_name"), response: new MockResponse(200));
+
+            Assert.AreEqual("Status: 200, Value: Name: test_name", response.ToString());
+        }
+
+        [Test]
+        public void ToStringsFormatsStatusAndResponsePhrase()
+        {
+            var response = new MockResponse(200, "Phrase");
+
+            Assert.AreEqual("Status: 200, ReasonPhrase: Phrase", response.ToString());
+        }
+
+        [Test]
         public void ValueThrowsIfUnspecified()
         {
             var response = new NoBodyResponse<TestPayload>(new MockResponse(304));
@@ -63,6 +79,15 @@ namespace Azure.Core.Tests
             Assert.True(throws);
         }
 
+        [Test]
+        public void ToStringsFormatsStatusAndMessageForNoBodyResponse()
+        {
+            var response = new NoBodyResponse<TestPayload>(new MockResponse(200));
+
+            Assert.AreEqual("Status: 200, Service returned no content", response.ToString());
+        }
+
+
         internal class TestPayload
         {
             public string Name { get; }
@@ -70,6 +95,11 @@ namespace Azure.Core.Tests
             public TestPayload(string name)
             {
                 Name = name;
+            }
+
+            public override string ToString()
+            {
+                return $"Name: {Name}";
             }
         }
     }

--- a/sdk/core/Azure.Core/tests/TestFramework/MockResponse.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/MockResponse.cs
@@ -29,8 +29,6 @@ namespace Azure.Core.Testing
 
         public bool IsDisposed { get; private set; }
 
-        public override string ToString() => $"{Status}";
-
         public void SetContent(byte[] content)
         {
             ContentStream = new MemoryStream(content);

--- a/sdk/storage/Azure.Storage.Blobs.Batching/src/DelayedResponse.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batching/src/DelayedResponse.cs
@@ -77,6 +77,11 @@ namespace Azure.Storage.Blobs.Specialized
             }
         }
 
+        public override string ToString()
+        {
+            return _live == null ? "Status: NotSent, Request is not sent yet." : base.ToString();
+        }
+
         // We directly forward the entire Response interface to LiveResponse
         #region forward Response members to Live
         /// <inheritdoc />

--- a/sdk/storage/Azure.Storage.Blobs.Batching/src/DelayedResponse.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batching/src/DelayedResponse.cs
@@ -79,7 +79,7 @@ namespace Azure.Storage.Blobs.Specialized
 
         public override string ToString()
         {
-            return _live == null ? "Status: NotSent, Request is not sent yet." : base.ToString();
+            return _live == null ? "Status: NotSent, the batch has not been submitted yet" : base.ToString();
         }
 
         // We directly forward the entire Response interface to LiveResponse

--- a/sdk/storage/Azure.Storage.Blobs.Batching/tests/DelayedResponseTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batching/tests/DelayedResponseTests.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core;
+using Azure.Core.Testing;
+using Azure.Storage.Blobs.Specialized;
+using NUnit.Framework;
+
+namespace Azure.Storage.Blobs.Test
+{
+    public class DelayedResponseTests
+    {
+        [Test]
+        public void DelayedResponseToStringDoesntThrow()
+        {
+            DelayedResponse delayedResponse = new DelayedResponse(new HttpMessage(new MockRequest(), new ResponseClassifier()));
+            Assert.AreEqual("Status: NotSent, the batch has not been submitted yet", delayedResponse.ToString());
+        }
+
+        [Test]
+        public void CompletedDelayedResponseToStringCallsBase()
+        {
+            DelayedResponse delayedResponse = new DelayedResponse(new HttpMessage(new MockRequest(), new ResponseClassifier()));
+            delayedResponse.SetLiveResponse(new MockResponse(200, "Yay"), false);
+            Assert.AreEqual("Status: 200, ReasonPhrase: Yay", delayedResponse.ToString());
+        }
+    }
+}


### PR DESCRIPTION
Adds ToString and debugger proxy to show GetRawResponse value:
![image](https://user-images.githubusercontent.com/1697911/67232839-018cff00-f3f7-11e9-8c3f-8022ff76d3a2.png)
