### PR TITLE
Update SharedTokenCacheCredential to filter accounts by tenant id

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Release History
+## Unreleased
+
+### Fixes and improvements
+- Update `SharedTokenCacheCredential` to filter accounts by tenant id
+  - Added `SharedTokenCacheCredentialOptions` class with properties `TenantId` and `Username`
+  - Added constructor overload to `SharedTokenCacheCredential` which accepts `SharedTokenCacheCredentialOptions` 
+  - Added property `SharedTokenCacheTenantId` to `DefaultAzureCredentialOptions`
 
 ## 1.0.0
 - First stable release of Azure.Identity package.

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredential.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredential.cs
@@ -145,7 +145,7 @@ namespace Azure.Identity
 
             if (!options.ExcludeSharedTokenCacheCredential)
             {
-                chain[i++] = factory.CreateSharedTokenCacheCredential(options.SharedTokenCacheUsername ?? EnvironmentVariables.Username);
+                chain[i++] = factory.CreateSharedTokenCacheCredential(options.SharedTokenCacheTenantId ?? EnvironmentVariables.TenantId, options.SharedTokenCacheUsername ?? EnvironmentVariables.Username);
             }
 
             if (!options.ExcludeInteractiveBrowserCredential)

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -26,9 +26,9 @@ namespace Azure.Identity
             return new ManagedIdentityCredential(clientId, Pipeline);
         }
 
