### PR TITLE
Add ConfigurationSetting to client operations.

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample1_HelloWorld.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample1_HelloWorld.cs
@@ -27,14 +27,14 @@ namespace Azure.Data.AppConfiguration.Samples
             // There are two ways to store a Configuration Setting:
             //   -AddAsync creates a setting only if the setting does not already exist in the store.
             //   -SetAsync creates a setting if it doesn't exist or overrides an existing setting
-            client.Set(setting);
+            client.SetConfigurationSetting(setting);
 
             // Retrieve a previously stored Configuration Setting by calling GetAsync.
-            ConfigurationSetting gotSetting = client.Get("some_key");
+            ConfigurationSetting gotSetting = client.GetConfigurationSetting("some_key");
             Debug.WriteLine(gotSetting.Value);
 
             // Delete the Configuration Setting from the Configuration Store when you don't need it anymore.
-            client.Delete("some_key");
+            client.DeleteConfigurationSetting("some_key");
         }
     }
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample2_HelloWorldExtended.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample2_HelloWorldExtended.cs
@@ -37,17 +37,17 @@ namespace Azure.Data.AppConfiguration.Samples
             // There are two(2) ways to store a Configuration Setting:
             //   -AddAsync creates a setting only if the setting does not already exist in the store.
             //   -SetAsync creates a setting if it doesn't exist or overrides an existing setting
-            await client.AddAsync(betaEndpoint);
-            await client.AddAsync(betaInstances);
-            await client.AddAsync(productionEndpoint);
-            await client.AddAsync(productionInstances);
+            await client.AddConfigurationSettingAsync(betaEndpoint);
+            await client.AddConfigurationSettingAsync(betaInstances);
+            await client.AddConfigurationSettingAsync(productionEndpoint);
+            await client.AddConfigurationSettingAsync(productionInstances);
 
             // There is a need to increase the production instances from 1 to 5.
             // The SetAsync will help us with this.
-            ConfigurationSetting instancesToUpdate = await client.GetAsync(productionInstances.Key, productionInstances.Label);
+            ConfigurationSetting instancesToUpdate = await client.GetConfigurationSettingAsync(productionInstances.Key, productionInstances.Label);
             instancesToUpdate.Value = "5";
 
-            await client.SetAsync(instancesToUpdate);
+            await client.SetConfigurationSettingAsync(instancesToUpdate);
 
             // We want to gather all the information available for the "production' environment.
             // By calling GetBatchSync with the proper filter for label "production", we will get
@@ -55,16 +55,16 @@ namespace Azure.Data.AppConfiguration.Samples
             var selector = new SettingSelector(null, "production");
 
             Debug.WriteLine("Settings for Production environmnet");
-            await foreach (ConfigurationSetting setting in client.GetSettingsAsync(selector))
+            await foreach (ConfigurationSetting setting in client.GetConfigurationSettingsAsync(selector))
             {
                 Debug.WriteLine(setting);
             }
 
             // Once we don't need the Configuration Setting, we can delete them.
-            await client.DeleteAsync(betaEndpoint.Key, betaEndpoint.Label);
-            await client.DeleteAsync(betaInstances.Key, betaInstances.Label);
-            await client.DeleteAsync(productionEndpoint.Key, productionEndpoint.Label);
-            await client.DeleteAsync(productionInstances.Key, productionInstances.Label);
+            await client.DeleteConfigurationSettingAsync(betaEndpoint.Key, betaEndpoint.Label);
+            await client.DeleteConfigurationSettingAsync(betaInstances.Key, betaInstances.Label);
+            await client.DeleteConfigurationSettingAsync(productionEndpoint.Key, productionEndpoint.Label);
+            await client.DeleteConfigurationSettingAsync(productionInstances.Key, productionInstances.Label);
         }
     }
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample3_SetClearReadOnly.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample3_SetClearReadOnly.cs
@@ -30,7 +30,7 @@ namespace Azure.Data.AppConfiguration.Samples
             var setting = new ConfigurationSetting("some_key", "some_value");
 
             // Add the setting to the Configuration Store.
-            client.Set(setting);
+            client.SetConfigurationSetting(setting);
 
             // Make the setting read only.
             client.SetReadOnly(setting.Key);
@@ -41,7 +41,7 @@ namespace Azure.Data.AppConfiguration.Samples
             try
             {
                 // Set() should throw because setting is read only and cannot be updated.
-                client.Set(setting);
+                client.SetConfigurationSetting(setting);
             }
             catch (RequestFailedException e)
             {
@@ -53,7 +53,7 @@ namespace Azure.Data.AppConfiguration.Samples
 
             // Try to update to the new value again.
             // Set() should now succeed because setting is read write.
-            client.Set(setting);
+            client.SetConfigurationSetting(setting);
         }
     }
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample4_Logging.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample4_Logging.cs
@@ -25,14 +25,14 @@ namespace Azure.Data.AppConfiguration.Samples
             // Setup a listener to monitor logged events.
             using AzureEventSourceListener listener = AzureEventSourceListener.CreateConsoleLogger(EventLevel.LogAlways);
 
-            Response<ConfigurationSetting> setResponse = client.Set(new ConfigurationSetting("some_key", "some_value"));
+            Response<ConfigurationSetting> setResponse = client.SetConfigurationSetting(new ConfigurationSetting("some_key", "some_value"));
             if (setResponse.GetRawResponse().Status != 200)
             {
                 throw new Exception("could not set configuration setting");
             }
 
             // Delete the setting when you don't need it anymore.
-            client.Delete("some_key");
+            client.DeleteConfigurationSetting("some_key");
         }
     }
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample6_ConfiguringRetries.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample6_ConfiguringRetries.cs
@@ -25,8 +25,8 @@ namespace Azure.Data.AppConfiguration.Samples
             // pass the policy options to the client
             var client = new ConfigurationClient(connectionString, options);
 
-            client.Set(new ConfigurationSetting("some_key", "some_value"));
-            client.Delete("some_key");
+            client.SetConfigurationSetting(new ConfigurationSetting("some_key", "some_value"));
+            client.DeleteConfigurationSetting("some_key");
         }
     }
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample7_ConfiguringPipeline.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample7_ConfiguringPipeline.cs
@@ -44,8 +44,8 @@ namespace Azure.Data.AppConfiguration.Samples
             // pass the policy options to the client
             var client = new ConfigurationClient(connectionString, options);
 
-            client.Set(new ConfigurationSetting("some_key", "some_value"));
-            client.Delete("some_key");
+            client.SetConfigurationSetting(new ConfigurationSetting("some_key", "some_value"));
+            client.DeleteConfigurationSetting("some_key");
         }
 
         private class AddHeaderPolicy : HttpPipelineSynchronousPolicy

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample8_MockClient.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample8_MockClient.cs
@@ -19,12 +19,12 @@ namespace Azure.Data.AppConfiguration.Samples
             var mock = new Mock<ConfigurationClient>();
 
             // Setup client method
