### PR TITLE
[EventHubs] Event Processor Client Public API (Remove Event Processor Client Reference from Partition Pump)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventProcessorClient.cs
@@ -531,7 +531,7 @@ namespace Azure.Messaging.EventHubs
                         InstanceOwnership = null;
 
                         await Task.WhenAll(PartitionPumps.Keys
-                            .Select(partitionId => RemovePartitionPumpIfItExistsAsync(partitionId, CloseReason.Shutdown)))
+                            .Select(partitionId => RemovePartitionPumpIfItExistsAsync(partitionId, ProcessingStoppedReason.Shutdown)))
                             .ConfigureAwait(false);
 
                         // We need to wait until all pumps have stopped before making the Active Load Balancing Task null.  If we did it sooner,
@@ -662,7 +662,7 @@ namespace Azure.Messaging.EventHubs
 
                 await Task.WhenAll(PartitionPumps.Keys
                     .Except(InstanceOwnership.Keys)
-                    .Select(partitionId => RemovePartitionPumpIfItExistsAsync(partitionId, CloseReason.OwnershipLost)))
+                    .Select(partitionId => RemovePartitionPumpIfItExistsAsync(partitionId, ProcessingStoppedReason.OwnershipLost)))
                     .ConfigureAwait(false);
 
                 // Now that we are left with pumps that should be running, check their status.  If any has stopped, it means an
@@ -674,7 +674,7 @@ namespace Azure.Messaging.EventHubs
                         {
                             if (PartitionPumps.TryGetValue(kvp.Key, out PartitionPump pump) && !pump.IsRunning)
                             {
-                                await RemovePartitionPumpIfItExistsAsync(kvp.Key, CloseReason.Exception).ConfigureAwait(false);
+                                await RemovePartitionPumpIfItExistsAsync(kvp.Key, ProcessingStoppedReason.Exception).ConfigureAwait(false);
                                 await AddPartitionPumpAsync(kvp.Key, kvp.Value.SequenceNumber).ConfigureAwait(false);
                             }
                         }))
