### PR TITLE
Removed reflection

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Infrastructure/IEventHubsSample.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Infrastructure/IEventHubsSample.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Threading.Tasks;
-
 namespace Azure.Messaging.EventHubs.Samples.Infrastructure
 {
     /// <summary>
@@ -24,15 +22,5 @@ namespace Azure.Messaging.EventHubs.Samples.Infrastructure
         /// </summary>
         ///
         public string Description { get; }
-
-        /// <summary>
-        ///   Allows for executing the sample.
-        /// </summary>
-        ///
-        /// <param name="connectionString">The connection string for the Event Hubs namespace that the sample should target.</param>
-        /// <param name="eventHubName">The name of the Event Hub, sometimes known as its path, that the sample should run against.</param>
-        ///
-        public Task RunAsync(string connectionString,
-                             string eventHubName);
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Infrastructure/SampleNames.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Infrastructure/SampleNames.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Messaging.EventHubs.Samples.Infrastructure
+{
+    public enum SampleNames
+    {
+        Sample01_HelloWorld = 0,
+        Sample02_ClientWithCustomOptions,
+        Sample03_PublishAnEvent,
+        Sample04_PublishEventsWithPartitionKey,
+        Sample05_PublishAnEventBatch,
+        Sample06_PublishEventsToSpecificPartitions,
+        Sample07_PublishEventsWithCustomMetadata,
+        Sample08_ConsumeEvents,
+        Sample09_ConsumeEventsWithMaximumWaitTime,
+        Sample10_ConsumeEventsFromAKnownPosition,
+        Sample11_ConsumeEventsByBatch,
+        Sample12_ConsumeEventsWithEventProcessor
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Program.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Program.cs
@@ -59,7 +59,7 @@ namespace Azure.Messaging.EventHubs.Samples
 
             Console.WriteLine();
 
-            var choice = ReadSelection(samples.Count);
+            int? choice = ReadSelection(samples.Count);
 
             if (choice == null)
             {
@@ -68,24 +68,6 @@ namespace Azure.Messaging.EventHubs.Samples
                 Console.WriteLine("Quitting...");
                 Console.WriteLine();
                 return;
-            }
-
-            // Prompt for the connection string, if it wasn't passed.
-
-            while (String.IsNullOrEmpty(parsedArgs.ConnectionString))
-            {
-                Console.Write("Please provide the connection string for the Event Hubs namespace that you'd like to use and then press Enter: ");
-                parsedArgs.ConnectionString = Console.ReadLine().Trim();
-                Console.WriteLine();
-            }
-
-            // Prompt for the Event Hub name, if it wasn't passed.
-
-            while (String.IsNullOrEmpty(parsedArgs.EventHub))
-            {
-                Console.Write("Please provide the name of the Event Hub that you'd like to use and then press Enter: ");
-                parsedArgs.EventHub = Console.ReadLine().Trim();
-                Console.WriteLine();
             }
 
             // Run the chosen sample
@@ -98,9 +80,245 @@ namespace Azure.Messaging.EventHubs.Samples
             Console.WriteLine("-------------------------------------------------------------------------");
             Console.WriteLine();
 
-            await samples[choice.Value].RunAsync(parsedArgs.ConnectionString, parsedArgs.EventHub);
+            await FindAndRunSample(parsedArgs, choice);
+        }
 
-            return;
+        private static async Task FindAndRunSample(CommandLineArguments parsedArgs, int? choice)
+        {
+            if (IsSample01(choice))
+            {
+                await RunSample01(parsedArgs);
+            }
+            else if (IsSample02(choice))
+            {
+                await RunSample02(parsedArgs);
+            }
+            else if (IsSample03(choice))
+            {
+                await RunSample03(parsedArgs);
+            }
+            else if (IsSample04(choice))
+            {
+                await RunSample04(parsedArgs);
+            }
+            else if (IsSample05(choice))
+            {
+                await RunSample05(parsedArgs);
+            }
+            else if (IsSample06(choice))
+            {
+                await RunSample06(parsedArgs);
+            }
+            else if (IsSample07(choice))
+            {
+                await RunSample07(parsedArgs);
+            }
+            else if (IsSample08(choice))
+            {
+                await RunSample08(parsedArgs);
+            }
+            else if (IsSample09(choice))
+            {
+                await RunSample09(parsedArgs);
+            }
+            else if (IsSample10(choice))
+            {
+                await RunSample10(parsedArgs);
+            }
+            else if (IsSample11(choice))
+            {
+                await RunSample11(parsedArgs);
+            }
+            else if (IsSample12(choice))
+            {
+                await RunSample12(parsedArgs);
+            }
+        }
+
+        private static bool IsSample01(int? choice)
+        {
+            return choice == (int)SampleNames.Sample01_HelloWorld;
+        }
+
+        private static async Task RunSample01(CommandLineArguments parsedArgs)
+        {
+            string connectionString = PromptConnectionString(parsedArgs);
+            string eventHubName = PromptEventHubName(parsedArgs);
+
+            await new Sample01_HelloWorld().RunAsync(connectionString, eventHubName);
+        }
+
+        private static bool IsSample02(int? choice)
+        {
+            return choice == (int)SampleNames.Sample02_ClientWithCustomOptions;
+        }
+
+        private static async Task RunSample02(CommandLineArguments parsedArgs)
+        {
+            string connectionString = PromptConnectionString(parsedArgs);
+            string eventHubName = PromptEventHubName(parsedArgs);
+
+            await new Sample02_ClientWithCustomOptions().RunAsync(connectionString, eventHubName);
+        }
+
+        private static bool IsSample03(int? choice)
+        {
+            return choice == (int)SampleNames.Sample03_PublishAnEvent;
+        }
+
+        private static async Task RunSample03(CommandLineArguments parsedArgs)
+        {
+            string connectionString = PromptConnectionString(parsedArgs);
+            string eventHubName = PromptEventHubName(parsedArgs);
+
+            await new Sample03_PublishAnEvent().RunAsync(connectionString, eventHubName);
+        }
+
+        private static bool IsSample04(int? choice)
+        {
+            return choice == (int)SampleNames.Sample04_PublishEventsWithPartitionKey;
+        }
+
+        private static async Task RunSample04(CommandLineArguments parsedArgs)
+        {
+            string connectionString = PromptConnectionString(parsedArgs);
+            string eventHubName = PromptEventHubName(parsedArgs);
+
+            await new Sample04_PublishEventsWithPartitionKey().RunAsync(connectionString, eventHubName);
+        }
+
+        private static bool IsSample05(int? choice)
+        {
+            return choice == (int)SampleNames.Sample05_PublishAnEventBatch;
+        }
+
+        private static async Task RunSample05(CommandLineArguments parsedArgs)
+        {
+            string connectionString = PromptConnectionString(parsedArgs);
+            string eventHubName = PromptEventHubName(parsedArgs);
+
+            await new Sample05_PublishAnEventBatch().RunAsync(connectionString, eventHubName);
+        }
+
+        private static bool IsSample06(int? choice)
+        {
+            return choice == (int)SampleNames.Sample06_PublishEventsToSpecificPartitions;
+        }
+
+        private static async Task RunSample06(CommandLineArguments parsedArgs)
+        {
+            string connectionString = PromptConnectionString(parsedArgs);
+            string eventHubName = PromptEventHubName(parsedArgs);
+
+            await new Sample06_PublishEventsToSpecificPartitions().RunAsync(connectionString, eventHubName);
+        }
+
+        private static bool IsSample07(int? choice)
+        {
+            return choice == (int)SampleNames.Sample07_PublishEventsWithCustomMetadata;
+        }
+
+        private static async Task RunSample07(CommandLineArguments parsedArgs)
+        {
+            string connectionString = PromptConnectionString(parsedArgs);
+            string eventHubName = PromptEventHubName(parsedArgs);
+
+            await new Sample07_PublishEventsWithCustomMetadata().RunAsync(connectionString, eventHubName);
+        }
+
+        private static bool IsSample08(int? choice)
+        {
+            return choice == (int)SampleNames.Sample08_ConsumeEvents;
+        }
+
+        private static async Task RunSample08(CommandLineArguments parsedArgs)
+        {
+            string connectionString = PromptConnectionString(parsedArgs);
+            string eventHubName = PromptEventHubName(parsedArgs);
+
+            await new Sample08_ConsumeEvents().RunAsync(connectionString, eventHubName);
+        }
+
+        private static bool IsSample09(int? choice)
+        {
+            return choice == (int)SampleNames.Sample09_ConsumeEventsWithMaximumWaitTime;
+        }
+
+        private static async Task RunSample09(CommandLineArguments parsedArgs)
+        {
+            string connectionString = PromptConnectionString(parsedArgs);
+            string eventHubName = PromptEventHubName(parsedArgs);
+
+            await new Sample09_ConsumeEventsWithMaximumWaitTime().RunAsync(connectionString, eventHubName);
+        }
+
+        private static bool IsSample10(int? choice)
+        {
+            return choice == (int)SampleNames.Sample10_ConsumeEventsFromAKnownPosition;
+        }
+
+        private static async Task RunSample10(CommandLineArguments parsedArgs)
+        {
+            string connectionString = PromptConnectionString(parsedArgs);
+            string eventHubName = PromptEventHubName(parsedArgs);
+
+            await new Sample10_ConsumeEventsFromAKnownPosition().RunAsync(connectionString, eventHubName);
+        }
+
+        private static bool IsSample11(int? choice)
+        {
+            return choice == (int)SampleNames.Sample11_ConsumeEventsByBatch;
+        }
+
+        private static async Task RunSample11(CommandLineArguments parsedArgs)
+        {
+            string connectionString = PromptConnectionString(parsedArgs);
+            string eventHubName = PromptEventHubName(parsedArgs);
+
+            await new Sample11_ConsumeEventsByBatch().RunAsync(connectionString, eventHubName);
+        }
+
+        private static bool IsSample12(int? choice)
+        {
+            return choice == (int)SampleNames.Sample12_ConsumeEventsWithEventProcessor;
+        }
+
+        private static async Task RunSample12(CommandLineArguments parsedArgs)
+        {
+            string connectionString = PromptConnectionString(parsedArgs);
+            string eventHubName = PromptEventHubName(parsedArgs);
+
+            await new Sample12_ConsumeEventsWithEventProcessor().RunAsync(connectionString, eventHubName);
+        }
+
+        private static string PromptEventHubName(CommandLineArguments parsedArgs)
+        {
+            // Prompt for the Event Hub name, if it wasn't passed.
+            string eventHubName = parsedArgs.EventHub;
+
+            while (String.IsNullOrEmpty(eventHubName))
+            {
+                Console.Write("Please provide the name of the Event Hub that you'd like to use and then press Enter: ");
+                eventHubName = Console.ReadLine().Trim();
+                Console.WriteLine();
+            }
+
+            return eventHubName;
+        }
+
+        private static string PromptConnectionString(CommandLineArguments parsedArgs)
+        {
+            // Prompt for the connection string, if it wasn't passed.
+            string connectionString = parsedArgs.ConnectionString;
+
+            while (String.IsNullOrEmpty(connectionString))
+            {
+                Console.Write("Please provide the connection string for the Event Hubs namespace that you'd like to use and then press Enter: ");
+                connectionString = Console.ReadLine().Trim();
+                Console.WriteLine();
+            }
+
+            return connectionString;
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Program.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Program.cs
@@ -42,6 +42,34 @@ namespace Azure.Messaging.EventHubs.Samples
             Console.WriteLine("=========================================");
             Console.WriteLine();
 
+            // Display the set of available samples and allow the user to choose.
+
+            var samples = LocateSamples();
+
+            Console.WriteLine();
+            Console.WriteLine("Available Samples:");
+            Console.WriteLine();
+
+            for (var index = 0; index < samples.Count; ++index)
+            {
+                Console.WriteLine($"{ index + 1 }) { samples[index].Name }");
+                Console.WriteLine($"\t{ samples[index].Description }");
+                Console.WriteLine();
+            }
+
+            Console.WriteLine();
+
+            var choice = ReadSelection(samples.Count);
+
+            if (choice == null)
+            {
+                Console.WriteLine();
+                Console.WriteLine();
+                Console.WriteLine("Quitting...");
+                Console.WriteLine();
+                return;
+            }
+
             // Prompt for the connection string, if it wasn't passed.
 
             while (String.IsNullOrEmpty(parsedArgs.ConnectionString))
@@ -60,45 +88,19 @@ namespace Azure.Messaging.EventHubs.Samples
                 Console.WriteLine();
             }
 
-            // Display the set of available samples and allow them to be run.
-
-            var samples = LocateSamples();
+            // Run the chosen sample
 
             Console.WriteLine();
-            Console.WriteLine("Available Samples:");
+            Console.WriteLine();
+            Console.WriteLine();
+            Console.WriteLine("-------------------------------------------------------------------------");
+            Console.WriteLine($"Running: { samples[choice.Value].Name }");
+            Console.WriteLine("-------------------------------------------------------------------------");
             Console.WriteLine();
 
-            for (var index = 0; index < samples.Count; ++index)
-            {
-                Console.WriteLine($"{ index + 1 }) { samples[index].Name }");
-                Console.WriteLine($"\t{ samples[index].Description }");
-                Console.WriteLine();
-            }
+            await samples[choice.Value].RunAsync(parsedArgs.ConnectionString, parsedArgs.EventHub);
 
-            Console.WriteLine();
-            var choice = ReadSelection(samples.Count);
-
-            if (choice == null)
-            {
-                Console.WriteLine();
-                Console.WriteLine();
-                Console.WriteLine("Quitting...");
-                Console.WriteLine();
-                return;
-            }
-            else
-            {
-                Console.WriteLine();
-                Console.WriteLine();
-                Console.WriteLine();
-                Console.WriteLine("-------------------------------------------------------------------------");
-                Console.WriteLine($"Running: { samples[choice.Value].Name }");
-                Console.WriteLine("-------------------------------------------------------------------------");
-                Console.WriteLine();
-
-                await samples[choice.Value].RunAsync(parsedArgs.ConnectionString, parsedArgs.EventHub);
-                return;
-            }
+            return;
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample01_HelloWorld.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample01_HelloWorld.cs
@@ -18,7 +18,7 @@ namespace Azure.Messaging.EventHubs.Samples
         ///   The name of the sample.
         /// </summary>
         ///
-        public string Name { get; } = nameof(Sample01_HelloWorld);
+        public string Name { get; } = nameof(SampleNames.Sample01_HelloWorld);
 
         /// <summary>
         ///   A short description of the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample02_ClientWithCustomOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample02_ClientWithCustomOptions.cs
@@ -19,7 +19,7 @@ namespace Azure.Messaging.EventHubs.Samples
         ///   The name of the sample.
         /// </summary>
         ///
-        public string Name { get; } = nameof(Sample02_ClientWithCustomOptions);
+        public string Name { get; } = nameof(SampleNames.Sample02_ClientWithCustomOptions);
 
         /// <summary>
         ///   A short description of the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample03_PublishAnEvent.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample03_PublishAnEvent.cs
@@ -18,7 +18,7 @@ namespace Azure.Messaging.EventHubs.Samples
         ///   The name of the sample.
         /// </summary>
         ///
-        public string Name { get; } = nameof(Sample03_PublishAnEvent);
+        public string Name { get; } = nameof(SampleNames.Sample03_PublishAnEvent);
 
         /// <summary>
         ///   A short description of the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample04_PublishEventsWithPartitionKey.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample04_PublishEventsWithPartitionKey.cs
@@ -18,7 +18,7 @@ namespace Azure.Messaging.EventHubs.Samples
         ///   The name of the sample.
         /// </summary>
         ///
-        public string Name { get; } = nameof(Sample04_PublishEventsWithPartitionKey);
+        public string Name { get; } = nameof(SampleNames.Sample04_PublishEventsWithPartitionKey);
 
         /// <summary>
         ///   A short description of the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample05_PublishAnEventBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample05_PublishAnEventBatch.cs
@@ -19,7 +19,7 @@ namespace Azure.Messaging.EventHubs.Samples
         ///   The name of the sample.
         /// </summary>
         ///
-        public string Name { get; } = nameof(Sample05_PublishAnEventBatch);
+        public string Name { get; } = nameof(SampleNames.Sample05_PublishAnEventBatch);
 
         /// <summary>
         ///   A short description of the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample06_PublishEventsToSpecificPartitions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample06_PublishEventsToSpecificPartitions.cs
@@ -18,7 +18,7 @@ namespace Azure.Messaging.EventHubs.Samples
         ///   The name of the sample.
         /// </summary>
         ///
-        public string Name { get; } = nameof(Sample06_PublishEventsToSpecificPartitions);
+        public string Name { get; } = nameof(SampleNames.Sample06_PublishEventsToSpecificPartitions);
 
         /// <summary>
         ///   A short description of the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample07_PublishEventsWithCustomMetadata.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample07_PublishEventsWithCustomMetadata.cs
@@ -18,7 +18,7 @@ namespace Azure.Messaging.EventHubs.Samples
         ///   The name of the sample.
         /// </summary>
         ///
-        public string Name { get; } = nameof(Sample07_PublishEventsWithCustomMetadata);
+        public string Name { get; } = nameof(SampleNames.Sample07_PublishEventsWithCustomMetadata);
 
         /// <summary>
         ///   A short description of the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample08_ConsumeEvents.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample08_ConsumeEvents.cs
@@ -21,7 +21,7 @@ namespace Azure.Messaging.EventHubs.Samples
         ///   The name of the sample.
         /// </summary>
         ///
-        public string Name { get; } = nameof(Sample08_ConsumeEvents);
+        public string Name { get; } = nameof(SampleNames.Sample08_ConsumeEvents);
 
         /// <summary>
         ///   A short description of the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample09_ConsumeEventsWithMaximumWaitTime.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample09_ConsumeEventsWithMaximumWaitTime.cs
@@ -22,7 +22,7 @@ namespace Azure.Messaging.EventHubs.Samples
         ///   The name of the sample.
         /// </summary>
         ///
-        public string Name { get; } = nameof(Sample09_ConsumeEventsWithMaximumWaitTime);
+        public string Name { get; } = nameof(SampleNames.Sample09_ConsumeEventsWithMaximumWaitTime);
 
         /// <summary>
         ///   A short description of the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample10_ConsumeEventsFromAKnownPosition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample10_ConsumeEventsFromAKnownPosition.cs
@@ -21,7 +21,7 @@ namespace Azure.Messaging.EventHubs.Samples
         ///   The name of the sample.
         /// </summary>
         ///
-        public string Name { get; } = nameof(Sample10_ConsumeEventsFromAKnownPosition);
+        public string Name { get; } = nameof(SampleNames.Sample10_ConsumeEventsFromAKnownPosition);
 
         /// <summary>
         ///   A short description of the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample11_ConsumeEventsByBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample11_ConsumeEventsByBatch.cs
@@ -20,7 +20,7 @@ namespace Azure.Messaging.EventHubs.Samples
         ///   The name of the sample.
         /// </summary>
         ///
-        public string Name { get; } = nameof(Sample11_ConsumeEventsByBatch);
+        public string Name { get; } = nameof(SampleNames.Sample11_ConsumeEventsByBatch);
 
         /// <summary>
         ///   A short description of the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample12_ConsumeEventsWithEventProcessor.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample12_ConsumeEventsWithEventProcessor.cs
@@ -22,7 +22,7 @@ namespace Azure.Messaging.EventHubs.Samples
         ///   The name of the sample.
         /// </summary>
         ///
-        public string Name { get; } = nameof(Sample12_ConsumeEventsWithEventProcessor);
+        public string Name { get; } = nameof(SampleNames.Sample12_ConsumeEventsWithEventProcessor);
 
         /// <summary>
         ///   A short description of the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Samples/SamplesLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Samples/SamplesLiveTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Samples;
 using Azure.Messaging.EventHubs.Samples.Infrastructure;
 using Azure.Messaging.EventHubs.Tests.Infrastructure;
 using NUnit.Framework;
@@ -26,31 +27,92 @@ namespace Azure.Messaging.EventHubs.Tests
     [Category(TestCategory.DisallowVisualStudioLiveUnitTesting)]
     public class SamplesLiveTests
     {
-        /// <summary>
-        ///   Provides a set of test cases for each available sample.
-        /// </summary>
-        ///
-        public static IEnumerable<object[]> SampleTestCases() =>
-            typeof(Samples.Program)
-              .Assembly
-              .ExportedTypes
-              .Where(type => (type.IsClass && typeof(IEventHubsSample).IsAssignableFrom(type)))
-              .Select(type => new object[] { (IEventHubsSample)Activator.CreateInstance(type) });
 
         /// <summary>
-        ///   Verifies that the specified <see cref="IEventHubsSample" /> is able to
+        ///   Verifies that each sample is able to
         ///   be run without encountering an exception.
         /// </summary>
         ///
         [Test]
-        [TestCaseSource(nameof(SampleTestCases))]
-        public async Task SmokeTestASample(IEventHubsSample sample)
+        public async Task SmokeTestSamples()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(2))
             {
                 var connectionString = TestEnvironment.EventHubsConnectionString;
-                Assert.That(async () => await sample.RunAsync(connectionString, scope.EventHubName), Throws.Nothing);
+
+                Run_Sample01(scope, connectionString);
+                Run_Sample02(scope, connectionString);
+                Run_Sample03(scope, connectionString);
+                Run_Sample04(scope, connectionString);
+                Run_Sample05(scope, connectionString);
+                Run_Sample06(scope, connectionString);
+                Run_Sample07(scope, connectionString);
+                Run_Sample08(scope, connectionString);
+                Run_Sample09(scope, connectionString);
+                Run_Sample10(scope, connectionString);
+                Run_Sample11(scope, connectionString);
+                Run_Sample12(scope, connectionString);
             }
+        }
+
+        private static void Run_Sample01(EventHubScope scope, string connectionString)
+        {
+            Assert.That(async () => await new Sample01_HelloWorld().RunAsync(connectionString, scope.EventHubName), Throws.Nothing);
+        }
+
+        private static void Run_Sample02(EventHubScope scope, string connectionString)
+        {
+            Assert.That(async () => await new Sample02_ClientWithCustomOptions().RunAsync(connectionString, scope.EventHubName), Throws.Nothing);
+        }
+
+        private static void Run_Sample03(EventHubScope scope, string connectionString)
+        {
+            Assert.That(async () => await new Sample03_PublishAnEvent().RunAsync(connectionString, scope.EventHubName), Throws.Nothing);
+        }
+
+        private static void Run_Sample04(EventHubScope scope, string connectionString)
+        {
+            Assert.That(async () => await new Sample04_PublishEventsWithPartitionKey().RunAsync(connectionString, scope.EventHubName), Throws.Nothing);
+        }
+
+        private static void Run_Sample05(EventHubScope scope, string connectionString)
+        {
+            Assert.That(async () => await new Sample05_PublishAnEventBatch().RunAsync(connectionString, scope.EventHubName), Throws.Nothing);
+        }
+
+        private static void Run_Sample06(EventHubScope scope, string connectionString)
+        {
+            Assert.That(async () => await new Sample06_PublishEventsToSpecificPartitions().RunAsync(connectionString, scope.EventHubName), Throws.Nothing);
+        }
+
+        private static void Run_Sample07(EventHubScope scope, string connectionString)
+        {
+            Assert.That(async () => await new Sample07_PublishEventsWithCustomMetadata().RunAsync(connectionString, scope.EventHubName), Throws.Nothing);
+        }
+
+        private static void Run_Sample08(EventHubScope scope, string connectionString)
+        {
+            Assert.That(async () => await new Sample08_ConsumeEvents().RunAsync(connectionString, scope.EventHubName), Throws.Nothing);
+        }
+
+        private static void Run_Sample09(EventHubScope scope, string connectionString)
+        {
+            Assert.That(async () => await new Sample09_ConsumeEventsWithMaximumWaitTime().RunAsync(connectionString, scope.EventHubName), Throws.Nothing);
+        }
+
+        private static void Run_Sample10(EventHubScope scope, string connectionString)
+        {
+            Assert.That(async () => await new Sample10_ConsumeEventsFromAKnownPosition().RunAsync(connectionString, scope.EventHubName), Throws.Nothing);
+        }
+
+        private static void Run_Sample11(EventHubScope scope, string connectionString)
+        {
+            Assert.That(async () => await new Sample11_ConsumeEventsByBatch().RunAsync(connectionString, scope.EventHubName), Throws.Nothing);
+        }
+
+        private static void Run_Sample12(EventHubScope scope, string connectionString)
+        {
+            Assert.That(async () => await new Sample12_ConsumeEventsWithEventProcessor().RunAsync(connectionString, scope.EventHubName), Throws.Nothing);
         }
     }
 }


### PR DESCRIPTION
The new samples for ```Azure.Identity```  in ```EventHubs``` require extra information such as the ```tenant```, the ```clientId``` or the ```secret``` and this does not work well with the existing solution that uses reflection.

We need a solution that would prioritize keeping the existing samples as they are: easy for the readers to understand. For the same reason, we want the infrastructure around the samples to be as light as possible.

One way to achieve these objectives would be to sacrifice reflection when invoking the samples.
