### PR TITLE
[Azure Search] Unblock Search SDK for release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,7 +29,7 @@
 
 /sdk/keyvault/ @schaabs @heaths
 
-/sdk/search/ @brjohnstmsft
+/sdk/search/ @brjohnstmsft @arv100kri @bleroy
 /sdk/servicebus/ @nemakam @jsquire
 /sdk/storage/ @seanmcc-msft @amnguye @tg-msft @JoshLove-msft
 # Management Plane

--- a/sdk/search/Microsoft.Azure.Search.Common/src/Microsoft.Azure.Search.Common.csproj
+++ b/sdk/search/Microsoft.Azure.Search.Common/src/Microsoft.Azure.Search.Common.csproj
@@ -6,6 +6,6 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <PackageReleaseNotes>See the Microsoft.Azure.Cognitive Search package for detailed release notes on the entire Azure Cognitive Search .NET SDK.</PackageReleaseNotes>
     <PackageReleaseNotes>See the Microsoft.Azure.Search package for detailed release notes on the entire Azure Search .NET SDK.</PackageReleaseNotes>
-    <Version>10.1.0-preview.1</Version>
+    <Version>10.1.0</Version>
   </PropertyGroup>
 </Project>

--- a/sdk/search/Microsoft.Azure.Search.Common/src/Microsoft.Azure.Search.Common.csproj
+++ b/sdk/search/Microsoft.Azure.Search.Common/src/Microsoft.Azure.Search.Common.csproj
@@ -4,8 +4,7 @@
     <Description>Common types needed by the Azure Cognitive Search .NET libraries. This is not the package you are looking for; It is only meant to be used as a dependency.</Description>
     <AssemblyTitle>Microsoft Azure Cognitive Search Common Library</AssemblyTitle>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <PackageReleaseNotes>See the Microsoft.Azure.Cognitive Search package for detailed release notes on the entire Azure Cognitive Search .NET SDK.</PackageReleaseNotes>
-    <PackageReleaseNotes>See the Microsoft.Azure.Search package for detailed release notes on the entire Azure Search .NET SDK.</PackageReleaseNotes>
+    <PackageReleaseNotes>See the Microsoft.Azure Search package for detailed release notes on the entire Azure Cognitive Search .NET SDK.</PackageReleaseNotes>
     <Version>10.1.0</Version>
   </PropertyGroup>
 </Project>

--- a/sdk/search/Microsoft.Azure.Search.Common/src/Microsoft.Azure.Search.Common.csproj
+++ b/sdk/search/Microsoft.Azure.Search.Common/src/Microsoft.Azure.Search.Common.csproj
@@ -4,7 +4,7 @@
     <Description>Common types needed by the Azure Cognitive Search .NET libraries. This is not the package you are looking for; It is only meant to be used as a dependency.</Description>
     <AssemblyTitle>Microsoft Azure Cognitive Search Common Library</AssemblyTitle>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <PackageReleaseNotes>See the Microsoft.Azure Search package for detailed release notes on the entire Azure Cognitive Search .NET SDK.</PackageReleaseNotes>
+    <PackageReleaseNotes>See the Microsoft.Azure.Search package for detailed release notes on the entire Azure Cognitive Search .NET SDK.</PackageReleaseNotes>
     <Version>10.1.0</Version>
   </PropertyGroup>
 </Project>

--- a/sdk/search/Microsoft.Azure.Search.Data/src/Microsoft.Azure.Search.Data.csproj
+++ b/sdk/search/Microsoft.Azure.Search.Data/src/Microsoft.Azure.Search.Data.csproj
@@ -8,7 +8,7 @@
 
     <!-- Disable warning for missing xml doc comments until we can add all the missing ones -->
     <NoWarn>$(NoWarn);1573;1591</NoWarn>
-    <Version>10.1.0-preview.1</Version>
+    <Version>10.1.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Spatial" />

--- a/sdk/search/Microsoft.Azure.Search.Service/src/Microsoft.Azure.Search.Service.csproj
+++ b/sdk/search/Microsoft.Azure.Search.Service/src/Microsoft.Azure.Search.Service.csproj
@@ -8,7 +8,7 @@
 
     <!-- Disable warning for missing xml doc comments until we can add all the missing ones -->
     <NoWarn>$(NoWarn);1591</NoWarn>
-    <Version>10.1.0-preview.1</Version>
+    <Version>10.1.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Spatial" />

--- a/sdk/search/Microsoft.Azure.Search/src/Microsoft.Azure.Search.csproj
+++ b/sdk/search/Microsoft.Azure.Search/src/Microsoft.Azure.Search.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>Microsoft Azure Cognitive Search Library</AssemblyTitle>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <PackageReleaseNotes>This is the newest major version of the Azure Cognitive Search .NET SDK, based on version 2019-05-06 of the Azure Cognitive Search REST API. New in this GA version are a few new skills and some general improvements that necessitate breaking changes. See this article for help on migrating to the latest version: http://aka.ms/search-sdk-upgrade. Complete release notes for this package are located here: http://aka.ms/search-sdk-changelog.</PackageReleaseNotes>
-    <Version>10.1.0-preview.1</Version>
+    <Version>10.1.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Azure.Search.Data\src\Microsoft.Azure.Search.Data.csproj" />


### PR DESCRIPTION
Partially "reverts" some changes from https://github.com/Azure/azure-sdk-for-net/pull/8270 that updated the version number incorrectly.