### PR TITLE
[Event Hubs Client] Track Two (Remove Consumer Partition Binding)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample08_ConsumeEvents.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample08_ConsumeEvents.cs
@@ -56,31 +56,16 @@ namespace Azure.Messaging.EventHubs.Samples
             // Because events are not removed from the partition when consuming, a consumer must specify where in the partition it
             // would like to begin reading events.  For example, this may be starting from the very beginning of the stream, at an
             // offset from the beginning, the next event available after a specific point in time, or at a specific event.
+            //
+            // In this example, we will create our consumer client using the default consumer group that is created with an Event Hub.
+            // Our consumer will begin watching the partition at the very end, reading only new events that we will publish for it.
 
-            // We will start by creating a client to inspect the Event Hub and select a partition to operate against to ensure that
-            // events are being published and read from the same partition.
-
-            string firstPartition;
-
-            await using (var inspectionClient = new EventHubProducerClient(connectionString, eventHubName))
+            await using (var consumerClient = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString, eventHubName))
             {
-                // With our client, we can now inspect the partitions and find the identifier
-                // of the first.
+                // We will start by using the consumer client inspect the Event Hub and select a partition to operate against to ensure that events are being
+                // published and read from the same partition.
 
-                firstPartition = (await inspectionClient.GetPartitionIdsAsync()).First();
-            }
-
-            // In this example, we will create our consumer client for the first partition in the Event Hub, using the default consumer group
-            // that is created with an Event Hub.  Our consumer will begin watching the partition at the very end, reading only new events
-            // that we will publish for it.
-
-            await using (var consumerClient = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, firstPartition, EventPosition.Latest, connectionString, eventHubName))
-            await using (var producerClient = new EventHubProducerClient(connectionString, eventHubName, new EventHubProducerClientOptions { PartitionId = firstPartition }))
-            {
-                PartitionEvent receivedEvent;
-
-                Stopwatch watch = Stopwatch.StartNew();
-                bool wereEventsPublished = false;
+                string firstPartition = (await consumerClient.GetPartitionIdsAsync()).First();
 
                 // Because our consumer is reading from the latest position, it won't see events that have previously
                 // been published.  Before we can publish the events and have them observed, we will need to ask the consumer
@@ -89,13 +74,14 @@ namespace Azure.Messaging.EventHubs.Samples
                 // We'll begin to iterate on the partition using a small wait time, so that control will return to our loop even when
                 // no event is available.  For the first call, we'll publish so that we can receive them.
                 //
-                // Because publishing and receiving events is asynchronous, the events that we published may not
-                // be immediately available for our consumer to see, so we'll have to guard against an empty event being sent as
-                // punctuation if our actual event is not available within the waiting time period.
-                //
                 // We will iterate over the available events in the partition, which should be just the event that we published.  Because
                 // we're expecting only the one event, we will exit the loop when we receive it.  To be sure that we do not block forever
                 // waiting on an event that is not published, we will request cancellation after a fairly long interval.
+
+                PartitionEvent receivedEvent;
+
+                Stopwatch watch = Stopwatch.StartNew();
+                bool wereEventsPublished = false;
 
                 CancellationTokenSource cancellationSource = new CancellationTokenSource();
                 cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
@@ -104,15 +90,16 @@ namespace Azure.Messaging.EventHubs.Samples
                 {
                     if (!wereEventsPublished)
                     {
+                        await using var producerClient = new EventHubProducerClient(connectionString, eventHubName, new EventHubProducerClientOptions { PartitionId = firstPartition });
                         await producerClient.SendAsync(new EventData(Encoding.UTF8.GetBytes("Hello, Event Hubs!")));
                         wereEventsPublished = true;
 
                         Console.WriteLine("The event batch has been published.");
                     }
 
-                    // Because publishing is non-deterministic, the event may not be available
-                    // before the next timeout returns control to us.  We'll guard against that by
-                    // ensuring the event has data associated with it.
+                    // Because publishing and receiving events is asynchronous, the events that we published may not
+                    // be immediately available for our consumer to see, so we'll have to guard against an empty event being sent as
+                    // punctuation if our actual event is not available within the waiting time period.
 
                     if (currentEvent.Data != null)
                     {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample09_ConsumeEventsWithMaximumWaitTime.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample09_ConsumeEventsWithMaximumWaitTime.cs
@@ -57,45 +57,20 @@ namespace Azure.Messaging.EventHubs.Samples
             // Because events are not removed from the partition when consuming, a consumer must specify where in the partition it
             // would like to begin reading events.  For example, this may be starting from the very beginning of the stream, at an
             // offset from the beginning, the next event available after a specific point in time, or at a specific event.
+            //
+            // In this example, we will create our consumer client using the default consumer group that is created with an Event Hub.
+            // Our consumer will begin watching the partition at the very end, reading only new events that we will publish for it.
 
-            // We will start by creating a client using its default set of options.
-
-            // We will start by creating a client to inspect the Event Hub and select a partition to operate against to ensure that
-            // events are being published and read from the same partition.
-
-            string firstPartition;
-
-            await using (var inspectionClient = new EventHubProducerClient(connectionString, eventHubName))
+            await using (var consumerClient = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString, eventHubName))
             {
-                // With our client, we can now inspect the partitions and find the identifier
-                // of the first.
+                // We will start by using the consumer client inspect the Event Hub and select a partition to operate against to ensure that events are being
+                // published and read from the same partition.
 
-                firstPartition = (await inspectionClient.GetPartitionIdsAsync()).First();
-            }
-
-            // In this example, we will create our consumer client for the first partition in the Event Hub, using the default consumer group
-            // that is created with an Event Hub.  Our consumer will begin watching the partition at the very end, reading only new events
-            // that we will publish for it.
-
-            await using (var consumerClient = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, firstPartition, EventPosition.Latest, connectionString, eventHubName))
-            await using (var producerClient = new EventHubProducerClient(connectionString, eventHubName, new EventHubProducerClientOptions { PartitionId = firstPartition }))
-            {
-                EventData[] eventsToPublish = new EventData[]
-                {
-                    new EventData(Encoding.UTF8.GetBytes("Hello, Event Hubs!")),
-                    new EventData(Encoding.UTF8.GetBytes("Goodbye, Event Hubs!"))
-                };
-
-                List<EventData> receivedEvents = new List<EventData>();
-                Stopwatch watch = Stopwatch.StartNew();
-                bool wereEventsPublished = false;
+                string firstPartition = (await consumerClient.GetPartitionIdsAsync()).First();
 
                 // Because our consumer is reading from the latest position, it won't see events that have previously
-                // been published.  Before we can publish the events and have them observed, we will need to ask the
-                // consumer to perform an operation, because it opens its connection only when it needs to.
-                //
-                // We'll begin to iterate on the partition using a small wait time, so that control will return to our loop even when
-                // no event is available.  For the first call, we'll publish so that we can receive them.
+                // been published.  Before we can publish the events and have them observed, we will need to ask the consumer
+                // to perform an operation, because it opens its connection only when it needs to.
                 //
                 // When a maximum wait time is specified, the iteration will ensure that it returns control after that time has elapsed,
                 // whether or not an event is available in the partition.  If no event was available a null value will be emitted instead.
@@ -103,11 +78,24 @@ namespace Azure.Messaging.EventHubs.Samples
                 // processors to verify that the iterator is still consuming the partition and to make decisions on whether or not to continue
                 // if events are not arriving.
                 //
+                // We'll begin to iterate on the partition using a small wait time, so that control will return to our loop even when
+                // no event is available.  For the first call, we'll publish so that we can receive them.
+                //
                 // For this example, we will specify a maximum wait time, and won't exit the loop until we've received at least one more
                 // event than we published, which is expected to be a null value triggered by exceeding the wait time.
                 //
                 // To be sure that we do not block forever waiting on an event that is not published, we will request cancellation after a
                 // fairly long interval.
+
+                EventData[] eventsToPublish = new EventData[]
+                {
+                    new EventData(Encoding.UTF8.GetBytes("Hello, Event Hubs!")),
+                    new EventData(Encoding.UTF8.GetBytes("Goodbye, Event Hubs!"))
+                };
+
+                bool wereEventsPublished = false;
+                Stopwatch watch = Stopwatch.StartNew();
+                List<EventData> receivedEvents = new List<EventData>();
 
                 CancellationTokenSource cancellationSource = new CancellationTokenSource();
                 cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
@@ -118,6 +106,7 @@ namespace Azure.Messaging.EventHubs.Samples
                 {
                     if (!wereEventsPublished)
                     {
+                        await using var producerClient = new EventHubProducerClient(connectionString, eventHubName, new EventHubProducerClientOptions { PartitionId = firstPartition });
                         await producerClient.SendAsync(eventsToPublish);
                         wereEventsPublished = true;
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample10_ConsumeEventsFromAKnownPosition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample10_ConsumeEventsFromAKnownPosition.cs
@@ -39,18 +39,7 @@ namespace Azure.Messaging.EventHubs.Samples
         public async Task RunAsync(string connectionString,
                                    string eventHubName)
         {
-            // We will start by creating a client to inspect the Event Hub and select a partition to operate against to ensure that
-            // events are being published and read from the same partition.
-
             string firstPartition;
-
-            await using (var inspectionClient = new EventHubProducerClient(connectionString, eventHubName))
-            {
-                // With our client, we can now inspect the partitions and find the identifier
-                // of the first.
-
-                firstPartition = (await inspectionClient.GetPartitionIdsAsync()).First();
-            }
 
             // In this example, we will make use of multiple clients.  Because clients are typically responsible for managing their own connection to the
             // Event Hubs service, each will implicitly create their own connection.  In this example, we will create a connection that may be shared amongst
@@ -58,7 +47,6 @@ namespace Azure.Messaging.EventHubs.Samples
             // lifespan and ensuring that it is properly closed or disposed when we are done using it.
 
             await using (var eventHubConnection = new EventHubConnection(connectionString, eventHubName))
-            await using (var producerClient = new EventHubProducerClient(eventHubConnection, new EventHubProducerClientOptions { PartitionId = firstPartition }))
             {
                 // Our initial consumer will begin watching the partition at the very end, reading only new events that we will publish for it. Before we can publish
                 // the events and have them observed, we will need to ask the consumer to perform an operation,
@@ -91,14 +79,12 @@ namespace Azure.Messaging.EventHubs.Samples
                 EventData thirdEvent;
                 int eventBatchSize = 50;
 
-                await using (var initialConsumerClient = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, firstPartition, EventPosition.Latest, eventHubConnection))
+                await using (var initialConsumerClient = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, eventHubConnection))
                 {
-                    EventData[] eventBatch = new EventData[eventBatchSize];
+                    // We will start by using the consumer client inspect the Event Hub and select a partition to operate against to ensure that events are being
+                    // published and read from the same partition.
 
-                    for (int index = 0; index < eventBatchSize; ++index)
-                    {
-                        eventBatch[index] = new EventData(Encoding.UTF8.GetBytes($"I am event #{ index }"));
-                    }
+                    firstPartition = (await initialConsumerClient.GetPartitionIdsAsync()).First();
 
                     // We will consume the events until all of the published events have been received.
 
@@ -112,12 +98,25 @@ namespace Azure.Messaging.EventHubs.Samples
                     {
                         if (!wereEventsPublished)
                         {
+                            EventData[] eventBatch = new EventData[eventBatchSize];
+
+                            for (int index = 0; index < eventBatchSize; ++index)
+                            {
+                                eventBatch[index] = new EventData(Encoding.UTF8.GetBytes($"I am event #{ index }"));
+                            }
+
+                            await using var producerClient = new EventHubProducerClient(connectionString, eventHubName, new EventHubProducerClientOptions { PartitionId = firstPartition });
                             await producerClient.SendAsync(eventBatch);
                             wereEventsPublished = true;
 
                             Console.WriteLine($"The event batch with { eventBatchSize } events has been published.");
                         }
-                        else
+
+                        // Because publishing and receiving events is asynchronous, the events that we published may not
+                        // be immediately available for our consumer to see, so we'll have to guard against an empty event being sent as
+                        // punctuation if our actual event is not available within the waiting time period.
+
+                        if (currentEvent.Data != null)
                         {
                             receivedEvents.Add(currentEvent.Data);
 
@@ -155,7 +154,7 @@ namespace Azure.Messaging.EventHubs.Samples
                 // Because our second consumer will begin watching the partition at a specific event, there is no need to ask for an initial operation to set our place; when
                 // we begin iterating, the consumer will locate the proper place in the partition to read from.
 
-                await using (var newConsumerClient = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, firstPartition, EventPosition.FromSequenceNumber(thirdEvent.SequenceNumber.Value), eventHubConnection))
+                await using (var newConsumerClient = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, eventHubConnection))
                 {
                     // We will consume the events using the new consumer until all of the published events have been received.
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample11_ConsumeEventsWithEventProcessor.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample11_ConsumeEventsWithEventProcessor.cs
@@ -76,7 +76,7 @@ namespace Azure.Messaging.EventHubs.Samples
                     // This is the last piece of code guaranteed to run before event processing, so all initialization
                     // must be done by the moment this method returns.
 
-                    // We want to receive events from the latest available position so older events don't interefere with our sample.
+                    // We want to receive events from the latest available position so older events don't interfere with our sample.
 
                     initializationContext.DefaultStartingPosition = EventPosition.Latest;
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/EventHubClientBuilderExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/EventHubClientBuilderExtensions.cs
@@ -55,30 +55,30 @@ namespace Microsoft.Extensions.Azure
         ///   Registers a <see cref="EventHubConsumerClientOptions"/> instance with the provided <paramref name="connectionString"/>
         /// </summary>
         ///
-        public static IAzureClientBuilder<EventHubConsumerClient, EventHubConsumerClientOptions> AddEventHubConsumerClient<TBuilder>(this TBuilder builder, string consumerGroup, string partitionId, EventPosition startingPosition, string connectionString)
+        public static IAzureClientBuilder<EventHubConsumerClient, EventHubConsumerClientOptions> AddEventHubConsumerClient<TBuilder>(this TBuilder builder, string consumerGroup, string connectionString)
             where TBuilder : IAzureClientFactoryBuilder
         {
-            return builder.RegisterClientFactory<EventHubConsumerClient, EventHubConsumerClientOptions>(options => new EventHubConsumerClient(consumerGroup, partitionId, startingPosition, connectionString, options));
+            return builder.RegisterClientFactory<EventHubConsumerClient, EventHubConsumerClientOptions>(options => new EventHubConsumerClient(consumerGroup, connectionString, options));
         }
 
         /// <summary>
         ///   Registers a <see cref="EventHubConsumerClient"/> instance with the provided <paramref name="connectionString"/> and <paramref name="eventHubName"/>
         /// </summary>
         ///
-        public static IAzureClientBuilder<EventHubConsumerClient, EventHubConsumerClientOptions> AddEventHubConsumerClient<TBuilder>(this TBuilder builder, string consumerGroup, string partitionId, EventPosition startingPosition, string connectionString, string eventHubName)
+        public static IAzureClientBuilder<EventHubConsumerClient, EventHubConsumerClientOptions> AddEventHubConsumerClient<TBuilder>(this TBuilder builder, string consumerGroup, string connectionString, string eventHubName)
             where TBuilder : IAzureClientFactoryBuilder
         {
-            return builder.RegisterClientFactory<EventHubConsumerClient, EventHubConsumerClientOptions>(options => new EventHubConsumerClient(consumerGroup, partitionId, startingPosition, connectionString, eventHubName, options));
+            return builder.RegisterClientFactory<EventHubConsumerClient, EventHubConsumerClientOptions>(options => new EventHubConsumerClient(consumerGroup, connectionString, eventHubName, options));
         }
 
         /// <summary>
         ///   Registers a <see cref="EventHubConsumerClient"/> instance with the provided <paramref name="fullyQualifiedNamespace"/> and <paramref name="eventHubName"/>
         /// </summary>
         ///
-        public static IAzureClientBuilder<EventHubConsumerClient, EventHubConsumerClientOptions> AddEventHubConsumerClientWithNamespace<TBuilder>(this TBuilder builder, string consumerGroup, string partitionId, EventPosition startingPosition, string fullyQualifiedNamespace, string eventHubName)
+        public static IAzureClientBuilder<EventHubConsumerClient, EventHubConsumerClientOptions> AddEventHubConsumerClientWithNamespace<TBuilder>(this TBuilder builder, string consumerGroup, string fullyQualifiedNamespace, string eventHubName)
             where TBuilder : IAzureClientFactoryBuilderWithCredential
         {
-            return builder.RegisterClientFactory<EventHubConsumerClient, EventHubConsumerClientOptions>((options, token) => new EventHubConsumerClient(consumerGroup, partitionId, startingPosition, fullyQualifiedNamespace, eventHubName, token, options));
+            return builder.RegisterClientFactory<EventHubConsumerClient, EventHubConsumerClientOptions>((options, token) => new EventHubConsumerClient(consumerGroup, fullyQualifiedNamespace, eventHubName, token, options));
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -191,14 +191,14 @@ namespace Azure.Messaging.EventHubs.Diagnostics
 
         /// <summary>
         ///   Indicates that a client is closing, which may correspond to an <see cref="EventHubConnection" />,
-        ///   <see cref="EventHubProducerClient" />, or <see cref="EventHubConsumerClient" />.
+        ///   <see cref="EventHubProducerClient" />, <see cref="EventHubConsumerClient" />, or <see cref="EventProcessorClient" />.
         /// </summary>
         ///
         /// <param name="clientType">The type of client being closed.</param>
         /// <param name="eventHubName">The name of the Event Hub associated with the client.</param>
         /// <param name="clientId">An identifier to associate with the client.</param>
         ///
-        [Event(9, Level = EventLevel.Verbose, Message = "Closing a {0} client (EventHub '{1}'; Identifier '{2}').")]
+        [Event(9, Level = EventLevel.Verbose, Message = "Closing an {0} (EventHub '{1}'; Identifier '{2}').")]
         public void ClientCloseStart(Type clientType,
                                      string eventHubName,
                                      string clientId)
@@ -211,14 +211,14 @@ namespace Azure.Messaging.EventHubs.Diagnostics
 
         /// <summary>
         ///   Indicates that a client has been closed, which may correspond to an <see cref="EventHubConnection" />,
-        ///   <see cref="EventHubProducerClient" />, or <see cref="EventHubConsumerClient" />.
+        ///   <see cref="EventHubProducerClient" />, <see cref="EventHubConsumerClient" />, or <see cref="EventProcessorClient" />.
         /// </summary>
         ///
         /// <param name="clientType">The type of client being closed.</param>
         /// <param name="eventHubName">The name of the Event Hub associated with the client.</param>
         /// <param name="clientId">An identifier to associate with the client.</param>
         ///
-        [Event(10, Level = EventLevel.Verbose, Message = "A {0} client has been closed (EventHub '{1}'; Identifier '{2}').")]
+        [Event(10, Level = EventLevel.Verbose, Message = "An {0} has been closed (EventHub '{1}'; Identifier '{2}').")]
         public void ClientCloseComplete(Type clientType,
                                         string eventHubName,
                                         string clientId)
@@ -230,7 +230,8 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         }
 
         /// <summary>
-        ///   Indicates that an exception was encountered while closing an <see cref="EventHubConnection" />.
+        ///   Indicates that an exception was encountered while closing an <see cref="EventHubConnection" />,
+        ///   <see cref="EventHubProducerClient" />, <see cref="EventHubConsumerClient" />, or <see cref="EventProcessorClient" />.
         /// </summary>
         ///
         /// <param name="clientType">The type of client being closed.</param>
@@ -238,7 +239,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="clientId">An identifier to associate with the client.</param>
         /// <param name="errorMessage">The message for the exception that occurred.</param>
         ///
-        [Event(11, Level = EventLevel.Error, Message = "An exception occurred while closing a {0} client (EventHub '{1}'; Identifier '{2}'). Error Message: '{3}'")]
+        [Event(11, Level = EventLevel.Error, Message = "An exception occurred while closing an {0} (EventHub '{1}'; Identifier '{2}'). Error Message: '{3}'")]
         public void ClientCloseError(Type clientType,
                                      string eventHubName,
                                      string clientId,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/PartitionPump.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/PartitionPump.cs
@@ -155,7 +155,7 @@ namespace Azure.Messaging.EventHubs.Processor
                         RunningTaskTokenSource?.Cancel();
                         RunningTaskTokenSource = new CancellationTokenSource();
 
-                        InnerConsumer = new EventHubConsumerClient(ConsumerGroup, Context.PartitionId, StartingPosition, Connection);
+                        InnerConsumer = new EventHubConsumerClient(ConsumerGroup, Connection);
 
                         RunningTask = RunAsync(RunningTaskTokenSource.Token);
                     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientLiveTests.cs
@@ -52,7 +52,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     {
                         Assert.That(async () => await ReadNothingAsync(consumer, partition, EventPosition.Latest), Throws.Nothing);
                     }
@@ -79,7 +79,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection, options))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, options))
                     {
                         Assert.That(async () => await ReadNothingAsync(consumer, partition, EventPosition.Latest), Throws.Nothing);
                     }
@@ -109,7 +109,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
                     await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connectionString))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                     {
                         // Read the events.
 
@@ -177,7 +177,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
                     await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connectionString))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                     {
                         /// Read the events.
 
@@ -247,7 +247,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
                     await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     {
                         // Read the events.
 
@@ -320,7 +320,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
                     await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition, RetryOptions = retryOptions }))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { RetryOptions = retryOptions }))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { RetryOptions = retryOptions }))
                     {
                         // Read the events.
 
@@ -397,7 +397,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
                     await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     {
                         // Read the events.
 
@@ -467,7 +467,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     stampEvent.Properties["stamp"] = Guid.NewGuid().ToString();
 
                     await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     {
                         // Sending some events beforehand so the partition has some information.
                         // We are not expecting to receive these.
@@ -523,7 +523,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var expectedEventsCount = 10;
 
                     await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Earliest, connection))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     {
                         for (int i = 0; i < expectedEventsCount; i++)
                         {
@@ -583,7 +583,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         var offset = (await producer.GetPartitionPropertiesAsync(partition)).LastEnqueuedOffset;
 
-                        await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.FromOffset(offset), connection))
+                        await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                         await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                         {
                             // Send a single event which is expected to go to the end of stream.
@@ -661,7 +661,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         await producer.SendAsync(stampEvent);
 
-                        await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.FromEnqueuedTime(enqueuedTime), connection))
+                        await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                         {
                             // Read the events.
 
@@ -721,7 +721,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         var sequenceNumber = (await producer.GetPartitionPropertiesAsync(partition)).LastEnqueuedSequenceNumber;
 
-                        await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.FromSequenceNumber(sequenceNumber, isInclusive), connection))
+                        await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                         await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                         {
                             // Send a single event which is expected to go to the end of stream.
@@ -776,7 +776,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     {
                         Func<Task> readAfterClose = async () =>
                         {
@@ -830,7 +830,7 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
-                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, invalidPartition, EventPosition.Latest, connectionString))
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                 {
                     Assert.That(async () => await ReadNothingAsync(consumer, invalidPartition, EventPosition.Latest), Throws.InstanceOf<ArgumentOutOfRangeException>());
                 }
@@ -853,7 +853,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var consumer = new EventHubConsumerClient("nonExistentConsumerGroup", partition, EventPosition.Latest, connection))
+                    await using (var consumer = new EventHubConsumerClient("nonExistentConsumerGroup", connection))
                     {
                         Assert.That(async () => await ReadNothingAsync(consumer, partition, EventPosition.Latest), Throws.InstanceOf<EventHubsResourceNotFoundException>());
                     }