-            mock.Setup(c => c.Get("Key", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            mock.Setup(c => c.GetConfigurationSetting("Key", It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .Returns(Response.FromValue(ConfigurationModelFactory.ConfigurationSetting("Key", "Value"), mockResponse.Object));
 
             // Use the client mock
             ConfigurationClient client = mock.Object;
-            ConfigurationSetting setting = client.Get("Key");
+            ConfigurationSetting setting = client.GetConfigurationSetting("Key");
             Assert.AreEqual("Value", setting.Value);
         }
     }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
-using Azure.Core.Diagnostics;
 using Azure.Core.Pipeline;
 
 namespace Azure.Data.AppConfiguration
@@ -69,10 +67,10 @@ namespace Azure.Data.AppConfiguration
         /// <param name="value">The value of the configuration setting.</param>
         /// <param name="label">The value used to group configuration settings.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        public virtual async Task<Response<ConfigurationSetting>> AddAsync(string key, string value, string label = default, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<ConfigurationSetting>> AddConfigurationSettingAsync(string key, string value, string label = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(key, nameof(key));
-            return await AddAsync(new ConfigurationSetting(key, value, label), cancellationToken).ConfigureAwait(false);
+            return await AddConfigurationSettingAsync(new ConfigurationSetting(key, value, label), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -82,10 +80,10 @@ namespace Azure.Data.AppConfiguration
         /// <param name="value">The value of the configuration setting.</param>
         /// <param name="label">The value used to group configuration settings.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        public virtual Response<ConfigurationSetting> Add(string key, string value, string label = default, CancellationToken cancellationToken = default)
+        public virtual Response<ConfigurationSetting> AddConfigurationSetting(string key, string value, string label = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(key, nameof(key));
-            return Add(new ConfigurationSetting(key, value, label), cancellationToken);
+            return AddConfigurationSetting(new ConfigurationSetting(key, value, label), cancellationToken);
         }
 
         /// <summary>
@@ -93,9 +91,9 @@ namespace Azure.Data.AppConfiguration
         /// </summary>
         /// <param name="setting"><see cref="ConfigurationSetting"/> to create.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        public virtual async Task<Response<ConfigurationSetting>> AddAsync(ConfigurationSetting setting, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<ConfigurationSetting>> AddConfigurationSettingAsync(ConfigurationSetting setting, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope("Azure.Data.AppConfiguration.ConfigurationClient.Add");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope("Azure.Data.AppConfiguration.ConfigurationClient.AddConfigurationSetting");
             scope.AddAttribute("key", setting?.Key);
             scope.Start();
 
@@ -127,9 +125,9 @@ namespace Azure.Data.AppConfiguration
         /// </summary>
         /// <param name="setting"><see cref="ConfigurationSetting"/> to create.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        public virtual Response<ConfigurationSetting> Add(ConfigurationSetting setting, CancellationToken cancellationToken = default)
+        public virtual Response<ConfigurationSetting> AddConfigurationSetting(ConfigurationSetting setting, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope("Azure.Data.AppConfiguration.ConfigurationClient.Add");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope("Azure.Data.AppConfiguration.ConfigurationClient.AddConfigurationSetting");
             scope.AddAttribute("key", setting?.Key);
             scope.Start();
 
@@ -187,10 +185,10 @@ namespace Azure.Data.AppConfiguration
         /// <param name="value">The value of the configuration setting.</param>
         /// <param name="label">The value used to group configuration settings.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        public virtual async Task<Response<ConfigurationSetting>> SetAsync(string key, string value, string label = default, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<ConfigurationSetting>> SetConfigurationSettingAsync(string key, string value, string label = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(key, nameof(key));
-            return await SetAsync(new ConfigurationSetting(key, value, label), default(MatchConditions), cancellationToken).ConfigureAwait(false);
+            return await SetConfigurationSettingAsync(new ConfigurationSetting(key, value, label), default(MatchConditions), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -200,10 +198,10 @@ namespace Azure.Data.AppConfiguration
         /// <param name="value">The value of the configuration setting.</param>
         /// <param name="label">The value used to group configuration settings.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        public virtual Response<ConfigurationSetting> Set(string key, string value, string label = default, CancellationToken cancellationToken = default)
+        public virtual Response<ConfigurationSetting> SetConfigurationSetting(string key, string value, string label = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(key, nameof(key));
-            return Set(new ConfigurationSetting(key, value, label), default(MatchConditions), cancellationToken);
+            return SetConfigurationSetting(new ConfigurationSetting(key, value, label), default(MatchConditions), cancellationToken);
         }
 
         /// <summary>
@@ -212,7 +210,7 @@ namespace Azure.Data.AppConfiguration
         /// <param name="setting"><see cref="ConfigurationSetting"/> to create.</param>
         /// <param name="onlyIfUnchanged"></param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        public virtual async Task<Response<ConfigurationSetting>> SetAsync(ConfigurationSetting setting, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<ConfigurationSetting>> SetConfigurationSettingAsync(ConfigurationSetting setting, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (setting == null)
                 throw new ArgumentNullException($"{nameof(setting)}");
@@ -224,7 +222,7 @@ namespace Azure.Data.AppConfiguration
                 requestOptions.IfMatch = setting.ETag;
             }
 
-            return await SetAsync(setting, requestOptions, cancellationToken).ConfigureAwait(false);
+            return await SetConfigurationSettingAsync(setting, requestOptions, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -233,7 +231,7 @@ namespace Azure.Data.AppConfiguration
         /// <param name="setting"><see cref="ConfigurationSetting"/> to create.</param>
         /// <param name="onlyIfUnchanged"></param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        public virtual Response<ConfigurationSetting> Set(ConfigurationSetting setting, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
+        public virtual Response<ConfigurationSetting> SetConfigurationSetting(ConfigurationSetting setting, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (setting == null)
                 throw new ArgumentNullException($"{nameof(setting)}");
@@ -245,7 +243,7 @@ namespace Azure.Data.AppConfiguration
                 requestOptions.IfMatch = setting.ETag;
             }
 
-            return Set(setting, requestOptions, cancellationToken);
+            return SetConfigurationSetting(setting, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -254,9 +252,9 @@ namespace Azure.Data.AppConfiguration
         /// <param name="setting"><see cref="ConfigurationSetting"/> to create.</param>
         /// <param name="requestOptions"></param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        internal virtual async Task<Response<ConfigurationSetting>> SetAsync(ConfigurationSetting setting, MatchConditions requestOptions, CancellationToken cancellationToken = default)
+        internal virtual async Task<Response<ConfigurationSetting>> SetConfigurationSettingAsync(ConfigurationSetting setting, MatchConditions requestOptions, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope("Azure.Data.AppConfiguration.ConfigurationClient.Set");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope("Azure.Data.AppConfiguration.ConfigurationClient.SetConfigurationSetting");
             scope.AddAttribute("key", setting?.Key);
             scope.Start();
 
@@ -287,9 +285,9 @@ namespace Azure.Data.AppConfiguration
         /// <param name="setting"><see cref="ConfigurationSetting"/> to create.</param>
         /// <param name="requestOptions"></param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        internal virtual Response<ConfigurationSetting> Set(ConfigurationSetting setting, MatchConditions requestOptions, CancellationToken cancellationToken = default)
+        internal virtual Response<ConfigurationSetting> SetConfigurationSetting(ConfigurationSetting setting, MatchConditions requestOptions, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope("Azure.Data.AppConfiguration.ConfigurationClient.Set");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope("Azure.Data.AppConfiguration.ConfigurationClient.SetConfigurationSetting");
             scope.AddAttribute("key", setting?.Key);
             scope.Start();
 
@@ -343,9 +341,9 @@ namespace Azure.Data.AppConfiguration
         /// <param name="label"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public virtual async Task<Response> DeleteAsync(string key, string label = default, CancellationToken cancellationToken = default)
+        public virtual async Task<Response> DeleteConfigurationSettingAsync(string key, string label = default, CancellationToken cancellationToken = default)
         {
-            return await DeleteAsync(key, label, default, cancellationToken).ConfigureAwait(false);
+            return await DeleteConfigurationSettingAsync(key, label, default, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -354,9 +352,9 @@ namespace Azure.Data.AppConfiguration
         /// <param name="label"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public virtual Response Delete(string key, string label = default, CancellationToken cancellationToken = default)
+        public virtual Response DeleteConfigurationSetting(string key, string label = default, CancellationToken cancellationToken = default)
         {
-            return Delete(key, label, default, cancellationToken);
+            return DeleteConfigurationSetting(key, label, default, cancellationToken);
         }
 
         /// <summary>
@@ -365,7 +363,7 @@ namespace Azure.Data.AppConfiguration
         /// <param name="setting"><see cref="ConfigurationSetting"/> to create.</param>
         /// <param name="onlyIfUnchanged"></param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        public virtual async Task<Response> DeleteAsync(ConfigurationSetting setting, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
+        public virtual async Task<Response> DeleteConfigurationSettingAsync(ConfigurationSetting setting, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (setting == null)
                 throw new ArgumentNullException($"{nameof(setting)}");
@@ -377,7 +375,7 @@ namespace Azure.Data.AppConfiguration
                 requestOptions.IfMatch = setting.ETag;
             }
 
-            return await DeleteAsync(setting.Key, setting.Label, requestOptions, cancellationToken).ConfigureAwait(false);
+            return await DeleteConfigurationSettingAsync(setting.Key, setting.Label, requestOptions, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -386,7 +384,7 @@ namespace Azure.Data.AppConfiguration
         /// <param name="setting"><see cref="ConfigurationSetting"/> to create.</param>
         /// <param name="onlyIfUnchanged"></param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        public virtual Response Delete(ConfigurationSetting setting, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
+        public virtual Response DeleteConfigurationSetting(ConfigurationSetting setting, bool onlyIfUnchanged = false, CancellationToken cancellationToken = default)
         {
             if (setting == null)
                 throw new ArgumentNullException($"{nameof(setting)}");
@@ -398,7 +396,7 @@ namespace Azure.Data.AppConfiguration
                 requestOptions.IfMatch = setting.ETag;
             }
 
-            return Delete(setting.Key, setting.Label, requestOptions, cancellationToken);
+            return DeleteConfigurationSetting(setting.Key, setting.Label, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -408,9 +406,9 @@ namespace Azure.Data.AppConfiguration
         /// <param name="label">The value used to group configuration settings.</param>
         /// <param name="requestOptions"></param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        internal virtual async Task<Response> DeleteAsync(string key, string label, MatchConditions requestOptions, CancellationToken cancellationToken = default)
+        internal virtual async Task<Response> DeleteConfigurationSettingAsync(string key, string label, MatchConditions requestOptions, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope("Azure.Data.AppConfiguration.ConfigurationClient.Delete");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope("Azure.Data.AppConfiguration.ConfigurationClient.DeleteConfigurationSetting");
             scope.AddAttribute("key", key);
             scope.Start();
 
@@ -443,9 +441,9 @@ namespace Azure.Data.AppConfiguration
         /// <param name="label">The value used to group configuration settings.</param>
         /// <param name="requestOptions"></param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        internal virtual Response Delete(string key, string label, MatchConditions requestOptions, CancellationToken cancellationToken = default)
+        internal virtual Response DeleteConfigurationSetting(string key, string label, MatchConditions requestOptions, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope("Azure.Data.AppConfiguration.ConfigurationClient.Delete");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope("Azure.Data.AppConfiguration.ConfigurationClient.DeleteConfigurationSetting");
             scope.AddAttribute("key", key);
             scope.Start();
 
@@ -493,9 +491,9 @@ namespace Azure.Data.AppConfiguration
         /// <param name="label"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public virtual async Task<Response<ConfigurationSetting>> GetAsync(string key, string label = default, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<ConfigurationSetting>> GetConfigurationSettingAsync(string key, string label = default, CancellationToken cancellationToken = default)
         {
-            return await GetAsync(key, label, acceptDateTime: default, requestOptions: default, cancellationToken).ConfigureAwait(false);
+            return await GetConfigurationSettingAsync(key, label, acceptDateTime: default, requestOptions: default, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -504,9 +502,9 @@ namespace Azure.Data.AppConfiguration
         /// <param name="label"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public virtual Response<ConfigurationSetting> Get(string key, string label = default, CancellationToken cancellationToken = default)
+        public virtual Response<ConfigurationSetting> GetConfigurationSetting(string key, string label = default, CancellationToken cancellationToken = default)
         {
-            return Get(key, label, acceptDateTime: default, requestOptions: default, cancellationToken);
+            return GetConfigurationSetting(key, label, acceptDateTime: default, requestOptions: default, cancellationToken);
         }
 
         /// <summary>
@@ -515,7 +513,7 @@ namespace Azure.Data.AppConfiguration
         /// <param name="onlyIfChanged"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public virtual async Task<Response<ConfigurationSetting>> GetAsync(ConfigurationSetting setting, bool onlyIfChanged = false, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<ConfigurationSetting>> GetConfigurationSettingAsync(ConfigurationSetting setting, bool onlyIfChanged = false, CancellationToken cancellationToken = default)
         {
             if (setting == null)
                 throw new ArgumentNullException($"{nameof(setting)}");
@@ -527,7 +525,7 @@ namespace Azure.Data.AppConfiguration
                 requestOptions.IfNoneMatch = setting.ETag;
             }
 
-            return await GetAsync(setting.Key, setting.Label, acceptDateTime: default, requestOptions, cancellationToken).ConfigureAwait(false);
+            return await GetConfigurationSettingAsync(setting.Key, setting.Label, acceptDateTime: default, requestOptions, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -536,7 +534,7 @@ namespace Azure.Data.AppConfiguration
         /// <param name="onlyIfChanged"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public virtual Response<ConfigurationSetting> Get(ConfigurationSetting setting, bool onlyIfChanged = false, CancellationToken cancellationToken = default)
+        public virtual Response<ConfigurationSetting> GetConfigurationSetting(ConfigurationSetting setting, bool onlyIfChanged = false, CancellationToken cancellationToken = default)
         {
             if (setting == null)
                 throw new ArgumentNullException($"{nameof(setting)}");
@@ -548,7 +546,7 @@ namespace Azure.Data.AppConfiguration
                 requestOptions.IfNoneMatch = setting.ETag;
             }
 
-            return Get(setting.Key, setting.Label, acceptDateTime: default, requestOptions, cancellationToken);
+            return GetConfigurationSetting(setting.Key, setting.Label, acceptDateTime: default, requestOptions, cancellationToken);
         }
 
         /// <summary>
@@ -559,9 +557,9 @@ namespace Azure.Data.AppConfiguration
         /// <param name="acceptDateTime">The setting will be retrieved exactly as it existed at the provided time.</param>
         /// <param name="requestOptions"></param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        internal virtual async Task<Response<ConfigurationSetting>> GetAsync(string key, string label, DateTimeOffset acceptDateTime, MatchConditions requestOptions, CancellationToken cancellationToken = default)
+        internal virtual async Task<Response<ConfigurationSetting>> GetConfigurationSettingAsync(string key, string label, DateTimeOffset acceptDateTime, MatchConditions requestOptions, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope("Azure.Data.AppConfiguration.ConfigurationClient.Get");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope("Azure.Data.AppConfiguration.ConfigurationClient.GetConfigurationSetting");
             scope.AddAttribute("key", key);
             scope.Start();
 
@@ -592,9 +590,9 @@ namespace Azure.Data.AppConfiguration
         /// <param name="acceptDateTime">The setting will be retrieved exactly as it existed at the provided time.</param>
         /// <param name="requestOptions"></param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        internal virtual Response<ConfigurationSetting> Get(string key, string label, DateTimeOffset acceptDateTime, MatchConditions requestOptions, CancellationToken cancellationToken = default)
+        internal virtual Response<ConfigurationSetting> GetConfigurationSetting(string key, string label, DateTimeOffset acceptDateTime, MatchConditions requestOptions, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope("Azure.Data.AppConfiguration.ConfigurationClient.Get");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope("Azure.Data.AppConfiguration.ConfigurationClient.GetConfigurationSetting");
             scope.AddAttribute(nameof(key), key);
             scope.Start();
 
@@ -624,10 +622,10 @@ namespace Azure.Data.AppConfiguration
         /// </summary>
         /// <param name="selector">Set of options for selecting <see cref="ConfigurationSetting"/> from the configuration store.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        public virtual AsyncPageable<ConfigurationSetting> GetSettingsAsync(SettingSelector selector, CancellationToken cancellationToken = default)
+        public virtual AsyncPageable<ConfigurationSetting> GetConfigurationSettingsAsync(SettingSelector selector, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(selector, nameof(selector));
-            return PageResponseEnumerator.CreateAsyncEnumerable(nextLink => GetSettingsPageAsync(selector, nextLink, cancellationToken));
+            return PageResponseEnumerator.CreateAsyncEnumerable(nextLink => GetConfigurationSettingsPageAsync(selector, nextLink, cancellationToken));
         }
 
         /// <summary>
@@ -635,10 +633,10 @@ namespace Azure.Data.AppConfiguration
         /// </summary>
         /// <param name="selector">Set of options for selecting <see cref="ConfigurationSetting"/> from the configuration store.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        public virtual Pageable<ConfigurationSetting> GetSettings(SettingSelector selector, CancellationToken cancellationToken = default)
+        public virtual Pageable<ConfigurationSetting> GetConfigurationSettings(SettingSelector selector, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(selector, nameof(selector));
-            return PageResponseEnumerator.CreateEnumerable(nextLink => GetSettingsPage(selector, nextLink, cancellationToken));
+            return PageResponseEnumerator.CreateEnumerable(nextLink => GetConfigurationSettingsPage(selector, nextLink, cancellationToken));
         }
 
         /// <summary>
@@ -693,9 +691,9 @@ namespace Azure.Data.AppConfiguration
         /// <param name="selector">Set of options for selecting settings from the configuration store.</param>
         /// <param name="pageLink"></param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        private async Task<Page<ConfigurationSetting>> GetSettingsPageAsync(SettingSelector selector, string pageLink, CancellationToken cancellationToken = default)
+        private async Task<Page<ConfigurationSetting>> GetConfigurationSettingsPageAsync(SettingSelector selector, string pageLink, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope("Azure.Data.AppConfiguration.ConfigurationClient.GetSettingsPage");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope("Azure.Data.AppConfiguration.ConfigurationClient.GetConfigurationSettingsPage");
             scope.Start();
 
             try
@@ -726,9 +724,9 @@ namespace Azure.Data.AppConfiguration
         /// <param name="selector">Set of options for selecting settings from the configuration store.</param>
         /// <param name="pageLink"></param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
-        private Page<ConfigurationSetting> GetSettingsPage(SettingSelector selector, string pageLink, CancellationToken cancellationToken = default)
+        private Page<ConfigurationSetting> GetConfigurationSettingsPage(SettingSelector selector, string pageLink, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _clientDiagnostics.CreateScope("Azure.Data.AppConfiguration.ConfigurationClient.GetSettingsPage");
+            using DiagnosticScope scope = _clientDiagnostics.CreateScope("Azure.Data.AppConfiguration.ConfigurationClient.GetConfigurationSettingsPage");
             scope.Start();
 
             try
@@ -846,18 +844,6 @@ namespace Azure.Data.AppConfiguration
                 request.Headers.Add(AcceptDatetimeHeader, dateTime);
             }
 
-            return request;
-        }
-
-        private Request CreateHeadRequest(string key, string label)
-        {
-            Argument.AssertNotNullOrEmpty(key, nameof(key));
-
-            Request request = _pipeline.CreateRequest();
-            request.Method = RequestMethod.Head;
-            BuildUriForKvRoute(request.Uri, key, label);
-            request.Headers.Add(s_mediaTypeKeyValueApplicationHeader);
-            request.Headers.Add(HttpHeader.Common.JsonContentType);
             return request;
         }
 

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
@@ -78,17 +78,17 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                Response<ConfigurationSetting> responseGet = await service.GetAsync(batchKey);
+                Response<ConfigurationSetting> responseGet = await service.GetConfigurationSettingAsync(batchKey);
                 key = responseGet.Value.Value;
             }
             catch
             {
                 for (int i = 0; i < expectedEvents; i++)
                 {
-                    await service.AddAsync(new ConfigurationSetting(key, "test_value", $"{i.ToString()}"));
+                    await service.AddConfigurationSettingAsync(new ConfigurationSetting(key, "test_value", $"{i.ToString()}"));
                 }
 
-                await service.SetAsync(new ConfigurationSetting(batchKey, key));
+                await service.SetConfigurationSettingAsync(new ConfigurationSetting(batchKey, key));
             }
             return key;
         }
@@ -99,7 +99,7 @@ namespace Azure.Data.AppConfiguration.Tests
             ConfigurationClient service = GetClient();
             ConfigurationSetting testSetting = CreateSetting();
 
-            Response response = await service.DeleteAsync(testSetting.Key);
+            Response response = await service.DeleteConfigurationSettingAsync(testSetting.Key);
 
             Assert.AreEqual(204, response.Status);
             response.Dispose();
@@ -116,23 +116,23 @@ namespace Azure.Data.AppConfiguration.Tests
                 // Prepare environment
                 ConfigurationSetting testSettingDiff = testSetting.Clone();
                 testSettingDiff.Label = null;
-                await service.SetAsync(testSetting);
-                await service.SetAsync(testSettingDiff);
+                await service.SetConfigurationSettingAsync(testSetting);
+                await service.SetConfigurationSettingAsync(testSettingDiff);
 
                 // Test
-                await service.DeleteAsync(testSettingDiff.Key);
+                await service.DeleteConfigurationSettingAsync(testSettingDiff.Key);
 
                 //Try to get the non-existing setting
                 RequestFailedException e = Assert.ThrowsAsync<RequestFailedException>(async () =>
                 {
-                    await service.GetAsync(testSettingDiff.Key);
+                    await service.GetConfigurationSettingAsync(testSettingDiff.Key);
                 });
 
                 Assert.AreEqual(404, e.Status);
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -147,23 +147,23 @@ namespace Azure.Data.AppConfiguration.Tests
                 // Prepare environment
                 ConfigurationSetting testSettingDiff = testSetting.Clone();
                 testSettingDiff.Label = "test_label_diff";
-                await service.SetAsync(testSetting);
-                await service.SetAsync(testSettingDiff);
+                await service.SetConfigurationSettingAsync(testSetting);
+                await service.SetConfigurationSettingAsync(testSettingDiff);
 
                 // Test
-                await service.DeleteAsync(testSettingDiff.Key, testSettingDiff.Label);
+                await service.DeleteConfigurationSettingAsync(testSettingDiff.Key, testSettingDiff.Label);
 
                 //Try to get the non-existing setting
                 RequestFailedException e = Assert.ThrowsAsync<RequestFailedException>(async () =>
                 {
-                    await service.GetAsync(testSettingDiff.Key, testSettingDiff.Label);
+                    await service.GetConfigurationSettingAsync(testSettingDiff.Key, testSettingDiff.Label);
                 });
 
                 Assert.AreEqual(404, e.Status);
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -175,19 +175,19 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                var setting = await service.AddAsync(testSetting);
+                var setting = await service.AddConfigurationSettingAsync(testSetting);
                 var readOnly = await service.SetReadOnlyAsync(testSetting.Key, testSetting.Label);
 
                 // Test
                 RequestFailedException exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
-                    await service.DeleteAsync(testSetting.Key, testSetting.Label)
+                    await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label)
                 );
                 Assert.AreEqual(409, exception.Status);
             }
             finally
             {
                 await service.ClearReadOnlyAsync(testSetting.Key, testSetting.Label);
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -199,15 +199,15 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                ConfigurationSetting setting = await service.AddAsync(testSetting);
+                ConfigurationSetting setting = await service.AddConfigurationSettingAsync(testSetting);
 
                 // Test
-                Response response = await service.DeleteAsync(setting, onlyIfUnchanged: true);
+                Response response = await service.DeleteConfigurationSettingAsync(setting, onlyIfUnchanged: true);
                 Assert.AreEqual(200, response.Status);
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -219,19 +219,19 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                ConfigurationSetting setting = await service.AddAsync(testSetting);
+                ConfigurationSetting setting = await service.AddConfigurationSettingAsync(testSetting);
                 ConfigurationSetting modifiedSetting = setting.Clone();
                 modifiedSetting.Value = "new_value";
-                modifiedSetting = await service.SetAsync(modifiedSetting);
+                modifiedSetting = await service.SetConfigurationSettingAsync(modifiedSetting);
 
                 // Test
                 RequestFailedException exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
-                    await service.DeleteAsync(setting, onlyIfUnchanged: true));
+                    await service.DeleteConfigurationSettingAsync(setting, onlyIfUnchanged: true));
                 Assert.AreEqual(412, exception.Status);
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -243,12 +243,12 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                ConfigurationSetting setting = await service.SetAsync(testSetting);
+                ConfigurationSetting setting = await service.SetConfigurationSettingAsync(testSetting);
                 Assert.True(ConfigurationSettingEqualityComparer.Instance.Equals(testSetting, setting));
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -260,14 +260,14 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                await service.AddAsync(testSetting);
+                await service.AddConfigurationSettingAsync(testSetting);
 
-                ConfigurationSetting setting = await service.SetAsync(testSetting);
+                ConfigurationSetting setting = await service.SetConfigurationSettingAsync(testSetting);
                 Assert.True(ConfigurationSettingEqualityComparer.Instance.Equals(testSetting, setting));
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -279,20 +279,20 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                var setting = await service.AddAsync(testSetting);
+                var setting = await service.AddConfigurationSettingAsync(testSetting);
                 var readOnly = await service.SetReadOnlyAsync(testSetting.Key, testSetting.Label);
 
                 testSetting.Value = "new_value";
 
                 // Test
                 RequestFailedException exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
-                    await service.SetAsync(testSetting.Key, "new_value", testSetting.Label));
+                    await service.SetConfigurationSettingAsync(testSetting.Key, "new_value", testSetting.Label));
                 Assert.AreEqual(409, exception.Status);
             }
             finally
             {
                 await service.ClearReadOnlyAsync(testSetting.Key, testSetting.Label);
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -304,18 +304,18 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                ConfigurationSetting setting = await service.AddAsync(testSetting);
+                ConfigurationSetting setting = await service.AddConfigurationSettingAsync(testSetting);
                 setting.Value = "new_value";
 
                 // Test
-                Response<ConfigurationSetting> response = await service.SetAsync(setting, onlyIfUnchanged: true);
+                Response<ConfigurationSetting> response = await service.SetConfigurationSettingAsync(setting, onlyIfUnchanged: true);
                 Assert.AreEqual(200, response.GetRawResponse().Status);
                 Assert.AreEqual(setting.Value, response.Value.Value);
                 Assert.AreNotEqual(setting.ETag, response.Value.ETag);
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -327,19 +327,19 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                ConfigurationSetting setting = await service.AddAsync(testSetting);
+                ConfigurationSetting setting = await service.AddConfigurationSettingAsync(testSetting);
                 ConfigurationSetting modifiedSetting = setting.Clone();
                 modifiedSetting.Value = "new_value";
-                modifiedSetting = await service.SetAsync(modifiedSetting);
+                modifiedSetting = await service.SetConfigurationSettingAsync(modifiedSetting);
 
                 // Test
                 RequestFailedException exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
-                    await service.SetAsync(setting, onlyIfUnchanged: true));
+                    await service.SetConfigurationSettingAsync(setting, onlyIfUnchanged: true));
                 Assert.AreEqual(412, exception.Status);
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -353,14 +353,14 @@ namespace Azure.Data.AppConfiguration.Tests
             try
             {
                 string value = "my_value";
-                ConfigurationSetting setting = await service.SetAsync(key, value);
+                ConfigurationSetting setting = await service.SetConfigurationSettingAsync(key, value);
 
                 Assert.AreEqual(key, setting.Key);
                 Assert.AreEqual(value, setting.Value);
             }
             finally
             {
-                await service.DeleteAsync(key);
+                await service.DeleteConfigurationSettingAsync(key);
             }
         }
 
@@ -375,7 +375,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                ConfigurationSetting setting = await service.SetAsync(key, value, label);
+                ConfigurationSetting setting = await service.SetConfigurationSettingAsync(key, value, label);
 
                 Assert.AreEqual(key, setting.Key);
                 Assert.AreEqual(value, setting.Value);
@@ -383,7 +383,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteAsync(key, label);
+                await service.DeleteConfigurationSettingAsync(key, label);
             }
         }
 
@@ -395,13 +395,13 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                Response<ConfigurationSetting> response = await service.SetAsync(testSetting);
+                Response<ConfigurationSetting> response = await service.SetConfigurationSettingAsync(testSetting);
                 response.GetRawResponse().Headers.TryGetValue("x-ms-client-request-id", out string requestId);
                 Assert.IsNotEmpty(requestId);
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -413,18 +413,18 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                await service.AddAsync(testSetting);
+                await service.AddConfigurationSettingAsync(testSetting);
 
                 RequestFailedException exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
                 {
-                    await service.AddAsync(testSetting);
+                    await service.AddConfigurationSettingAsync(testSetting);
                 });
 
                 Assert.AreEqual(412, exception.Status);
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -436,12 +436,12 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                ConfigurationSetting setting = await service.AddAsync(testSetting);
+                ConfigurationSetting setting = await service.AddConfigurationSettingAsync(testSetting);
                 Assert.True(ConfigurationSettingEqualityComparer.Instance.Equals(testSetting, setting));
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -456,12 +456,12 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                ConfigurationSetting setting = await service.AddAsync(testSettingNoLabel);
+                ConfigurationSetting setting = await service.AddConfigurationSettingAsync(testSettingNoLabel);
                 Assert.True(ConfigurationSettingEqualityComparer.Instance.Equals(testSettingNoLabel, setting));
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key);
             }
         }
 
@@ -475,14 +475,14 @@ namespace Azure.Data.AppConfiguration.Tests
             try
             {
                 string value = "my_value";
-                ConfigurationSetting setting = await service.AddAsync(key, value);
+                ConfigurationSetting setting = await service.AddConfigurationSettingAsync(key, value);
 
                 Assert.AreEqual(key, setting.Key);
                 Assert.AreEqual(value, setting.Value);
             }
             finally
             {
-                await service.DeleteAsync(key);
+                await service.DeleteConfigurationSettingAsync(key);
             }
         }
 
