### PR TITLE
Change versions of Azure.Core and Azure.Identity to 1.0.0!

### DIFF
--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -6,9 +6,7 @@
     <PackageTags>Microsoft Azure Client Pipeline</PackageTags>
     <PackageReleaseNotes>
       <![CDATA[
-      Added console and trace logger listener.
-      Added additional content and header logging options.
-      Moved commonly used types to Azure namespace.
+      GA release of Azure.Core package.
       ]]>
     </PackageReleaseNotes>
     <Nullable>enable</Nullable>

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is the implementation of the Azure Client Pipeline</Description>
     <AssemblyTitle>Microsoft Azure Client Pipeline</AssemblyTitle>
-    <Version>1.0.0-preview.10</Version>
+    <Version>1.0.0</Version>
     <PackageTags>Microsoft Azure Client Pipeline</PackageTags>
     <PackageReleaseNotes>
       <![CDATA[

--- a/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
+++ b/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the implementation of the Azure SDK Client Library for Azure Identity</Description>
     <AssemblyTitle>Microsoft Azure.Identity Component</AssemblyTitle>
-    <Version>1.0.0-preview.6</Version>
+    <Version>1.0.0</Version>
     <PackageTags>Microsoft Azure Identity</PackageTags>
     <PackageReleaseNotes>
       <![CDATA[

--- a/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
+++ b/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
@@ -7,9 +7,7 @@
     <PackageTags>Microsoft Azure Identity</PackageTags>
     <PackageReleaseNotes>
       <![CDATA[
-      * Updated InteractiveBrowserCredential and DeviceCodeCredential to optionally accept a tenantId.
-      * Added DefaultAzureCredentialOptions for configuring DefaultAzureCredential authentication.
-      * Added AuthenticationCodeCredential to enable the authentication code authentication flow.
+      GA release of Azure.Identity package.
       ]]>
     </PackageReleaseNotes>
 


### PR DESCRIPTION
This PR changes the version numbers of ```Azure.Core``` and ```Azure.Identity``` to 1.0.0 in preparation for GA. Once this merges and the packages are shipped we can start cutting the dependencies over the package references.