@@ -881,12 +881,12 @@ namespace Azure.Messaging.EventHubs.Tests
                     using var cancellationSource = new CancellationTokenSource();
                     cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
 
-                    await using var exclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
+                    await using var exclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
                     await foreach (var exclusiveEvent in exclusiveConsumer.ReadEventsFromPartitionAsync(partition, EventPosition.Latest, TimeSpan.FromMilliseconds(50), cancellationSource.Token))
                     {
                         if (!firstIteration)
                         {
-                            await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection);
+                            await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
                             Assert.That(async () => await ReadNothingAsync(nonExclusiveConsumer, partition, EventPosition.Latest), Throws.InstanceOf<ConsumerDisconnectedException>());
 
                             break;
@@ -919,12 +919,12 @@ namespace Azure.Messaging.EventHubs.Tests
                     using var cancellationSource = new CancellationTokenSource();
                     cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
 
-                    await using var higherExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
+                    await using var higherExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
                     await foreach (var higherEvent in higherExclusiveConsumer.ReadEventsFromPartitionAsync(partition, EventPosition.Latest, TimeSpan.FromMilliseconds(50), cancellationSource.Token))
                     {
                         if (!firstIteration)
                         {
-                            await using var lowerExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
+                            await using var lowerExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
                             Assert.That(async () => await ReadNothingAsync(lowerExclusiveConsumer, partition, EventPosition.Latest), Throws.InstanceOf<ConsumerDisconnectedException>());
 
                             break;
@@ -957,15 +957,15 @@ namespace Azure.Messaging.EventHubs.Tests
                     var cancellationSource = new CancellationTokenSource();
                     cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
 
-                    await using var higherExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionIds[0], EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
+                    await using var higherExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
                     await foreach (var higherEvent in higherExclusiveConsumer.ReadEventsFromPartitionAsync(partitionIds[0], EventPosition.Latest, TimeSpan.FromMilliseconds(50), cancellationSource.Token))
                     {
                         if (!firstIteration)
                         {
-                            await using var lowerExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionIds[1], EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
+                            await using var lowerExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
                             Assert.That(async () => await ReadNothingAsync(lowerExclusiveConsumer, partitionIds[1], EventPosition.Latest), Throws.Nothing);
 
-                            await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionIds[2], EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
+                            await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
                             Assert.That(async () => await ReadNothingAsync(nonExclusiveConsumer, partitionIds[2], EventPosition.Latest), Throws.Nothing);
 
                             break;
@@ -1004,15 +1004,15 @@ namespace Azure.Messaging.EventHubs.Tests
                     using var cancellationSource = new CancellationTokenSource();
                     cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
 
-                    await using var higherExclusiveConsumer = new EventHubConsumerClient(consumerGroups[0], partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
+                    await using var higherExclusiveConsumer = new EventHubConsumerClient(consumerGroups[0], connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
                     await foreach (var higherEvent in higherExclusiveConsumer.ReadEventsFromPartitionAsync(partition, EventPosition.Latest, TimeSpan.FromMilliseconds(50), cancellationSource.Token))
                     {
                         if (!firstIteration)
                         {
-                            await using var lowerExclusiveConsumer = new EventHubConsumerClient(consumerGroups[1], partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
+                            await using var lowerExclusiveConsumer = new EventHubConsumerClient(consumerGroups[1], connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
                             Assert.That(async () => await ReadNothingAsync(lowerExclusiveConsumer, partition, EventPosition.Latest), Throws.Nothing);
 
-                            await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection);
+                            await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
                             Assert.That(async () => await ReadNothingAsync(nonExclusiveConsumer, partition, EventPosition.Latest), Throws.Nothing);
 
                             break;
@@ -1047,12 +1047,12 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     // Non-exclusive may read before an exclusive claims.
 
-                    await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection);
+                    await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
                     Assert.That(async () => await ReadNothingAsync(nonExclusiveConsumer, partition, EventPosition.Latest), Throws.Nothing);
 
                     // Exclusive may read without an issue.
 
-                    await using var exclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
+                    await using var exclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
                     Assert.That(async () => await ReadNothingAsync(exclusiveConsumer, partition, EventPosition.Latest), Throws.Nothing);
 
                     // Once the exclusive is active, ensure that the non-exclusive is denied access.
@@ -1094,12 +1094,12 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     // Non-exclusive may read before an exclusive claims.
 
-                    await using var lowerExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
+                    await using var lowerExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
                     Assert.That(async () => await ReadNothingAsync(lowerExclusiveConsumer, partition, EventPosition.Latest), Throws.Nothing);
 
                     // Exclusive may read without an issue.
 
-                    await using var higherExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
+                    await using var higherExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
                     Assert.That(async () => await ReadNothingAsync(higherExclusiveConsumer, partition, EventPosition.Latest), Throws.Nothing);
 
                     // Once the exclusive is active, ensure that the non-exclusive is denied access.
@@ -1141,7 +1141,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     // Begin reading with the non-exclusive consumer so that it is actively engaged when the others read.
 
-                    await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionIds[0], EventPosition.Latest, connection);
+                    await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
                     await foreach (var nonExclusiveEvent in nonExclusiveConsumer.ReadEventsFromPartitionAsync(partitionIds[0], EventPosition.Latest, TimeSpan.FromMilliseconds(50), cancellationSource.Token))
                     {
                         if (!firstIteration)
@@ -1150,14 +1150,14 @@ namespace Azure.Messaging.EventHubs.Tests
 
                             var innerFirstIteration = true;
 
-                            await using var lowerExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionIds[1], EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
+                            await using var lowerExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
                             await foreach (var lowerExclusiveEvent in lowerExclusiveConsumer.ReadEventsFromPartitionAsync(partitionIds[1], EventPosition.Latest, TimeSpan.FromMilliseconds(50), cancellationSource.Token))
                             {
                                 // Ensure that the higher level consumer can read without interfering with the other active consumers.
 
                                 if (!innerFirstIteration)
                                 {
-                                    await using var higherExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionIds[2], EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
+                                    await using var higherExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
                                     Assert.That(async () => await ReadNothingAsync(higherExclusiveConsumer, partitionIds[2], EventPosition.Latest), Throws.Nothing);
 
                                     break;
@@ -1203,19 +1203,19 @@ namespace Azure.Messaging.EventHubs.Tests
                     using var cancellationSource = new CancellationTokenSource();
                     cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
 
-                    await using var nonExclusiveConsumer = new EventHubConsumerClient(consumerGroups[0], partition, EventPosition.Latest, connection);
+                    await using var nonExclusiveConsumer = new EventHubConsumerClient(consumerGroups[0], connection);
                     await foreach (var exclusiveEvent in nonExclusiveConsumer.ReadEventsFromPartitionAsync(partition, EventPosition.Latest, TimeSpan.FromMilliseconds(50), cancellationSource.Token))
                     {
                         if (!firstIteration)
                         {
                             var innerFirstIteration = true;
 
-                            await using var lowerExclusiveConsumer = new EventHubConsumerClient(consumerGroups[1], partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
+                            await using var lowerExclusiveConsumer = new EventHubConsumerClient(consumerGroups[1], connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
                             await foreach (var lowerEvent in lowerExclusiveConsumer.ReadEventsFromPartitionAsync(partition, EventPosition.Latest, TimeSpan.FromMilliseconds(50), cancellationSource.Token))
                             {
                                 if (!innerFirstIteration)
                                 {
-                                    await using var higherExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
+                                    await using var higherExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
                                     Assert.That(async () => await ReadNothingAsync(higherExclusiveConsumer, partition, EventPosition.Latest), Throws.Nothing);
 
                                     break;
@@ -1261,39 +1261,39 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     var firstIteration = true;
 
-                    await using var lowerExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionIds[0], EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
+                    await using var lowerExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
                     await foreach (var lowerEvent in lowerExclusiveConsumer.ReadEventsFromPartitionAsync(partitionIds[0], EventPosition.Latest, TimeSpan.FromMilliseconds(50), cancellationSource.Token))
                     {
                         if (!firstIteration)
                         {
                             // Since there is an exclusive consumer reading, the non-exclusive consumer should be rejected.
 
-                            await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionIds[0], EventPosition.Latest, connection);
+                            await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
                             Assert.That(async () => await ReadNothingAsync(nonExclusiveConsumer, partitionIds[0], EventPosition.Latest), Throws.InstanceOf<ConsumerDisconnectedException>());
 
                             // Create the higher level exclusive consumer; this should force the lower exclusive consumer to disconnect.
 
                             var innerFirstIteration = true;
 
-                            await using var higherExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionIds[0], EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 30 });
+                            await using var higherExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 30 });
                             await foreach (var higherEvent in higherExclusiveConsumer.ReadEventsFromPartitionAsync(partitionIds[0], EventPosition.Latest, TimeSpan.FromMilliseconds(50), cancellationSource.Token))
                             {
                                 if (!innerFirstIteration)
                                 {
                                     // Consumers for other partitions and consumer groups should be allowed to read without interference.
 
-                                    await using var differentConsumerGroupConsumer = new EventHubConsumerClient(customConsumerGroup, partitionIds[0], EventPosition.Latest, connection);
+                                    await using var differentConsumerGroupConsumer = new EventHubConsumerClient(customConsumerGroup, connection);
                                     Assert.That(async () => await ReadNothingAsync(differentConsumerGroupConsumer, partitionIds[0], EventPosition.Latest), Throws.Nothing);
 
-                                    await using var differentPartitionConsumer = new EventHubConsumerClient(customConsumerGroup, partitionIds[0], EventPosition.Latest, connection);
+                                    await using var differentPartitionConsumer = new EventHubConsumerClient(customConsumerGroup, connection);
                                     Assert.That(async () => await ReadNothingAsync(differentPartitionConsumer, partitionIds[1], EventPosition.Latest), Throws.Nothing);
 
                                     // Exceptions for invalid resources should continue to be thrown.
 
-                                    await using var invalidConsumerGroupConsumer = new EventHubConsumerClient("XYZ", partitionIds[0], EventPosition.Latest, connection);
+                                    await using var invalidConsumerGroupConsumer = new EventHubConsumerClient("XYZ", connection);
                                     Assert.That(async () => await ReadNothingAsync(invalidConsumerGroupConsumer, partitionIds[0], EventPosition.Latest), Throws.InstanceOf<EventHubsResourceNotFoundException>());
 
-                                    await using var invalidPartitionConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "ABC", EventPosition.Latest, connection);
+                                    await using var invalidPartitionConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
                                     Assert.That(async () => await ReadNothingAsync(invalidPartitionConsumer, "ABC", EventPosition.Latest), Throws.InstanceOf<ArgumentOutOfRangeException>());
 
                                     break;
@@ -1334,25 +1334,25 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     // Begin with attempting to read from an invalid partition.
 
-                    await using var invalidPartitionConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "XYZ", EventPosition.Latest, connection);
+                    await using var invalidPartitionConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
                     Assert.That(async () => await ReadNothingAsync(invalidPartitionConsumer, "XYZ", EventPosition.Latest), Throws.InstanceOf<ArgumentOutOfRangeException>());
 
                     // It should be possible to create new valid consumers.
 
-                    await using var exclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
+                    await using var exclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
                     Assert.That(async () => await ReadNothingAsync(exclusiveConsumer, partition, EventPosition.Latest), Throws.Nothing);
 
                     // Exceptions should continue to be thrown properly.
 
                     await foreach (var exclusiveItem in exclusiveConsumer.ReadEventsFromPartitionAsync(partition, EventPosition.Latest, TimeSpan.FromMilliseconds(50), cancellationSource.Token))
                     {
-                        await using var invalidConsumerGroupConsumer = new EventHubConsumerClient("fake", partition, EventPosition.Latest, connection);
+                        await using var invalidConsumerGroupConsumer = new EventHubConsumerClient("fake", connection);
                         Assert.That(async () => await ReadNothingAsync(invalidConsumerGroupConsumer, partition, EventPosition.Latest), Throws.InstanceOf<EventHubsResourceNotFoundException>());
 
-                        await using var otherInvalidPartitionConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "ABC", EventPosition.Latest, connection);
+                        await using var otherInvalidPartitionConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
                         Assert.That(async () => await ReadNothingAsync(otherInvalidPartitionConsumer, "ABC", EventPosition.Latest), Throws.InstanceOf<ArgumentOutOfRangeException>());
 
-                        await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection);
+                        await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
                         Assert.That(async () => await ReadNothingAsync(nonExclusiveConsumer, partition, EventPosition.Latest), Throws.InstanceOf<ConsumerDisconnectedException>());
 
                         break;
@@ -1382,12 +1382,12 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     // Begin with attempting to read from an invalid partition.
 
-                    await using var invalidConsumerGroupConsumer = new EventHubConsumerClient("notreal", partition, EventPosition.Latest, connection);
+                    await using var invalidConsumerGroupConsumer = new EventHubConsumerClient("notreal", connection);
                     Assert.That(async () => await ReadNothingAsync(invalidConsumerGroupConsumer, partition, EventPosition.Latest), Throws.InstanceOf<EventHubsResourceNotFoundException>());
 
                     // It should be possible to create new valid consumers.
 
-                    await using var exclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
+                    await using var exclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
                     Assert.That(async () => await ReadNothingAsync(exclusiveConsumer, partition, EventPosition.Latest), Throws.Nothing);
 
                     // Exceptions should continue to be thrown properly.
@@ -1398,13 +1398,13 @@ namespace Azure.Messaging.EventHubs.Tests
                     {
                         if (!firstIteration)
                         {
-                            await using var otherInvalidConsumerGroupConsumer = new EventHubConsumerClient("XYZ", partition, EventPosition.Latest, connection);
+                            await using var otherInvalidConsumerGroupConsumer = new EventHubConsumerClient("XYZ", connection);
                             Assert.That(async () => await ReadNothingAsync(otherInvalidConsumerGroupConsumer, partition, EventPosition.Latest), Throws.InstanceOf<EventHubsResourceNotFoundException>());
 
-                            await using var invalidPartitionConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "ABC", EventPosition.Latest, connection);
+                            await using var invalidPartitionConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
                             Assert.That(async () => await ReadNothingAsync(invalidPartitionConsumer, "ABC", EventPosition.Latest), Throws.InstanceOf<ArgumentOutOfRangeException>());
 
-                            await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection);
+                            await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
                             Assert.That(async () => await ReadNothingAsync(nonExclusiveConsumer, partition, EventPosition.Latest), Throws.InstanceOf<ConsumerDisconnectedException>());
 
                             break;
@@ -1444,7 +1444,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
 
                     await using var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partitionIds[0] });
-                    await using var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionIds[1], EventPosition.Latest, connectionString);
+                    await using var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString);
 
                     var receivedEvents = new List<EventData>();
                     var wereEventsPublished = false;
@@ -1511,8 +1511,8 @@ namespace Azure.Messaging.EventHubs.Tests
                     using var cancellationSource = new CancellationTokenSource();
                     cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
 
-                    await using var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Earliest, connectionString);
-                    await using var anotherConsumer = new EventHubConsumerClient(customConsumerGroup, partition, EventPosition.Earliest, connection);
+                    await using var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString);
+                    await using var anotherConsumer = new EventHubConsumerClient(customConsumerGroup, connection);
 
                     // Send the batch of events.
 
@@ -1582,7 +1582,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     using var cancellationSource = new CancellationTokenSource();
                     cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
 
-                    await using var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection);
+                    await using var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
 
                     var startTime = DateTime.UtcNow;
                     var elapsedTime = 0.0;
@@ -1626,7 +1626,7 @@ namespace Azure.Messaging.EventHubs.Tests
                         for (int i = 0; i < maximumConsumersQuota; i++)
                         {
                             var consumerOptions = new EventHubConsumerClientOptions { Identifier = $"consumer{i}" };
-                            var newConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection, consumerOptions);
+                            var newConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, consumerOptions);
                             var newReader = newConsumer.ReadEventsFromPartitionAsync(partition, EventPosition.Latest, TimeSpan.FromMilliseconds(50), cancellationSource.Token).GetAsyncEnumerator();
 
                             Assert.That(async () => await newReader.MoveNextAsync(), Throws.Nothing);
@@ -1637,7 +1637,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         // Attempt to create 6th consumer. This should fail.
 
-                        await using var failConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connectionString);
+                        await using var failConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString);
                         await ReadNothingAsync(failConsumer, partition, EventPosition.Latest);
 
                         throw new InvalidOperationException("6th consumer should have encountered QuotaExceededException.");
@@ -1682,7 +1682,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { TryTimeout = TimeSpan.FromMinutes(2) } };
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var invalidProxyConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, invalidProxyConnection, options))
+                    await using (var invalidProxyConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, invalidProxyConnection, options))
                     {
                         Assert.That(async () => await ReadNothingAsync(invalidProxyConsumer, partition, EventPosition.Latest), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
                     }
@@ -1707,7 +1707,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 var connectionString = TestEnvironment.EventHubsConnectionString;
                 var consumerOptions = new EventHubConsumerClientOptions { ConnectionOptions = new EventHubConnectionOptions { TransportType = transportType } };
 
-                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, connectionString, scope.EventHubName, consumerOptions))
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString, scope.EventHubName, consumerOptions))
                 {
                     EventHubProperties properties = await consumer.GetEventHubPropertiesAsync();
 
@@ -1737,7 +1737,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var consumerOptions = new EventHubConsumerClientOptions { ConnectionOptions = new EventHubConnectionOptions { TransportType = transportType } };
 
-                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, connectionString, scope.EventHubName, consumerOptions))
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString, scope.EventHubName, consumerOptions))
                 {
                     var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(20));
                     var properties = await consumer.GetEventHubPropertiesAsync();