@@ -497,7 +497,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                ConfigurationSetting setting = await service.AddAsync(key, value, label);
+                ConfigurationSetting setting = await service.AddConfigurationSettingAsync(key, value, label);
 
                 Assert.AreEqual(key, setting.Key);
                 Assert.AreEqual(value, setting.Value);
@@ -505,7 +505,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteAsync(key, label);
+                await service.DeleteConfigurationSettingAsync(key, label);
             }
         }
 
@@ -529,8 +529,8 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                await service.SetAsync(setting);
-                await service.SetAsync(testSettingUpdate);
+                await service.SetConfigurationSettingAsync(setting);
+                await service.SetConfigurationSettingAsync(testSettingUpdate);
 
                 // Test
                 var selector = new SettingSelector(setting.Key)
@@ -556,8 +556,8 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteAsync(setting.Key, setting.Label);
-                await service.DeleteAsync(testSettingUpdate.Key, testSettingUpdate.Label);
+                await service.DeleteConfigurationSettingAsync(setting.Key, setting.Label);
+                await service.DeleteConfigurationSettingAsync(testSettingUpdate.Key, testSettingUpdate.Label);
             }
         }
 
@@ -573,14 +573,14 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                await service.SetAsync(testSettingNoLabel);
+                await service.SetConfigurationSettingAsync(testSettingNoLabel);
                 // Test
