### PR TITLE
[Storage]: Use null instead of empty dictionary when metadata wasn't requested

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -1674,7 +1674,7 @@ namespace Azure.Storage.Blobs
                           async: async,
                           cancellationToken: cancellationToken)
                           .ConfigureAwait(false);
-                    if (!traits.Equals(BlobTraits.Metadata))
+                    if ((traits & BlobTraits.Metadata) != BlobTraits.Metadata)
                     {
                         IEnumerable<BlobItem> blobItems = response.Value.BlobItems;
                         foreach (BlobItem blobItem in blobItems)

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -1663,17 +1663,26 @@ namespace Azure.Storage.Blobs
 
                 try
                 {
-                    return await BlobRestClient.Container.ListBlobsFlatSegmentAsync(
-                        ClientDiagnostics,
-                        Pipeline,
-                        Uri,
-                        marker: marker,
-                        prefix: prefix,
-                        maxresults: pageSizeHint,
-                        include: BlobExtensions.AsIncludeItems(traits, states),
-                        async: async,
-                        cancellationToken: cancellationToken)
-                        .ConfigureAwait(false);
+                    Response<BlobsFlatSegment> response = await BlobRestClient.Container.ListBlobsFlatSegmentAsync(
+                          ClientDiagnostics,
+                          Pipeline,
+                          Uri,
+                          marker: marker,
+                          prefix: prefix,
+                          maxresults: pageSizeHint,
+                          include: BlobExtensions.AsIncludeItems(traits, states),
+                          async: async,
+                          cancellationToken: cancellationToken)
+                          .ConfigureAwait(false);
+                    if (!traits.Equals(BlobTraits.Metadata))
+                    {
+                        IEnumerable<BlobItem> blobItems = response.Value.BlobItems;
+                        foreach (BlobItem blobItem in blobItems)
+                        {
+                            blobItem.Metadata = null;
+                        }
+                    }
+                    return response;
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Issue - https://github.com/Azure/azure-sdk-for-net/issues/8397