### PR TITLE
Replace Assert.CatchAsync with something that doesn't block and re-enable tests

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs.Batch/tests/BlobBatchClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/tests/BlobBatchClientTests.cs
@@ -175,7 +175,6 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [Test]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/8358")]
         public async Task Batch_AcrossContainers()
         {
             await using TestScenario scenario = Scenario();

--- a/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
@@ -741,7 +741,6 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [Test]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/8351")]
         public async Task AppendBlockFromUriAsync_AccessConditions()
         {
             var garbageLeaseId = GetGarbageLeaseId();

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -96,7 +96,6 @@ namespace Azure.Storage.Blobs.Test
 
         #region Secondary Storage
         [Test]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/8356")]
         public async Task DownloadAsync_ReadFromSecondaryStorage()
         {
             await using DisposingContainer test = await GetTestContainerAsync(GetServiceClient_SecondaryAccount_ReadEnabledOnRetry(1, out TestExceptionPolicy testExceptionPolicy));
@@ -313,7 +312,7 @@ namespace Azure.Storage.Blobs.Test
                 BlobRequestConditions accessConditions = BuildAccessConditions(parameters);
 
                 // Act
-                Assert.CatchAsync<Exception>(
+                await TestHelper.CatchAsync<Exception>(
                     async () =>
                     {
                         var _ = (await blob.DownloadAsync(
@@ -438,7 +437,6 @@ namespace Azure.Storage.Blobs.Test
             }
         }
 
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/8356")]
         [Test]
         [TestCase(512)]
         [TestCase(1 * Constants.KB)]
@@ -1483,6 +1481,7 @@ namespace Azure.Storage.Blobs.Test
             foreach (AccessConditionParameters parameters in GetAccessConditionsFail_Data(garbageLeaseId))
             {
                 await using DisposingContainer test = await GetTestContainerAsync();
+
                 // Arrange
                 BlobBaseClient blob = await GetNewBlobClient(test.Container);
 
@@ -1490,13 +1489,12 @@ namespace Azure.Storage.Blobs.Test
                 BlobRequestConditions accessConditions = BuildAccessConditions(parameters);
 
                 // Act
-                Assert.CatchAsync<Exception>(
+                await TestHelper.CatchAsync<Exception>(
                     async () =>
                     {
                         var _ = (await blob.GetPropertiesAsync(
                             conditions: accessConditions)).Value;
                     });
-
             }
         }
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
@@ -503,7 +503,6 @@ namespace Azure.Storage.Blobs.Test
         [TestCase(20 * Constants.KB)]
         [TestCase(30 * Constants.KB)]
         [TestCase(50 * Constants.KB)]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/8354")]
         // [TestCase(501 * Constants.KB)] // TODO: #6781 We don't want to add 500K of random data in the recordings
         public async Task UploadStreamAsync_SmallBlobs(long size) =>
             // Use a 1KB threshold so we get a lot of individual blocks
@@ -518,7 +517,6 @@ namespace Azure.Storage.Blobs.Test
         [TestCase(20 * Constants.KB)]
         [TestCase(30 * Constants.KB)]
         [TestCase(50 * Constants.KB)]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/8354")]
         // [TestCase(501 * Constants.KB)] // TODO: #6781 We don't want to add 500K of random data in the recordings
         public async Task UploadFileAsync_SmallBlobs(long size) =>
             // Use a 1KB threshold so we get a lot of individual blocks
@@ -541,7 +539,6 @@ namespace Azure.Storage.Blobs.Test
         [TestCase(1 * Constants.GB, 8)]
         [TestCase(1 * Constants.GB, 16)]
         [TestCase(1 * Constants.GB, null)]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/8354")]
         public async Task UploadStreamAsync_LargeBlobs(long size, int? maximumThreadCount)
         {
             // TODO: #6781 We don't want to add 1GB of random data in the recordings
@@ -565,7 +562,6 @@ namespace Azure.Storage.Blobs.Test
         [TestCase(1 * Constants.GB, 8)]
         [TestCase(1 * Constants.GB, 16)]
         [TestCase(1 * Constants.GB, null)]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/8354")]
         public async Task UploadFileAsync_LargeBlobs(long size, int? maximumThreadCount)
         {
             // TODO: #6781 We don't want to add 1GB of random data in the recordings

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
@@ -238,7 +238,6 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [Test]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/8354")]
         public async Task StageBlockAsync_WithUnreliableConnection()
         {
             const int blobSize = 1 * Constants.MB;
@@ -325,7 +324,6 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [Test]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/8353")]
         public async Task StageBlockFromUriAsync_CPK()
         {
             await using DisposingContainer test = await GetTestContainerAsync();
@@ -1318,7 +1316,6 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [Test]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/8354")]
         public async Task UploadAsync_WithUnreliableConnection()
         {
             const int blobSize = 1 * Constants.MB;

--- a/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
@@ -477,7 +477,6 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [Test]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/8354")]
         public async Task UploadPagesAsync_WithUnreliableConnection()
         {
             const int blobSize = 1 * Constants.MB;
@@ -825,7 +824,7 @@ namespace Azure.Storage.Blobs.Test
                     lease: true);
 
                 // Act
-                Assert.CatchAsync<Exception>(
+                await TestHelper.CatchAsync<Exception>(
                     async () =>
                     {
                         var _ = (await blob.GetPageRangesAsync(
@@ -979,7 +978,7 @@ namespace Azure.Storage.Blobs.Test
                     lease: true);
 
                 // Act
-                Assert.CatchAsync<Exception>(
+                await TestHelper.CatchAsync<Exception>(
                     async () =>
                     {
                         var _ = (await blob.GetPageRangesDiffAsync(
@@ -1564,7 +1563,6 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [Test]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/8353")]
         public async Task UploadPagesFromUriAsync_CPK()
         {
             await using DisposingContainer test = await GetTestContainerAsync();

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/TestHelper.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/TestHelper.cs
@@ -106,6 +106,26 @@ namespace Azure.Storage.Test
             }
         }
 
+        public static async Task<T> CatchAsync<T>(Func<Task> action)
+            where T : Exception
+        {
+            try
+            {
+                await action().ConfigureAwait(false);
+                Assert.Fail("Expected exception not found");
+            }
+            catch (T ex)
+            {
+                return ex;
+            }
+            catch (Exception other)
+            {
+                Assert.Fail($"Expected exception of type {typeof(T).Name}, not {other.ToString()}");
+            }
+
+            throw new InvalidOperationException("Won't ever get here!");
+        }
+
         public static void AssertCacheableProperty<T>(T expected, Func<T> property)
         {
             T actual = property();

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
@@ -1035,7 +1035,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                     DataLakeRequestConditions conditions = BuildDataLakeRequestConditions(parameters);
 
                     // Act
-                    Assert.CatchAsync<Exception>(
+                    await TestHelper.CatchAsync<Exception>(
                         async () =>
                         {
                             var _ = (await directory.GetPropertiesAsync(

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/FileClientTests.cs
@@ -1081,7 +1081,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                     DataLakeRequestConditions conditions = BuildDataLakeRequestConditions(parameters);
 
                     // Act
-                    Assert.CatchAsync<Exception>(
+                    await TestHelper.CatchAsync<Exception>(
                         async () =>
                         {
                             var _ = (await file.GetPropertiesAsync(
@@ -1792,7 +1792,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                     DataLakeRequestConditions conditions = BuildDataLakeRequestConditions(parameters);
 
                     // Act
-                    Assert.CatchAsync<Exception>(
+                    await TestHelper.CatchAsync<Exception>(
                         async () =>
                         {
                             var _ = (await file.ReadAsync(

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
@@ -945,7 +945,6 @@ namespace Azure.Storage.Files.Shares.Test
         [TestCase(33 * Constants.MB)]
         [TestCase(257 * Constants.MB)]
         [TestCase(1 * Constants.GB)]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/8354")]
         public async Task UploadAsync_LargeBlobs(int size) =>
             // TODO: #6781 We don't want to add 1GB of random data in the recordings
             await UploadAndVerify(size, Constants.MB);
@@ -1036,7 +1035,6 @@ namespace Azure.Storage.Files.Shares.Test
 
         [Test]
         [LiveOnly]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/8354")]
         // TODO: #7645
         public async Task UploadRangeFromUriAsync()
         {


### PR DESCRIPTION
Also try the following to force starvation:

```
     public abstract class StorageTestBase : RecordedTestBase
     {
+        static StorageTestBase()
+        {
+            int max = Environment.ProcessorCount;
+            System.Threading.ThreadPool.SetMaxThreads(max, max);
+        }
+
         public StorageTestBase(bool async, RecordedTestMode? mode = null)
-            : base(async, mode ?? RecordedTestUtilities.GetModeFromEnvironment())
+            : base(async, RecordedTestMode.Live)
         {
```