-        public virtual IExtendedTokenCredential CreateSharedTokenCacheCredential(string username)
+        public virtual IExtendedTokenCredential CreateSharedTokenCacheCredential(string tenantId, string username)
         {
-            return new SharedTokenCacheCredential(username, Pipeline);
+            return new SharedTokenCacheCredential(tenantId, username, Pipeline);
         }
 
         public virtual IExtendedTokenCredential CreateInteractiveBrowserCredential()

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialOptions.cs
@@ -9,6 +9,16 @@ namespace Azure.Identity
     public class DefaultAzureCredentialOptions : TokenCredentialOptions
     {
         /// <summary>
+        /// Specifies the tenant id of the preferred authentication account, to be retrieved from the shared token cache for single sign on authentication with
+        /// development tools, in the case multiple accounts are found in the shared token.
+        /// </summary>
+        /// <remarks>
+        /// If multiple accounts are found in the shared token cache and no value is specified, or the specified value matches no accounts in
+        /// the cache the SharedTokenCacheCredential will not be used for authentication.
+        /// </remarks>
+        public string SharedTokenCacheTenantId { get; set; }
+
+        /// <summary>
         /// Specifies the preferred authentication account to be retrieved from the shared token cache for single sign on authentication with
         /// development tools. In the case multiple accounts are found in the shared token.
         /// </summary>

--- a/sdk/identity/Azure.Identity/src/SharedTokenCacheCredential.cs
+++ b/sdk/identity/Azure.Identity/src/SharedTokenCacheCredential.cs
@@ -8,7 +8,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Linq;
 using System.Collections.Generic;
-using System.Collections;
+using System.Text;
+using System.IO;
+using System.Globalization;
 
 namespace Azure.Identity
 {
@@ -17,41 +19,49 @@ namespace Azure.Identity
     /// </summary>
     public class SharedTokenCacheCredential : TokenCredential, IExtendedTokenCredential
     {
-        internal const string MultipleAccountsErrorMessage = "Multiple accounts were discovered in the shared token cache. To fix, set the AZURE_USERNAME environment variable to the preferred username, or specify it when constructing SharedTokenCacheCredential.";
-
-        internal const string NoAccountsErrorMessage = "No accounts were discovered in the shared token cache. To fix, authenticate through tooling supporting azure developer sign on.";
-
         private readonly MsalPublicClient _client;
         private readonly CredentialPipeline _pipeline;
+        private readonly string _tenantId;
         private readonly string _username;
         private readonly Lazy<Task<(IAccount, Exception)>> _account;
 
         /// <summary>
-        /// Creates a new SharedTokenCacheCredential which will authenticate users with the specified application.
+        /// Creates a new <see cref="SharedTokenCacheCredential"/> which will authenticate users signed in through developer tools supporting Azure single sign on.
         /// </summary>
         public SharedTokenCacheCredential()
-            : this(null, CredentialPipeline.GetInstance(null))
+            : this(null, null, CredentialPipeline.GetInstance(null))
         {
 
         }
 
         /// <summary>
-        /// Creates a new SharedTokenCacheCredential with the specified options, which will authenticate users with the specified application.
+        /// Creates a new <see cref="SharedTokenCacheCredential"/> which will authenticate users signed in through developer tools supporting Azure single sign on.
+        /// </summary>
+        /// <param name="options">The client options for the newly created <see cref="SharedTokenCacheCredential"/></param>
+        public SharedTokenCacheCredential(SharedTokenCacheCredentialOptions options)
+            : this(options?.TenantId, options?.Username, CredentialPipeline.GetInstance(options))
+        {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="SharedTokenCacheCredential"/> which will authenticate users signed in through developer tools supporting Azure single sign on.
         /// </summary>
         /// <param name="username">The username of the user to authenticate</param>
-        /// <param name="options">The client options for the newly created SharedTokenCacheCredential</param>
+        /// <param name="options">The client options for the newly created <see cref="SharedTokenCacheCredential"/></param>
         public SharedTokenCacheCredential(string username, TokenCredentialOptions options = default)
-            : this(username, CredentialPipeline.GetInstance(options))
+            : this(tenantId: null, username: username, pipeline: CredentialPipeline.GetInstance(options))
         {
         }
 
-        internal SharedTokenCacheCredential(string username, CredentialPipeline pipeline)
-            : this(username, pipeline, pipeline.CreateMsalPublicClient(Constants.DeveloperSignOnClientId, attachSharedCache: true))
+        internal SharedTokenCacheCredential(string tenantId, string username, CredentialPipeline pipeline)
+            : this(tenantId: tenantId, username: username, pipeline: pipeline, client: pipeline.CreateMsalPublicClient(Constants.DeveloperSignOnClientId, tenantId: tenantId, attachSharedCache: true))
         {
         }
 
-        internal SharedTokenCacheCredential(string username, CredentialPipeline pipeline, MsalPublicClient client)
+        internal SharedTokenCacheCredential(string tenantId, string username, CredentialPipeline pipeline, MsalPublicClient client)
         {
+            _tenantId = tenantId;
+
             _username = username;
 
             _pipeline = pipeline;
@@ -118,7 +128,7 @@ namespace Azure.Identity
             }
             catch (MsalUiRequiredException)
             {
-                return new ExtendedAccessToken(scope.Failed(new CredentialUnavailableException($"Token aquisition failed for user '{_username}'. To fix, reauthenticate through tooling supporting azure developer sign on.")));
+                return new ExtendedAccessToken(scope.Failed(new CredentialUnavailableException($"Token acquisition failed for user {_username}. To fix, re-authenticate through developer tooling supporting Azure single sign on.")));
             }
             catch (Exception e)
             {
@@ -128,53 +138,46 @@ namespace Azure.Identity
 
         private async Task<(IAccount, Exception)> GetAccountAsync()
         {
-            Exception ex = null;
+            List<IAccount> accounts = (await _client.GetAccountsAsync().ConfigureAwait(false)).ToList();
 
-            IAccount account = null;
+            List<IAccount> filteredAccounts = accounts.Where(a => (string.IsNullOrEmpty(_username) || a.Username == _username) && (string.IsNullOrEmpty(_tenantId) || a.HomeAccountId?.TenantId == _tenantId)).ToList();
 
-            List<IAccount> allAccounts = (await _client.GetAccountsAsync().ConfigureAwait(false)).ToList();
-
-            List<IAccount> accounts = (!string.IsNullOrEmpty(_username)) ? allAccounts.Where(a => a.Username == _username).ToList() : allAccounts.ToList();
-
-            if (accounts.Count == 0)
+            if (filteredAccounts.Count != 1)
             {
-                if (allAccounts.Count == 0)
-                {
-                    ex = new CredentialUnavailableException(NoAccountsErrorMessage);
-                }
-                else
-                {
-                    ex = new CredentialUnavailableException($"User account '{_username}' was not found in the shared token cache.{Environment.NewLine}  Discovered Accounts: [ '{string.Join("', '", allAccounts.Select(a => a.Username))}' ]");
-                }
-            }
-            else
-            {
-                // we already know there is at least one account
-                IAccount proposedAccount = accounts.First();
-
-                // if all accounts have the same home account id they are interchangable, so we can just use the first account which we picked
-                if (accounts.All(a => a.HomeAccountId.Identifier == proposedAccount.HomeAccountId.Identifier))
-                {
-                    account = proposedAccount;
-                }
-                // otherwise we need to error so we don't indiscriminantly choose between different tenents / subscriptions
-                else
-                {
-                    // if username wasn't specified it's possible that they can rectify this situation by specifying
-                    if (string.IsNullOrEmpty(_username))
-                    {
-                        ex = new CredentialUnavailableException($"{MultipleAccountsErrorMessage}{Environment.NewLine} Discovered Accounts: [ '{string.Join("', '", allAccounts.Select(a => a.Username))}' ]");
-                    }
-                    // if they already specified username the cache is essentially unusable to use without more information
-                    else
-                    {
-                        ex = new CredentialUnavailableException($"Multiple entries for the user account '{_username}' were found in the shared token cache. This is not currently supported by the SharedTokenCacheCredential.");
-                    }
-                }
+                return (null, new CredentialUnavailableException(GetCredentialUnavailableMessage(accounts, filteredAccounts)));
             }
 
-            return (account, ex);
+            return (filteredAccounts.First(), null);
         }
 
+        internal const string NoAccountsInCacheMessage = "No accounts were found in the cache.  To authenticate with the SharedTokenCacheCredential, login an account through developer tooling supporting Azure single sign on.";
+        internal const string MultipleAccountsInCacheMessage = "Multiple accounts were found in the cache. To authenticate with the SharedTokenCacheCredential, set the AZURE_USERNAME and AZURE_TENANT_ID environment variables to the preferred username and tenantId, or specify them to the constructor. {0}";
+        internal const string NoMatchingAccountsInCacheMessage = "No account matching the specified{0}{1} was found in the cache. To authenticate with the SharedTokenCacheCredential, login an account through developer tooling supporting Azure single sign on. {2}";
+        internal const string MultipleMatchingAccountsInCacheMessage = "Multiple accounts matching the specified{0}{1} were found in the cache. To authenticate with the SharedTokenCacheCredential, set the AZURE_USERNAME and AZURE_TENANT_ID environment variables to the preferred username and tenantId, or specify them to the constructor. {2}";
+
+        private string GetCredentialUnavailableMessage(List<IAccount> accounts, List<IAccount> filteredAccounts)
+        {
+            if (accounts.Count == 0)
+            {
+                return NoAccountsInCacheMessage;
+            }
+
+            var discoveredAccountsStr = $"[ {{{string.Join("}, {", accounts.Select(a => $"username: {a.Username} tenantId: {a.HomeAccountId?.TenantId}"))}}} ]";
+
+            if (string.IsNullOrEmpty(_username) && string.IsNullOrEmpty(_tenantId))
+            {
+                return string.Format(CultureInfo.InvariantCulture, MultipleAccountsInCacheMessage, discoveredAccountsStr);
+            }
+
+            var usernameStr = string.IsNullOrEmpty(_username) ? string.Empty : $" username: {_username}";
+            var tenantIdStr = string.IsNullOrEmpty(_tenantId) ? string.Empty : $" tenantId: {_tenantId}";
+
+            if (filteredAccounts.Count == 0)
+            {
+                return string.Format(CultureInfo.InvariantCulture, NoMatchingAccountsInCacheMessage, usernameStr, tenantIdStr, discoveredAccountsStr);
+            }
+
+            return string.Format(CultureInfo.InvariantCulture, MultipleMatchingAccountsInCacheMessage, usernameStr, tenantIdStr, discoveredAccountsStr);
+        }
     }
 }

--- a/sdk/identity/Azure.Identity/src/SharedTokenCacheCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/SharedTokenCacheCredentialOptions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Identity
+{
+    /// <summary>
+    /// Options to configure the <see cref="SharedTokenCacheCredential"/> authentication.
+    /// </summary>
+    public class SharedTokenCacheCredentialOptions : TokenCredentialOptions
+    {
+        /// <summary>
+        /// Specifies the preferred authentication account username, or UPN, to be retrieved from the shared token cache for single sign on authentication with
+        /// development tools, in the case multiple accounts are found in the shared token.
+        /// </summary>
+        public string Username { get; set; }
+
+        /// <summary>
+        /// Specifies the tenant id of the preferred authentication account, to be retrieved from the shared token cache for single sign on authentication with
+        /// development tools, in the case multiple accounts are found in the shared token.
+        /// </summary>
+        public string TenantId { get; set; }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/AzureIdentityEventSourceTests.cs
+++ b/sdk/identity/Azure.Identity/tests/AzureIdentityEventSourceTests.cs
@@ -104,7 +104,7 @@ namespace Azure.Identity.Tests
                 SilentAuthFactory = (_) => { return AuthenticationResultFactory.Create(accessToken: Guid.NewGuid().ToString(), expiresOn: DateTimeOffset.UtcNow.AddMinutes(10)); }
             };
 
-            var credential = InstrumentClient(new SharedTokenCacheCredential("mockuser@mockdomain.com", CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new SharedTokenCacheCredential(null, "mockuser@mockdomain.com", CredentialPipeline.GetInstance(null), mockMsalClient));
 
             var method = "Azure.Identity.SharedTokenCacheCredential.GetToken";
 
@@ -178,7 +178,7 @@ namespace Azure.Identity.Tests
                 SilentAuthFactory = (_) => throw new MockClientException(expExMessage)
             };
 
-            var credential = InstrumentClient(new SharedTokenCacheCredential("mockuser@mockdomain.com", CredentialPipeline.GetInstance(null), mockMsalClient));
+            var credential = InstrumentClient(new SharedTokenCacheCredential(null, "mockuser@mockdomain.com", CredentialPipeline.GetInstance(null), mockMsalClient));
 
             var method = "Azure.Identity.SharedTokenCacheCredential.GetToken";
 

--- a/sdk/identity/Azure.Identity/tests/Mock/MockAccount.cs
+++ b/sdk/identity/Azure.Identity/tests/Mock/MockAccount.cs
@@ -8,11 +8,13 @@ namespace Azure.Identity.Tests.Mock
 {
     public class MockAccount : IAccount
     {
-        public MockAccount(string username, string homeId = null)
+        public MockAccount(string username, string tenantId = null)
         {
-            homeId ??= Guid.NewGuid().ToString();
+            tenantId ??= Guid.NewGuid().ToString();
+            var objectId = Guid.NewGuid().ToString();
+            var identifier = objectId + "." + tenantId;
             Username = username;
-            HomeAccountId = new AccountId(homeId);
+            HomeAccountId = new AccountId(identifier, objectId, tenantId);
         }
 
         public string Username { get; set; }

--- a/sdk/identity/Azure.Identity/tests/Mock/MockDefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/tests/Mock/MockDefaultAzureCredentialFactory.cs
@@ -13,7 +13,7 @@ namespace Azure.Identity.Tests.Mock
 
         public Action<IExtendedTokenCredential> OnCreateEnvironmentCredential { get; set; }
         public Action<string, IExtendedTokenCredential> OnCreateManagedIdentityCredential { get; set; }
-        public Action<string, IExtendedTokenCredential> OnCreateSharedTokenCacheCredential { get; set; }
+        public Action<string, string, IExtendedTokenCredential> OnCreateSharedTokenCacheCredential { get; set; }
         public Action<IExtendedTokenCredential> OnCreateInteractiveBrowserCredential { get; set; }
 
         public override IExtendedTokenCredential CreateEnvironmentCredential()
@@ -34,11 +34,11 @@ namespace Azure.Identity.Tests.Mock
             return cred;
         }
 
-        public override IExtendedTokenCredential CreateSharedTokenCacheCredential(string username)
+        public override IExtendedTokenCredential CreateSharedTokenCacheCredential(string tenantId, string username)
         {
             IExtendedTokenCredential cred = new MockExtendedTokenCredential();
 
-            OnCreateSharedTokenCacheCredential?.Invoke(username, cred);
+            OnCreateSharedTokenCacheCredential?.Invoke(tenantId, username, cred);
 
             return cred;
         }


### PR DESCRIPTION
  - Added `SharedTokenCacheCredentialOptions` class with properties `TenantId` and `Username`
  - Added constructor overload to `SharedTokenCacheCredential` which accepts `SharedTokenCacheCredentialOptions` 
  - Added property `SharedTokenCacheTenantId` to `DefaultAzureCredentialOptions`

Fixes #8689