-                ConfigurationSetting setting = await service.GetAsync(testSettingNoLabel.Key);
+                ConfigurationSetting setting = await service.GetConfigurationSettingAsync(testSettingNoLabel.Key);
                 Assert.True(ConfigurationSettingEqualityComparer.Instance.Equals(testSettingNoLabel, setting));
             }
             finally
             {
-                await service.DeleteAsync(testSettingNoLabel.Key);
+                await service.DeleteConfigurationSettingAsync(testSettingNoLabel.Key);
             }
         }
 
@@ -592,7 +592,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             RequestFailedException exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
             {
-                await service.GetAsync(testSetting.Key);
+                await service.GetConfigurationSettingAsync(testSetting.Key);
             });
 
             Assert.AreEqual(404, exception.Status);
@@ -610,17 +610,17 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                await service.SetAsync(testSettingNoLabel);
-                await service.SetAsync(testSetting);
+                await service.SetConfigurationSettingAsync(testSettingNoLabel);
+                await service.SetConfigurationSettingAsync(testSetting);
 
                 // Test
-                ConfigurationSetting responseSetting = await service.GetAsync(testSetting.Key, testSetting.Label);
+                ConfigurationSetting responseSetting = await service.GetConfigurationSettingAsync(testSetting.Key, testSetting.Label);
                 Assert.True(ConfigurationSettingEqualityComparer.Instance.Equals(testSetting, responseSetting));
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
-                await service.DeleteAsync(testSettingNoLabel.Key);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSettingNoLabel.Key);
             }
         }
 
