### PR TITLE
[Event Hubs Client] Track Two (Partition Context)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/Argument.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/Argument.cs
@@ -113,7 +113,7 @@ namespace Azure.Core
         {
             if (wasDisposed)
             {
-                throw new ObjectDisposedException(targetName, string.Format(CultureInfo.CurrentCulture, Resources.DisposedInstanceCannotPerformOperation, targetName));
+                throw new ObjectDisposedException(targetName, string.Format(CultureInfo.CurrentCulture, Resources.ClosedInstanceCannotPerformOperation, targetName));
             }
         }
 
@@ -129,7 +129,7 @@ namespace Azure.Core
         {
             if (wasClosed)
             {
-                throw new EventHubsClientClosedException(targetName, string.Format(CultureInfo.CurrentCulture, Resources.DisposedInstanceCannotPerformOperation, targetName));
+                throw new EventHubsClientClosedException(targetName, string.Format(CultureInfo.CurrentCulture, Resources.ClosedInstanceCannotPerformOperation, targetName));
             }
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerClient.cs
@@ -399,7 +399,7 @@ namespace Azure.Messaging.EventHubs
         ///   When information about the partition's last enqueued event is being tracked, each event received from the Event Hubs
         ///   service will carry metadata about the partition that it otherwise would not. This results in a small amount of
         ///   additional network bandwidth consumption that is generally a favorable trade-off when considered
-        ///   against periodically making requests for partition properties using the Event Hub client.
+        ///   against periodically making requests for partition properties using an Event Hub client.
         /// </remarks>
         ///
         /// <exception cref="InvalidOperationException">Occurs when this method is invoked without <see cref="EventHubConsumerClientOptions.TrackLastEnqueuedEventInformation" /> set.</exception>
@@ -675,7 +675,7 @@ namespace Azure.Messaging.EventHubs
             try
             {
                 transportConsumer = Connection.CreateTransportConsumer(ConsumerGroup, partitionId, startingPosition, Options);
-                publishingTask = StartBackgroundChannelPublishingAsync(transportConsumer, channel, new PartitionContext(partitionId), publishingCancellationSource.Token);
+                publishingTask = StartBackgroundChannelPublishingAsync(transportConsumer, channel, new PartitionContext(EventHubName, partitionId, transportConsumer), publishingCancellationSource.Token);
             }
             catch (Exception ex)
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventProcessorClient.cs
@@ -827,7 +827,7 @@ namespace Azure.Messaging.EventHubs
         private async Task AddPartitionPumpAsync(string partitionId,
                                                  long? initialSequenceNumber)
         {
-            var partitionContext = new PartitionContext(partitionId);
+            var partitionContext = new PartitionContext(EventHubName, partitionId);
 
             try
             {
@@ -887,7 +887,7 @@ namespace Azure.Messaging.EventHubs
                 {
                     try
                     {
-                        var partitionContext = new PartitionContext(partitionId);
+                        var partitionContext = new PartitionContext(EventHubName, partitionId);
                         var stopContext = new PartitionProcessingStoppedContext(partitionContext, reason);
 
                         await ProcessingForPartitionStoppedAsync(stopContext);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/PartitionContext.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/PartitionContext.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Azure.Core;
+using Azure.Messaging.EventHubs.Core;
+using Azure.Messaging.EventHubs.Errors;
+using Azure.Messaging.EventHubs.Metadata;
 
 namespace Azure.Messaging.EventHubs
 {
@@ -13,21 +17,90 @@ namespace Azure.Messaging.EventHubs
     public class PartitionContext
     {
         /// <summary>
+        ///   The name of the Event Hub this context is associated with.
+        /// </summary>
+        ///
+        public string EventHubName { get; }
+
+        /// <summary>
         ///   The identifier of the Event Hub partition this context is associated with.
         /// </summary>
         ///
         public string PartitionId { get; }
 
         /// <summary>
+        ///   The <see cref="TransportConsumer" /> for this context to use as the source for information.
+        /// </summary>
+        ///
+        private WeakReference<TransportConsumer> SourceConsumer { get; }
+
+        /// <summary>
+        ///   A set of information about the last enqueued event of a partition, as observed by the <see cref="EventHubConsumerClient" />
+        ///   associated with this context as events are received from the Event Hubs service.  This is only available if the consumer was
+        ///   created with <see cref="EventHubConsumerClientOptions.TrackLastEnqueuedEventInformation" /> set.
+        /// </summary>
+        ///
+        /// <remarks>
+        ///   When information about the partition's last enqueued event is being tracked, each event received from the Event Hubs
+        ///   service will carry metadata about the partition that it otherwise would not. This results in a small amount of
+        ///   additional network bandwidth consumption that is generally a favorable trade-off when considered
+        ///   against periodically making requests for partition properties using an Event Hub client.
+        /// </remarks>
+        ///
+        /// <exception cref="EventHubsClientClosedException">Occurs when the <see cref="EventHubConsumerClient" /> needed to read this information is no longer available.</exception>
+        /// <exception cref="InvalidOperationException">Occurs when this method is invoked without <see cref="EventHubConsumerClientOptions.TrackLastEnqueuedEventInformation" /> set.</exception>
+        ///
+        public virtual LastEnqueuedEventProperties ReadLastEnqueuedEventInformation()
+        {
+            var consumer = default(TransportConsumer);
+
+            if ((SourceConsumer?.TryGetTarget(out consumer) == false) || (consumer == null))
+            {
+                // If the consumer instance was not available, treat it as a closed instance for
+                // messaging consistency.
+
+                Argument.AssertNotClosed(true, Resources.ClientNeededForThisInformation);
+            }
+
+            return new LastEnqueuedEventProperties(EventHubName, PartitionId, consumer.LastReceivedEvent);
+        }
+
+        /// <summary>
         ///   Initializes a new instance of the <see cref="PartitionContext"/> class.
         /// </summary>
         ///
+        /// <param name="eventHubName">The name of the Event Hub that this context is associated with.</param>
+        /// <param name="partitionId">The identifier of the Event Hub partition this context is associated with.</param>
+        /// <param name="consumer">The <see cref="TransportConsumer" /> for this context to use as the source for information.</param>
+        ///
+        /// <remarks>
+        ///   The <paramref name="consumer" />, if provided, will be held in a weak reference to ensure that it
+        ///   does not impact resource use should the partition context be held beyond the lifespan of the
+        ///   consumer instance.
+        /// </remarks>
+        ///
+        internal PartitionContext(string eventHubName,
+                                  string partitionId,
+                                  TransportConsumer consumer) : this(eventHubName, partitionId)
+        {
+            Argument.AssertNotNull(consumer, nameof(consumer));
+            SourceConsumer = new WeakReference<TransportConsumer>(consumer);
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="PartitionContext"/> class.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the Event Hub that this context is associated with.</param>
         /// <param name="partitionId">The identifier of the Event Hub partition this context is associated with.</param>
         ///
-        protected internal PartitionContext(string partitionId)
+        protected internal PartitionContext(string eventHubName,
+                                            string partitionId)
         {
+            Argument.AssertNotNullOrEmpty(eventHubName, nameof(eventHubName));
             Argument.AssertNotNullOrEmpty(partitionId, nameof(partitionId));
 
+            EventHubName = eventHubName;
             PartitionId = partitionId;
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.Designer.cs
@@ -121,13 +121,13 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to {0} has already been disposed and cannot perform the requested operation..
+        ///   Looks up a localized string similar to {0} has already been closed and cannot perform the requested operation..
         /// </summary>
-        internal static string DisposedInstanceCannotPerformOperation
+        internal static string ClosedInstanceCannotPerformOperation
         {
             get
             {
-                return ResourceManager.GetString("DisposedInstanceCannotPerformOperation", resourceCulture);
+                return ResourceManager.GetString("ClosedInstanceCannotPerformOperation", resourceCulture);
             }
         }
 
@@ -469,6 +469,17 @@ namespace Azure.Messaging.EventHubs
             get
             {
                 return ResourceManager.GetString("TrackLastEnqueuedEventInformationNotSet", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The Event Hub client responsible for this information.
+        /// </summary>
+        internal static string ClientNeededForThisInformation
+        {
+            get
+            {
+                return ResourceManager.GetString("ClientNeededForThisInformation", resourceCulture);
             }
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.resx
@@ -198,8 +198,8 @@
   <data name="UnrecoverableException" xml:space="preserve">
     <value>An unrecoverable exception was encountered that left the environment in a bad state.</value>
   </data>
-  <data name="DisposedInstanceCannotPerformOperation" xml:space="preserve">
-    <value>{0} has already been disposed and cannot perform the requested operation.</value>
+  <data name="ClosedInstanceCannotPerformOperation" xml:space="preserve">
+    <value>{0} has already been closed and cannot perform the requested operation.</value>
   </data>
   <data name="CouldNotAcquireAccessToken" xml:space="preserve">
     <value>Unable to acquire an access token using the provided credential.</value>
@@ -227,5 +227,8 @@
   </data>
   <data name="RunningEventProcessorCannotPerformOperation" xml:space="preserve">
     <value>The event processor is already running and needs to be stopped in order to perform this operation.</value>
+  </data>
+  <data name="ClientNeededForThisInformation" xml:space="preserve">
+    <value>The Event Hub client responsible for this information</value>
   </data>
 </root>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/PartitionContextTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/PartitionContextTests.cs
@@ -1,0 +1,156 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Core;
+using Azure.Messaging.EventHubs.Errors;
+using Moq;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="PartitionContext" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class PartitionContextTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void ConstructorValidatesTheEventHubName(string value)
+        {
+            Assert.That(() => new PartitionContext(value, "test"), Throws.InstanceOf<ArgumentException>(), "The constructor with consumer should validate.");
+            Assert.That(() => new PartitionContext(value, "test", Mock.Of<TransportConsumer>()), Throws.InstanceOf<ArgumentException>(), "The constructor with no consumer should validate.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void ConstructorValidatesThePartition(string value)
+        {
+            Assert.That(() => new PartitionContext("hub-name", value), Throws.InstanceOf<ArgumentException>(), "The constructor with consumer should validate.");
+            Assert.That(() => new PartitionContext("hub-name", value, Mock.Of<TransportConsumer>()), Throws.InstanceOf<ArgumentException>(), "The constructor with no consumer should validate.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorValidatesTheConsumer()
+        {
+            Assert.That(() => new PartitionContext("hub-name", "partition", null), Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionContext.ReadLastEnqueuedEventInformation" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void ReadLastEnqueuedEventInformationDelegatesToTheConsumer()
+        {
+            var lastEvent = new EventData
+            (
+                eventBody: Array.Empty<byte>(),
+                lastPartitionSequenceNumber: 1234,
+                lastPartitionOffset: 42,
+                lastPartitionEnqueuedTime: DateTimeOffset.Parse("2015-10-27T00:00:00Z"),
+                lastPartitionInformationRetrievalTime: DateTimeOffset.Parse("2012-03-04T08:42Z")
+            );
+
+            var eventHubName = "hub-name";
+            var partitionId = "id-value";
+            var mockConsumer = new LastEventConsumerMock(lastEvent);
+            var context = new PartitionContext(eventHubName, partitionId, mockConsumer);
+            var information = context.ReadLastEnqueuedEventInformation();
+
+            Assert.That(information.EventHubName, Is.EqualTo(eventHubName), "The event hub name should match.");
+            Assert.That(information.PartitionId, Is.EqualTo(partitionId), "The partition identifier should match.");
+            Assert.That(information.LastEnqueuedSequenceNumber, Is.EqualTo(lastEvent.LastPartitionSequenceNumber), "The sequence number should match.");
+            Assert.That(information.LastEnqueuedOffset, Is.EqualTo(lastEvent.LastPartitionOffset), "The offset should match.");
+            Assert.That(information.LastEnqueuedTime, Is.EqualTo(lastEvent.LastPartitionEnqueuedTime), "The last enqueue time should match.");
+            Assert.That(information.InformationReceived, Is.EqualTo(lastEvent.LastPartitionInformationRetrievalTime), "The retrieval time should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionContext.ReadLastEnqueuedEventInformation" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task TheConsumerIsNotKeptAlive()
+        {
+            var eventHubName = "hub-name";
+            var partitionId = "id-value";
+            var mockConsumer = new LastEventConsumerMock(new EventData(Array.Empty<byte>()));
+            var context = new PartitionContext(eventHubName, partitionId, mockConsumer);
+
+            // Attempt to clear out the consumer and force GC.
+
+            mockConsumer = null;
+
+            // Because cleanup may be non-deterministic, allow a small set of
+            // retries.
+
+            var attempts = 0;
+            var maxAttempts = 5;
+
+            while (attempts <= maxAttempts)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1));
+
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+
+                try
+                {
+                    Assert.That(() => context.ReadLastEnqueuedEventInformation(), Throws.TypeOf<EventHubsClientClosedException>());
+                }
+                catch (AssertionException)
+                {
+                    if (++attempts <= maxAttempts)
+                    {
+                        continue;
+                    }
+
+                    throw;
+                }
+
+                // If things have gotten here, the test passes.
+
+                break;
+            }
+        }
+
+        /// <summary>
+        ///   Allows for setting the last received event by the consumer
+        ///   for testing purposes.
+        /// </summary>
+        ///
+        private class LastEventConsumerMock : TransportConsumer
+        {
+            public LastEventConsumerMock(EventData lastEvent)
+            {
+                LastReceivedEvent = lastEvent;
+            }
+
+            public override Task<IEnumerable<EventData>> ReceiveAsync(int maximumMessageCount, TimeSpan? maximumWaitTime, CancellationToken cancellationToken) => throw new NotImplementedException();
+            public override Task CloseAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
@@ -244,7 +244,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var eventHubName = "SomeName";
             var endpoint = new Uri("amqp://some.endpoint.com/path");
             var fakeConnection = new MockConnection(endpoint, eventHubName);
-            var context = new PartitionContext("partition");
+            var context = new PartitionContext(eventHubName, "partition");
             var data = new EventData(new byte[0], sequenceNumber: 0, offset: 0);
 
             var processor = new EventProcessorClient("cg", new InMemoryPartitionManager(), fakeConnection, null);
@@ -306,8 +306,7 @@ namespace Azure.Messaging.EventHubs.Tests
             };
 
             var updateCheckpointMock = Mock.Of<Func<EventData, PartitionContext, Task>>();
-
-            var manager = new PartitionPump(connectionMock.Object, "cg", new PartitionContext("pid"), EventPosition.Earliest, processEventAsync, updateCheckpointMock, new EventProcessorClientOptions());
+            var manager = new PartitionPump(connectionMock.Object, "cg", new PartitionContext("eventHubName", "pid"), EventPosition.Earliest, processEventAsync, updateCheckpointMock, new EventProcessorClientOptions());
 
             await manager.StartAsync();
             await processorCalledSource.Task;


### PR DESCRIPTION
# Summary

The focus of these changes is to flesh out the partition context, allowing the last event information to be read and including the name of the associated Event Hub.

#### Pending

- Refactor the Receive method to a dedicated class and offer a `CreateReceiver` replacement
- Remove the shared inner transport consumer
- Remove the partition identifier and starting position from constructors

# Last Upstream Rebase

Friday, November 08, 8:23am (EST)

# Related and Follow-Up Issues

- [Release Event Hubs Track 2 Library for .NET](https://github.com/Azure/azure-sdk-for-net/issues/8552) (#8552) 
- [ Remove partition affinity from Event Hub Consumer Client ](https://github.com/Azure/azure-sdk-for-net/issues/8565) (#8565) 
- [Implement ReadLastEnqueuedEventInformation on the Partition Context](https://github.com/Azure/azure-sdk-for-net/issues/8570) (#8570) 