@@ -1766,7 +1766,7 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
-                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, connectionString))
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                 {
                     EventHubProperties properties = await consumer.GetEventHubPropertiesAsync();
                     var partitions = await consumer.GetPartitionIdsAsync();
@@ -1793,7 +1793,7 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
-                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, connectionString))
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                 {
                     var partition = (await consumer.GetPartitionIdsAsync()).First();
 
@@ -1834,7 +1834,7 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
-                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, connectionString))
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                 {
                     Assert.That(async () => await consumer.GetPartitionPropertiesAsync(invalidPartition), Throws.TypeOf<ArgumentOutOfRangeException>());
                 }
@@ -1864,8 +1864,8 @@ namespace Azure.Messaging.EventHubs.Tests
                     }
                 };
 
-                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, connectionString))
-                await using (var invalidProxyConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, connectionString, invalidProxyOptions))
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
+                await using (var invalidProxyConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString, invalidProxyOptions))
                 {
                     var partition = (await consumer.GetPartitionIdsAsync()).First();
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientTests.cs
@@ -67,34 +67,8 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ConstructorValidatesTheConsumerGroup(string consumerGroup)
         {
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            Assert.That(() => new EventHubConsumerClient(consumerGroup, "1332", EventPosition.Earliest, "dummyConnection", new EventHubConsumerClientOptions()), Throws.InstanceOf<ArgumentException>(), "The connection string constructor should validate the consumer group.");
-            Assert.That(() => new EventHubConsumerClient(consumerGroup, "1332", EventPosition.Earliest, "dummyNamespace", "dummyEventHub", credential.Object, new EventHubConsumerClientOptions()), Throws.InstanceOf<ArgumentException>(), "The namespace constructor should validate the consumer group.");
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the constructor.
-        /// </summary>
-        ///
-        [Test]
-        [TestCase(null)]
-        [TestCase("")]
-        public void ConstructorValidatesThePartition(string partition)
-        {
-            var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            Assert.That(() => new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Earliest, "dummyConnection", new EventHubConsumerClientOptions()), Throws.InstanceOf<ArgumentException>(), "The connection string constructor should validate the partition.");
-            Assert.That(() => new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Earliest, "dummyNamespace", "dummyEventHub", credential.Object, new EventHubConsumerClientOptions()), Throws.InstanceOf<ArgumentException>(), "The namespace constructor should validate the partition.");
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the constructor.
-        /// </summary>
-        ///
-        [Test]
-        public void ConstructorValidatesTheEventPosition()
-        {
-            var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            Assert.That(() => new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "1234", null, "dummyConnection", new EventHubConsumerClientOptions()), Throws.InstanceOf<ArgumentException>());
-            Assert.That(() => new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "1234", null, "dummyNamespace", "dummyEventHub", credential.Object, new EventHubConsumerClientOptions()), Throws.InstanceOf<ArgumentException>(), "The namespace constructor should validate the event position.");
+            Assert.That(() => new EventHubConsumerClient(consumerGroup, "dummyConnection", new EventHubConsumerClientOptions()), Throws.InstanceOf<ArgumentException>(), "The connection string constructor should validate the consumer group.");
+            Assert.That(() => new EventHubConsumerClient(consumerGroup, "dummyNamespace", "dummyEventHub", credential.Object, new EventHubConsumerClientOptions()), Throws.InstanceOf<ArgumentException>(), "The namespace constructor should validate the consumer group.");
         }
 
         /// <summary>