@@ -632,16 +632,16 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                await service.SetAsync(testSetting);
+                await service.SetConfigurationSettingAsync(testSetting);
 
                 // Test
                 // TODO: add a test with a more granular timestamp.
-                ConfigurationSetting responseSetting = await service.GetAsync(testSetting.Key, testSetting.Label, DateTimeOffset.MaxValue, requestOptions: default);
+                ConfigurationSetting responseSetting = await service.GetConfigurationSettingAsync(testSetting.Key, testSetting.Label, DateTimeOffset.MaxValue, requestOptions: default);
                 Assert.True(ConfigurationSettingEqualityComparer.Instance.Equals(testSetting, responseSetting));
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -653,18 +653,18 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                ConfigurationSetting setting = await service.AddAsync(testSetting);
+                ConfigurationSetting setting = await service.AddConfigurationSettingAsync(testSetting);
                 ConfigurationSetting modifiedSetting = setting.Clone();
                 modifiedSetting.Value = "new_value";
-                modifiedSetting = await service.SetAsync(modifiedSetting);
+                modifiedSetting = await service.SetConfigurationSettingAsync(modifiedSetting);
 
-                Response<ConfigurationSetting> response = await service.GetAsync(setting, onlyIfChanged: true).ConfigureAwait(false);
+                Response<ConfigurationSetting> response = await service.GetConfigurationSettingAsync(setting, onlyIfChanged: true).ConfigureAwait(false);
                 Assert.AreEqual(200, response.GetRawResponse().Status);
                 Assert.True(ConfigurationSettingEqualityComparer.Instance.Equals(modifiedSetting, response.Value));
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -676,10 +676,10 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                ConfigurationSetting setting = await service.AddAsync(testSetting);
+                ConfigurationSetting setting = await service.AddConfigurationSettingAsync(testSetting);
 
                 // Test
-                Response<ConfigurationSetting> response = await service.GetAsync(setting, onlyIfChanged: true).ConfigureAwait(false);
+                Response<ConfigurationSetting> response = await service.GetConfigurationSettingAsync(setting, onlyIfChanged: true).ConfigureAwait(false);
                 Assert.AreEqual(304, response.GetRawResponse().Status);
 
                 bool throws = false;
@@ -696,7 +696,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -712,15 +712,15 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                await service.SetAsync(testSettingNoLabel);
+                await service.SetConfigurationSettingAsync(testSettingNoLabel);
 
                 // Test
-                ConfigurationSetting setting = await service.GetAsync(testSettingNoLabel.Key);
+                ConfigurationSetting setting = await service.GetConfigurationSettingAsync(testSettingNoLabel.Key);
                 Assert.True(ConfigurationSettingEqualityComparer.Instance.Equals(testSettingNoLabel, setting));
             }
             finally
             {
-                await service.DeleteAsync(testSettingNoLabel.Key);
+                await service.DeleteConfigurationSettingAsync(testSettingNoLabel.Key);
             }
         }
 
@@ -732,15 +732,15 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                await service.SetAsync(testSetting);
+                await service.SetConfigurationSettingAsync(testSetting);
 
                 // Test
