### PR TITLE
[Event Hubs Client] Track Two (Shared Access Credential Fix)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Authorization/SharedAccessSignature.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Authorization/SharedAccessSignature.cs
@@ -49,10 +49,10 @@ namespace Azure.Messaging.EventHubs.Authorization
         private const char TokenValuePairDelimiter = '&';
 
         /// <summary>The default length of time to consider a signature valid, if not otherwise specified.</summary>
-        private static readonly TimeSpan s_defaultSignatureValidityDuration = TimeSpan.FromMinutes(30);
+        private static readonly TimeSpan DefaultSignatureValidityDuration = TimeSpan.FromMinutes(30);
 
         /// <summary>Represents the Unix epoch time value, January 1, 1970 12:00:00, UTC.</summary>
-        private static readonly DateTimeOffset s_epoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        private static readonly DateTimeOffset Epoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
         /// <summary>
         ///   The name of the shared access key, either for the Event Hubs namespace
@@ -102,7 +102,7 @@ namespace Azure.Messaging.EventHubs.Authorization
                                      string sharedAccessKey,
                                      TimeSpan? signatureValidityDuration = default)
         {
-            signatureValidityDuration ??= s_defaultSignatureValidityDuration;
+            signatureValidityDuration ??= DefaultSignatureValidityDuration;
 
             Argument.AssertNotNullOrEmpty(eventHubResource, nameof(eventHubResource));
             Argument.AssertNotNullOrEmpty(sharedAccessKeyName, nameof(sharedAccessKeyName));
@@ -393,7 +393,7 @@ namespace Azure.Messaging.EventHubs.Authorization
         /// <returns>The date/time, in UTC, which corresponds to the specified timestamp.</returns>
         ///
         private static DateTimeOffset ConvertFromUnixTime(long unixTime) =>
-            s_epoch.AddSeconds(unixTime);
+            Epoch.AddSeconds(unixTime);
 
         /// <summary>
         ///   Converts a <see cref="DateTimeOffset" /> value to the corresponding Unix-style timestamp.
@@ -404,8 +404,6 @@ namespace Azure.Messaging.EventHubs.Authorization
         /// <returns>The Unix-style timestamp which corresponds to the specified date/time.</returns>
         ///
         private static long ConvertToUnixTime(DateTimeOffset dateTimeOffset) =>
-            Convert.ToInt64((dateTimeOffset - s_epoch).TotalSeconds);
-
-
+            Convert.ToInt64((dateTimeOffset - Epoch).TotalSeconds);
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Authorization/SharedAccessSignatureCredential.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Authorization/SharedAccessSignatureCredential.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -17,6 +18,12 @@ namespace Azure.Messaging.EventHubs.Authorization
     ///
     internal class SharedAccessSignatureCredential : TokenCredential
     {
+        /// <summary>The buffer to apply when considering refreshing; signatures that expire less than this duration will be refreshed.</summary>
+        private static readonly TimeSpan SignatureRefreshBuffer = TimeSpan.FromMinutes(5);
+
+        /// <summary>The length of time extend signature validity, if a token was requested.</summary>
+        private static readonly TimeSpan SignatureExtensionDuration = TimeSpan.FromMinutes(30);
+
         /// <summary>
         ///   The shared access signature that forms the basis of this security token.
         /// </summary>
@@ -46,7 +53,15 @@ namespace Azure.Messaging.EventHubs.Authorization
         /// <returns>The token representing the shared access signature for this credential.</returns>
         ///
         public override AccessToken GetToken(TokenRequestContext requestContext,
-                                             CancellationToken cancellationToken) => new AccessToken(SharedAccessSignature.Value, SharedAccessSignature.SignatureExpiration);
+                                             CancellationToken cancellationToken)
+        {
+            if (SharedAccessSignature.SignatureExpiration <= DateTimeOffset.UtcNow.Add(SignatureRefreshBuffer))
+            {
+                SharedAccessSignature.ExtendExpiration(SignatureExtensionDuration);
+            }
+
+            return new AccessToken(SharedAccessSignature.Value, SharedAccessSignature.SignatureExpiration);
+        }
 
         /// <summary>
         ///   Retrieves the token that represents the shared access signature credential, for
@@ -59,6 +74,6 @@ namespace Azure.Messaging.EventHubs.Authorization
         /// <returns>The token representing the shared access signature for this credential.</returns>
         ///
         public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext,
-                                                             CancellationToken cancellationToken) => new ValueTask<AccessToken>(new AccessToken(SharedAccessSignature.Value, SharedAccessSignature.SignatureExpiration));
+                                                             CancellationToken cancellationToken) => new ValueTask<AccessToken>(GetToken(requestContext, cancellationToken));
     }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to fix the shared access signature credential such that it correctly requests extension for the expiration of an expired or nearly expired token.

# Last Upstream Rebase

Monday, November 11, 12:52pm (EST)

# Related and Follow-Up Issues

- [Release Event Hubs Track 2 Library for .NET](https://github.com/Azure/azure-sdk-for-net/issues/8552) (#8552) 