@@ -106,8 +80,8 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorValidatesTheConnectionString(string connectionString)
         {
-            Assert.That(() => new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "1234", EventPosition.Earliest, connectionString), Throws.InstanceOf<ArgumentException>(), "The constructor without options should ensure a connection string.");
-            Assert.That(() => new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "1234", EventPosition.Earliest, connectionString, "dummy", new EventHubConsumerClientOptions()), Throws.InstanceOf<ArgumentException>(), "The constructor with options should ensure a connection string.");
+            Assert.That(() => new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString), Throws.InstanceOf<ArgumentException>(), "The constructor without options should ensure a connection string.");
+            Assert.That(() => new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString, "dummy", new EventHubConsumerClientOptions()), Throws.InstanceOf<ArgumentException>(), "The constructor with options should ensure a connection string.");
         }
 
         /// <summary>
@@ -120,7 +94,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ConstructorValidatesTheNamespace(string constructorArgument)
         {
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            Assert.That(() => new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "1234", EventPosition.Earliest, constructorArgument, "dummy", credential.Object), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, constructorArgument, "dummy", credential.Object), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -133,7 +107,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ConstructorValidatesTheEventHub(string constructorArgument)
         {
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            Assert.That(() => new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "1234", EventPosition.Earliest, "namespace", constructorArgument, credential.Object), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "namespace", constructorArgument, credential.Object), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -143,7 +117,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorValidatesTheCredential()
         {
-            Assert.That(() => new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "1234", EventPosition.Earliest, "namespace", "hubName", default(TokenCredential)), Throws.ArgumentNullException);
+            Assert.That(() => new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "namespace", "hubName", default(TokenCredential)), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -153,7 +127,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorValidatesTheConnection()
         {
-            Assert.That(() => new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "1234", EventPosition.Earliest, default(EventHubConnection)), Throws.ArgumentNullException);
+            Assert.That(() => new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, default(EventHubConnection)), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -166,7 +140,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var expected = Mock.Of<EventHubsRetryPolicy>();
             var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = expected } };
             var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, connectionString, options);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString, options);
 
             Assert.That(GetRetryPolicy(consumer), Is.SameAs(expected));
         }
