### PR TITLE
Updating DefaultAzureCredentialTests to propertly handle env vars

### DIFF
--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredential.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredential.cs
@@ -145,7 +145,7 @@ namespace Azure.Identity
 
             if (!options.ExcludeSharedTokenCacheCredential)
             {
-                chain[i++] = factory.CreateSharedTokenCacheCredential(options.SharedTokenCacheTenantId ?? EnvironmentVariables.TenantId, options.SharedTokenCacheUsername ?? EnvironmentVariables.Username);
+                chain[i++] = factory.CreateSharedTokenCacheCredential(options.SharedTokenCacheTenantId, options.SharedTokenCacheUsername);
             }
 
             if (!options.ExcludeInteractiveBrowserCredential)

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Azure.Identity
 {
     /// <summary>
@@ -16,7 +18,7 @@ namespace Azure.Identity
         /// If multiple accounts are found in the shared token cache and no value is specified, or the specified value matches no accounts in
         /// the cache the SharedTokenCacheCredential will not be used for authentication.
         /// </remarks>
-        public string SharedTokenCacheTenantId { get; set; }
+        public string SharedTokenCacheTenantId { get; set; } = EnvironmentVariables.TenantId;
 
         /// <summary>
         /// Specifies the preferred authentication account to be retrieved from the shared token cache for single sign on authentication with
@@ -26,12 +28,12 @@ namespace Azure.Identity
         /// If multiple accounts are found in the shared token cache and no value is specified, or the specified value matches no accounts in
         /// the cache the SharedTokenCacheCredential will not be used for authentication.
         /// </remarks>
-        public string SharedTokenCacheUsername { get; set; }
+        public string SharedTokenCacheUsername { get; set; } = EnvironmentVariables.Username;
 
         /// <summary>
         /// Specifies the client id of the azure ManagedIdentity in the case of user assigned identity.
         /// </summary>
-        public string ManagedIdentityClientId { get; set; }
+        public string ManagedIdentityClientId { get; set; } = EnvironmentVariables.ClientId;
 
         /// <summary>
         /// Specifies whether the <see cref="EnvironmentCredential"/> will be excluded from the authentication flow. Setting to true disables reading

--- a/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialTests.cs
@@ -91,6 +91,8 @@ namespace Azure.Identity.Tests
             var expClientId = clientIdSpecified ? Guid.NewGuid().ToString() : null;
             var expUsername = usernameSpecified ? Guid.NewGuid().ToString() : null;
             var expTenantId = tenantIdSpecified ? Guid.NewGuid().ToString() : null;
+            bool onCreateSharedCalled = false;
+            bool onCreatedManagedCalled = false;
 
             using (new TestEnvVar("AZURE_CLIENT_ID", expClientId))
             using (new TestEnvVar("AZURE_USERNAME", expUsername))
@@ -100,22 +102,29 @@ namespace Azure.Identity.Tests
 
                 credFactory.OnCreateManagedIdentityCredential = (clientId, _) =>
                 {
+                    onCreatedManagedCalled = true;
                     Assert.AreEqual(expClientId, clientId);
                 };
 
                 credFactory.OnCreateSharedTokenCacheCredential = (tenantId, username, _) =>
                 {
+                    onCreateSharedCalled = true;
                     Assert.AreEqual(expTenantId, tenantId);
                     Assert.AreEqual(expUsername, username);
                 };
 
                 var options = new DefaultAzureCredentialOptions
                 {
-                    ExcludeEnvironmentCredential = false,
-                    ExcludeManagedIdentityCredential = true,
-                    ExcludeSharedTokenCacheCredential = true,
-                    ExcludeInteractiveBrowserCredential = false
+                    ExcludeEnvironmentCredential = true,
+                    ExcludeManagedIdentityCredential = false,
+                    ExcludeSharedTokenCacheCredential = false,
+                    ExcludeInteractiveBrowserCredential = true
                 };
+
+                var cred = new DefaultAzureCredential(credFactory, options);
+
+                Assert.IsTrue(onCreateSharedCalled);
+                Assert.IsTrue(onCreatedManagedCalled);
             }
         }
 


### PR DESCRIPTION
Currently DefaultAzureCredentialTests require a clean environment to run properly. This change fixes this so that tests which are affected by environment variables  setup their expected environment.

fixes #8731