### PR TITLE
[Event Hubs Client] Track Two: Fifth Preview (Documentation Updates)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blobs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blobs/CHANGELOG.md
@@ -1,8 +1,27 @@
 # Release History
 
+## 1.0.0-preview.3 (2019-11-04)
+
+### Acknowledgments 
+
+Thank you to our developer community members who helped to make the Azure SDKs better with their contributions to this release:
+
+- Vyacheslav Benedichuk _([GitHub](https://github.com/vbenedichuk))_
+
+### Changes
+
+#### Organization and naming
+
+- For consistency with the official nomenclature of the Azure Storage Blobs service, the package has been renamed to `Azure.Messaging.EventHubs.CheckpointStore.Blobs` and the namespaces have also been adjusted to "Blobs."  
+  _(A community contribution, courtesy of [vbenedichuk](https://github.com/vbenedichuk))_
+
+- Some minor documentation updates to reflect the changes made to the `EventProcessorClient` and its associated namespaces.
+
 ## 1.0.0-preview.2 (2019-10-09)
 
-### Event Hubs
+### Changes
+
+#### Event Hubs
 
 - The Azure Event Hubs client library has included the Event Hubs fully qualified namespace as part of the checkpoint information, ensuring that there is no conflict between Event Hubs instances in different regions using the same Event Hub and consumer group names.  As a consequence, this library has been updated to reflect these changes.
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blobs/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blobs/README.md
@@ -20,10 +20,10 @@ To quickly create the needed resources in Azure and to receive connection string
 
 ### Install the package
 
-Install the Azure Event Hubs Checkpoint Store for Azure Storage blobs client library for .NET using [NuGet](https://www.nuget.org/):
+Install the Azure Event Hubs Checkpoint Store for Azure Storage Blobs client library for .NET using [NuGet](https://www.nuget.org/):
 
 ```PowerShell
-Install-Package Azure.Messaging.EventHubs.CheckpointStore.Blob -Version 1.0.0-preview.2
+Install-Package Azure.Messaging.EventHubs.CheckpointStore.Blobs -Version 1.0.0-preview.3
 ```
 
 ### Obtain an Event Hubs connection string
@@ -34,7 +34,7 @@ For the event processor to interact with an Event Hub, it will need to understan
 
 For checkpoint storage to make use of Azure Storage blobs, it will need to understand how to connect to a storage account and authorize with it.  The most straightforward method of doing so is to use a connection string, which is generated at the time that the storage account is created.  If you aren't familiar with storage accounts in Azure, you may wish to follow the step-by-step guide to [configure Azure Storage connection strings](https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string).
 
-### Create an Event Processor that persists checkpoints in Azure Storage blobs
+### Create an Event Processor that persists checkpoints in Azure Storage Blobs
 
 Once the Azure resources and connection strings are available, they can be used to create an event processor for interacting with Azure Event Hubs which persists its state via checkpoints in Azure Storage blobs.  The simplest way to create an `EventProcessor` that uses the `**TODO: CHECKPOINT BLOB NAME THING HERE**` is:
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -1,14 +1,51 @@
 # Release History
 
+## 5.0.0-preview.5 (2019-11-04)
+
+### Acknowledgments 
+
+Thank you to our developer community members who helped to make the Azure SDKs better with their contributions to this release:
+
+- Alberto De Natale _([GitHub](https://github.com/albertodenatale))_
+
+### Changes
+
+#### Organization and naming
+
+- The early stages of a large refactoring of the Event Hub client type hierarchy is complete;  Event Hub producers and consumers are now stand-alone clients that can be created independently, and which may or may not share a connection to the Event Hubs service at the discretion of the developer.    
+
+  **_Please Note:_** These changes are part of a larger effort that is currently in process.  The client types have not yet been refactored to remove affinity to a specific partition which leaves some operations feeling somewhat awkward with the new structure.
+  
+#### Bug fixes and foundation improvements
+
+- Client types using Azure identity for authorization should now be working properly; a bug was fixed to allow the proper authorization scopes to be requested.  
+  _(A community contribution, courtesy of [albertodenatale](https://github.com/albertodenatale))_
+  
+- Service communication is now being performed by an internal communication stack; previously, it had been delegated to an internal copy of the legacy client library.
+
+- Cancellation tokens are now supported throughout the client hierarchy and across operations.
+
+- Telemetry is now emitting a `User-Agent` member, which is standard across other client libraries in the Azure SDK.
+
+- With the new hierarchy allowing clients to be more self-contained, the configuration of retry policies and timeouts have been made more consistent and easier to reason about.  Each may be configured as part of the options for a client and will retain either the value provided by developers or the default.  There is no longer a notion of inherited values from a "parent" client.
+
+#### Consuming events
+
+- The body of an `EventData` instance is now available as a stream, for convenience.
+
+- The information about the last event enqueued to an Event Hub partition is now presented on-demand as an immutable object, if the tracking option was enabled.  This ensures that the properties are stable and consistent when being read, rather than being subject to in-place updates each time a new event is received.
+
 ## 5.0.0-preview.4 (2019-10-07)
 
-### Event Processor
+### Changes
+
+#### Event Processor
 
 - Included the Event Hubs fully qualified namespace as part of the checkpoint information, ensuring that there is no conflict between Event Hubs instances in different regions using the same Event Hub and consumer group names.
 
 - Distributed tracing support has been added to the Event Processor.
 
-### Bug fixes and foundation improvements
+#### Bug fixes and foundation improvements
 
 - Fixed date parsing for time zones ahead of UTC in the Event Hub Consumer when tracking of the last event was disabled.
 
@@ -18,7 +55,9 @@
 
 ## 5.0.0-preview.3 (2019-09-06)
 
-### Consuming Events
+### Changes
+
+#### Consuming Events
 
 - The full set of system properties was reintroduced to the `EventData` for events received from the service.  In addition to the well-known properties for identifying an event's place in the partition (`Offset`, `SequenceNumber`, and `EnqueuedTime`), any additional metadata sent as part of an event will appear in the `SystemProperties` dictionary.
 
@@ -26,7 +65,7 @@
 
 - Consuming events using `SubscribeToEvents` has been refactored for better performance and lower resource use. 
 
-### Event Processor
+#### Event Processor
 
 - Creation of an `EventProcessor` has been refined with the goal of allowing simpler use for standard scenarios while maintaining flexibility for complex ones.  The `EventProcessor` is now able to manage partition processor instances for implementations with a default constructor.
 
@@ -34,7 +73,7 @@
 
 - The interface for processing partitions has been changed to a base class, in order to allow developers to make the decision which of the available methods they would like to override, rather than being forced to implement each one.
 
-### General
+#### General
 
 - The client library for Event Hubs is now emitting diagnostics information for distributed tracing.  _(see: [proposal](https://github.com/w3c/trace-context-amqp/blob/411fdeabea45d36db827b7097235549b30fac8e8/spec/20-AMQP_FORMAT.md))_
 
@@ -42,7 +81,9 @@
 
 ## 5.0.0-preview.2 (2019-08-06)
 
-### General
+### Changes
+
+#### General
 
 - Public members of type `DateTime` were converted to `DateTimeOffset` to explicitly represent that they are UTC
 
@@ -54,25 +95,25 @@
 
 - Ongoing minor tweaks to formatting, wording, and spelling of documentation and XML document comments.
 
-### Publishing events
+#### Publishing events
 
 - Reintroduced the `EventDataBatch`, allowing for publication of a batch of events with known size constraint.  This is intended to ensure that publishers can build batches without the potential for an error when sending and to allow publishers with bandwidth concerns to control the size of each batch published.
 
 - Enhanced the `EventHubProducer` to allow creation of an `EventDataBatch` and to accept them for publication.
 
-### Consuming events
+#### Consuming events
 
 - Added a means to subscribe to the events exposed by an `EventHubConsumer` in the form of an asynchronous iterator.   Using the iterator, consumers are able to use the familiar `foreach` pattern to enumerate events as they are available and process them.  Optionally, consumers may specify a maximum time to wait for events to arrive which, when exceeded, will emit a null event if none were available, returning control to the loop and allowing cancellation or other processing needs.
 
 - Introduced the initial concept of a new version of the `EventProcessor`, intended as a neutral framework for processing events across all partitions for a given Event Hub and in the context of a specific Consumer Group.  This early preview is intended to allow consumers to test the new design using a single instance that does not persist checkpoints to any durable store.
 
-### Exceptions
+#### Exceptions
 
 - Created an exception hierarchy that incorporates the exceptions exposed by the legacy client library, covering the same set of scenarios with minor changes to naming to better clarify the context.
 
 - Ensured that custom Event Hubs exceptions are properly translated to the new versions, no longer exposing legacy exception types.
 
-### Retries and timeouts
+#### Retries and timeouts
 
 - Removed the exposed retry policies in favor of a set of retry options based on the options found in `Azure.Core` in order to keep the API familiar.
 
@@ -82,6 +123,7 @@
 Operation timeouts have been moved from the associated client options and incorporated into the retry options and retry policies.
 
 ## 5.0.0-preview.1 (2019-07-01)
+
 Version 5.0.0-preview.1 is a preview of our efforts in creating a client library that is developer-friendly, idiomatic to the .NET ecosystem, and as consistent across different languages and platforms as possible.  The principles that guide our efforts can be found in the [Azure SDK Design Guidelines for .NET](https://azure.github.io/azure-sdk/dotnet_introduction.html).
 
 For more information, please visit: [https://aka.ms/azure-sdk-preview1-net](https://aka.ms/azure-sdk-preview1-net).

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample03_PublishAnEvent.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample03_PublishAnEvent.cs
@@ -24,7 +24,7 @@ namespace Azure.Messaging.EventHubs.Samples
         ///   A short description of the sample.
         /// </summary>
         ///
-        public string Description { get; } = "An introduction to publishing events, using a simple Event Hub producer.";
+        public string Description { get; } = "An introduction to publishing events, using a simple Event Hub producer client.";
 
         /// <summary>
         ///   Runs the sample using the specified Event Hubs connection information.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample06_PublishEventsToSpecificPartitions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample06_PublishEventsToSpecificPartitions.cs
@@ -42,7 +42,7 @@ namespace Azure.Messaging.EventHubs.Samples
             // It will be available again in the near future when the associated
             // changes have been completed.  We apologize for the inconvenience.
 
-            await Task.Delay(500);
+            await Task.Delay(15);
             Console.WriteLine("Temporarily disabled due to pending work.");
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample08_ConsumeEvents.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample08_ConsumeEvents.cs
@@ -27,7 +27,7 @@ namespace Azure.Messaging.EventHubs.Samples
         ///   A short description of the sample.
         /// </summary>
         ///
-        public string Description { get; } = "An introduction to consuming events, using a simple Event Hub consumer.";
+        public string Description { get; } = "An introduction to consuming events, using a simple Event Hub consumer client.";
 
         /// <summary>
         ///   Runs the sample using the specified Event Hubs connection information.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample09_ConsumeEventsWithMaximumWaitTime.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample09_ConsumeEventsWithMaximumWaitTime.cs
@@ -28,7 +28,7 @@ namespace Azure.Messaging.EventHubs.Samples
         ///   A short description of the sample.
         /// </summary>
         ///
-        public string Description { get; } = "An introduction to consuming events, using an Event Hub consumer with maximum wait time.";
+        public string Description { get; } = "An introduction to consuming events, using an Event Hub consumer client with maximum wait time.";
 
         /// <summary>
         ///   Runs the sample using the specified Event Hubs connection information.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample12_ConsumeEventsWithEventProcessor.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample12_ConsumeEventsWithEventProcessor.cs
@@ -28,7 +28,7 @@ namespace Azure.Messaging.EventHubs.Samples
         ///   A short description of the sample.
         /// </summary>
         ///
-        public string Description { get; } = "An example of consuming events from all Event Hub partitions at once, using the Event Processor.";
+        public string Description { get; } = "An example of consuming events from all Event Hub partitions at once, using the Event Processor client.";
 
         /// <summary>
         ///   Runs the sample using the specified Event Hubs connection information.
@@ -127,10 +127,14 @@ namespace Azure.Messaging.EventHubs.Samples
 
                 eventProcessor.ProcessExceptionAsync = (PartitionContext partitionContext, Exception exception) =>
                 {
-                    // Any exception which occurs within the event processor itself will be passed to this delegate so that they may be
-                    // handled.  Note that this does not include exceptions which occur in the event processing handler or the other delegate properties.
-                    // It is considered responsibility of the developer writing the handler code to ensure that proper exception handling practices are
-                    // followed.
+                    // Any exception which occurs as a result of the event processor itself will be passed to
+                    // this delegate so it may be handled.  The processor will continue to process events if
+                    // it is able to unless this handler explicitly requests that it stop doing so.
+                    //
+                    // It is important to note that this does not include exceptions during event processing; those
+                    // are considered responsibility of the developer implementing the event processing handler.  It
+                    // is, therefore, highly encouraged that best practices for exception handling practices are
+                    // followed with that delegate.
                     //
                     // This piece of code is not supposed to be reached by this sample.  If the following message has been printed
                     // to the Console, then something unexpected has happened.


### PR DESCRIPTION
# Summary

Updates for the README and CHANGELOG files to align with the new client hierarchy.  Additionally, some of the sample descriptions have been tweaked.

# Last Upstream Rebase

Thursday, October 31, 9:51am (EDT)

# Related and Follow-Up Issues

- [Release Event Hubs Track 2 Library Preview 5 for .Net ](https://github.com/Azure/azure-sdk-for-net/issues/8190) (#8190) 
- [Review and update documentation ](https://github.com/Azure/azure-sdk-for-net/issues/8191) (#8191) 

