### PR TITLE
[Event Hubs Client] Track Two (Minor Refactoring)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
@@ -177,7 +177,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         ///
         /// <returns>The set of information for the Event Hub that this client is associated with.</returns>
         ///
-        public override async Task<EventHubProperties> GetPropertiesAsync(EventHubRetryPolicy retryPolicy,
+        public override async Task<EventHubProperties> GetPropertiesAsync(EventHubsRetryPolicy retryPolicy,
                                                                           CancellationToken cancellationToken)
         {
             Argument.AssertNotClosed(_closed, nameof(AmqpClient));
@@ -270,7 +270,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// <returns>The set of information for the requested partition under the Event Hub this client is associated with.</returns>
         ///
         public override async Task<PartitionProperties> GetPartitionPropertiesAsync(string partitionId,
-                                                                                    EventHubRetryPolicy retryPolicy,
+                                                                                    EventHubsRetryPolicy retryPolicy,
                                                                                     CancellationToken cancellationToken)
         {
             Argument.AssertNotClosed(_closed, nameof(AmqpClient));

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
@@ -68,7 +68,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         ///   The policy to use for determining retry behavior for when an operation fails.
         /// </summary>
         ///
-        private EventHubRetryPolicy RetryPolicy { get; }
+        private EventHubsRetryPolicy RetryPolicy { get; }
 
         /// <summary>
         ///   The converter to use for translating between AMQP messages and client library
@@ -118,7 +118,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                             EventHubConsumerClientOptions consumerOptions,
                             AmqpConnectionScope connectionScope,
                             AmqpMessageConverter messageConverter,
-                            EventHubRetryPolicy retryPolicy)
+                            EventHubsRetryPolicy retryPolicy)
         {
             Argument.AssertNotNullOrEmpty(eventHubName, nameof(eventHubName));
             Argument.AssertNotNullOrEmpty(consumerGroup, nameof(consumerGroup));

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpMessageConverter.cs
@@ -231,11 +231,11 @@ namespace Azure.Messaging.EventHubs.Amqp
             return new PartitionProperties(
                 (string)responseData[AmqpManagement.ResponseMap.Name],
                 (string)responseData[AmqpManagement.ResponseMap.PartitionIdentifier],
+                (bool)responseData[AmqpManagement.ResponseMap.PartitionRuntimeInfoPartitionIsEmpty],
                 (long)responseData[AmqpManagement.ResponseMap.PartitionBeginSequenceNumber],
                 (long)responseData[AmqpManagement.ResponseMap.PartitionLastEnqueuedSequenceNumber],
                 long.Parse((string)responseData[AmqpManagement.ResponseMap.PartitionLastEnqueuedOffset]),
-                new DateTimeOffset((DateTime)responseData[AmqpManagement.ResponseMap.PartitionLastEnqueuedTimeUtc], TimeSpan.Zero),
-                (bool)responseData[AmqpManagement.ResponseMap.PartitionRuntimeInfoPartitionIsEmpty]);
+                new DateTimeOffset((DateTime)responseData[AmqpManagement.ResponseMap.PartitionLastEnqueuedTimeUtc], TimeSpan.Zero));
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
@@ -60,7 +60,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         ///   The policy to use for determining retry behavior for when an operation fails.
         /// </summary>
         ///
-        private EventHubRetryPolicy RetryPolicy { get; }
+        private EventHubsRetryPolicy RetryPolicy { get; }
 
         /// <summary>
         ///   The converter to use for translating between AMQP messages and client library
@@ -113,7 +113,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                             string partitionId,
                             AmqpConnectionScope connectionScope,
                             AmqpMessageConverter messageConverter,
-                            EventHubRetryPolicy retryPolicy)
+                            EventHubsRetryPolicy retryPolicy)
         {
             Argument.AssertNotNullOrEmpty(eventHubName, nameof(eventHubName));
             Argument.AssertNotNull(connectionScope, nameof(connectionScope));

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/BasicRetryPolicy.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/BasicRetryPolicy.cs
@@ -18,7 +18,7 @@ namespace Azure.Messaging.EventHubs.Core
     ///
     /// <seealso cref="RetryOptions"/>
     ///
-    internal class BasicRetryPolicy : EventHubRetryPolicy
+    internal class BasicRetryPolicy : EventHubsRetryPolicy
     {
         /// <summary>The seed to use for initializing random number generated for a given thread-specific instance.</summary>
         private static int s_randomSeed = Environment.TickCount;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportClient.cs
@@ -43,7 +43,7 @@ namespace Azure.Messaging.EventHubs.Core
         ///
         /// <returns>The set of information for the Event Hub that this client is associated with.</returns>
         ///
-        public abstract Task<EventHubProperties> GetPropertiesAsync(EventHubRetryPolicy retryPolicy,
+        public abstract Task<EventHubProperties> GetPropertiesAsync(EventHubsRetryPolicy retryPolicy,
                                                                     CancellationToken cancellationToken);
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace Azure.Messaging.EventHubs.Core
         /// <returns>The set of information for the requested partition under the Event Hub this client is associated with.</returns>
         ///
         public abstract Task<PartitionProperties> GetPartitionPropertiesAsync(string partitionId,
-                                                                              EventHubRetryPolicy retryPolicy,
+                                                                              EventHubsRetryPolicy retryPolicy,
                                                                               CancellationToken cancellationToken);
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -133,7 +133,7 @@ namespace Azure.Messaging.EventHubs
         ///   <see cref="EventHubConsumerClientOptions.TrackLastEnqueuedEventInformation" /> is enabled.
         /// </remarks>
         ///
-        protected internal long? LastPartitionSequenceNumber { get; }
+        internal long? LastPartitionSequenceNumber { get; }
 
         /// <summary>
         ///   The offset of the event that was last enqueued into the Event Hub partition from which this event was
@@ -145,7 +145,7 @@ namespace Azure.Messaging.EventHubs
         ///   <see cref="EventHubConsumerClientOptions.TrackLastEnqueuedEventInformation" /> is enabled.
         /// </remarks>
         ///
-        protected internal long? LastPartitionOffset { get; }
+        internal long? LastPartitionOffset { get; }
 
         /// <summary>
         ///   The date and time, in UTC, that the last event was enqueued into the Event Hub partition from
@@ -157,7 +157,7 @@ namespace Azure.Messaging.EventHubs
         ///   <see cref="EventHubConsumerClientOptions.TrackLastEnqueuedEventInformation" /> is enabled.
         /// </remarks>
         ///
-        protected internal DateTimeOffset? LastPartitionEnqueuedTime { get; }
+        internal DateTimeOffset? LastPartitionEnqueuedTime { get; }
 
         /// <summary>
         ///   The date and time, in UTC, that the last event information for the Event Hub partition was retrieved
@@ -169,7 +169,7 @@ namespace Azure.Messaging.EventHubs
         ///   <see cref="EventHubConsumerClientOptions.TrackLastEnqueuedEventInformation" /> is enabled.
         /// </remarks>
         ///
-        protected internal DateTimeOffset? LastPartitionInformationRetrievalTime { get; }
+        internal DateTimeOffset? LastPartitionInformationRetrievalTime { get; }
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="EventData"/> class.
@@ -177,7 +177,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <param name="eventBody">The raw data to use as the body of the event.</param>
         ///
-        public EventData(ReadOnlyMemory<byte> eventBody) : this(eventBody, null)
+        public EventData(ReadOnlyMemory<byte> eventBody) : this(eventBody, lastPartitionSequenceNumber: null)
 
         {
         }
@@ -198,17 +198,17 @@ namespace Azure.Messaging.EventHubs
         /// <param name="lastPartitionEnqueuedTime">The date and time, in UTC, of the event that was last enqueued into the Event Hub partition.</param>
         /// <param name="lastPartitionInformationRetrievalTime">The date and time, in UTC, that the last event information for the Event Hub partition was retrieved from the serivce.</param>
         ///
-        protected internal EventData(ReadOnlyMemory<byte> eventBody,
-                                     IDictionary<string, object> properties = null,
-                                     IReadOnlyDictionary<string, object> systemProperties = null,
-                                     long? sequenceNumber = null,
-                                     long? offset = null,
-                                     DateTimeOffset? enqueuedTime = null,
-                                     string partitionKey = null,
-                                     long? lastPartitionSequenceNumber = null,
-                                     long? lastPartitionOffset = null,
-                                     DateTimeOffset? lastPartitionEnqueuedTime = null,
-                                     DateTimeOffset? lastPartitionInformationRetrievalTime = null)
+        internal EventData(ReadOnlyMemory<byte> eventBody,
+                           IDictionary<string, object> properties = null,
+                           IReadOnlyDictionary<string, object> systemProperties = null,
+                           long? sequenceNumber = null,
+                           long? offset = null,
+                           DateTimeOffset? enqueuedTime = null,
+                           string partitionKey = null,
+                           long? lastPartitionSequenceNumber = null,
+                           long? lastPartitionOffset = null,
+                           DateTimeOffset? lastPartitionEnqueuedTime = null,
+                           DateTimeOffset? lastPartitionInformationRetrievalTime = null)
         {
             Body = eventBody;
             Properties = properties ?? new Dictionary<string, object>();
@@ -221,6 +221,28 @@ namespace Azure.Messaging.EventHubs
             LastPartitionOffset = lastPartitionOffset;
             LastPartitionEnqueuedTime = lastPartitionEnqueuedTime;
             LastPartitionInformationRetrievalTime = lastPartitionInformationRetrievalTime;
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventData"/> class.
+        /// </summary>
+        ///
+        /// <param name="eventBody">The raw data to use as the body of the event.</param>
+        /// <param name="properties">The set of free-form event properties to send with the event.</param>
+        /// <param name="systemProperties">The set of system properties received from the Event Hubs service.</param>
+        /// <param name="sequenceNumber">The sequence number assigned to the event when it was enqueued in the associated Event Hub partition.</param>
+        /// <param name="offset">The offset of the event when it was received from the associated Event Hub partition.</param>
+        /// <param name="enqueuedTime">The date and time, in UTC, of when the event was enqueued in the Event Hub partition.</param>
+        /// <param name="partitionKey">The partition hashing key applied to the batch that the associated <see cref="EventData"/>, was sent with.</param>
+        ///
+        protected EventData(ReadOnlyMemory<byte> eventBody,
+                            IDictionary<string, object> properties = null,
+                            IReadOnlyDictionary<string, object> systemProperties = null,
+                            long? sequenceNumber = null,
+                            long? offset = null,
+                            DateTimeOffset? enqueuedTime = null,
+                            string partitionKey = null) : this(eventBody, properties, systemProperties, sequenceNumber, offset, enqueuedTime, partitionKey, lastPartitionSequenceNumber: null)
+        {
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnection.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnection.cs
@@ -30,14 +30,14 @@ namespace Azure.Messaging.EventHubs
         ///   to be similar to <c>{yournamespace}.servicebus.windows.net</c>.
         /// </summary>
         ///
-        public string FullyQualifiedNamespace { get; protected set; }
+        public string FullyQualifiedNamespace { get; }
 
         /// <summary>
         ///   The name of the Event Hub that the connection is associated with, specific to the
         ///   Event Hubs namespace that contains it.
         /// </summary>
         ///
-        public string EventHubName { get; protected set; }
+        public string EventHubName { get; }
 
         /// <summary>
         ///   Indicates whether or not this <see cref="EventHubConnection"/> has been closed.
@@ -82,7 +82,7 @@ namespace Azure.Messaging.EventHubs
         ///   Event Hub will result in a connection string that contains the name.
         /// </remarks>
         ///
-        public EventHubConnection(string connectionString) : this(connectionString, null, null)
+        public EventHubConnection(string connectionString) : this(connectionString, null, connectionOptions: null)
         {
         }
 
@@ -121,7 +121,7 @@ namespace Azure.Messaging.EventHubs
         /// </remarks>
         ///
         public EventHubConnection(string connectionString,
-                                  string eventHubName) : this(connectionString, eventHubName, null)
+                                  string eventHubName) : this(connectionString, eventHubName, connectionOptions: null)
         {
         }
 
@@ -206,6 +206,7 @@ namespace Azure.Messaging.EventHubs
                     break;
             }
 
+            FullyQualifiedNamespace = fullyQualifiedNamespace;
             EventHubName = eventHubName;
             Options = connectionOptions;
             InnerClient = CreateTransportClient(fullyQualifiedNamespace, eventHubName, credential, connectionOptions);
@@ -285,7 +286,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <returns>The set of information for the Event Hub that this connection is associated with.</returns>
         ///
-        internal virtual Task<EventHubProperties> GetPropertiesAsync(EventHubRetryPolicy retryPolicy,
+        internal virtual Task<EventHubProperties> GetPropertiesAsync(EventHubsRetryPolicy retryPolicy,
                                                                      CancellationToken cancellationToken = default) => InnerClient.GetPropertiesAsync(retryPolicy, cancellationToken);
 
         /// <summary>
@@ -298,14 +299,14 @@ namespace Azure.Messaging.EventHubs
         /// <returns>The set of identifiers for the partitions within the Event Hub that this connection is associated with.</returns>
         ///
         /// <remarks>
-        ///   This method is synonymous with invoking <see cref="GetPropertiesAsync(EventHubRetryPolicy, CancellationToken)" /> and reading the <see cref="EventHubProperties.PartitionIds"/>
+        ///   This method is synonymous with invoking <see cref="GetPropertiesAsync(EventHubsRetryPolicy, CancellationToken)" /> and reading the <see cref="EventHubProperties.PartitionIds"/>
         ///   property that is returned. It is offered as a convenience for quick access to the set of partition identifiers for the associated Event Hub.
         ///   No new or extended information is presented.
         /// </remarks>
         ///
-        internal virtual async Task<string[]> GetPartitionIdsAsync(EventHubRetryPolicy retryPolicy,
+        internal virtual async Task<string[]> GetPartitionIdsAsync(EventHubsRetryPolicy retryPolicy,
                                                                    CancellationToken cancellationToken = default) =>
-            (await GetPropertiesAsync(retryPolicy, cancellationToken).ConfigureAwait(false))?.PartitionIds;
+            (await GetPropertiesAsync(retryPolicy, cancellationToken).ConfigureAwait(false)).PartitionIds;
 
         /// <summary>
         ///   Retrieves information about a specific partition for an Event Hub, including elements that describe the available
@@ -319,7 +320,7 @@ namespace Azure.Messaging.EventHubs
         /// <returns>The set of information for the requested partition under the Event Hub this connection is associated with.</returns>
         ///
         internal virtual Task<PartitionProperties> GetPartitionPropertiesAsync(string partitionId,
-                                                                               EventHubRetryPolicy retryPolicy,
+                                                                               EventHubsRetryPolicy retryPolicy,
                                                                                CancellationToken cancellationToken = default) => InnerClient.GetPartitionPropertiesAsync(partitionId, retryPolicy, cancellationToken);
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerClient.cs
@@ -138,7 +138,7 @@ namespace Azure.Messaging.EventHubs
         ///   The policy to use for determining retry behavior for when an operation fails.
         /// </summary>
         ///
-        private EventHubRetryPolicy RetryPolicy { get; }
+        private EventHubsRetryPolicy RetryPolicy { get; }
 
         /// <summary>
         ///   The active connection to the Azure Event Hubs service, enabling client communications for metadata

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducerClient.cs
@@ -87,7 +87,7 @@ namespace Azure.Messaging.EventHubs
         ///   The policy to use for determining retry behavior for when an operation fails.
         /// </summary>
         ///
-        private EventHubRetryPolicy RetryPolicy { get; }
+        private EventHubsRetryPolicy RetryPolicy { get; }
 
         /// <summary>
         ///   The active connection to the Azure Event Hubs service, enabling client communications for metadata

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsRetryPolicy.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsRetryPolicy.cs
@@ -18,7 +18,7 @@ namespace Azure.Messaging.EventHubs
     ///
     /// <seealso cref="RetryOptions"/>
     ///
-    public abstract class EventHubRetryPolicy
+    public abstract class EventHubsRetryPolicy
     {
         /// <summary>
         ///   Calculates the amount of time to allow the current attempt for an operation to

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventProcessorClient.cs
@@ -104,10 +104,17 @@ namespace Azure.Messaging.EventHubs
         public string EventHubName => Connection.EventHubName;
 
         /// <summary>
+        ///   The name of the consumer group this event processor is associated with.  Events will be
+        ///   read only in the context of this group.
+        /// </summary>
+        ///
+        public string ConsumerGroup { get; }
+
+        /// <summary>
         ///   A unique name used to identify this event processor.
         /// </summary>
         ///
-        public virtual string Identifier { get; }
+        public string Identifier { get; }
 
         /// <summary>
         ///   The minimum amount of time to be elapsed between two load balancing verifications.
@@ -127,13 +134,6 @@ namespace Azure.Messaging.EventHubs
         /// </summary>
         ///
         private EventHubConnection Connection { get; }
-
-        /// <summary>
-        ///   The name of the consumer group this event processor is associated with.  Events will be
-        ///   read only in the context of this group.
-        /// </summary>
-        ///
-        private string ConsumerGroup { get; }
 
         /// <summary>
         ///   Interacts with the storage system with responsibility for creation of checkpoints and for ownership claim.
@@ -169,7 +169,7 @@ namespace Azure.Messaging.EventHubs
         ///   processor.
         /// </summary>
         ///
-        private EventHubRetryPolicy RetryPolicy { get; }
+        private EventHubsRetryPolicy RetryPolicy { get; }
 
         /// <summary>
         ///   A <see cref="CancellationTokenSource"/> instance to signal the request to cancel the current running task.
@@ -350,14 +350,13 @@ namespace Azure.Messaging.EventHubs
         /// <param name="processorOptions">The set of options to use for this processor.</param>
         ///
         /// <remarks>
-        ///   This constructor is intended only to support internal functional testing; it should not be used for production scenarios nor
-        ///   external mocking.
+        ///   This constructor is intended only to support functional testing and mocking; it should not be used for production scenarios.
         /// </remarks>
         ///
-        internal EventProcessorClient(string consumerGroup,
-                                      PartitionManager partitionManager,
-                                      EventHubConnection connection,
-                                      EventProcessorClientOptions processorOptions)
+        protected internal EventProcessorClient(string consumerGroup,
+                                                PartitionManager partitionManager,
+                                                EventHubConnection connection,
+                                                EventProcessorClientOptions processorOptions)
         {
             Argument.AssertNotNullOrEmpty(consumerGroup, nameof(consumerGroup));
             Argument.AssertNotNull(partitionManager, nameof(partitionManager));

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Metadata/EventHubProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Metadata/EventHubProperties.cs
@@ -9,7 +9,7 @@ namespace Azure.Messaging.EventHubs.Metadata
     ///   A set of information for an Event Hub.
     /// </summary>
     ///
-    public class EventHubProperties
+    public struct EventHubProperties
     {
         /// <summary>
         ///   The name of the Event Hub, specific to the namespace
@@ -38,9 +38,9 @@ namespace Azure.Messaging.EventHubs.Metadata
         /// <param name="createdAt">The date and time at which the Event Hub was created.</param>
         /// <param name="partitionIds">The set of unique identifiers for each partition.</param>
         ///
-        protected internal EventHubProperties(string name,
-                                              DateTimeOffset createdAt,
-                                              string[] partitionIds)
+        public EventHubProperties(string name,
+                                  DateTimeOffset createdAt,
+                                  string[] partitionIds)
         {
             Name = name;
             CreatedAt = createdAt;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Metadata/LastEnqueuedEventProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Metadata/LastEnqueuedEventProperties.cs
@@ -9,7 +9,7 @@ namespace Azure.Messaging.EventHubs.Metadata
     ///   A set of information about the enqueued state of a partition, as observed by the consumer.
     /// </summary>
     ///
-    public class LastEnqueuedEventProperties
+    public struct LastEnqueuedEventProperties
     {
         /// <summary>
         ///   The name of the Event Hub where the partitions reside, specific to the
@@ -59,12 +59,12 @@ namespace Azure.Messaging.EventHubs.Metadata
         /// <param name="lastEnqueuedTime">The date and time, in UTC, that the last event was enqueued in the partition.</param>
         /// <param name="lastReceivedTime">The date and time, in UTC, that the information was last received.</param>
         ///
-        protected internal LastEnqueuedEventProperties(string eventHubName,
-                                                       string partitionId,
-                                                       long? lastSequenceNumber,
-                                                       long? lastOffset,
-                                                       DateTimeOffset? lastEnqueuedTime,
-                                                       DateTimeOffset? lastReceivedTime)
+        public LastEnqueuedEventProperties(string eventHubName,
+                                           string partitionId,
+                                           long? lastSequenceNumber,
+                                           long? lastOffset,
+                                           DateTimeOffset? lastEnqueuedTime,
+                                           DateTimeOffset? lastReceivedTime)
         {
             EventHubName = eventHubName;
             PartitionId = partitionId;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Metadata/PartitionProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Metadata/PartitionProperties.cs
@@ -9,7 +9,7 @@ namespace Azure.Messaging.EventHubs.Metadata
     ///   A set of information for a single partition of an Event Hub.
     /// </summary>
     ///
-    public class PartitionProperties
+    public struct PartitionProperties
     {
         /// <summary>
         ///   The name of the Event Hub where the partitions reside, specific to the
@@ -60,23 +60,23 @@ namespace Azure.Messaging.EventHubs.Metadata
         ///   Initializes a new instance of the <see cref="PartitionProperties"/> class.
         /// </summary>
         ///
-        /// <param name="name">The name of the Event Hub that contains the partitions.</param>
+        /// <param name="eventHubName">The name of the Event Hub that contains the partitions.</param>
         /// <param name="partitionId">The identifier of the partition.</param>
+        /// <param name="isEmpty">Indicates whether or not the partition is currently empty.</param>
         /// <param name="beginningSequenceNumber">The first sequence number available for events in the partition.</param>
         /// <param name="lastSequenceNumber">The sequence number observed the last event to be enqueued in the partition.</param>
         /// <param name="lastOffset">The offset of the last event to be enqueued in the partition.</param>
         /// <param name="lastEnqueuedTime">The date and time, in UTC, that the last event was enqueued in the partition.</param>
-        /// <param name="isEmpty">Indicates whether or not the partition is currently empty.</param>
         ///
-        protected internal PartitionProperties(string name,
-                                               string partitionId,
-                                               long beginningSequenceNumber,
-                                               long lastSequenceNumber,
-                                               long lastOffset,
-                                               DateTimeOffset lastEnqueuedTime,
-                                               bool isEmpty)
+        public PartitionProperties(string eventHubName,
+                                   string partitionId,
+                                   bool isEmpty,
+                                   long beginningSequenceNumber,
+                                   long lastSequenceNumber,
+                                   long lastOffset,
+                                   DateTimeOffset lastEnqueuedTime)
         {
-            EventHubName = name;
+            EventHubName = eventHubName;
             Id = partitionId;
             BeginningSequenceNumber = beginningSequenceNumber;
             LastEnqueuedSequenceNumber = lastSequenceNumber;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/PartitionContext.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/PartitionContext.cs
@@ -6,8 +6,8 @@ using Azure.Core;
 namespace Azure.Messaging.EventHubs
 {
     /// <summary>
-    ///   Contains information about a partition, like its identifier and information about its last
-    ///   enqueued event.
+    ///   Represents an Event Hub partition and its relative state, as scoped to an associated
+    ///   operation performed against it.
     /// </summary>
     ///
     public class PartitionContext

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/PartitionEvent.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/PartitionEvent.cs
@@ -13,14 +13,20 @@ namespace Azure.Messaging.EventHubs
     public struct PartitionEvent
     {
         /// <summary>
-        ///   The context of the Event Hub partition this instance is associated with.
+        ///   The Event Hub partition that the <see cref="PartitionEvent.Data" /> is associated with.
         /// </summary>
         ///
         public PartitionContext Context { get; }
 
         /// <summary>
-        ///   The received event to be processed.  Expected to be <c>null</c> if the receive call has timed out.
+        ///   An event that was read from the associated <see cref="PartitionEvent.Context" />.
         /// </summary>
+        ///
+        /// <value>
+        ///   The <see cref="EventData" /> read from the Event Hub partition, if data was available.
+        ///   If a maximum wait time was specified when reading events and no event was available in that
+        ///   time period, <c>null</c>.
+        /// </value>
         ///
         public EventData Data { get; }
 
@@ -28,8 +34,8 @@ namespace Azure.Messaging.EventHubs
         ///   Initializes a new instance of the <see cref="PartitionEvent"/> structure.
         /// </summary>
         ///
-        /// <param name="partitionContext">The context of the Event Hub partition this instance is associated with.</param>
-        /// <param name="eventData">The received event to be processed.  Expected to be <c>null</c> if the receive call has timed out.</param>
+        /// <param name="partitionContext">The Event Hub partition that the <paramref name="eventData" /> is associated with.</param>
+        /// <param name="eventData">The event that was read, if events were available; otherwise, <c>null</c>.</param>
         ///
         public PartitionEvent(PartitionContext partitionContext,
                               EventData eventData)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/PartitionPump.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/PartitionPump.cs
@@ -22,7 +22,7 @@ namespace Azure.Messaging.EventHubs.Processor
         // TODO: Remove this when moving to the consumer's iterator.
         private const int MaximumMessageCount = 25;
 
-        /// <summary>The <see cref="EventHubRetryPolicy" /> used to verify whether an exception is retriable or not.</summary>
+        /// <summary>The <see cref="EventHubsRetryPolicy" /> used to verify whether an exception is retriable or not.</summary>
         private static readonly BasicRetryPolicy RetryPolicy = new BasicRetryPolicy(new RetryOptions());
 
         /// <summary>The primitive for synchronizing access during start and close operations.</summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/RetryOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/RetryOptions.cs
@@ -109,7 +109,7 @@ namespace Azure.Messaging.EventHubs
         ///   options provided.
         /// </remarks>
         ///
-        public EventHubRetryPolicy CustomRetryPolicy { get; set; }
+        public EventHubsRetryPolicy CustomRetryPolicy { get; set; }
 
         /// <summary>
         ///   Creates a new copy of the current <see cref="RetryOptions" />, cloning its attributes into a new instance.
@@ -132,8 +132,8 @@ namespace Azure.Messaging.EventHubs
         ///   Converts the options into a retry policy for use.
         /// </summary>
         ///
-        /// <returns>The <see cref="EventHubRetryPolicy" /> represented by the options.</returns>
-        internal EventHubRetryPolicy ToRetryPolicy() =>
+        /// <returns>The <see cref="EventHubsRetryPolicy" /> represented by the options.</returns>
+        internal EventHubsRetryPolicy ToRetryPolicy() =>
             CustomRetryPolicy ?? new BasicRetryPolicy(this);
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpClientTests.cs
@@ -135,7 +135,7 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.Cancel();
 
             var client = new AmqpClient("my.eventhub.com", "somePath", Mock.Of<TokenCredential>(), new EventHubConnectionOptions());
-            Assert.That(async () => await client.GetPropertiesAsync(Mock.Of<EventHubRetryPolicy>(), cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
+            Assert.That(async () => await client.GetPropertiesAsync(Mock.Of<EventHubsRetryPolicy>(), cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
         }
 
         /// <summary>
@@ -165,7 +165,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var client = new AmqpClient("my.eventhub.com", "somePath", Mock.Of<TokenCredential>(), new EventHubConnectionOptions());
             await client.CloseAsync(cancellationSource.Token);
 
-            Assert.That(async () => await client.GetPropertiesAsync(Mock.Of<EventHubRetryPolicy>(), cancellationSource.Token), Throws.InstanceOf<EventHubsClientClosedException>());
+            Assert.That(async () => await client.GetPropertiesAsync(Mock.Of<EventHubsRetryPolicy>(), cancellationSource.Token), Throws.InstanceOf<EventHubsClientClosedException>());
         }
 
         /// <summary>
@@ -199,7 +199,7 @@ namespace Azure.Messaging.EventHubs.Tests
             // place immediately following the conversion and result in a well-known exception.
 
             var client = new InjectableMockClient("my.eventhub.com", eventHubName, mockCredential.Object, new EventHubConnectionOptions(), null, mockConverter.Object);
-            Assert.That(async () => await client.GetPropertiesAsync(Mock.Of<EventHubRetryPolicy>(), cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
+            Assert.That(async () => await client.GetPropertiesAsync(Mock.Of<EventHubsRetryPolicy>(), cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
 
             mockCredential.VerifyAll();
             mockConverter.VerifyAll();
@@ -255,7 +255,7 @@ namespace Azure.Messaging.EventHubs.Tests
             ExactTypeConstraint typeConstraint = partition is null ? Throws.ArgumentNullException : Throws.ArgumentException;
 
             var client = new AmqpClient("my.eventhub.com", "somePath", Mock.Of<TokenCredential>(), new EventHubConnectionOptions());
-            Assert.That(async () => await client.GetPartitionPropertiesAsync(partition, Mock.Of<EventHubRetryPolicy>(), CancellationToken.None), typeConstraint);
+            Assert.That(async () => await client.GetPartitionPropertiesAsync(partition, Mock.Of<EventHubsRetryPolicy>(), CancellationToken.None), typeConstraint);
         }
 
         /// <summary>
@@ -282,7 +282,7 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.Cancel();
 
             var client = new AmqpClient("my.eventhub.com", "somePath", Mock.Of<TokenCredential>(), new EventHubConnectionOptions());
-            Assert.That(async () => await client.GetPartitionPropertiesAsync("Fred", Mock.Of<EventHubRetryPolicy>(), cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
+            Assert.That(async () => await client.GetPartitionPropertiesAsync("Fred", Mock.Of<EventHubsRetryPolicy>(), cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
         }
 
         /// <summary>
@@ -298,7 +298,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var client = new AmqpClient("my.eventhub.com", "somePath", Mock.Of<TokenCredential>(), new EventHubConnectionOptions());
             await client.CloseAsync(cancellationSource.Token);
 
-            Assert.That(async () => await client.GetPartitionPropertiesAsync("Fred", Mock.Of<EventHubRetryPolicy>(), cancellationSource.Token), Throws.InstanceOf<EventHubsClientClosedException>());
+            Assert.That(async () => await client.GetPartitionPropertiesAsync("Fred", Mock.Of<EventHubsRetryPolicy>(), cancellationSource.Token), Throws.InstanceOf<EventHubsClientClosedException>());
         }
 
         /// <summary>
@@ -333,7 +333,7 @@ namespace Azure.Messaging.EventHubs.Tests
             // place immediately following the conversion and result in a well-known exception.
 
             var client = new InjectableMockClient("my.eventhub.com", eventHubName, mockCredential.Object, new EventHubConnectionOptions(), null, mockConverter.Object);
-            Assert.That(async () => await client.GetPartitionPropertiesAsync(partitionId, Mock.Of<EventHubRetryPolicy>(), cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
+            Assert.That(async () => await client.GetPartitionPropertiesAsync(partitionId, Mock.Of<EventHubsRetryPolicy>(), cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
 
             mockCredential.VerifyAll();
             mockConverter.VerifyAll();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
@@ -41,7 +41,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorRequiresTheEventHubName(string eventHub)
         {
-            Assert.That(() => new AmqpConsumer(eventHub, "$DEFAULT", "0", EventPosition.Earliest, new EventHubConsumerClientOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new AmqpConsumer(eventHub, "$DEFAULT", "0", EventPosition.Earliest, new EventHubConsumerClientOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorRequiresTheConsumerGroup(string group)
         {
-            Assert.That(() => new AmqpConsumer("myHub", group, "0", EventPosition.Earliest, new EventHubConsumerClientOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new AmqpConsumer("myHub", group, "0", EventPosition.Earliest, new EventHubConsumerClientOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorRequiresThePartition(string partition)
         {
-            Assert.That(() => new AmqpConsumer("aHub", "$DEFAULT", partition, EventPosition.Earliest, new EventHubConsumerClientOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new AmqpConsumer("aHub", "$DEFAULT", partition, EventPosition.Earliest, new EventHubConsumerClientOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorRequiresTheEventPosition()
         {
-            Assert.That(() => new AmqpConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", null, new EventHubConsumerClientOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>()), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", null, new EventHubConsumerClientOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorRequiresTheOptions()
         {
-            Assert.That(() => new AmqpConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.FromOffset(1), null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>()), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.FromOffset(1), null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorRequiresTheConnectionScope()
         {
-            Assert.That(() => new AmqpConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.FromSequenceNumber(123), new EventHubConsumerClientOptions(), null, Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>()), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.FromSequenceNumber(123), new EventHubConsumerClientOptions(), null, Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task CloseMarksTheConsumerAsClosed()
         {
-            var consumer = new AmqpConsumer("aHub", "$DEFAULT", "0", EventPosition.Earliest, new EventHubConsumerClientOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>());
+            var consumer = new AmqpConsumer("aHub", "$DEFAULT", "0", EventPosition.Earliest, new EventHubConsumerClientOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>());
             Assert.That(consumer.Closed, Is.False, "The consumer should not be closed on creation");
 
             await consumer.CloseAsync(CancellationToken.None);
@@ -131,7 +131,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void CloseRespectsTheCancellationToken()
         {
-            var consumer = new AmqpConsumer("aHub", "$DEFAULT", "0", EventPosition.Earliest, new EventHubConsumerClientOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>());
+            var consumer = new AmqpConsumer("aHub", "$DEFAULT", "0", EventPosition.Earliest, new EventHubConsumerClientOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>());
             using var cancellationSource = new CancellationTokenSource();
 
             cancellationSource.Cancel();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
@@ -44,7 +44,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorRequiresTheEventHubName(string eventHub)
         {
-            Assert.That(() => new AmqpProducer(eventHub, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new AmqpProducer(eventHub, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorRequiresTheConnectionScope()
         {
-            Assert.That(() => new AmqpProducer("theMostAwesomeHubEvar", "0", null, Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>()), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpProducer("theMostAwesomeHubEvar", "0", null, Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task CloseMarksTheProducerAsClosed()
         {
-            var producer = new AmqpProducer("aHub", "0", Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>());
+            var producer = new AmqpProducer("aHub", "0", Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>());
             Assert.That(producer.Closed, Is.False, "The producer should not be closed on creation");
 
             await producer.CloseAsync(CancellationToken.None);
@@ -90,7 +90,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void CloseRespectsTheCancellationToken()
         {
-            var producer = new AmqpProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>());
+            var producer = new AmqpProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>());
             using var cancellationSource = new CancellationTokenSource();
 
             cancellationSource.Cancel();
@@ -106,7 +106,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void CreateBatchAsyncValidatesTheOptions()
         {
-            var producer = new AmqpProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubRetryPolicy>());
+            var producer = new AmqpProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>());
             Assert.That(async () => await producer.CreateBatchAsync(null, CancellationToken.None), Throws.ArgumentNullException);
         }
 
@@ -271,7 +271,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void SendEnumerableValidatesTheEvents()
         {
-            var producer = new AmqpProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubRetryPolicy>());
+            var producer = new AmqpProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubsRetryPolicy>());
             Assert.That(async () => await producer.SendAsync(null, new SendOptions(), CancellationToken.None), Throws.ArgumentNullException);
         }
 
@@ -283,7 +283,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task SendEnumerableEnsuresNotClosed()
         {
-            var producer = new AmqpProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubRetryPolicy>());
+            var producer = new AmqpProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubsRetryPolicy>());
             await producer.CloseAsync(CancellationToken.None);
 
             Assert.That(async () => await producer.SendAsync(Enumerable.Empty<EventData>(), new SendOptions(), CancellationToken.None), Throws.InstanceOf<EventHubsClientClosedException>());
@@ -333,7 +333,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var messageFactory = default(Func<AmqpMessage>);
             var events = new[] { new EventData(new byte[] { 0x15 }) };
 
-            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubRetryPolicy>())
+            var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubsRetryPolicy>())
             {
                 CallBase = true
             };
@@ -367,7 +367,7 @@ namespace Azure.Messaging.EventHubs.Tests
             using CancellationTokenSource cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();
 
-            var producer = new AmqpProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubRetryPolicy>());
+            var producer = new AmqpProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubsRetryPolicy>());
             Assert.That(async () => await producer.SendAsync(new[] { new EventData(new byte[] { 0x15 }) }, new SendOptions(), cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
         }
 
@@ -416,7 +416,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void SendBatchValidatesTheBatch()
         {
-            var producer = new AmqpProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubRetryPolicy>());
+            var producer = new AmqpProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubsRetryPolicy>());
             Assert.That(async () => await producer.SendAsync(null, CancellationToken.None), Throws.ArgumentNullException);
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
@@ -332,7 +332,6 @@ namespace Azure.Messaging.EventHubs.Tests
                                   string eventHubName) : base(MockConnectionString, eventHubName)
             {
                 _serviceEndpoint = serviceEndpoint;
-                EventHubName = eventHubName;
             }
 
             internal override TransportClient CreateTransportClient(string fullyQualifiedNamespace,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConnection/EventHubConnectionLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConnection/EventHubConnectionLiveTests.cs
@@ -326,7 +326,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         private class TestConnectionWithTransport : EventHubConnection
         {
-            public EventHubRetryPolicy RetryPolicy { get; set; } = new BasicRetryPolicy(new RetryOptions());
+            public EventHubsRetryPolicy RetryPolicy { get; set; } = new BasicRetryPolicy(new RetryOptions());
 
             public TestConnectionWithTransport(string connectionString,
                                                EventHubConnectionOptions connectionOptions = default) : base(connectionString, connectionOptions)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConnection/EventHubConnectionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConnection/EventHubConnectionTests.cs
@@ -581,12 +581,12 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockClient
                 .Setup(client => client.GetPropertiesAsync(
-                    It.IsAny<EventHubRetryPolicy>(),
+                    It.IsAny<EventHubsRetryPolicy>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(properties))
                 .Verifiable("GetPropertiesAcync should have been delegated to.");
 
-            var actual = await mockClient.Object.GetPartitionIdsAsync(Mock.Of<EventHubRetryPolicy>(), CancellationToken.None);
+            var actual = await mockClient.Object.GetPartitionIdsAsync(Mock.Of<EventHubsRetryPolicy>(), CancellationToken.None);
 
             Assert.That(actual, Is.Not.Null);
             Assert.That(actual, Is.EqualTo(partitionIds));
@@ -605,7 +605,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var transportClient = new ObservableTransportClientMock();
             var client = new InjectableTransportClientMock(transportClient, "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake");
 
-            await client.GetPropertiesAsync(Mock.Of<EventHubRetryPolicy>(), CancellationToken.None);
+            await client.GetPropertiesAsync(Mock.Of<EventHubsRetryPolicy>(), CancellationToken.None);
 
             Assert.That(transportClient.WasGetPropertiesCalled, Is.True);
         }
@@ -622,7 +622,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var client = new InjectableTransportClientMock(transportClient, "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake");
             var expectedId = "BB33";
 
-            await client.GetPartitionPropertiesAsync(expectedId, Mock.Of<EventHubRetryPolicy>());
+            await client.GetPartitionPropertiesAsync(expectedId, Mock.Of<EventHubsRetryPolicy>());
 
             Assert.That(transportClient.GetPartitionPropertiesCalledForId, Is.EqualTo(expectedId));
         }
@@ -900,7 +900,7 @@ namespace Azure.Messaging.EventHubs.Tests
             public bool WasGetPropertiesCalled;
             public bool WasCloseCalled;
 
-            public override Task<EventHubProperties> GetPropertiesAsync(EventHubRetryPolicy retryPolicy,
+            public override Task<EventHubProperties> GetPropertiesAsync(EventHubsRetryPolicy retryPolicy,
                                                                         CancellationToken cancellationToken = default)
             {
                 WasGetPropertiesCalled = true;
@@ -908,7 +908,7 @@ namespace Azure.Messaging.EventHubs.Tests
             }
 
             public override Task<PartitionProperties> GetPartitionPropertiesAsync(string partitionId,
-                                                                                  EventHubRetryPolicy retryPolicy,
+                                                                                  EventHubsRetryPolicy retryPolicy,
                                                                                   CancellationToken cancellationToken = default)
             {
                 GetPartitionPropertiesCalledForId = partitionId;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientTests.cs
@@ -157,7 +157,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConnectionStringConstructorSetsTheRetryPolicy()
         {
-            var expected = Mock.Of<EventHubRetryPolicy>();
+            var expected = Mock.Of<EventHubsRetryPolicy>();
             var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = expected } };
             var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, connectionString, options);
@@ -172,7 +172,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ExpandedConstructorSetsTheRetryPolicy()
         {
-            var expected = Mock.Of<EventHubRetryPolicy>();
+            var expected = Mock.Of<EventHubsRetryPolicy>();
             var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = expected } };
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, "namespace", "hub", Mock.Of<TokenCredential>(), options);
 
@@ -186,7 +186,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConnectionConstructorSetsTheRetryPolicy()
         {
-            var expected = Mock.Of<EventHubRetryPolicy>();
+            var expected = Mock.Of<EventHubsRetryPolicy>();
             var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = expected } };
             var mockConnection = new MockConnection();
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, mockConnection, options);
@@ -475,7 +475,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task GetEventHubPropertiesAsyncUsesTheRetryPolicy()
         {
             var mockConnection = new MockConnection();
-            var retryPolicy = Mock.Of<EventHubRetryPolicy>();
+            var retryPolicy = Mock.Of<EventHubsRetryPolicy>();
             var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = retryPolicy } };
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, mockConnection, options);
 
@@ -492,7 +492,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task GetPartitionIdsUsesTheRetryPolicy()
         {
             var mockConnection = new MockConnection();
-            var retryPolicy = Mock.Of<EventHubRetryPolicy>();
+            var retryPolicy = Mock.Of<EventHubsRetryPolicy>();
             var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = retryPolicy } };
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, mockConnection, options);
 
@@ -509,7 +509,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task GetPartitionPropertiesUsesTheRetryPolicy()
         {
             var mockConnection = new MockConnection();
-            var retryPolicy = Mock.Of<EventHubRetryPolicy>();
+            var retryPolicy = Mock.Of<EventHubsRetryPolicy>();
             var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = retryPolicy } };
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, mockConnection, options);
 
@@ -1419,7 +1419,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 throw exception;
             };
 
-            var mockRetryPolicy = new Mock<EventHubRetryPolicy>();
+            var mockRetryPolicy = new Mock<EventHubsRetryPolicy>();
             var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = mockRetryPolicy.Object } };
             var transportConsumer = new ReceiveCallbackTransportConsumerMock(receiveCallback);
             var mockConnection = new MockConnection(transportConsumer);
@@ -1465,7 +1465,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 throw exception;
             };
 
-            var mockRetryPolicy = new Mock<EventHubRetryPolicy>();
+            var mockRetryPolicy = new Mock<EventHubsRetryPolicy>();
             var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = mockRetryPolicy.Object } };
             var transportConsumer = new ReceiveCallbackTransportConsumerMock(receiveCallback);
             var mockConnection = new MockConnection(transportConsumer);
@@ -1606,8 +1606,8 @@ namespace Azure.Messaging.EventHubs.Tests
         ///   Retrieves the RetryPolicy for the consumer using its private accessor.
         /// </summary>
         ///
-        private static EventHubRetryPolicy GetRetryPolicy(EventHubConsumerClient consumer) =>
-            (EventHubRetryPolicy)
+        private static EventHubsRetryPolicy GetRetryPolicy(EventHubConsumerClient consumer) =>
+            (EventHubsRetryPolicy)
                 typeof(EventHubConsumerClient)
                     .GetProperty("RetryPolicy", BindingFlags.Instance | BindingFlags.NonPublic)
                     .GetValue(consumer);
@@ -1779,17 +1779,15 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         private class MockConnection : EventHubConnection
         {
-            public EventHubRetryPolicy GetPropertiesInvokedWith = null;
-            public EventHubRetryPolicy GetPartitionIdsInvokedWith = null;
-            public EventHubRetryPolicy GetPartitionPropertiesInvokedWith = null;
+            public EventHubsRetryPolicy GetPropertiesInvokedWith = null;
+            public EventHubsRetryPolicy GetPartitionIdsInvokedWith = null;
+            public EventHubsRetryPolicy GetPartitionPropertiesInvokedWith = null;
             public TransportConsumer TransportConsumer = Mock.Of<TransportConsumer>();
             public bool WasClosed = false;
 
             public MockConnection(string namespaceName = "fakeNamespace",
                                   string eventHubName = "fakeEventHub") : base(namespaceName, eventHubName, Mock.Of<TokenCredential>())
             {
-                FullyQualifiedNamespace = namespaceName;
-                EventHubName = eventHubName;
             }
 
             public MockConnection(TransportConsumer transportConsumer,
@@ -1803,14 +1801,14 @@ namespace Azure.Messaging.EventHubs.Tests
             {
             }
 
-            internal override Task<EventHubProperties> GetPropertiesAsync(EventHubRetryPolicy retryPolicy,
+            internal override Task<EventHubProperties> GetPropertiesAsync(EventHubsRetryPolicy retryPolicy,
                                                                         CancellationToken cancellationToken = default)
             {
                 GetPropertiesInvokedWith = retryPolicy;
                 return Task.FromResult(new EventHubProperties(EventHubName, DateTimeOffset.Parse("2015-10-27T00:00:00Z"), new string[] { "0", "1" }));
             }
 
-            internal async override Task<string[]> GetPartitionIdsAsync(EventHubRetryPolicy retryPolicy,
+            internal async override Task<string[]> GetPartitionIdsAsync(EventHubsRetryPolicy retryPolicy,
                                                                         CancellationToken cancellationToken = default)
             {
                 GetPartitionIdsInvokedWith = retryPolicy;
@@ -1818,7 +1816,7 @@ namespace Azure.Messaging.EventHubs.Tests
             }
 
             internal override Task<PartitionProperties> GetPartitionPropertiesAsync(string partitionId,
-                                                                                    EventHubRetryPolicy retryPolicy,
+                                                                                    EventHubsRetryPolicy retryPolicy,
                                                                                     CancellationToken cancellationToken = default)
             {
                 GetPartitionPropertiesInvokedWith = retryPolicy;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientTests.cs
@@ -87,7 +87,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConnectionStringConstructorSetsTheRetryPolicy()
         {
-            var expected = Mock.Of<EventHubRetryPolicy>();
+            var expected = Mock.Of<EventHubsRetryPolicy>();
             var options = new EventHubProducerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = expected } };
             var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
             var producer = new EventHubProducerClient(connectionString, options);
@@ -102,7 +102,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ExpandedConstructorSetsTheRetryPolicy()
         {
-            var expected = Mock.Of<EventHubRetryPolicy>();
+            var expected = Mock.Of<EventHubsRetryPolicy>();
             var options = new EventHubProducerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = expected } };
             var producer = new EventHubProducerClient("namespace", "eventHub", Mock.Of<TokenCredential>(), options);
 
@@ -116,7 +116,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConnectionConstructorSetsTheRetryPolicy()
         {
-            var expected = Mock.Of<EventHubRetryPolicy>();
+            var expected = Mock.Of<EventHubsRetryPolicy>();
             var options = new EventHubProducerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = expected } };
             var mockConnection = new MockConnection();
             var producer = new EventHubProducerClient(mockConnection, options);
@@ -217,7 +217,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task GetEventHubPropertiesAsyncUsesTheRetryPolicy()
         {
             var mockConnection = new MockConnection();
-            var retryPolicy = Mock.Of<EventHubRetryPolicy>();
+            var retryPolicy = Mock.Of<EventHubsRetryPolicy>();
             var options = new EventHubProducerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = retryPolicy } };
             var producer = new EventHubProducerClient(mockConnection, options);
 
@@ -234,7 +234,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task GetPartitionIdsUsesTheRetryPolicy()
         {
             var mockConnection = new MockConnection();
-            var retryPolicy = Mock.Of<EventHubRetryPolicy>();
+            var retryPolicy = Mock.Of<EventHubsRetryPolicy>();
             var options = new EventHubProducerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = retryPolicy } };
             var producer = new EventHubProducerClient(mockConnection, options);
 
@@ -251,7 +251,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task GetPartitionPropertiesUsesTheRetryPolicy()
         {
             var mockConnection = new MockConnection();
-            var retryPolicy = Mock.Of<EventHubRetryPolicy>();
+            var retryPolicy = Mock.Of<EventHubsRetryPolicy>();
             var options = new EventHubProducerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = retryPolicy } };
             var producer = new EventHubProducerClient(mockConnection, options);
 
@@ -669,8 +669,8 @@ namespace Azure.Messaging.EventHubs.Tests
         ///   Retrieves the RetryPolicy for the producer using its private accessor.
         /// </summary>
         ///
-        private static EventHubRetryPolicy GetRetryPolicy(EventHubProducerClient producer) =>
-            (EventHubRetryPolicy)
+        private static EventHubsRetryPolicy GetRetryPolicy(EventHubProducerClient producer) =>
+            (EventHubsRetryPolicy)
                 typeof(EventHubProducerClient)
                     .GetProperty("RetryPolicy", BindingFlags.Instance | BindingFlags.NonPublic)
                     .GetValue(producer);
@@ -720,17 +720,15 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         private class MockConnection : EventHubConnection
         {
-            public EventHubRetryPolicy GetPropertiesInvokedWith = null;
-            public EventHubRetryPolicy GetPartitionIdsInvokedWith = null;
-            public EventHubRetryPolicy GetPartitionPropertiesInvokedWith = null;
+            public EventHubsRetryPolicy GetPropertiesInvokedWith = null;
+            public EventHubsRetryPolicy GetPartitionIdsInvokedWith = null;
+            public EventHubsRetryPolicy GetPartitionPropertiesInvokedWith = null;
             public TransportProducer TransportProducer = Mock.Of<TransportProducer>();
             public bool WasClosed = false;
 
             public MockConnection(string namespaceName = "fakeNamespace",
                                   string eventHubName = "fakeEventHub") : base(namespaceName, eventHubName, Mock.Of<TokenCredential>())
             {
-                FullyQualifiedNamespace = namespaceName;
-                EventHubName = eventHubName;
             }
 
             public MockConnection(TransportProducer transportProducer,
@@ -744,14 +742,14 @@ namespace Azure.Messaging.EventHubs.Tests
             {
             }
 
-            internal override Task<EventHubProperties> GetPropertiesAsync(EventHubRetryPolicy retryPolicy,
+            internal override Task<EventHubProperties> GetPropertiesAsync(EventHubsRetryPolicy retryPolicy,
                                                                         CancellationToken cancellationToken = default)
             {
                 GetPropertiesInvokedWith = retryPolicy;
                 return Task.FromResult(new EventHubProperties(EventHubName, DateTimeOffset.Parse("2015-10-27T00:00:00Z"), new string[] { "0", "1" }));
             }
 
-            internal async override Task<string[]> GetPartitionIdsAsync(EventHubRetryPolicy retryPolicy,
+            internal async override Task<string[]> GetPartitionIdsAsync(EventHubsRetryPolicy retryPolicy,
                                                                         CancellationToken cancellationToken = default)
             {
                 GetPartitionIdsInvokedWith = retryPolicy;
@@ -759,7 +757,7 @@ namespace Azure.Messaging.EventHubs.Tests
             }
 
             internal override Task<PartitionProperties> GetPartitionPropertiesAsync(string partitionId,
-                                                                                    EventHubRetryPolicy retryPolicy,
+                                                                                    EventHubsRetryPolicy retryPolicy,
                                                                                     CancellationToken cancellationToken = default)
             {
                 GetPartitionPropertiesInvokedWith = retryPolicy;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/RetryOptionsExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/RetryOptionsExtensionsTests.cs
@@ -94,7 +94,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void IsEquivalentToDetectsCustomPolicy()
         {
-            var first = new RetryOptions { CustomRetryPolicy = Mock.Of<EventHubRetryPolicy>() };
+            var first = new RetryOptions { CustomRetryPolicy = Mock.Of<EventHubsRetryPolicy>() };
             var second = new RetryOptions { CustomRetryPolicy = new BasicRetryPolicy(new RetryOptions()) };
 
             Assert.That(first.IsEquivalentTo(second), Is.False);
@@ -108,7 +108,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void IsEquivalentToDetectsEqualOptionSets()
         {
-            var customPolicy = Mock.Of<EventHubRetryPolicy>();
+            var customPolicy = Mock.Of<EventHubsRetryPolicy>();
             var first = new RetryOptions { CustomRetryPolicy = customPolicy };
             var second = new RetryOptions { CustomRetryPolicy = customPolicy };
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Processor/EventProcessorClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Processor/EventProcessorClientLiveTests.cs
@@ -33,7 +33,7 @@ namespace Azure.Messaging.EventHubs.Tests
         private const int ReceiveRetryLimit = 10;
 
         /// <summary>The default retry policy to use for test operations.</summary>
-        private static readonly EventHubRetryPolicy DefaultRetryPolicy = new RetryOptions().ToRetryPolicy();
+        private static readonly EventHubsRetryPolicy DefaultRetryPolicy = new RetryOptions().ToRetryPolicy();
 
         /// <summary>
         ///   Verifies that the <see cref="EventProcessorClient" /> is able to

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Processor/EventProcessorClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Processor/EventProcessorClientTests.cs
@@ -115,7 +115,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConnectionStringConstructorSetsTheRetryPolicy()
         {
-            var expected = Mock.Of<EventHubRetryPolicy>();
+            var expected = Mock.Of<EventHubsRetryPolicy>();
             var options = new EventProcessorClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = expected } };
             var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
             var processor = new EventProcessorClient(EventHubConsumerClient.DefaultConsumerGroupName, Mock.Of<PartitionManager>(), connectionString, options);
@@ -130,7 +130,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void NamespaceConstructorSetsTheRetryPolicy()
         {
-            var expected = Mock.Of<EventHubRetryPolicy>();
+            var expected = Mock.Of<EventHubsRetryPolicy>();
             var options = new EventProcessorClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = expected } };
             var processor = new EventProcessorClient(EventHubConsumerClient.DefaultConsumerGroupName, Mock.Of<PartitionManager>(), "namespace", "hubName", Mock.Of<TokenCredential>(), options);
 
@@ -439,8 +439,8 @@ namespace Azure.Messaging.EventHubs.Tests
         ///   Retrieves the RetryPolicy for the processor client using its private accessor.
         /// </summary>
         ///
-        private static EventHubRetryPolicy GetRetryPolicy(EventProcessorClient client) =>
-            (EventHubRetryPolicy)
+        private static EventHubsRetryPolicy GetRetryPolicy(EventProcessorClient client) =>
+            (EventHubsRetryPolicy)
                 typeof(EventProcessorClient)
                     .GetProperty("RetryPolicy", BindingFlags.Instance | BindingFlags.NonPublic)
                     .GetValue(client);
@@ -482,8 +482,6 @@ namespace Azure.Messaging.EventHubs.Tests
             public MockConnection(string namespaceName = "fakeNamespace",
                                   string eventHubName = "fakeEventHub") : base(namespaceName, eventHubName, Mock.Of<TokenCredential>())
             {
-                FullyQualifiedNamespace = namespaceName;
-                EventHubName = eventHubName;
             }
 
             internal override TransportClient CreateTransportClient(string fullyQualifiedNamespace, string eventHubName, TokenCredential credential, EventHubConnectionOptions options)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/RetryPolicies/RetryOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/RetryPolicies/RetryOptionsTests.cs
@@ -31,7 +31,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 Delay = TimeSpan.FromSeconds(1),
                 MaximumDelay = TimeSpan.FromSeconds(2),
                 TryTimeout = TimeSpan.FromSeconds(3),
-                CustomRetryPolicy = Mock.Of<EventHubRetryPolicy>()
+                CustomRetryPolicy = Mock.Of<EventHubsRetryPolicy>()
             };
 
             RetryOptions clone = options.Clone();
@@ -158,7 +158,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 Delay = TimeSpan.FromSeconds(1),
                 MaximumDelay = TimeSpan.FromSeconds(2),
                 TryTimeout = TimeSpan.FromSeconds(3),
-                CustomRetryPolicy = Mock.Of<EventHubRetryPolicy>()
+                CustomRetryPolicy = Mock.Of<EventHubsRetryPolicy>()
             };
 
             var policy = options.ToRetryPolicy();


### PR DESCRIPTION
# Summary

Some minor refactoring to move closer to the design for GA.  Changes were focused on naming, ensuring mocking with least visibility, and changing the metadata types to `struct`.

# Last Upstream Rebase

Monday, November 4, 5:31pm (EST)

# Related and Follow-Up Issues

- [Release Event Hubs Track 2 Library for .NET ](https://github.com/Azure/azure-sdk-for-net/issues/8552) (#8552) 

