### PR TITLE
[Event Hubs CheckpointStore Blobs] Fifth Preview (Release Preparation)

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -11,8 +11,8 @@
     <PackageReference Update="ApprovalUtilities" Version="3.0.22" />
     <PackageReference Update="Azure.Core" Version="1.0.0" />
     <PackageReference Update="Azure.Identity" Version="1.0.0" />
-    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.0.0-preview.4" />
-    <PackageReference Update="Azure.Storage.Blobs" Version="12.0.0-preview.4" />
+    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.0.0-preview.5" />
+    <PackageReference Update="Azure.Storage.Blobs" Version="12.0.0" />
     <PackageReference Update="BenchmarkDotNet" Version="0.11.5" />
     <PackageReference Update="FsCheck.Xunit" Version="2.14.0" />
     <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
@@ -100,6 +100,7 @@
     <PackageReference Update="xunit" Version="2.4.1" />
     <PackageReference Update="StyleCop.Analyzers" Version="1.1.118" />
   </ItemGroup>
+
   <!-- Track 2 specific versions -->
   <ItemGroup Condition="'$(IsClientLibrary)' == 'true'">
     <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20190716.1" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blobs/Directory.Build.props
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.CheckpointStore.Blobs/Directory.Build.props
@@ -28,6 +28,6 @@
     <EnableClientSdkAnalyzers>false</EnableClientSdkAnalyzers>
 
     <!-- If there was no override specified, set the type of reference to use for client libraries from the Azure SDK repository -->
-    <UseProjectReferenceToAzureClients Condition="'$(UseProjectReferenceToAzureClients)' == ''">true</UseProjectReferenceToAzureClients>
+    <UseProjectReferenceToAzureClients Condition="'$(UseProjectReferenceToAzureClients)' == ''">false</UseProjectReferenceToAzureClients>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
# Summary

Updating dependency versions and toggling reference type to NuGet packages.

# Last Upstream Rebase

Friday, November 1, 8:58am (EDT)

# Related and Follow-Up Issues

- [Release Event Hubs Track 2 Library Preview 5 for .Net ](https://github.com/Azure/azure-sdk-for-net/issues/8190) (#8190) 