-                ConfigurationSetting setting = await service.GetAsync(testSetting.Key, testSetting.Label);
+                ConfigurationSetting setting = await service.GetConfigurationSettingAsync(testSetting.Key, testSetting.Label);
                 Assert.True(ConfigurationSettingEqualityComparer.Instance.Equals(testSetting, setting));
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key);
             }
         }
 
@@ -755,7 +755,7 @@ namespace Azure.Data.AppConfiguration.Tests
             int resultsReturned = 0;
             SettingSelector selector = new SettingSelector(key);
 
-            await foreach (ConfigurationSetting item in service.GetSettingsAsync(selector, CancellationToken.None))
+            await foreach (ConfigurationSetting item in service.GetConfigurationSettingsAsync(selector, CancellationToken.None))
             {
                 Assert.AreEqual("test_value", item.Value);
                 resultsReturned++;
@@ -772,14 +772,14 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                await service.SetAsync(testSetting);
+                await service.SetConfigurationSettingAsync(testSetting);
 
                 var selector = new SettingSelector();
 
                 Assert.AreEqual("*", selector.Keys.First());
                 Assert.AreEqual("*", selector.Labels.First());
 
-                var resultsReturned = (await service.GetSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync())
+                var resultsReturned = (await service.GetConfigurationSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync())
                     .Count();
 
                 //At least there should be one key available
@@ -787,7 +787,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -799,10 +799,10 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                await service.SetAsync(testSetting);
+                await service.SetConfigurationSettingAsync(testSetting);
 
                 var selector = new SettingSelector(testSetting.Key, testSetting.Label);
-                ConfigurationSetting[] batch = (await service.GetSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync())
+                ConfigurationSetting[] batch = (await service.GetConfigurationSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync())
                     .ToArray();
 
                 Assert.AreEqual(1, batch.Length);
@@ -811,7 +811,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -823,10 +823,10 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                await service.SetAsync(testSetting);
+                await service.SetConfigurationSettingAsync(testSetting);
 
                 var selector = new SettingSelector(testSetting.Key);
-                ConfigurationSetting[] batch = (await service.GetSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync())
+                ConfigurationSetting[] batch = (await service.GetConfigurationSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync())
                     .ToArray();
 
                 Assert.AreEqual(1, batch.Length);
@@ -834,7 +834,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -846,13 +846,13 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                await service.SetAsync(testSetting);
+                await service.SetConfigurationSettingAsync(testSetting);
 
                 var selector = new SettingSelector(null, testSetting.Label);
 
                 Assert.AreEqual("*", selector.Keys.First());
 
-                ConfigurationSetting[] batch = (await service.GetSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync())
+                ConfigurationSetting[] batch = (await service.GetConfigurationSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync())
                     .ToArray();
 
                 //At least there should be one key available
@@ -861,7 +861,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -871,7 +871,7 @@ namespace Azure.Data.AppConfiguration.Tests
             ConfigurationClient service = GetClient();
 
             string key = GenerateKeyId("keyFields-");
-            ConfigurationSetting setting = await service.AddAsync(key, "my_value", "my_label");
+            ConfigurationSetting setting = await service.AddConfigurationSettingAsync(key, "my_value", "my_label");
 
             try
             {
@@ -880,7 +880,7 @@ namespace Azure.Data.AppConfiguration.Tests
                     Fields = SettingFields.Key | SettingFields.Label | SettingFields.ETag
                 };
 
-                ConfigurationSetting[] batch = (await service.GetSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync())
+                ConfigurationSetting[] batch = (await service.GetConfigurationSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync())
                     .ToArray();
 
                 Assert.AreEqual(1, batch.Length);
@@ -895,7 +895,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteAsync(setting.Key, setting.Label);
+                await service.DeleteConfigurationSettingAsync(setting.Key, setting.Label);
             }
         }
 
@@ -905,7 +905,7 @@ namespace Azure.Data.AppConfiguration.Tests
             ConfigurationClient service = GetClient();
 
             string key = GenerateKeyId("key-");
-            ConfigurationSetting setting = await service.AddAsync(key, "my_value", "my_label");
+            ConfigurationSetting setting = await service.AddConfigurationSettingAsync(key, "my_value", "my_label");
 
             try
             {
@@ -914,7 +914,7 @@ namespace Azure.Data.AppConfiguration.Tests
                     Fields = SettingFields.Key | SettingFields.ReadOnly
                 };
 
-                List<ConfigurationSetting> batch = await service.GetSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync();
+                List<ConfigurationSetting> batch = await service.GetConfigurationSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync();
 
                 CollectionAssert.IsNotEmpty(batch);
                 Assert.IsNotNull(batch[0].Key);
@@ -927,7 +927,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteAsync(setting.Key, setting.Label);
+                await service.DeleteConfigurationSettingAsync(setting.Key, setting.Label);
             }
         }
 
@@ -936,7 +936,7 @@ namespace Azure.Data.AppConfiguration.Tests
         {
             ConfigurationClient service = GetClient();
             string key = GenerateKeyId("keyFields-");
-            ConfigurationSetting setting = await service.AddAsync(new ConfigurationSetting(key, "my_value", "my_label")
+            ConfigurationSetting setting = await service.AddConfigurationSettingAsync(new ConfigurationSetting(key, "my_value", "my_label")
             {
                 ContentType = "content-type"
             });
@@ -948,7 +948,7 @@ namespace Azure.Data.AppConfiguration.Tests
                     Fields = SettingFields.All
                 };
 
-                ConfigurationSetting[] batch = (await service.GetSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync())
+                ConfigurationSetting[] batch = (await service.GetConfigurationSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync())
                     .ToArray();
 
                 Assert.AreEqual(1, batch.Length);
@@ -963,7 +963,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteAsync(setting.Key, setting.Label);
+                await service.DeleteConfigurationSettingAsync(setting.Key, setting.Label);
             }
         }
 
@@ -975,11 +975,11 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                await service.SetAsync(testSetting);
+                await service.SetConfigurationSettingAsync(testSetting);
 
                 var selector = new SettingSelector(testSetting.Key);
 
-                ConfigurationSetting[] settings = (await service.GetSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync()).ToArray();
+                ConfigurationSetting[] settings = (await service.GetConfigurationSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync()).ToArray();
 
                 // There should be at least one key available
                 CollectionAssert.IsNotEmpty(settings);
@@ -988,7 +988,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key);
             }
         }
 
@@ -1000,11 +1000,11 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                await service.SetAsync(testSetting);
+                await service.SetConfigurationSettingAsync(testSetting);
 
                 var selector = new SettingSelector("abc*");
 
-                ConfigurationSetting[] settings = (await service.GetSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync()).ToArray();
+                ConfigurationSetting[] settings = (await service.GetConfigurationSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync()).ToArray();
 
                 // There should be at least one key available.
                 CollectionAssert.IsNotEmpty(settings);
@@ -1016,7 +1016,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key);
             }
         }
 
@@ -1029,11 +1029,11 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                await service.SetAsync(testSetting);
+                await service.SetConfigurationSettingAsync(testSetting);
 
                 var selector = new SettingSelector($"*{endsWith}");
 
-                ConfigurationSetting[] settings = (await service.GetSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync()).ToArray();
+                ConfigurationSetting[] settings = (await service.GetConfigurationSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync()).ToArray();
 
                 // There should be at least one key available.
                 CollectionAssert.IsNotEmpty(settings);
@@ -1045,7 +1045,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key);
             }
         }
 
@@ -1057,11 +1057,11 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                await service.SetAsync(testSetting);
+                await service.SetConfigurationSettingAsync(testSetting);
 
                 var selector = new SettingSelector("*abc*");
 
-                ConfigurationSetting[] settings = (await service.GetSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync()).ToArray();
+                ConfigurationSetting[] settings = (await service.GetConfigurationSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync()).ToArray();
 
                 // There should be at least one key available.
                 CollectionAssert.IsNotEmpty(settings);
@@ -1073,7 +1073,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key);
             }
         }
 
@@ -1087,13 +1087,13 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                await service.SetAsync(abcSetting);
-                await service.SetAsync(xyzSetting);
+                await service.SetConfigurationSettingAsync(abcSetting);
+                await service.SetConfigurationSettingAsync(xyzSetting);
 
                 var selector = new SettingSelector("ab,cd");
                 selector.Keys.Add("wx,yz");
 
-                ConfigurationSetting[] settings = (await service.GetSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync()).ToArray();
+                ConfigurationSetting[] settings = (await service.GetConfigurationSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync()).ToArray();
 
                 Assert.GreaterOrEqual(settings.Length, 2);
                 Assert.IsTrue(settings.Any(s => s.Key == "ab,cd"));
