### PR TITLE
Add a flag to allow the analyze-deps script to export dependency data

### DIFF
--- a/tools/AnalyzeDeps/AnalyzeDeps.ps1
+++ b/tools/AnalyzeDeps/AnalyzeDeps.ps1
@@ -10,12 +10,16 @@
 
   .PARAMETER OutPath
   The path to the write the HTML-formatted report.
+
+  .PARAMETER DumpPath
+  The path to the write the JSONP-formatted dependency data file.
 #>
 
 Param(
   [Parameter(Mandatory = $true)][string]$PackagesPath,
   [Parameter(Mandatory = $false)][string]$LockfilePath,
-  [Parameter(Mandatory = $false)][string]$OutPath
+  [Parameter(Mandatory = $false)][string]$OutPath,
+  [Parameter(Mandatory = $false)][string]$DumpPath
 )
 
 Add-Type -AssemblyName System.IO.Compression.FileSystem
@@ -60,6 +64,18 @@ Function Save-Dep($Deps, $TargetFramework, $DepName, $DepVersion, $DependentPack
   }
 }
 
+Function Save-PkgDep($PkgDeps, $TargetFramework, $DepName, $DepVersion) {
+  if (-Not $PkgDeps[$DepName]) {
+    $PkgDeps[$DepName] = @{ }
+  }
+  if (-Not $PkgDeps[$DepName][$DepVersion]) {
+    $PkgDeps[$DepName][$DepVersion] = New-Object System.Collections.ArrayList
+  }
+  if (-Not $PkgDeps[$DepName][$DepVersion].Contains($TargetFramework)) {
+    $PkgDeps[$DepName][$DepVersion].Add($TargetFramework) | Out-Null
+  }
+}
+
 Function Save-Locked($Locked, $DepName, $DepVersion, $Condition) {
   if (-Not $Locked[$DepName]) {
     $Locked[$DepName] = @{ }
@@ -72,6 +88,34 @@ Function Save-Locked($Locked, $DepName, $DepVersion, $Condition) {
   }
 }
 
+Function Get-PackageExport($Pkgs, $Internal) {
+  $DumpData = @{ }
+  foreach ($PkgName in $Pkgs.Keys) {
+    $PkgInfo = $Pkgs[$PkgName]
+    $Id = $PkgName + ":" + $PkgInfo.Ver
+    $DumpData[$Id] = @{
+      name    = $PkgName;
+      version = $PkgInfo.Ver;
+      type    = "internal";
+      deps    = $PkgInfo.Deps
+    }
+
+    foreach ($Dep in $PkgInfo.Deps) {
+      $DepId = $Dep.name + ":" + $Dep.version
+      if (-Not $DumpData.ContainsKey($DepId)) {
+        $DumpData[$DepId] = @{
+          name    = $Dep.name;
+          version = $Dep.version;
+          type    = If ($Internal.Contains($dep.name)) { "internalbinary" } else { "external" };
+          deps    = @()
+        }
+      }
+    }
+  }
+  
+  return $DumpData
+}
+
 # Analyze package dependencies
 $Pkgs = @{ }
 $Deps = @{ }
@@ -80,23 +124,37 @@ foreach ($PkgFile in Resolve-Path $PackagesPath) {
   $LibraryName = $Nuspec.package.metadata.id
   $LibraryVer = $Nuspec.package.metadata.version
 
-  $Pkgs[$LibraryName] = @($LibraryVer, $PkgFile)
-
+  $Pkgs[$LibraryName] = @{ Ver = $LibraryVer; Src = $PkgFile; Deps = New-Object System.Collections.ArrayList }
+  $PkgDeps = @{ }
+  
   foreach ($Group in $Nuspec.package.metadata.dependencies.group) {
     foreach ($Dep in $Group.dependency) {
+      Save-PkgDep $PkgDeps $Group.targetFramework $Dep.id $Dep.version
       Save-Dep $Deps $Group.targetFramework $Dep.id $Dep.version $LibraryName
     }
   }
 
   foreach ($Dep in $Nuspec.package.metadata.dependencies.dependency) {
+    Save-PkgDep $PkgDeps "" $Dep.id $Dep.version
     if ($Deps.Count) {
       foreach ($TargetFramework in $Deps.Keys) {
         Save-Dep $Deps $TargetFramework $Dep.id $Dep.version $LibraryName
       }
       Save-Dep $Deps "(others)" $Dep.id $Dep.version $LibraryName
-    }
-    else {
+    } else {
       Save-Dep $Deps "(any)" $Dep.id $Dep.version $LibraryName
+    }
+  }
+  
+  foreach ($DepName in $PkgDeps.Keys) {
+    $DepVersions = $PkgDeps[$DepName]
+    if ($DepVersions.Count -gt 1) {
+      foreach ($DepVersion in $DepVersions.Keys) {
+        $TargetFrameworks = $DepVersions[$DepVersion]
+        $Pkgs[$LibraryName]["Deps"].Add(@{name = $DepName; version = $DepVersion; label = ($TargetFrameworks -Join ", ") }) | Out-Null
+      }
+    } else {
+      $Pkgs[$LibraryName]["Deps"].Add(@{name = $DepName; version = ($DepVersions.Keys | Select-Object -first 1) }) | Out-Null
     }
   }
 }
@@ -176,6 +234,13 @@ if ($OutPath) {
   Write-Host "Generating HTML report..."
   $__template__ = Get-Content "$PSScriptRoot/deps.html.tpl" -Raw
   Invoke-Expression "@`"`r`n$__template__`r`n`"@" | Out-File -FilePath $OutPath
+}
+
+if ($DumpPath) {
+  Write-Host "Generating JSONP data export..."
+  $Internal = $Pkgs.Keys | ForEach-Object ToString
+  $DumpData = Get-PackageExport $Pkgs $Internal
+  "const data = " + (ConvertTo-Json -InputObject $DumpData -Compress -Depth 10) + ";" | Out-File -FilePath $DumpPath
 }
 
 exit $ExitCode

--- a/tools/AnalyzeDeps/AnalyzeDeps.ps1
+++ b/tools/AnalyzeDeps/AnalyzeDeps.ps1
@@ -99,8 +99,11 @@ Function Get-PackageExport($Pkgs, $Internal) {
       type    = "internal";
       deps    = $PkgInfo.Deps
     }
+  }
 
-    foreach ($Dep in $PkgInfo.Deps) {
+  $PkgIds = $DumpData.Keys | ForEach-Object ToString
+  foreach ($PkgId in $PkgIds) {
+    foreach ($Dep in $DumpData[$PkgId].deps) {
       $DepId = $Dep.name + ":" + $Dep.version
       if (-Not $DumpData.ContainsKey($DepId)) {
         $DumpData[$DepId] = @{

--- a/tools/AnalyzeDeps/deps.html.tpl
+++ b/tools/AnalyzeDeps/deps.html.tpl
@@ -283,7 +283,7 @@ $(
         <tbody>
         $(
           foreach ($PkgName in ($Pkgs.Keys | sort)) {
-            "<tr><td>$PkgName</td><td>$($Pkgs[$PkgName][0])</td><td>$($Pkgs[$PkgName][1])</td></tr>"
+            "<tr><td>$PkgName</td><td>$($Pkgs[$PkgName]['Ver'])</td><td>$($Pkgs[$PkgName]['Src'])</td></tr>"
           }
         )
         </tbody>


### PR DESCRIPTION
The data is exported in a format that will be consumed by the client side dependency graph (currently available in Azure/azure-sdk-tools#278)