@@ -871,7 +871,7 @@ namespace Azure.Messaging.EventHubs
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///
         private async Task RemovePartitionPumpIfItExistsAsync(string partitionId,
-                                                              CloseReason reason)
+                                                              ProcessingStoppedReason reason)
         {
             if (PartitionPumps.TryRemove(partitionId, out PartitionPump pump))
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventProcessorClient.cs
@@ -54,7 +54,7 @@ namespace Azure.Messaging.EventHubs
         ///
         public Func<InitializePartitionProcessingContext, Task> InitializeProcessingForPartitionAsync
         {
-            protected get => _initializeProcessingForPartitionAsync;
+            get => _initializeProcessingForPartitionAsync;
             set => EnsureNotRunningAndInvoke(() => _initializeProcessingForPartitionAsync = value);
         }
 
@@ -64,7 +64,7 @@ namespace Azure.Messaging.EventHubs
         ///
         public Func<PartitionProcessingStoppedContext, Task> ProcessingForPartitionStoppedAsync
         {
-            protected get => _processingForPartitionStoppedAsync;
+            get => _processingForPartitionStoppedAsync;
             set => EnsureNotRunningAndInvoke(() => _processingForPartitionStoppedAsync = value);
         }
 
@@ -74,7 +74,7 @@ namespace Azure.Messaging.EventHubs
         ///
         public Func<EventProcessorEvent, Task> ProcessEventAsync
         {
-            protected get => _processEventAsync;
+            get => _processEventAsync;
             set => EnsureNotRunningAndInvoke(() => _processEventAsync = value);
         }
 
@@ -85,7 +85,7 @@ namespace Azure.Messaging.EventHubs
         ///
         public Func<ProcessorErrorContext, Task> ProcessExceptionAsync
         {
-            protected get => _processExceptionAsync;
+            get => _processExceptionAsync;
             set => EnsureNotRunningAndInvoke(() => _processExceptionAsync = value);
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/PartitionProcessingStoppedContext.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/PartitionProcessingStoppedContext.cs
@@ -21,7 +21,7 @@ namespace Azure.Messaging.EventHubs.Processor
         ///   The reason why the processing for the associated partition is being stopped.
         /// </summary>
         ///
-        public CloseReason Reason { get; }
+        public ProcessingStoppedReason Reason { get; }
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="PartitionProcessingStoppedContext"/> class.
@@ -31,7 +31,7 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="reason">The reason why the processing for the associated partition is being stopped.</param>
         ///
         protected internal PartitionProcessingStoppedContext(PartitionContext partitionContext,
-                                                             CloseReason reason)
+                                                             ProcessingStoppedReason reason)
         {
             Argument.AssertNotNull(partitionContext, nameof(partitionContext));
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/ProcessingStoppedReason.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/ProcessingStoppedReason.cs
@@ -7,7 +7,7 @@ namespace Azure.Messaging.EventHubs.Processor
     ///   The reason for stopping event processing for a given partition.
     /// </summary>
     ///
-    public enum CloseReason
+    public enum ProcessingStoppedReason
     {
         /// <summary>An unknown circumstance forced the processing to stop.</summary>
         Unknown,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Processor/EventProcessorClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Processor/EventProcessorClientLiveTests.cs
@@ -110,7 +110,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 await using (var connection = new EventHubConnection(connectionString))
                 {
                     var closeCalls = new ConcurrentDictionary<string, int>();
-                    var closeReasons = new ConcurrentDictionary<string, CloseReason>();
+                    var stopReasons = new ConcurrentDictionary<string, ProcessingStoppedReason>();
 
                     // Create the event processor manager to manage our event processors.
 
@@ -121,7 +121,7 @@ namespace Azure.Messaging.EventHubs.Tests
                             onStop: stopContext =>
                             {
                                 closeCalls.AddOrUpdate(stopContext.Context.PartitionId, 1, (partitionId, value) => value + 1);
-                                closeReasons[stopContext.Context.PartitionId] = stopContext.Reason;
+                                stopReasons[stopContext.Context.PartitionId] = stopContext.Reason;
                             }
                         );
 
@@ -152,8 +152,8 @@ namespace Azure.Messaging.EventHubs.Tests
                         Assert.That(closeCalls.TryGetValue(partitionId, out var calls), Is.True, $"{ partitionId }: CloseAsync should have been called.");
                         Assert.That(calls, Is.EqualTo(1), $"{ partitionId }: CloseAsync should have been called only once.");
 
-                        Assert.That(closeReasons.TryGetValue(partitionId, out CloseReason reason), Is.True, $"{ partitionId }: close reason should have been set.");
-                        Assert.That(reason, Is.EqualTo(CloseReason.Shutdown), $"{ partitionId }: unexpected close reason.");
+                        Assert.That(stopReasons.TryGetValue(partitionId, out ProcessingStoppedReason reason), Is.True, $"{ partitionId }: processing stopped reason should have been set.");
+                        Assert.That(reason, Is.EqualTo(ProcessingStoppedReason.Shutdown), $"{ partitionId }: unexpected processing stopped reason.");
                     }
 
                     Assert.That(closeCalls.Keys.Count, Is.EqualTo(partitionIds.Count()));


### PR DESCRIPTION
The intent of these changes is to make the `PartitionPump` less dependent on the `EventProcessorClient`. In the long term, our goal is to completely remove the `PartitionPump` type.

Changelog:

- Initialization handler is not called by the `PartitionPump` start method anymore. That's the processor's responsibility.
- Processing Stopped handler is not called by the `PartitionPump` stop method anymore. That's the processor's responsibility. For this reason, there's no need to specify a reason when closing the pump.
- `PartitionPump` does not take an `EventProcessorClient` reference upon construction anymore. It only needs the `ProcessEvent` and `UpdateCheckpoint` handlers.
- `PartitionPump` does not have a reference to the `ProcessError` handler anymore. It will bubble up any exception it encounters to the `EventProcessorClient`.
- `CloseReason` renamed to `ProcessingStoppedReason`.