### PR TITLE
Update Links to API Docs

### DIFF
--- a/sdk/identity/Azure.Identity/README.md
+++ b/sdk/identity/Azure.Identity/README.md
@@ -213,6 +213,5 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 [queues_client_library]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/storage/Azure.Storage.Queues
 [eventhubs_client_library]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/eventhub/Azure.Messaging.EventHubs
 [azure_core_library]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/core/Azure.Core
-[identity_api_docs]: https://azure.github.io/azure-sdk-for-net/api/Azure.Identity.html
-
+[identity_api_docs]: https://azuresdkdocs.blob.core.windows.net/$web/dotnet/Azure.Identity/1.0.0/api/index.html
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsdk%2Fidentity%2FAzure.Identity%2FFREADME.png)


### PR DESCRIPTION
Updating links from package readmes to point to docs for the specific version stored in blob storage.