@@ -181,7 +155,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var expected = Mock.Of<EventHubsRetryPolicy>();
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
             var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = expected } };
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, "namespace", "hub", credential.Object, options);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "namespace", "hub", credential.Object, options);
 
             Assert.That(GetRetryPolicy(consumer), Is.SameAs(expected));
         }
@@ -196,7 +170,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var expected = Mock.Of<EventHubsRetryPolicy>();
             var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = expected } };
             var mockConnection = new MockConnection();
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, mockConnection, options);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection, options);
 
             Assert.That(GetRetryPolicy(consumer), Is.SameAs(expected));
         }
@@ -210,7 +184,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var expected = new EventHubConsumerClientOptions().RetryOptions;
             var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, connectionString);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString);
 
             var policy = GetRetryPolicy(consumer);
             Assert.That(policy, Is.Not.Null, "There should have been a retry policy set.");
@@ -229,7 +203,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
             var expected = new EventHubConsumerClientOptions().RetryOptions;
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, "some-namespace", "hubName", credential.Object);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "some-namespace", "hubName", credential.Object);
 
             var policy = GetRetryPolicy(consumer);
             Assert.That(policy, Is.Not.Null, "There should have been a retry policy set.");
@@ -248,7 +222,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var expected = new EventHubConsumerClientOptions().RetryOptions;
             var mockConnection = new MockConnection();
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, mockConnection);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
 
             var policy = GetRetryPolicy(consumer);
             Assert.That(policy, Is.Not.Null, "There should have been a retry policy set.");
@@ -263,52 +237,10 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public void ConnectionStringConstructorSetsThePartition()
-        {
-            var partition = "aPartition";
-            var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Earliest, connectionString);
-
-            Assert.That(consumer.PartitionId, Is.EqualTo(partition));
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the constructor.
-        /// </summary>
-        ///
-        [Test]
-        public void ExpandedConstructorSetsThePartition()
-        {
-            var partition = "aPartition";
-            var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Earliest, "aNamespace", "underclothing", credential.Object);
-
-            Assert.That(consumer.PartitionId, Is.EqualTo(partition));
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the constructor.
-        /// </summary>
-        ///
-        [Test]
-        public void ConnectionConstructorSetsThePartition()
-        {
-            var partition = "aPartition";
-            var mockConnection = new MockConnection();
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Earliest, mockConnection);
-
-            Assert.That(consumer.PartitionId, Is.EqualTo(partition));
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the constructor.
-        /// </summary>
-        ///
-        [Test]
         [TestCase(null)]
         [TestCase(1)]
         [TestCase(32769)]
-        public void ConnectionStringConstructorSetsThePriority(long? priority)
+        public void ConnectionStringConstructorSetsTheOwnerLevel(long? priority)
         {
             var options = new EventHubConsumerClientOptions
             {
@@ -316,7 +248,7 @@ namespace Azure.Messaging.EventHubs.Tests
             };
 
             var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, connectionString, options);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString, options);
 
             Assert.That(consumer.OwnerLevel, Is.EqualTo(priority));
         }
@@ -329,7 +261,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase(null)]
         [TestCase(1)]
         [TestCase(32769)]
-        public void ExpandedConstructorSetsThePriority(long? priority)
+        public void ExpandedConstructorSetsTheOwnerLevel(long? priority)
         {
             var options = new EventHubConsumerClientOptions
             {
@@ -337,7 +269,7 @@ namespace Azure.Messaging.EventHubs.Tests
             };
 
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, "namespace-name", "hub-name", credential.Object, options);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "namespace-name", "hub-name", credential.Object, options);
             Assert.That(consumer.OwnerLevel, Is.EqualTo(priority));
         }
 
@@ -349,7 +281,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase(null)]
         [TestCase(1)]
         [TestCase(32769)]
-        public void ConnectionConstructorSetsThePriority(long? priority)
+        public void ConnectionConstructorSetsTheOwnerLevel(long? priority)
         {
             var options = new EventHubConsumerClientOptions
             {
@@ -357,52 +289,9 @@ namespace Azure.Messaging.EventHubs.Tests
             };
 
             var mockConnection = new MockConnection();
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "2", EventPosition.Earliest, mockConnection, options);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection, options);
 
             Assert.That(consumer.OwnerLevel, Is.EqualTo(priority));
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the constructor.
-        /// </summary>
-        ///
-        [Test]
-        public void ConnectionStringConstructorSetsTheStartingPosition()
-        {
-            var expectedPosition = EventPosition.FromSequenceNumber(5641);
-            var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", expectedPosition, connectionString);
-
-
-            Assert.That(consumer.StartingPosition, Is.EqualTo(expectedPosition));
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the constructor.
-        /// </summary>
-        ///
-        [Test]
-        public void ExpandedConstructorSetsTheStartingPosition()
-        {
-            var expectedPosition = EventPosition.FromSequenceNumber(5641);
-            var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", expectedPosition, "namespace", "eventHub", credential.Object);
-
-            Assert.That(consumer.StartingPosition, Is.EqualTo(expectedPosition));
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the constructor.
-        /// </summary>
-        ///
-        [Test]
-        public void ConnectionConstructorSetsTheStartingPosition()
-        {
-            var expectedPosition = EventPosition.FromSequenceNumber(5641);
-            var mockConnection = new MockConnection();
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "2", expectedPosition, mockConnection);
-
-            Assert.That(consumer.StartingPosition, Is.EqualTo(expectedPosition));
         }
 
         /// <summary>
@@ -414,7 +303,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var consumerGroup = "SomeGroup";
             var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
-            var consumer = new EventHubConsumerClient(consumerGroup, "0", EventPosition.Latest, connectionString);
+            var consumer = new EventHubConsumerClient(consumerGroup, connectionString);
 
             Assert.That(consumer.ConsumerGroup, Is.EqualTo(consumerGroup));
         }
@@ -428,7 +317,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var consumerGroup = "SomeGroup";
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var consumer = new EventHubConsumerClient(consumerGroup, "0", EventPosition.Latest, "namespace", "eventHub", credential.Object);
+            var consumer = new EventHubConsumerClient(consumerGroup, "namespace", "eventHub", credential.Object);
 
             Assert.That(consumer.ConsumerGroup, Is.EqualTo(consumerGroup));
         }
@@ -442,7 +331,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var consumerGroup = "SomeGroup";
             var mockConnection = new MockConnection();
-            var consumer = new EventHubConsumerClient(consumerGroup, "2", EventPosition.FromOffset(12), mockConnection);
+            var consumer = new EventHubConsumerClient(consumerGroup, mockConnection);
 
             Assert.That(consumer.ConsumerGroup, Is.EqualTo(consumerGroup));
         }
@@ -457,7 +346,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var expected = "SomeNamespace";
             var mockConnection = new MockConnection(expected);
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, mockConnection);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
 
             Assert.That(consumer.FullyQualifiedNamespace, Is.EqualTo(expected));
         }
@@ -472,7 +361,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var expected = "EventHubName";
             var mockConnection = new MockConnection(eventHubName: expected);
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, mockConnection);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
 
             Assert.That(consumer.EventHubName, Is.EqualTo(expected));
         }
