### PR TITLE
Make the AzureServiceTokenProvider mockable

### DIFF
--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication.TestCommon/MockUtil.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication.TestCommon/MockUtil.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace Microsoft.Azure.Services.AppAuthentication.TestCommon
+{
+    public class MockUtil
+    {
+        public static void AssertPublicMethodsAreVirtual<T>()
+        {
+            foreach (MethodInfo methodInfo in typeof(T).GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly))
+            {
+                Assert.True(methodInfo.IsVirtual, $"Method {methodInfo.Name} is not virtual");
+            }
+        }
+    }
+}

--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/AzureServiceTokenProviderTests.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/AzureServiceTokenProviderTests.cs
@@ -304,5 +304,14 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             Environment.SetEnvironmentVariable(Constants.MsiAppServiceEndpointEnv,null);
             Environment.SetEnvironmentVariable(Constants.MsiAppServiceSecretEnv, null);
         }
+
+        /// <summary>
+        /// Ensure that all public methods are marked virtual to maintain mockability
+        /// </summary>
+        [Fact]
+        public void RemainMockable()
+        {
+            MockUtil.AssertPublicMethodsAreVirtual<AzureServiceTokenProvider>();
+        }
     }
 }

--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProvider.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
         /// <summary>
         /// The principal used to acquire token. This will be of type "User" for local development scenarios, and "App" when client credentials flow is used. 
         /// </summary>
-        public Principal PrincipalUsed => _principalUsed;
+        public virtual Principal PrincipalUsed => _principalUsed;
 
         /// <summary>
         /// Creates an instance of the AzureServiceTokenProvider class.

--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProvider.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProvider.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
         /// KeyVaultClient keyVaultClient = new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(azureServiceTokenProvider.KeyVaultTokenCallback));
         /// </code>
         /// </example>
