### PR TITLE
Disable package and tag release steps for Microsoft.Extensions.Azure

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -10,7 +10,6 @@ resources:
     - repository: azure-sdk-build-tools
       type: git
       name: internal/azure-sdk-build-tools
-      ref: refs/heads/add-per-artifact-skips
 
 trigger:
   branches:

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -10,6 +10,7 @@ resources:
     - repository: azure-sdk-build-tools
       type: git
       name: internal/azure-sdk-build-tools
+      ref: ref/heads/add-per-artifact-skips
 
 trigger:
   branches:
@@ -41,3 +42,8 @@ stages:
     Artifacts:
     - name: Azure.Core
       safeName: AzureCore
+    - name: Microsoft.Extensions.Azure
+      safeName: MicrosoftExtensionsAzure
+      options:
+        skipTagRepository: true
+        skipPublishPackage: true

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -10,7 +10,7 @@ resources:
     - repository: azure-sdk-build-tools
       type: git
       name: internal/azure-sdk-build-tools
-      ref: ref/heads/add-per-artifact-skips
+      ref: refs/heads/add-per-artifact-skips
 
 trigger:
   branches:


### PR DESCRIPTION
This PR blocks the Microsoft.Extensions.Azure package in the core pipeline from being tagged in GitHub or published to NuGet.org. This is something that I was setting up for @chidozieononiwu.