@@ -488,7 +377,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockConnection = new MockConnection();
             var retryPolicy = Mock.Of<EventHubsRetryPolicy>();
             var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = retryPolicy } };
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, mockConnection, options);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection, options);
 
             await consumer.GetEventHubPropertiesAsync();
             Assert.That(mockConnection.GetPropertiesInvokedWith, Is.SameAs(retryPolicy), "Either the call was not delegated or the retry policy was not passed.");
@@ -505,7 +394,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockConnection = new MockConnection();
             var retryPolicy = Mock.Of<EventHubsRetryPolicy>();
             var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = retryPolicy } };
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, mockConnection, options);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection, options);
 
             await consumer.GetPartitionIdsAsync();
             Assert.That(mockConnection.GetPartitionIdsInvokedWith, Is.SameAs(retryPolicy), "Either the call was not delegated or the retry policy was not passed.");
@@ -522,7 +411,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockConnection = new MockConnection();
             var retryPolicy = Mock.Of<EventHubsRetryPolicy>();
             var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = retryPolicy } };
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, mockConnection, options);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection, options);
 
             await consumer.GetPartitionPropertiesAsync("1");
             Assert.That(mockConnection.GetPartitionPropertiesInvokedWith, Is.SameAs(retryPolicy), "Either the call was not delegated or the retry policy was not passed.");
@@ -534,11 +423,14 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task CloseAsyncClosesTheTransportConsumer()
+        public async Task CloseAsyncClosesActiveTransportConsumers()
         {
             var transportConsumer = new ObservableTransportConsumerMock();
             var mockConnection = new MockConnection(() => transportConsumer);
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.FromOffset(12), mockConnection);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
+
+            await using var firstReceiver = consumer.CreatePartitionReceiver("0", EventPosition.Earliest);
+            await using var secondReceiver = consumer.CreatePartitionReceiver("0", EventPosition.FromOffset(23));
 
             await consumer.CloseAsync();
             Assert.That(transportConsumer.WasCloseCalled, Is.True);
@@ -550,14 +442,59 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public void CloseClosesTheTransportConsumer()
+        public async Task CloseAsyncSurfacesExceptionsForActiveTransportConsumers()
+        {
+            var mockTransportConsumer = new Mock<TransportConsumer>();
+            var mockConnection = new MockConnection(() => mockTransportConsumer.Object);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
+
+            mockTransportConsumer
+                .Setup(consumer => consumer.CloseAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromException(new InvalidCastException()));
+
+            try { await using var receiver = consumer.CreatePartitionReceiver("0", EventPosition.Earliest); } catch {}
+
+            Assert.That(async () => await consumer.CloseAsync(), Throws.InstanceOf<InvalidCastException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubConsumerClient.CloseAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CloseClosesActiveTransportConsumers()
         {
             var transportConsumer = new ObservableTransportConsumerMock();
             var mockConnection = new MockConnection(() => transportConsumer);
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.FromOffset(12), mockConnection);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
+
+            await using var firstReceiver = consumer.CreatePartitionReceiver("0", EventPosition.Earliest);
+            await using var secondReceiver = consumer.CreatePartitionReceiver("0", EventPosition.FromOffset(23));
 
             consumer.Close();
             Assert.That(transportConsumer.WasCloseCalled, Is.True);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubConsumerClient.CloseAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CloseSurfacesExceptionsForActiveTransportConsumers()
+        {
+            var mockTransportConsumer = new Mock<TransportConsumer>();
+            var mockConnection = new MockConnection(() => mockTransportConsumer.Object);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
+
+            mockTransportConsumer
+                .Setup(consumer => consumer.CloseAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromException(new InvalidCastException()));
+
+            try { await using var receiver = consumer.CreatePartitionReceiver("0", EventPosition.Earliest); } catch {}
+
+            Assert.That(() => consumer.Close(), Throws.InstanceOf<InvalidCastException>());
         }
 
         /// <summary>
@@ -570,7 +507,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var transportConsumer = new ObservableTransportConsumerMock();
             var mockConnection = new MockConnection(() => transportConsumer);
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.FromOffset(12), mockConnection);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
 
             IAsyncEnumerable<PartitionEvent> enumerable = consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(12));
 
@@ -594,7 +531,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var transportConsumer = new ObservableTransportConsumerMock();
             var mockConnection = new MockConnection(() => transportConsumer);
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.FromOffset(12), mockConnection);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
 
             IAsyncEnumerable<PartitionEvent> enumerable = consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(12), TimeSpan.FromSeconds(15));
 
@@ -627,7 +564,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var transportConsumer = new PublishingTransportConsumerMock(events);
             var mockConnection = new MockConnection(() => transportConsumer);
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.FromOffset(12), mockConnection);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
             var receivedEvents = 0;
 
             using var cancellation = new CancellationTokenSource();
@@ -671,7 +608,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var transportConsumer = new PublishingTransportConsumerMock(events);
             var mockConnection = new MockConnection(() => transportConsumer);
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.FromOffset(12), mockConnection);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
             var receivedEvents = 0;
 
             using var cancellation = new CancellationTokenSource();
@@ -713,7 +650,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var transportConsumer = new PublishingTransportConsumerMock(events);
             var mockConnection = new MockConnection(() => transportConsumer);
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.FromOffset(12), mockConnection);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
             var expectedEvents = events.Count - 2;
             var receivedEvents = 0;
 
@@ -754,7 +691,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var transportConsumer = new PublishingTransportConsumerMock(events);
             var mockConnection = new MockConnection(() => transportConsumer);
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.FromOffset(12), mockConnection);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
             var expectedEvents = events.Count - 2;
             var receivedEvents = 0;
 
@@ -791,7 +728,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var transportConsumer = new PublishingTransportConsumerMock(events);
             var mockConnection = new MockConnection(() => transportConsumer);
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.FromOffset(12), mockConnection);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
             var expectedEvents = 100;
             var receivedEvents = 0;
 
@@ -838,7 +775,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var transportConsumer = new PublishingTransportConsumerMock(events);
             var mockConnection = new MockConnection(() => transportConsumer);
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.FromOffset(12), mockConnection);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
             var expectedEvents = 100;
             var receivedEvents = 0;
 
@@ -897,7 +834,7 @@ namespace Azure.Messaging.EventHubs.Tests
             });
 
             var mockConnection = new MockConnection(() => transportConsumer);
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.FromOffset(12), mockConnection);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
 
             using var cancellation = new CancellationTokenSource();
             cancellation.CancelAfter(TimeSpan.FromSeconds(30));
@@ -943,7 +880,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var transportConsumer = new PublishingTransportConsumerMock(events);
             var mockConnection = new MockConnection(() => transportConsumer);
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.FromOffset(12), mockConnection);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
             var receivedEvents = new List<EventData>();
 
             using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(60));
@@ -983,7 +920,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var partition = "0";
             var position = EventPosition.FromOffset(22);
             var mockConnection = new MockConnection(() => new PublishingTransportConsumerMock(events));
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, position, mockConnection);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
             var firstSubscriberEvents = new List<EventData>();
             var secondSubscriberEvents = new List<EventData>();
             var firstCompletionSource = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1046,7 +983,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var events = new List<EventData>();
             var transportConsumer = new PublishingTransportConsumerMock(events);
             var mockConnection = new MockConnection(() => transportConsumer);
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.FromOffset(12), mockConnection);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
             var receivedEvents = new List<EventData>();
 
             events.AddRange(
@@ -1083,7 +1020,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var partition = "0";
             var position = EventPosition.FromSequenceNumber(453);
             var mockConnection = new MockConnection(() => new PublishingTransportConsumerMock(events));
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, position, mockConnection);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
             var firstSubscriberEvents = new List<EventData>();
             var secondSubscriberEvents = new List<EventData>();
             var firstCompletionSource = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1161,7 +1098,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var publishDelay = maxWaitTime.Add(TimeSpan.FromMilliseconds(15));
             var transportConsumer = new PublishingTransportConsumerMock(events, () => publishDelay);
             var mockConnection = new MockConnection(() => transportConsumer);
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.FromOffset(12), mockConnection);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
             var receivedEvents = new List<EventData>();
             var consecutiveEmptyCount = 0;
 
@@ -1199,7 +1136,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var transportConsumer = new ReceiveCallbackTransportConsumerMock((_max, _time) => throw (Exception)Activator.CreateInstance(exceptionType));
             var mockConnection = new MockConnection(() => transportConsumer);
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.FromOffset(12), mockConnection);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
             var receivedEvents = 0;
 
             using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -1229,7 +1166,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var transportConsumer = new ReceiveCallbackTransportConsumerMock((_max, _time) => throw (Exception)Activator.CreateInstance(exceptionType));
             var mockConnection = new MockConnection(() => transportConsumer);
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.FromOffset(12), mockConnection);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
             var receivedEvents = 0;
 
             using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -1258,7 +1195,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var transportConsumer = new ReceiveCallbackTransportConsumerMock((_max, _time) => throw exception);
             var mockConnection = new MockConnection(() => transportConsumer);
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.FromOffset(12), mockConnection);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
             var receivedEvents = 0;
 
             using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -1301,7 +1238,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = mockRetryPolicy.Object } };
             var transportConsumer = new ReceiveCallbackTransportConsumerMock(receiveCallback);
             var mockConnection = new MockConnection(() => transportConsumer);
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.FromOffset(12), mockConnection, options);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection, options);
             var receivedEvents = 0;
 
             mockRetryPolicy
@@ -1346,7 +1283,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = mockRetryPolicy.Object } };
             var transportConsumer = new ReceiveCallbackTransportConsumerMock(receiveCallback);
             var mockConnection = new MockConnection(() => transportConsumer);
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.FromOffset(12), mockConnection, options);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection, options);
             var receivedEvents = 0;
 
             mockRetryPolicy
@@ -1379,7 +1316,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task CloseAsyncClosesTheConnectionWhenOwned()
         {
             var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, connectionString);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString);
 
             await consumer.CloseAsync();
 
@@ -1396,7 +1333,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CloseClosesTheConnectionWhenOwned()
         {
             var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, connectionString);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString);
 
             consumer.Close();
 
@@ -1414,7 +1351,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var transportConsumer = new ObservableTransportConsumerMock();
             var connection = new MockConnection(() => transportConsumer);
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, connection);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
 
             await consumer.CloseAsync();
             Assert.That(connection.Closed, Is.False);
@@ -1430,7 +1367,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var transportConsumer = new ObservableTransportConsumerMock();
             var connection = new MockConnection(() => transportConsumer);
-            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "0", EventPosition.Earliest, connection);
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
 
             consumer.Close();
             Assert.That(connection.Closed, Is.False);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/PartitionReceiverLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/PartitionReceiverLiveTests.cs