@@ -1101,8 +1101,8 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteAsync(abcSetting.Key);
-                await service.DeleteAsync(xyzSetting.Key);
+                await service.DeleteConfigurationSettingAsync(abcSetting.Key);
+                await service.DeleteConfigurationSettingAsync(xyzSetting.Key);
             }
         }
 
@@ -1116,19 +1116,19 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                await service.SetAsync(abcSetting);
-                await service.SetAsync(xyzSetting);
+                await service.SetConfigurationSettingAsync(abcSetting);
+                await service.SetConfigurationSettingAsync(xyzSetting);
 
                 var selector = new SettingSelector($"{abcSetting.Key},{xyzSetting.Key}");
 
-                ConfigurationSetting[] settings = (await service.GetSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync()).ToArray();
+                ConfigurationSetting[] settings = (await service.GetConfigurationSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync()).ToArray();
 
                 CollectionAssert.IsEmpty(settings);
             }
             finally
             {
-                await service.DeleteAsync(abcSetting.Key);
-                await service.DeleteAsync(xyzSetting.Key);
+                await service.DeleteConfigurationSettingAsync(abcSetting.Key);
+                await service.DeleteConfigurationSettingAsync(xyzSetting.Key);
             }
         }
 
@@ -1142,13 +1142,13 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                await service.SetAsync(abcSetting);
-                await service.SetAsync(xyzSetting);
+                await service.SetConfigurationSettingAsync(abcSetting);
+                await service.SetConfigurationSettingAsync(xyzSetting);
 
                 var selector = new SettingSelector("abc");
                 selector.Keys.Add("xyz");
 
-                ConfigurationSetting[] settings = (await service.GetSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync()).ToArray();
+                ConfigurationSetting[] settings = (await service.GetConfigurationSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync()).ToArray();
 
                 Assert.GreaterOrEqual(settings.Length, 2);
                 Assert.IsTrue(settings.Any(s => s.Key == "abc"));
@@ -1156,8 +1156,8 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteAsync(abcSetting.Key);
-                await service.DeleteAsync(xyzSetting.Key);
+                await service.DeleteConfigurationSettingAsync(abcSetting.Key);
+                await service.DeleteConfigurationSettingAsync(xyzSetting.Key);
             }
         }
 
@@ -1171,13 +1171,13 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                await service.SetAsync(abcSetting);
-                await service.SetAsync(xyzSetting);
+                await service.SetConfigurationSettingAsync(abcSetting);
+                await service.SetConfigurationSettingAsync(xyzSetting);
 
                 var selector = new SettingSelector(null, "abc");
                 selector.Labels.Add("xyz");
 
-                ConfigurationSetting[] settings = (await service.GetSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync()).ToArray();
+                ConfigurationSetting[] settings = (await service.GetConfigurationSettingsAsync(selector, CancellationToken.None).ToEnumerableAsync()).ToArray();
 
                 Assert.GreaterOrEqual(settings.Length, 2);
                 Assert.IsTrue(settings.Any(s => s.Label == "abc"));
@@ -1185,8 +1185,8 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteAsync(abcSetting.Key);
-                await service.DeleteAsync(xyzSetting.Key);
+                await service.DeleteConfigurationSettingAsync(abcSetting.Key);
+                await service.DeleteConfigurationSettingAsync(xyzSetting.Key);
             }
         }
 
@@ -1198,14 +1198,14 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                var setting = await service.AddAsync(testSetting);
+                var setting = await service.AddConfigurationSettingAsync(testSetting);
                 var readOnly = await service.SetReadOnlyAsync(testSetting.Key, testSetting.Label);
                 Assert.IsTrue(readOnly.Value.ReadOnly);
             }
             finally
             {
                 await service.ClearReadOnlyAsync(testSetting.Key, testSetting.Label);
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -1224,7 +1224,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -1236,13 +1236,13 @@ namespace Azure.Data.AppConfiguration.Tests
 
             try
             {
-                var setting = await service.AddAsync(testSetting);
+                var setting = await service.AddConfigurationSettingAsync(testSetting);
                 var readOnly = await service.ClearReadOnlyAsync(testSetting.Key, testSetting.Label);
                 Assert.IsFalse(readOnly.Value.ReadOnly);
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -1261,7 +1261,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteAsync(testSetting.Key, testSetting.Label);
+                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
             }
         }
     }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationMockTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationMockTests.cs
@@ -63,7 +63,7 @@ namespace Azure.Data.AppConfiguration.Tests
             var mockTransport = new MockTransport(response);
             ConfigurationClient service = CreateTestService(mockTransport);
 
-            ConfigurationSetting setting = await service.GetAsync(s_testSetting.Key);
+            ConfigurationSetting setting = await service.GetConfigurationSettingAsync(s_testSetting.Key);
 
             MockRequest request = mockTransport.SingleRequest;
 
@@ -82,7 +82,7 @@ namespace Azure.Data.AppConfiguration.Tests
             var mockTransport = new MockTransport(response);
             ConfigurationClient service = CreateTestService(mockTransport);
 
-            ConfigurationSetting setting = await service.GetAsync(s_testSetting.Key, s_testSetting.Label);
+            ConfigurationSetting setting = await service.GetConfigurationSettingAsync(s_testSetting.Key, s_testSetting.Label);
             MockRequest request = mockTransport.SingleRequest;
 
             AssertRequestCommon(request);
@@ -100,7 +100,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             RequestFailedException exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
             {
-                await service.GetAsync(key: s_testSetting.Key);
+                await service.GetConfigurationSettingAsync(key: s_testSetting.Key);
             });
 
             Assert.AreEqual(404, exception.Status);
@@ -121,7 +121,7 @@ namespace Azure.Data.AppConfiguration.Tests
             var mockTransport = new MockTransport(mockResponse);
             ConfigurationClient service = CreateTestService(mockTransport);
 
-            Response<ConfigurationSetting> response = await service.GetAsync(requestSetting, onlyIfChanged: true);
+            Response<ConfigurationSetting> response = await service.GetConfigurationSettingAsync(requestSetting, onlyIfChanged: true);
 
             // TODO: Should this be response.Status?
             Assert.AreEqual(200, response.GetRawResponse().Status);
@@ -147,7 +147,7 @@ namespace Azure.Data.AppConfiguration.Tests
             var mockTransport = new MockTransport(new MockResponse(304));
             ConfigurationClient service = CreateTestService(mockTransport);
 
-            Response<ConfigurationSetting> response = await service.GetAsync(requestSetting, onlyIfChanged: true);
+            Response<ConfigurationSetting> response = await service.GetConfigurationSettingAsync(requestSetting, onlyIfChanged: true);
 
             MockRequest request = mockTransport.SingleRequest;
 
@@ -179,7 +179,7 @@ namespace Azure.Data.AppConfiguration.Tests
             var mockTransport = new MockTransport(mockResponse);
             ConfigurationClient service = CreateTestService(mockTransport);
 
-            Response<ConfigurationSetting> response = await service.GetAsync(s_testSetting.Key, s_testSetting.Label, DateTimeOffset.MaxValue, requestOptions: default);
+            Response<ConfigurationSetting> response = await service.GetConfigurationSettingAsync(s_testSetting.Key, s_testSetting.Label, DateTimeOffset.MaxValue, requestOptions: default);
 
             MockRequest request = mockTransport.SingleRequest;
 
@@ -208,7 +208,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             var requestOptions = new MatchConditions { IfMatch = new ETag("v1") };
 
-            ConfigurationSetting setting = await service.GetAsync(testSetting.Key, testSetting.Label, default, requestOptions);
+            ConfigurationSetting setting = await service.GetConfigurationSettingAsync(testSetting.Key, testSetting.Label, default, requestOptions);
 
             MockRequest request = mockTransport.SingleRequest;
 
@@ -230,7 +230,7 @@ namespace Azure.Data.AppConfiguration.Tests
             var mockTransport = new MockTransport(response);
             ConfigurationClient service = CreateTestService(mockTransport);
 
-            ConfigurationSetting setting = await service.AddAsync(s_testSetting);
+            ConfigurationSetting setting = await service.AddConfigurationSettingAsync(s_testSetting);
             MockRequest request = mockTransport.SingleRequest;
 
             AssertRequestCommon(request);
@@ -252,7 +252,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             RequestFailedException exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
             {
-                ConfigurationSetting setting = await service.AddAsync(s_testSetting);
+                ConfigurationSetting setting = await service.AddConfigurationSettingAsync(s_testSetting);
             });
             Assert.AreEqual(412, exception.Status);
         }
@@ -266,7 +266,7 @@ namespace Azure.Data.AppConfiguration.Tests
             var mockTransport = new MockTransport(response);
             ConfigurationClient service = CreateTestService(mockTransport);
 