-        public TokenCallback KeyVaultTokenCallback => async (authority, resource, scope) =>
+        public virtual TokenCallback KeyVaultTokenCallback => async (authority, resource, scope) =>
         {
             var authResult = await GetAuthResultAsyncImpl(resource, authority).ConfigureAwait(false);
             return authResult.AccessToken;
@@ -240,7 +240,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
         /// <returns>Access token</returns>
         /// <exception cref="ArgumentNullException">Thrown if resource is null or empty.</exception>
         /// <exception cref="AzureServiceTokenProviderException">Thrown if access token cannot be acquired.</exception>
-        public async Task<string> GetAccessTokenAsync(string resource, string tenantId = default(string),
+        public virtual async Task<string> GetAccessTokenAsync(string resource, string tenantId = default(string),
             CancellationToken cancellationToken = default(CancellationToken))
         {
             var authResult = await GetAuthenticationResultAsync(resource, tenantId, cancellationToken).ConfigureAwait(false);
@@ -248,7 +248,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
             return authResult.AccessToken;
         }
 
-        public Task<string> GetAccessTokenAsync(string resource, string tenantId)
+        public virtual Task<string> GetAccessTokenAsync(string resource, string tenantId)
         {
             return GetAccessTokenAsync(resource, tenantId, default(CancellationToken));
         }
@@ -267,7 +267,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
         /// <returns>Access token</returns>
         /// <exception cref="ArgumentNullException">Thrown if resource is null or empty.</exception>
         /// <exception cref="AzureServiceTokenProviderException">Thrown if access token cannot be acquired.</exception>
-        public Task<AppAuthenticationResult> GetAuthenticationResultAsync(string resource, string tenantId = default(string),
+        public virtual Task<AppAuthenticationResult> GetAuthenticationResultAsync(string resource, string tenantId = default(string),
             CancellationToken cancellationToken = default(CancellationToken))
         {
             if (string.IsNullOrWhiteSpace(resource))
@@ -280,7 +280,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
             return GetAuthResultAsyncImpl(resource, authority, cancellationToken);
         }
 
-        public Task<AppAuthenticationResult> GetAuthenticationResultAsync(string resource, string tenantId)
+        public virtual Task<AppAuthenticationResult> GetAuthenticationResultAsync(string resource, string tenantId)
         {
             return GetAuthenticationResultAsync(resource, tenantId, default(CancellationToken));
         }

--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/Microsoft.Azure.Services.AppAuthentication.csproj
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/Microsoft.Azure.Services.AppAuthentication.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <PackageId>Microsoft.Azure.Services.AppAuthentication</PackageId>
         <Description>Enables a service to authenticate to Azure services using the developer's Azure Active Directory/ Microsoft account during development, and authenticate as itself (using OAuth 2.0 Client Credentials flow) when deployed to Azure.</Description>
-        <Version>1.3.1</Version>
+        <Version>1.3.2</Version>
         <AssemblyName>Microsoft.Azure.Services.AppAuthentication</AssemblyName>
         <PackageTags>Azure Authentication AppAuthentication</PackageTags>
 	    <PackageReleaseNotes>

--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/Microsoft.Azure.Services.AppAuthentication.csproj
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/Microsoft.Azure.Services.AppAuthentication.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <PackageId>Microsoft.Azure.Services.AppAuthentication</PackageId>
         <Description>Enables a service to authenticate to Azure services using the developer's Azure Active Directory/ Microsoft account during development, and authenticate as itself (using OAuth 2.0 Client Credentials flow) when deployed to Azure.</Description>
-        <Version>1.3.2</Version>
+        <Version>1.4.0</Version>
         <AssemblyName>Microsoft.Azure.Services.AppAuthentication</AssemblyName>
         <PackageTags>Azure Authentication AppAuthentication</PackageTags>
 	    <PackageReleaseNotes>

--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/Properties/AssemblyInfo.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/Properties/AssemblyInfo.cs
@@ -4,8 +4,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("Microsoft.Azure.Services.AppAuthentication")]
 [assembly: AssemblyDescription("Enables a service to authenticate to Azure services using the developer's Azure Active Directory/ Microsoft account during development, and authenticate as itself (using OAuth 2.0 Client Credentials flow) when deployed to Azure.")]
 
-[assembly: AssemblyVersion("1.3.2.0")]
-[assembly: AssemblyFileVersion("1.3.2.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]
 [assembly: AssemblyCompany("Microsoft Corporation")]
 [assembly: AssemblyProduct("Microsoft Azure")]
 [assembly: AssemblyCopyright("Copyright (c) Microsoft Corporation. All rights reserved.")]

--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/Properties/AssemblyInfo.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/Properties/AssemblyInfo.cs
@@ -4,8 +4,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("Microsoft.Azure.Services.AppAuthentication")]
 [assembly: AssemblyDescription("Enables a service to authenticate to Azure services using the developer's Azure Active Directory/ Microsoft account during development, and authenticate as itself (using OAuth 2.0 Client Credentials flow) when deployed to Azure.")]
 
-[assembly: AssemblyVersion("1.3.1.0")]
-[assembly: AssemblyFileVersion("1.3.1.0")]
+[assembly: AssemblyVersion("1.3.2.0")]
+[assembly: AssemblyFileVersion("1.3.2.0")]
 [assembly: AssemblyCompany("Microsoft Corporation")]
 [assembly: AssemblyProduct("Microsoft Azure")]
 [assembly: AssemblyCopyright("Copyright (c) Microsoft Corporation. All rights reserved.")]


### PR DESCRIPTION
Make the AzureServiceTokenProvider mockable as requested in #7603

Mock example
```csharp
//bogus
var jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
var mockProvider =  new Mock<AzureServiceTokenProvider>(() => new AzureServiceTokenProvider(null, "https://login.microsoftonline.com/"));
var mockTokenCallback = new Mock<AzureServiceTokenProvider.TokenCallback>();
mockProvider
    .SetupGet(p => p.KeyVaultTokenCallback)
    .Returns(mockTokenCallback.Object);
	
var kv = new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(mockProvider.Object.KeyVaultTokenCallback));
mockTokenCallback
    .Setup(tc => tc(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
    .ReturnsAsync (() => jwt);

try
{
    await kv.GetSecretAsync("https://someKeyVaultName.vault.azure.net", "someSecretName");
}
catch(KeyVaultErrorException ex)
{
    //Operation returned an invalid status code 'Unauthorized' (for bogus jwt)
    Console.WriteLine(ex.Message);
}
	
mockTokenCallback
    .Setup(tc => tc(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
    .Throws(new Exception("foo"));

try
{
    await kv.GetSecretAsync("https://someKeyVaultName.vault.azure.net", "someSecretName");
}
catch (Exception ex)
{
    //foo
    Console.WriteLine(ex.Message);
}
```