@@ -61,7 +61,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
                     await using (var producer = new EventHubProducerClient(connectionString, new EventHubProducerClientOptions { PartitionId = partition }))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     {
                         // Initiate an operation to force the consumer to connect and set its position at the
@@ -128,7 +128,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
                     await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     {
                         // Create the batch of events to publish.
@@ -216,7 +216,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
                     await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     {
                         // Create the batch of events to publish.
@@ -298,7 +298,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
                     await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connectionString))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     {
                         // Initiate an operation to force the consumer to connect and set its position at the
@@ -361,7 +361,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
                     await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connectionString))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     {
                         // Initiate an operation to force the consumer to connect and set its position at the
@@ -426,7 +426,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
                     await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     {
                         // Initiate an operation to force the consumer to connect and set its position at the
@@ -494,7 +494,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
                     await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition, RetryOptions = retryOptions }))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { RetryOptions = retryOptions }))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { RetryOptions = retryOptions }))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     {
                         // Initiate an operation to force the consumer to connect and set its position at the
@@ -570,7 +570,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
                     await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     {
                         // Initiate an operation to force the consumer to connect and set its position at the
@@ -628,7 +628,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
                     await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     {
                         // Sending some events beforehand so the partition has some information.
@@ -691,7 +691,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Earliest, connection))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Earliest))
                     {
@@ -751,7 +751,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         var offset = (await producer.GetPartitionPropertiesAsync(partition)).LastEnqueuedOffset;
 
-                        await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.FromOffset(offset), connection))
+                        await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                         await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.FromOffset(offset)))
                         {
                             // Send a single event which is expected to go to the end of stream.
@@ -815,7 +815,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         DateTimeOffset enqueuedTime = (await producer.GetPartitionPropertiesAsync(partition)).LastEnqueuedTime;
 
-                        await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.FromEnqueuedTime(enqueuedTime), connection))
+                        await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                         await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.FromEnqueuedTime(enqueuedTime)))
                         {
                             // Send a single event which is expected to go to the end of stream.
@@ -882,7 +882,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         var sequenceNumber = (await producer.GetPartitionPropertiesAsync(partition)).LastEnqueuedSequenceNumber;
 
-                        await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.FromSequenceNumber(sequenceNumber, isInclusive), connection))
+                        await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                         await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.FromSequenceNumber(sequenceNumber, isInclusive)))
                         {
                             // Send a single event which is expected to go to the end of stream.
@@ -937,7 +937,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
 
                     {
@@ -975,7 +975,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
                 await using (var connection = new EventHubConnection(connectionString))
-                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, invalidPartition, EventPosition.Latest, connection))
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                 await using (var receiver = consumer.CreatePartitionReceiver(invalidPartition, EventPosition.Latest))
                 {
                     Assert.That(async () => await receiver.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<ArgumentOutOfRangeException>());
@@ -1011,7 +1011,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
                     await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     {
                         // Initiate an operation to force the consumer to connect and set its position at the
@@ -1055,7 +1055,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var consumer = new EventHubConsumerClient("nonExistentConsumerGroup", partition, EventPosition.Latest, connection))
+                    await using (var consumer = new EventHubConsumerClient("nonExistentConsumerGroup", connection))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     {
                         Assert.That(async () => await receiver.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<EventHubsResourceNotFoundException>());
@@ -1080,11 +1080,11 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using var exclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
+                    await using var exclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
                     await using var exclusiveReceiver = exclusiveConsumer.CreatePartitionReceiver(partition, EventPosition.Latest);
                     await exclusiveReceiver.ReceiveAsync(1, TimeSpan.FromSeconds(2));
 
-                    await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection);
+                    await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
                     await using var nonExclusiveReceiver = nonExclusiveConsumer.CreatePartitionReceiver(partition, EventPosition.Latest);
                     Assert.That(async () => await nonExclusiveReceiver.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<ConsumerDisconnectedException>());
                 }
@@ -1107,11 +1107,11 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using var higherExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
+                    await using var higherExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
                     await using var higherExclusiveReceiver = higherExclusiveConsumer.CreatePartitionReceiver(partition, EventPosition.Latest);
                     await higherExclusiveReceiver.ReceiveAsync(1, TimeSpan.FromSeconds(2));
 
-                    await using var lowerExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
+                    await using var lowerExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
                     await using var lowerExclusiveReceiver = lowerExclusiveConsumer.CreatePartitionReceiver(partition, EventPosition.Latest);
                     Assert.That(async () => await lowerExclusiveReceiver.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<ConsumerDisconnectedException>());
                 }
@@ -1134,15 +1134,15 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partitionIds = await connection.GetPartitionIdsAsync(DefaultRetryPolicy);
 
-                    await using var higherExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionIds[0], EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
+                    await using var higherExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
                     await using var higherExclusiveReceiver = higherExclusiveConsumer.CreatePartitionReceiver(partitionIds[0], EventPosition.Latest);
                     await higherExclusiveReceiver.ReceiveAsync(1, TimeSpan.FromSeconds(2));
 
-                    await using var lowerExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionIds[1], EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
+                    await using var lowerExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
                     await using var lowerExclusiveReceiver = lowerExclusiveConsumer.CreatePartitionReceiver(partitionIds[1], EventPosition.Latest);
                     Assert.That(async () => await lowerExclusiveReceiver.ReceiveAsync(1, TimeSpan.Zero), Throws.Nothing);
 
-                    await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionIds[2], EventPosition.Latest, connection);
+                    await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
                     await using var nonExclusiveReceiver = nonExclusiveConsumer.CreatePartitionReceiver(partitionIds[2], EventPosition.Latest);
                     Assert.That(async () => await nonExclusiveReceiver.ReceiveAsync(1, TimeSpan.Zero), Throws.Nothing);
                 }
@@ -1153,7 +1153,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///   Verifies that the <see cref="PartitionReceiver" /> is able to
         ///   connect to the Event Hubs service and perform operations.
         /// </summary>
-        /////
+        ///
         [Test]
         public async Task LowerOrNoOwnerLevelReceiverCanStartReceivingFromOtherConsumerGroups()
         {
@@ -1171,15 +1171,15 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using var higherExclusiveConsumer = new EventHubConsumerClient(consumerGroups[0], partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
+                    await using var higherExclusiveConsumer = new EventHubConsumerClient(consumerGroups[0], connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
                     await using var higherExclusiveReceiver = higherExclusiveConsumer.CreatePartitionReceiver(partition, EventPosition.Latest);
                     await higherExclusiveReceiver.ReceiveAsync(1, TimeSpan.FromSeconds(2));
 
-                    await using var lowerExclusiveConsumer = new EventHubConsumerClient(consumerGroups[1], partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
+                    await using var lowerExclusiveConsumer = new EventHubConsumerClient(consumerGroups[1], connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
                     await using var lowerExclusiveReceiver = lowerExclusiveConsumer.CreatePartitionReceiver(partition, EventPosition.Latest);
                     Assert.That(async () => await lowerExclusiveReceiver.ReceiveAsync(1, TimeSpan.Zero), Throws.Nothing);
 
-                    await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection);
+                    await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
                     await using var nonExclusiveReceiver = nonExclusiveConsumer.CreatePartitionReceiver(partition, EventPosition.Latest);
                     Assert.That(async () => await nonExclusiveReceiver.ReceiveAsync(1, TimeSpan.Zero), Throws.Nothing);
                 }
@@ -1202,10 +1202,10 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using var exclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
+                    await using var exclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
                     await using var exclusiveReceiver = exclusiveConsumer.CreatePartitionReceiver(partition, EventPosition.Latest);
 
-                    await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection);
+                    await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
                     await using var nonExclusiveReceiver = nonExclusiveConsumer.CreatePartitionReceiver(partition, EventPosition.Latest);
 
                     Assert.That(async () => await nonExclusiveReceiver.ReceiveAsync(1, TimeSpan.FromSeconds(2)), Throws.Nothing);
@@ -1233,10 +1233,10 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using var higherExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
+                    await using var higherExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
                     await using var higherExclusiveReceiver = higherExclusiveConsumer.CreatePartitionReceiver(partition, EventPosition.Latest);
 
-                    await using var lowerExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
+                    await using var lowerExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
                     await using var lowerExclusiveReceiver = lowerExclusiveConsumer.CreatePartitionReceiver(partition, EventPosition.Latest);
 
                     Assert.That(async () => await lowerExclusiveReceiver.ReceiveAsync(1, TimeSpan.FromSeconds(2)), Throws.Nothing);
@@ -1264,13 +1264,13 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partitionIds = await connection.GetPartitionIdsAsync(DefaultRetryPolicy);
 
-                    await using var higherExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionIds[0], EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
+                    await using var higherExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
                     await using var higherExclusiveReceiver = higherExclusiveConsumer.CreatePartitionReceiver(partitionIds[0], EventPosition.Latest);
 
-                    await using var lowerExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionIds[1], EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
+                    await using var lowerExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
                     await using var lowerExclusiveReceiver = lowerExclusiveConsumer.CreatePartitionReceiver(partitionIds[1], EventPosition.Latest);
 
-                    await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionIds[2], EventPosition.Latest, connection);
+                    await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
                     await using var nonExclusiveReceiver = nonExclusiveConsumer.CreatePartitionReceiver(partitionIds[2], EventPosition.Latest);
 
                     await nonExclusiveReceiver.ReceiveAsync(1, TimeSpan.FromSeconds(2));
@@ -1305,13 +1305,13 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using var higherExclusiveConsumer = new EventHubConsumerClient(consumerGroups[0], partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
+                    await using var higherExclusiveConsumer = new EventHubConsumerClient(consumerGroups[0], connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
                     await using var higherExclusiveReceiver = higherExclusiveConsumer.CreatePartitionReceiver(partition, EventPosition.Latest);
 
-                    await using var lowerExclusiveConsumer = new EventHubConsumerClient(consumerGroups[1], partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
+                    await using var lowerExclusiveConsumer = new EventHubConsumerClient(consumerGroups[1], connection, new EventHubConsumerClientOptions { OwnerLevel = 10 });
                     await using var lowerExclusiveReceiver = lowerExclusiveConsumer.CreatePartitionReceiver(partition, EventPosition.Latest);
 
-                    await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection);
+                    await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
                     await using var nonExclusiveReceiver = nonExclusiveConsumer.CreatePartitionReceiver(partition, EventPosition.Latest);
 
                     await higherExclusiveReceiver.ReceiveAsync(1, TimeSpan.FromSeconds(2));
@@ -1340,9 +1340,9 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partitionIds = await connection.GetPartitionIdsAsync(DefaultRetryPolicy);
 
-                    await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionIds[0], EventPosition.Latest, connection);
+                    await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
                     await using var nonExclusiveReceiver = nonExclusiveConsumer.CreatePartitionReceiver(partitionIds[0], EventPosition.Latest);
-                    await using var exclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionIds[0], EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
+                    await using var exclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
                     await using var exclusiveReceiver = exclusiveConsumer.CreatePartitionReceiver(partitionIds[0], EventPosition.Latest);
                     await exclusiveReceiver.ReceiveAsync(1, TimeSpan.FromSeconds(2));
 
@@ -1352,11 +1352,11 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     // It should be possible to create new valid consumers.
 
-                    await using var newExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionIds[0], EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 30 });
+                    await using var newExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 30 });
                     await using var newExclusiveReceiver = newExclusiveConsumer.CreatePartitionReceiver(partitionIds[0], EventPosition.Latest);
