### PR TITLE
Azure.Identity Fixing live id user account login

### DIFF
--- a/sdk/identity/Azure.Identity/src/Constants.cs
+++ b/sdk/identity/Azure.Identity/src/Constants.cs
@@ -8,6 +8,8 @@ namespace Azure.Identity
 {
     internal class Constants
     {
+        public const string OrganizationsTenantId = "organizations";
+
         // TODO: Currently this is piggybacking off the Azure CLI client ID, but needs to be switched once the Developer Sign On application is available
         public const string DeveloperSignOnClientId = "04b07795-8ddb-461a-bbee-02f9e1bf7b46";
 

--- a/sdk/identity/Azure.Identity/src/MsalPublicClient.cs
+++ b/sdk/identity/Azure.Identity/src/MsalPublicClient.cs
@@ -24,7 +24,7 @@ namespace Azure.Identity
         {
             PublicClientApplicationBuilder pubAppBuilder = PublicClientApplicationBuilder.Create(clientId).WithHttpClientFactory(new HttpPipelineClientFactory(pipeline));
 
-            tenantId ??= "organizations";
+            tenantId ??= Constants.OrganizationsTenantId;
 
             pubAppBuilder = pubAppBuilder.WithTenantId(tenantId);
 

--- a/sdk/identity/Azure.Identity/src/MsalPublicClient.cs
+++ b/sdk/identity/Azure.Identity/src/MsalPublicClient.cs
@@ -24,10 +24,9 @@ namespace Azure.Identity
         {
             PublicClientApplicationBuilder pubAppBuilder = PublicClientApplicationBuilder.Create(clientId).WithHttpClientFactory(new HttpPipelineClientFactory(pipeline));
 
-            if (!string.IsNullOrEmpty(tenantId))
-            {
-                pubAppBuilder = pubAppBuilder.WithTenantId(tenantId);
-            }
+            tenantId ??= "organizations";
+
+            pubAppBuilder = pubAppBuilder.WithTenantId(tenantId);
 
             if (!string.IsNullOrEmpty(redirectUrl))
             {

--- a/sdk/identity/Azure.Identity/src/SharedTokenCacheCredential.cs
+++ b/sdk/identity/Azure.Identity/src/SharedTokenCacheCredential.cs
@@ -19,6 +19,11 @@ namespace Azure.Identity
     /// </summary>
     public class SharedTokenCacheCredential : TokenCredential, IExtendedTokenCredential
     {
+        internal const string NoAccountsInCacheMessage = "No accounts were found in thecache.  To authenticate with the SharedTokenCacheCredential, login an account through developer tooling supporting Azure single sign on.";
+        internal const string MultipleAccountsInCacheMessage = "Multiple accounts were found in the cache. To authenticate with the SharedTokenCacheCredential, set the AZURE_USERNAME and AZURE_TENANT_ID environment variables to the preferred username and tenantId, or specify them to the constructor. {0}";
+        internal const string NoMatchingAccountsInCacheMessage = "No account matching the specified{0}{1} was found in the cache. To authenticate with the SharedTokenCacheCredential, login an account through developer tooling supporting Azure single sign on. {2}";
+        internal const string MultipleMatchingAccountsInCacheMessage = "Multiple accounts matching the specified{0}{1} were found in the cache. To authenticate with the SharedTokenCacheCredential, set the AZURE_USERNAME and AZURE_TENANT_ID environment variables to the preferred username and tenantId, or specify them to the constructor. {2}";
+
         private readonly MsalPublicClient _client;
         private readonly CredentialPipeline _pipeline;
         private readonly string _tenantId;
@@ -149,11 +154,6 @@ namespace Azure.Identity
 
             return (filteredAccounts.First(), null);
         }
-
-        internal const string NoAccountsInCacheMessage = "No accounts were found in the cache.  To authenticate with the SharedTokenCacheCredential, login an account through developer tooling supporting Azure single sign on.";
-        internal const string MultipleAccountsInCacheMessage = "Multiple accounts were found in the cache. To authenticate with the SharedTokenCacheCredential, set the AZURE_USERNAME and AZURE_TENANT_ID environment variables to the preferred username and tenantId, or specify them to the constructor. {0}";
-        internal const string NoMatchingAccountsInCacheMessage = "No account matching the specified{0}{1} was found in the cache. To authenticate with the SharedTokenCacheCredential, login an account through developer tooling supporting Azure single sign on. {2}";
-        internal const string MultipleMatchingAccountsInCacheMessage = "Multiple accounts matching the specified{0}{1} were found in the cache. To authenticate with the SharedTokenCacheCredential, set the AZURE_USERNAME and AZURE_TENANT_ID environment variables to the preferred username and tenantId, or specify them to the constructor. {2}";
 
         private string GetCredentialUnavailableMessage(List<IAccount> accounts, List<IAccount> filteredAccounts)
         {

--- a/sdk/identity/Azure.Identity/tests/DeviceCodeCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DeviceCodeCredentialTests.cs
@@ -166,7 +166,7 @@ namespace Azure.Identity.Tests
                 return DiscoveryInstanceResponse;
             }
 
-            if (requestUrl.StartsWith("https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration"))
+            if (requestUrl.StartsWith("https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration"))
             {
                 return OpenIdConfigurationResponse;
             }

--- a/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialTests.cs
@@ -26,6 +26,8 @@ namespace Azure.Identity.Tests
         [Ignore("This test is an integration test which can only be run with user interaction")]
         public async Task AuthenticateWithBrowserAsync()
         {
+            // to fully manually verify the InteraciveBrowserCredential this test should be run both authenticating with a
+            // school / organization account as well as a personal live account, i.e. a @outlook.com, @live.com, or @hotmail.com
             var cred = new InteractiveBrowserCredential();
 
             AccessToken token = await cred.GetTokenAsync(new TokenRequestContext(new string[] { "https://vault.azure.net/.default" })).ConfigureAwait(false);

--- a/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/InteractiveBrowserCredentialTests.cs
@@ -26,7 +26,7 @@ namespace Azure.Identity.Tests
         [Ignore("This test is an integration test which can only be run with user interaction")]
         public async Task AuthenticateWithBrowserAsync()
         {
-            // to fully manually verify the InteraciveBrowserCredential this test should be run both authenticating with a
+            // to fully manually verify the InteractiveBrowserCredential this test should be run both authenticating with a
             // school / organization account as well as a personal live account, i.e. a @outlook.com, @live.com, or @hotmail.com
             var cred = new InteractiveBrowserCredential();
 


### PR DESCRIPTION
Enable live id account login through the `SharedTokenCacheCredential` and `InteractiveBrowserCredential`.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/8679