-            ConfigurationSetting setting = await service.SetAsync(s_testSetting);
+            ConfigurationSetting setting = await service.SetConfigurationSettingAsync(s_testSetting);
             MockRequest request = mockTransport.SingleRequest;
 
             AssertRequestCommon(request);
@@ -286,7 +286,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             RequestFailedException exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
             {
-                ConfigurationSetting setting = await service.SetAsync(s_testSetting);
+                ConfigurationSetting setting = await service.SetConfigurationSettingAsync(s_testSetting);
             });
             Assert.AreEqual(409, exception.Status);
         }
@@ -306,7 +306,7 @@ namespace Azure.Data.AppConfiguration.Tests
             var mockTransport = new MockTransport(response);
             ConfigurationClient service = CreateTestService(mockTransport);
 
-            ConfigurationSetting setting = await service.SetAsync(requestSetting, onlyIfUnchanged: true);
+            ConfigurationSetting setting = await service.SetConfigurationSettingAsync(requestSetting, onlyIfUnchanged: true);
             MockRequest request = mockTransport.SingleRequest;
 
             AssertRequestCommon(request);
@@ -335,7 +335,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             RequestFailedException exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
             {
-                Response<ConfigurationSetting> response = await service.SetAsync(requestSetting, onlyIfUnchanged: true);
+                Response<ConfigurationSetting> response = await service.SetConfigurationSettingAsync(requestSetting, onlyIfUnchanged: true);
             });
             Assert.AreEqual(412, exception.Status);
 
@@ -365,7 +365,7 @@ namespace Azure.Data.AppConfiguration.Tests
                 IfMatch = new ETag("v2")
             };
 
-            ConfigurationSetting setting = await service.SetAsync(s_testSetting, requestOptions);
+            ConfigurationSetting setting = await service.SetConfigurationSettingAsync(s_testSetting, requestOptions);
             MockRequest request = mockTransport.SingleRequest;
 
             AssertRequestCommon(request);
@@ -388,7 +388,7 @@ namespace Azure.Data.AppConfiguration.Tests
             var mockTransport = new MockTransport(response);
             ConfigurationClient service = CreateTestService(mockTransport);
 
-            await service.DeleteAsync(s_testSetting.Key);
+            await service.DeleteConfigurationSettingAsync(s_testSetting.Key);
             MockRequest request = mockTransport.SingleRequest;
 
             AssertRequestCommon(request);
@@ -405,7 +405,7 @@ namespace Azure.Data.AppConfiguration.Tests
             var mockTransport = new MockTransport(response);
             ConfigurationClient service = CreateTestService(mockTransport);
 
-            await service.DeleteAsync(s_testSetting.Key, s_testSetting.Label);
+            await service.DeleteConfigurationSettingAsync(s_testSetting.Key, s_testSetting.Label);
             MockRequest request = mockTransport.SingleRequest;
 
             AssertRequestCommon(request);
@@ -422,7 +422,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             RequestFailedException exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
             {
-                await service.DeleteAsync(s_testSetting.Key);
+                await service.DeleteConfigurationSettingAsync(s_testSetting.Key);
             });
 
             Assert.AreEqual(404, exception.Status);
@@ -436,7 +436,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             RequestFailedException exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
             {
-                Response response = await service.DeleteAsync(s_testSetting);
+                Response response = await service.DeleteConfigurationSettingAsync(s_testSetting);
             });
             Assert.AreEqual(409, exception.Status);
         }
@@ -456,7 +456,7 @@ namespace Azure.Data.AppConfiguration.Tests
             var mockTransport = new MockTransport(mockResponse);
             ConfigurationClient service = CreateTestService(mockTransport);
 
-            Response response = await service.DeleteAsync(requestSetting, onlyIfUnchanged: true);
+            Response response = await service.DeleteConfigurationSettingAsync(requestSetting, onlyIfUnchanged: true);
             MockRequest request = mockTransport.SingleRequest;
 
             AssertRequestCommon(request);
@@ -484,7 +484,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             RequestFailedException exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
             {
-                Response response = await service.DeleteAsync(requestSetting, onlyIfUnchanged: true);
+                Response response = await service.DeleteConfigurationSettingAsync(requestSetting, onlyIfUnchanged: true);
             });
             Assert.AreEqual(412, exception.Status);
 
@@ -514,7 +514,7 @@ namespace Azure.Data.AppConfiguration.Tests
                 IfMatch = new ETag("v2")
             };
 
-            Response response = await service.DeleteAsync(s_testSetting.Key, s_testSetting.Label, requestOptions);
+            Response response = await service.DeleteConfigurationSettingAsync(s_testSetting.Key, s_testSetting.Label, requestOptions);
             MockRequest request = mockTransport.SingleRequest;
 
             AssertRequestCommon(request);
@@ -551,7 +551,7 @@ namespace Azure.Data.AppConfiguration.Tests
             var query = new SettingSelector();
             int keyIndex = 0;
 
-            await foreach (ConfigurationSetting value in service.GetSettingsAsync(query, CancellationToken.None))
+            await foreach (ConfigurationSetting value in service.GetConfigurationSettingsAsync(query, CancellationToken.None))
             {
                 Assert.AreEqual("key" + keyIndex, value.Key);
                 keyIndex++;
@@ -584,7 +584,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             ConfigurationClient client = CreateClient<ConfigurationClient>(s_connectionString, options);
 
-            ConfigurationSetting setting = await client.GetAsync(s_testSetting.Key);
+            ConfigurationSetting setting = await client.GetConfigurationSettingAsync(s_testSetting.Key);
             Assert.True(ConfigurationSettingEqualityComparer.Instance.Equals(s_testSetting, setting));
             Assert.AreEqual(2, mockTransport.Requests.Count);
         }
@@ -598,7 +598,7 @@ namespace Azure.Data.AppConfiguration.Tests
             var mockTransport = new MockTransport(response);
             ConfigurationClient service = CreateTestService(mockTransport);
 
-            ConfigurationSetting setting = await service.AddAsync(s_testSetting);
+            ConfigurationSetting setting = await service.AddConfigurationSettingAsync(s_testSetting);
             MockRequest request = mockTransport.SingleRequest;
 
             StringAssert.Contains("api-version", request.Uri.ToUri().ToString());
@@ -617,7 +617,7 @@ namespace Azure.Data.AppConfiguration.Tests
 
             ConfigurationClient client = CreateClient<ConfigurationClient>(s_connectionString, options);
 
-            ConfigurationSetting setting = await client.AddAsync(s_testSetting);
+            ConfigurationSetting setting = await client.AddConfigurationSettingAsync(s_testSetting);
             MockRequest request = mockTransport.SingleRequest;
 
             StringAssert.Contains("api-version=1.0", request.Uri.ToUri().ToString());
@@ -634,7 +634,7 @@ namespace Azure.Data.AppConfiguration.Tests
             var mockTransport = new MockTransport(response);
             ConfigurationClient service = CreateTestService(mockTransport);
 
-            ConfigurationSetting setting = await service.AddAsync(s_testSetting);
+            ConfigurationSetting setting = await service.AddConfigurationSettingAsync(s_testSetting);
             MockRequest request = mockTransport.SingleRequest;
 
             AssertRequestCommon(request);
@@ -806,7 +806,7 @@ namespace Azure.Data.AppConfiguration.Tests
             activity.AddTag("correlation-context", "CorrelationContextValue1,CorrelationContextValue2");
             activity.AddTag("x-ms-random-id", "RandomValue");
 
-            ConfigurationSetting setting = await service.SetAsync(s_testSetting);
+            ConfigurationSetting setting = await service.SetConfigurationSettingAsync(s_testSetting);
             activity.Stop();
 
             MockRequest request = mockTransport.SingleRequest;
@@ -830,7 +830,7 @@ namespace Azure.Data.AppConfiguration.Tests
             var mockTransport = new MockTransport(new MockResponse(503), response);
             ConfigurationClient service = CreateTestService(mockTransport);
 
-            ConfigurationSetting setting = await service.GetAsync(s_testSetting.Key, s_testSetting.Label);
+            ConfigurationSetting setting = await service.GetConfigurationSettingAsync(s_testSetting.Key, s_testSetting.Label);
 
             var retriedRequest = mockTransport.Requests[1];
 

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/Performance/ConfigurationClientBenchmark.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/Performance/ConfigurationClientBenchmark.cs
@@ -45,7 +45,7 @@ namespace Azure.Data.AppConfiguration.Performance
         [Benchmark]
         public async Task GetAsync()
         {
-            await s_configurationClient.GetAsync("key");
+            await s_configurationClient.GetConfigurationSettingAsync("key");
         }
 
 


### PR DESCRIPTION
Per API Review feedback to make client operation names consistent across languages, and to be consistent with other service naming conventions, e.g. SetSecret in KeyVault.