-                    await using var anotherPartitionConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionIds[1], EventPosition.Latest, connection);
+                    await using var anotherPartitionConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
                     await using var anotherPartitionReceiver = anotherPartitionConsumer.CreatePartitionReceiver(partitionIds[1], EventPosition.Latest);
-                    await using var anotherConsumerGroupConsumer = new EventHubConsumerClient(customConsumerGroup, partitionIds[0], EventPosition.Latest, connection);
+                    await using var anotherConsumerGroupConsumer = new EventHubConsumerClient(customConsumerGroup, connection);
                     await using var anotherConsumerGroupReceiver = anotherConsumerGroupConsumer.CreatePartitionReceiver(partitionIds[0], EventPosition.Latest);
 
                     Assert.That(async () => await newExclusiveReceiver.ReceiveAsync(1, TimeSpan.Zero), Throws.Nothing);
@@ -1365,9 +1365,9 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     // Proper exceptions should be thrown as well.
 
-                    await using var invalidPartitionConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "XYZ", EventPosition.Latest, connection);
+                    await using var invalidPartitionConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
                     await using var invalidPartitionReceiver = invalidPartitionConsumer.CreatePartitionReceiver("XYZ", EventPosition.Latest);
-                    await using var invalidConsumerGroupConsumer = new EventHubConsumerClient("imNotAConsumerGroup", partitionIds[0], EventPosition.Latest, connection);
+                    await using var invalidConsumerGroupConsumer = new EventHubConsumerClient("imNotAConsumerGroup", connection);
                     await using var invalidConsumerGroupReceiver = invalidConsumerGroupConsumer.CreatePartitionReceiver(partitionIds[0], EventPosition.Latest);
 
                     Assert.That(async () => await nonExclusiveReceiver.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<ConsumerDisconnectedException>());
@@ -1393,7 +1393,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using var invalidPartitionConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "XYZ", EventPosition.Latest, connection);
+                    await using var invalidPartitionConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
                     await using var invalidPartitionReceiver = invalidPartitionConsumer.CreatePartitionReceiver("XYZ", EventPosition.Latest);
 
                     // Failing at consumer creation should not compromise future ReceiveAsync calls.
@@ -1402,16 +1402,16 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     // It should be possible to create new valid consumers.
 
-                    await using var exclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
+                    await using var exclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
                     await using var exlusiveReceiver = exclusiveConsumer.CreatePartitionReceiver(partition, EventPosition.Latest);
 
                     Assert.That(async () => await exlusiveReceiver.ReceiveAsync(1, TimeSpan.Zero), Throws.Nothing);
 
                     // Proper exceptions should be thrown as well.
 
-                    await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection);
+                    await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
                     await using var nonExclusiveReceiver = nonExclusiveConsumer.CreatePartitionReceiver(partition, EventPosition.Latest);
-                    await using var invalidConsumerGroupConsumer = new EventHubConsumerClient("imNotAConsumerGroup", partition, EventPosition.Latest, connection);
+                    await using var invalidConsumerGroupConsumer = new EventHubConsumerClient("imNotAConsumerGroup", connection);
                     await using var invalidConsumerGroupReceiver = invalidConsumerGroupConsumer.CreatePartitionReceiver(partition, EventPosition.Latest);
 
                     Assert.That(async () => await nonExclusiveReceiver.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<ConsumerDisconnectedException>());
@@ -1437,7 +1437,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using var invalidConsumerGroupConsumer = new EventHubConsumerClient("imNotAConsumerGroup", partition, EventPosition.Latest, connection);
+                    await using var invalidConsumerGroupConsumer = new EventHubConsumerClient("imNotAConsumerGroup", connection);
                     await using var invalidConsumerGroupReceiver = invalidConsumerGroupConsumer.CreatePartitionReceiver(partition, EventPosition.Latest);
 
                     // Failing at consumer creation should not compromise future ReceiveAsync calls.
@@ -1446,16 +1446,16 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     // It should be possible to create new valid consumers.
 
-                    await using var exclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
+                    await using var exclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { OwnerLevel = 20 });
                     await using var exclusiveReceiver = exclusiveConsumer.CreatePartitionReceiver(partition, EventPosition.Latest);
 
                     Assert.That(async () => await exclusiveReceiver.ReceiveAsync(1, TimeSpan.Zero), Throws.Nothing);
 
                     // Proper exceptions should be thrown as well.
 
-                    await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection);
+                    await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
                     await using var nonExclusiveReceiver = nonExclusiveConsumer.CreatePartitionReceiver(partition, EventPosition.Latest);
-                    await using var invalidPartitionConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "XYZ", EventPosition.Latest, connection);
+                    await using var invalidPartitionConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
                     await using var invalidPartitionReceiver = invalidConsumerGroupConsumer.CreatePartitionReceiver("XYZ", EventPosition.Latest);
 
                     Assert.That(async () => await nonExclusiveReceiver.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<ConsumerDisconnectedException>());
@@ -1489,7 +1489,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partitionIds = await connection.GetPartitionIdsAsync(DefaultRetryPolicy);
 
                     await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partitionIds[0] }))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionIds[1], EventPosition.Latest, connectionString))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                     await using (var receiver = consumer.CreatePartitionReceiver(partitionIds[1], EventPosition.Latest))
                     {
                         // Initiate an operation to force the consumer to connect and set its position at the
@@ -1550,8 +1550,8 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
                     await using var producer = new EventHubProducerClient(connectionString, new EventHubProducerClientOptions { PartitionId = partition });
-                    await using var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connectionString);
-                    await using var anotherConsumer = new EventHubConsumerClient(customConsumerGroup, partition, EventPosition.Latest, connection);
+                    await using var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString);
+                    await using var anotherConsumer = new EventHubConsumerClient(customConsumerGroup, connection);
 
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     await using (var anotherReceiver = anotherConsumer.CreatePartitionReceiver(partition, EventPosition.Latest))
@@ -1613,7 +1613,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     {
                         // Initiate an operation to force the consumers to connect and set their positions at the
@@ -1659,7 +1659,7 @@ namespace Azure.Messaging.EventHubs.Tests
                         DefaultMaximumReceiveWaitTime = TimeSpan.FromSeconds(defaultMaximumWaitTimeInSecs)
                     };
 
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connectionString, consumerOptions))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString, consumerOptions))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     {
                         var maximumWaitTimeInSecs = 10;
@@ -1719,7 +1719,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     IEnumerable<Task> tasks = Enumerable.Range(0, 10)
                         .Select(async i =>
                         {
-                            await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, connection))
+                            await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                             await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                             {
                                 Assert.That(async () => await receiver.ReceiveAsync(1, TimeSpan.FromSeconds(receiveTimeoutInSeconds)), Throws.Nothing);
@@ -1755,7 +1755,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { TryTimeout = TimeSpan.FromMinutes(2) } };
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var invalidProxyConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Latest, invalidProxyConnection, options))
+                    await using (var invalidProxyConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, invalidProxyConnection, options))
                     await using (var invalidProxyReceiver = invalidProxyConsumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     {
                         Assert.That(async () => await invalidProxyReceiver.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientLiveTests.cs
@@ -747,7 +747,7 @@ namespace Azure.Messaging.EventHubs.Tests
                         {
                             for (var index = 0; index < partitions; index++)
                             {
-                                consumers.Add(new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionIds[index], EventPosition.Latest, connection));
+                                consumers.Add(new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection));
                                 receivers.Add(consumers[index].CreatePartitionReceiver(partitionIds[index], EventPosition.Latest));
 
                                 // Initiate an operation to force the consumer to connect and set its position at the
@@ -827,7 +827,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     {
                         for (var index = 0; index < partitions; index++)
                         {
-                            consumers.Add(new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionIds[index], EventPosition.Latest, connection));
+                            consumers.Add(new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection));
                             receivers.Add(consumers[index].CreatePartitionReceiver(partitionIds[index], EventPosition.Latest));
 
                             // Initiate an operation to force the consumer to connect and set its position at the
@@ -902,7 +902,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     {
                         for (var index = 0; index < partitions; index++)
                         {
-                            consumers.Add(new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionIds[index], EventPosition.Latest, connection));
+                            consumers.Add(new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection));
                             receivers.Add(consumers[index].CreatePartitionReceiver(partitionIds[index], EventPosition.Latest));
 
                             // Initiate an operation to force the consumer to connect and set its position at the

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventProcessorClient/EventProcessorClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventProcessorClient/EventProcessorClientLiveTests.cs
@@ -529,7 +529,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partitionId = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
                     await using (var producer = new EventHubProducerClient(connectionString))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionId, EventPosition.Earliest, connection))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     await using (var receiver = consumer.CreatePartitionReceiver(partitionId, EventPosition.Earliest))
                     {
                         // Send a few dummy events.  We are not expecting to receive these.
@@ -636,7 +636,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partitionId = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
                     await using (var producer = new EventHubProducerClient(connection))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, partitionId, EventPosition.Earliest, connectionString))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                     await using (var receiver = consumer.CreatePartitionReceiver(partitionId, EventPosition.Earliest))
                     {
                         // Send a few events.  We are only interested in the last one of them.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Shared/LiveResourceManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Shared/LiveResourceManager.cs
@@ -31,7 +31,7 @@ namespace Azure.Messaging.EventHubs.Tests.Infrastructure
         private const double RetryExponentialBackoffSeconds = 2.5;
 
         /// <summary>The number of seconds to use as the basis for applying jitter to retry back-off calculations.</summary>
-        private const double RetryBaseJitterSeconds = 18.0;
+        private const double RetryBaseJitterSeconds = 20.0;
 
         /// <summary>The buffer to apply when considering refreshing; credentials that expire less than this duration will be refreshed.</summary>
         private static readonly TimeSpan CredentialRefreshBuffer = TimeSpan.FromMinutes(5);


### PR DESCRIPTION
# Summary

The focus of these changes is to complete the removal of partition affinity from the Event Hub consumer client, allowing it to be created without the context of a partition, with its operations allowing the partition and starting position to be specified.

# Last Upstream Rebase

Wednesday, November 13, 2:38pm (EST)

# Related and Follow-Up Issues

- [Release Event Hubs Track 2 Library for .NET](https://github.com/Azure/azure-sdk-for-net/issues/8552) (#8552) 
- [ Remove partition affinity from Event Hub Consumer Client ](https://github.com/Azure/azure-sdk-for-net/issues/8565) (#8565) 