### PR TITLE
[Event Hubs Client] Track Two (Remove Producer Partition Affinity)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample03_PublishAnEvent.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample03_PublishAnEvent.cs
@@ -57,14 +57,15 @@ namespace Azure.Messaging.EventHubs.Samples
                 //
                 // In our case, we will translate a simple sentence into bytes and send it to our Event Hub.
 
-                var eventData = new EventData(Encoding.UTF8.GetBytes("Hello, Event Hubs!"));
+                using EventDataBatch eventBatch = await producerClient.CreateBatchAsync();
+                eventBatch.TryAdd(new EventData(Encoding.UTF8.GetBytes("Hello, Event Hubs!")));
 
                 // When the producer sends the event, it will receive an acknowledgment from the Event Hubs service; so
                 // long as there is no exception thrown by this call, the service is now responsible for delivery.  Your
                 // event data will be published to one of the Event Hub partitions, though there may be a (very) slight
                 // delay until it is available to be consumed.
 
-                await producerClient.SendAsync(eventData);
+                await producerClient.SendAsync(eventBatch);
 
                 Console.WriteLine("The event has been published.");
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample04_PublishEventsWithPartitionKey.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample04_PublishEventsWithPartitionKey.cs
@@ -51,23 +51,21 @@ namespace Azure.Messaging.EventHubs.Samples
                 // Note that there is no means of accurately predicting which partition will be associated with a given partition key;
                 // we can only be assured that it will be a consistent choice of partition.  If you have a need to understand which
                 // exact partition an event is published to, you will need to use an Event Hub producer associated with that partition.
-
+                //
                 // We will publish a small batch of events based on simple sentences.
-
-                var eventBatch = new EventData[]
-                {
-                    new EventData(Encoding.UTF8.GetBytes("Hello, Event Hubs!")),
-                    new EventData(Encoding.UTF8.GetBytes("Goodbye, Event Hubs!"))
-                };
 
                 // To choose a partition key, you will need to create a custom set of send options.
 
-                var sendOptions = new SendOptions
+                var batchOptions = new CreateBatchOptions
                 {
                     PartitionKey = "Any Value Will Do..."
                 };
 
-                await producerClient.SendAsync(eventBatch, sendOptions);
+                using EventDataBatch eventBatch = await producerClient.CreateBatchAsync(batchOptions);
+                eventBatch.TryAdd(new EventData(Encoding.UTF8.GetBytes("Hello, Event Hubs!")));
+                eventBatch.TryAdd(new EventData(Encoding.UTF8.GetBytes("Goodbye, Event Hubs!")));
+
+                await producerClient.SendAsync(eventBatch);
 
                 Console.WriteLine("The event batch has been published.");
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample05_PublishAnEventBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample05_PublishAnEventBatch.cs
@@ -69,7 +69,7 @@ namespace Azure.Messaging.EventHubs.Samples
                 // If a size limit is not specified, the maximum size allowed by the transport is used.  In this example, we
                 // will set a custom partition key and otherwise use the default options.
 
-                BatchOptions options = new BatchOptions { PartitionKey = "This is a custom key!" };
+                CreateBatchOptions options = new CreateBatchOptions { PartitionKey = "This is a custom key!" };
                 EventDataBatch batch = await producerClient.CreateBatchAsync(options);
 
                 foreach (EventData eventData in events)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample07_PublishEventsWithCustomMetadata.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample07_PublishEventsWithCustomMetadata.cs
@@ -64,7 +64,11 @@ namespace Azure.Messaging.EventHubs.Samples
                 secondEvent.Properties.Add("priority", "17");
                 secondEvent.Properties.Add("blob", true);
 
-                await producerClient.SendAsync(new[] { firstEvent, secondEvent });
+                using EventDataBatch eventBatch = await producerClient.CreateBatchAsync();
+                eventBatch.TryAdd(firstEvent);
+                eventBatch.TryAdd(secondEvent);
+
+                await producerClient.SendAsync(eventBatch);
 
                 Console.WriteLine("The event batch has been published.");
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample08_ConsumeEvents.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample08_ConsumeEvents.cs
@@ -90,11 +90,16 @@ namespace Azure.Messaging.EventHubs.Samples
                 {
                     if (!wereEventsPublished)
                     {
-                        await using var producerClient = new EventHubProducerClient(connectionString, eventHubName, new EventHubProducerClientOptions { PartitionId = firstPartition });
-                        await producerClient.SendAsync(new EventData(Encoding.UTF8.GetBytes("Hello, Event Hubs!")));
-                        wereEventsPublished = true;
+                        await using (var producerClient = new EventHubProducerClient(connectionString, eventHubName))
+                        {
+                            using EventDataBatch eventBatch = await producerClient.CreateBatchAsync(new CreateBatchOptions { PartitionId = firstPartition });
+                            eventBatch.TryAdd(new EventData(Encoding.UTF8.GetBytes("Hello, Event Hubs!")));
 
-                        Console.WriteLine("The event batch has been published.");
+                            await producerClient.SendAsync(eventBatch);
+                            wereEventsPublished = true;
+
+                            Console.WriteLine("The event batch has been published.");
+                        }
                     }
 
                     // Because publishing and receiving events is asynchronous, the events that we published may not

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample11_ConsumeEventsWithEventProcessor.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample11_ConsumeEventsWithEventProcessor.cs
@@ -172,14 +172,9 @@ namespace Azure.Messaging.EventHubs.Samples
                     // To test our event processor, we are publishing 10 sets of events to the Event Hub.  Notice that we are not
                     // specifying a partition to send events to, so these sets may end up in different partitions.
 
-                    EventData[] eventsToPublish = new EventData[]
-                    {
-                        new EventData(Encoding.UTF8.GetBytes("I am not the second event.")),
-                        new EventData(Encoding.UTF8.GetBytes("I am not the first event."))
-                    };
-
                     int amountOfSets = 10;
-                    int expectedAmountOfEvents = amountOfSets * eventsToPublish.Length;
+                    int eventsPerSet = 2;
+                    int expectedAmountOfEvents = amountOfSets * eventsPerSet;
 
                     Console.WriteLine();
                     Console.WriteLine("Sending events to the Event Hub.");
@@ -187,7 +182,11 @@ namespace Azure.Messaging.EventHubs.Samples
 
                     for (int i = 0; i < amountOfSets; i++)
                     {
-                        await producerClient.SendAsync(eventsToPublish);
+                        using EventDataBatch eventBatch = await producerClient.CreateBatchAsync();
+                        eventBatch.TryAdd(new EventData(Encoding.UTF8.GetBytes("I am not the second event.")));
+                        eventBatch.TryAdd(new EventData(Encoding.UTF8.GetBytes("I am not the first event.")));
+
+                        await producerClient.SendAsync(eventBatch);
                     }
 
                     // Because there is some non-determinism in the messaging flow, the sent events may not be immediately

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
@@ -357,18 +357,20 @@ namespace Azure.Messaging.EventHubs.Amqp
         ///   responsible for publishing <see cref="EventData" /> to the Event Hub.
         /// </summary>
         ///
+        /// <param name="partitionId">The identifier of the partition to which the transport producer should be bound; if <c>null</c>, the producer is unbound.</param>
         /// <param name="producerOptions">The set of options to apply when creating the producer.</param>
         ///
         /// <returns>A <see cref="TransportProducer"/> configured in the requested manner.</returns>
         ///
-        public override TransportProducer CreateProducer(EventHubProducerClientOptions producerOptions)
+        public override TransportProducer CreateProducer(string partitionId,
+                                                         EventHubProducerClientOptions producerOptions)
         {
             Argument.AssertNotClosed(_closed, nameof(AmqpClient));
 
             return new AmqpProducer
             (
                 EventHubName,
-                producerOptions.PartitionId,
+                partitionId,
                 ConnectionScope,
                 MessageConverter,
                 producerOptions.RetryOptions.ToRetryPolicy()

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpEventBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpEventBatch.cs
@@ -63,7 +63,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         ///   The set of options to apply to the batch.
         /// </summary>
         ///
-        private BatchOptions Options { get; }
+        private CreateBatchOptions Options { get; }
 
         /// <summary>
         ///   The set of messages that have been added to the batch.
@@ -79,7 +79,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// <param name="options">The set of options to apply to the batch.</param>
         ///
         public AmqpEventBatch(AmqpMessageConverter messageConverter,
-                              BatchOptions options)
+                              CreateBatchOptions options)
         {
             Argument.AssertNotNull(messageConverter, nameof(messageConverter));
             Argument.AssertNotNull(options, nameof(options));

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
@@ -189,7 +189,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         ///
         /// <returns>An <see cref="EventDataBatch" /> with the requested <paramref name="options"/>.</returns>
         ///
-        public override async ValueTask<TransportEventBatch> CreateBatchAsync(BatchOptions options,
+        public override async ValueTask<TransportEventBatch> CreateBatchAsync(CreateBatchOptions options,
                                                                               CancellationToken cancellationToken)
         {
             Argument.AssertNotNull(options, nameof(options));

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportClient.cs
@@ -66,11 +66,13 @@ namespace Azure.Messaging.EventHubs.Core
         ///   responsible for publishing <see cref="EventData" /> to the Event Hub.
         /// </summary>
         ///
+        /// <param name="partitionId">The identifier of the partition to which the transport producer should be bound; if <c>null</c>, the producer is unbound.</param>
         /// <param name="producerOptions">The set of options to apply when creating the producer.</param>
         ///
         /// <returns>A <see cref="TransportProducer"/> configured in the requested manner.</returns>
         ///
-        public abstract TransportProducer CreateProducer(EventHubProducerClientOptions producerOptions);
+        public abstract TransportProducer CreateProducer(string partitionId,
+                                                         EventHubProducerClientOptions producerOptions);
 
         /// <summary>
         ///   Creates a consumer strongly aligned with the active protocol and transport, responsible

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportProducer.cs
@@ -65,9 +65,9 @@ namespace Azure.Messaging.EventHubs.Core
         ///
         /// <returns>An <see cref="EventDataBatch" /> with the requested <paramref name="options"/>.</returns>
         ///
-        /// <seealso cref="CreateBatchAsync(BatchOptions, CancellationToken)" />
+        /// <seealso cref="CreateBatchAsync(CreateBatchOptions, CancellationToken)" />
         ///
-        public abstract ValueTask<TransportEventBatch> CreateBatchAsync(BatchOptions options,
+        public abstract ValueTask<TransportEventBatch> CreateBatchAsync(CreateBatchOptions options,
                                                                         CancellationToken cancellationToken);
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/CreateBatchOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/CreateBatchOptions.cs
@@ -11,7 +11,7 @@ namespace Azure.Messaging.EventHubs
     ///   behaves and is sent to the Event Hubs service.
     /// </summary>
     ///
-    public class BatchOptions : SendOptions
+    public class CreateBatchOptions : SendOptions
     {
         /// <summary>The requested maximum size to allow for the batch, in bytes.</summary>
         private long? _maximumSizeInBytes = null;
@@ -41,14 +41,15 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
-        ///   Creates a new copy of the current <see cref="BatchOptions" />, cloning its attributes into a new instance.
+        ///   Creates a new copy of the current <see cref="CreateBatchOptions" />, cloning its attributes into a new instance.
         /// </summary>
         ///
-        /// <returns>A new copy of <see cref="BatchOptions" />.</returns>
+        /// <returns>A new copy of <see cref="CreateBatchOptions" />.</returns>
         ///
-        internal BatchOptions Clone() =>
-            new BatchOptions
+        internal CreateBatchOptions Clone() =>
+            new CreateBatchOptions
             {
+                PartitionId = PartitionId,
                 PartitionKey = PartitionKey,
                 _maximumSizeInBytes = MaximumSizeInBytes
             };

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnection.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnection.cs
@@ -349,12 +349,14 @@ namespace Azure.Messaging.EventHubs
         ///   responsible for publishing <see cref="EventData" /> to the Event Hub.
         /// </summary>
         ///
+        /// <param name="partitionId">The identifier of the partition to which the transport producer should be bound; if <c>null</c>, the producer is unbound.</param>
         /// <param name="producerOptions">The set of options to apply when creating the producer.</param>
         ///
         /// <returns>A <see cref="TransportProducer"/> configured in the requested manner.</returns>
         ///
-        internal virtual TransportProducer CreateTransportProducer(EventHubProducerClientOptions producerOptions = default) =>
-            InnerClient.CreateProducer(producerOptions?.Clone() ?? new EventHubProducerClientOptions());
+        internal virtual TransportProducer CreateTransportProducer(string partitionId,
+                                                                   EventHubProducerClientOptions producerOptions = default) =>
+            InnerClient.CreateProducer(partitionId, producerOptions?.Clone() ?? new EventHubProducerClientOptions());
 
         /// <summary>
         ///   Creates a consumer strongly aligned with the active protocol and transport, responsible

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerClient.cs
@@ -101,7 +101,7 @@ namespace Azure.Messaging.EventHubs
         private bool OwnsConnection { get; } = true;
 
         /// <summary>
-        ///   The set of consumer options used for creation of this consumer.
+        ///   The set of options used for creation of this consumer.
         /// </summary>
         ///
         private EventHubConsumerClientOptions Options { get; }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducerClient.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
@@ -55,18 +56,6 @@ namespace Azure.Messaging.EventHubs
         public string EventHubName => Connection.EventHubName;
 
         /// <summary>
-        ///   The identifier of the Event Hub partition that the <see cref="EventHubProducerClient" /> is bound to, indicating
-        ///   that it will send events to only that partition.
-        ///
-        ///   If the identifier was not specified at creation, the producer will allow the Event Hubs service to be
-        ///   responsible for routing events that are sent to an available partition.
-        /// </summary>
-        ///
-        /// <value>If <c>null</c>, the producer is not specific to a partition and events will be automatically routed; otherwise, the identifier of the partition events will be sent to.</value>
-        ///
-        public string PartitionId { get; }
-
-        /// <summary>
         ///   Indicates whether or not this <see cref="EventHubProducerClient"/> has been closed.
         /// </summary>
         ///
@@ -84,6 +73,12 @@ namespace Azure.Messaging.EventHubs
         private bool OwnsConnection { get; } = true;
 
         /// <summary>
+        ///   The set of options used for creation of this producer.
+        /// </summary>
+        ///
+        private EventHubProducerClientOptions Options { get; }
+
+        /// <summary>
         ///   The policy to use for determining retry behavior for when an operation fails.
         /// </summary>
         ///
@@ -97,10 +92,18 @@ namespace Azure.Messaging.EventHubs
         private EventHubConnection Connection { get; }
 
         /// <summary>
-        ///   An abstracted Event Hub producer specific to the active protocol and transport intended to perform delegated operations.
+        ///   An abstracted Event Hub transport-specific producer that is associated with the
+        ///   Event Hub gateway rather than a specific partition; intended to perform delegated operations.
         /// </summary>
         ///
-        private TransportProducer InnerProducer { get; }
+        private TransportProducer GatewayProducer { get; }
+
+        /// <summary>
+        ///   The set of active Event Hub transport-specific producers created by this client which are specific to
+        ///   a given partition; intended to perform delegated operations.
+        /// </summary>
+        ///
+        private ConcurrentDictionary<string, TransportProducer> PartitionProducers { get; } = new ConcurrentDictionary<string, TransportProducer>();
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="EventHubProducerClient"/> class.
@@ -183,9 +186,9 @@ namespace Azure.Messaging.EventHubs
 
             OwnsConnection = true;
             Connection = new EventHubConnection(connectionString, eventHubName, producerOptions.ConnectionOptions);
-            PartitionId = producerOptions.PartitionId;
+            Options = producerOptions;
             RetryPolicy = producerOptions.RetryOptions.ToRetryPolicy();
-            InnerProducer = Connection.CreateTransportProducer(producerOptions);
+            GatewayProducer = Connection.CreateTransportProducer(null, producerOptions);
         }
 
         /// <summary>
@@ -210,9 +213,9 @@ namespace Azure.Messaging.EventHubs
 
             OwnsConnection = true;
             Connection = new EventHubConnection(fullyQualifiedNamespace, eventHubName, credential, producerOptions.ConnectionOptions);
-            PartitionId = producerOptions.PartitionId;
+            Options = producerOptions;
             RetryPolicy = producerOptions.RetryOptions.ToRetryPolicy();
-            InnerProducer = Connection.CreateTransportProducer(producerOptions);
+            GatewayProducer = Connection.CreateTransportProducer(null, producerOptions);
         }
 
         /// <summary>
@@ -230,9 +233,9 @@ namespace Azure.Messaging.EventHubs
 
             OwnsConnection = false;
             Connection = connection;
-            PartitionId = producerOptions.PartitionId;
+            Options = producerOptions;
             RetryPolicy = producerOptions.RetryOptions.ToRetryPolicy();
-            InnerProducer = Connection.CreateTransportProducer(producerOptions);
+            GatewayProducer = Connection.CreateTransportProducer(null, producerOptions);
         }
 
         /// <summary>
@@ -255,7 +258,7 @@ namespace Azure.Messaging.EventHubs
 
             OwnsConnection = false;
             Connection = connection;
-            InnerProducer = transportProducer;
+            GatewayProducer = transportProducer;
         }
 
         /// <summary>
@@ -335,8 +338,8 @@ namespace Azure.Messaging.EventHubs
         /// <seealso cref="SendAsync(IEnumerable{EventData}, SendOptions, CancellationToken)" />
         /// <seealso cref="SendAsync(EventDataBatch, CancellationToken)" />
         ///
-        public virtual Task SendAsync(EventData eventData,
-                                      CancellationToken cancellationToken = default)
+        internal virtual Task SendAsync(EventData eventData,
+                                        CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(eventData, nameof(eventData));
             return SendAsync(new[] { eventData }, null, cancellationToken);
@@ -358,9 +361,9 @@ namespace Azure.Messaging.EventHubs
         /// <seealso cref="SendAsync(IEnumerable{EventData}, SendOptions, CancellationToken)" />
         /// <seealso cref="SendAsync(EventDataBatch, CancellationToken)" />
         ///
-        public virtual Task SendAsync(EventData eventData,
-                                      SendOptions options,
-                                      CancellationToken cancellationToken = default)
+        internal virtual Task SendAsync(EventData eventData,
+                                        SendOptions options,
+                                        CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(eventData, nameof(eventData));
             return SendAsync(new[] { eventData }, options, cancellationToken);
@@ -378,8 +381,8 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <seealso cref="SendAsync(IEnumerable{EventData}, SendOptions, CancellationToken)"/>
         ///
-        public virtual Task SendAsync(IEnumerable<EventData> events,
-                                      CancellationToken cancellationToken = default) => SendAsync(events, null, cancellationToken);
+        internal virtual Task SendAsync(IEnumerable<EventData> events,
+                                        CancellationToken cancellationToken = default) => SendAsync(events, null, cancellationToken);
 
         /// <summary>
         ///   Sends a set of events to the associated Event Hub using a batched approach.  If the size of events exceed the
@@ -397,14 +400,29 @@ namespace Azure.Messaging.EventHubs
         /// <seealso cref="SendAsync(IEnumerable{EventData}, CancellationToken)" />
         /// <seealso cref="SendAsync(EventDataBatch, CancellationToken)" />
         ///
-        public virtual async Task SendAsync(IEnumerable<EventData> events,
-                                            SendOptions options,
-                                            CancellationToken cancellationToken = default)
+        internal virtual async Task SendAsync(IEnumerable<EventData> events,
+                                              SendOptions options,
+                                              CancellationToken cancellationToken = default)
         {
             options ??= DefaultSendOptions;
 
             Argument.AssertNotNull(events, nameof(events));
-            AssertSinglePartitionReference(PartitionId, options.PartitionKey);
+            AssertSinglePartitionReference(options.PartitionId, options.PartitionKey);
+
+            // Determine the transport producer to delegate the send operation to.  Because sending to a specific
+            // partition requires a dedicated client, use (or create) that client if a partition was specified.  Otherwise
+            // the default gateway producer can be used to request automatic routing from the Event Hubs service gateway.
+
+            TransportProducer activeProducer;
+
+            if (String.IsNullOrEmpty(options.PartitionId))
+            {
+                activeProducer = GatewayProducer;
+            }
+            else
+            {
+                activeProducer = PartitionProducers.GetOrAdd(options.PartitionId, id => Connection.CreateTransportProducer(id, Options));
+            }
 
             using DiagnosticScope scope = CreateDiagnosticScope();
 
@@ -413,7 +431,7 @@ namespace Azure.Messaging.EventHubs
 
             try
             {
-                await InnerProducer.SendAsync(events, options, cancellationToken).ConfigureAwait(false);
+                await activeProducer.SendAsync(events, options, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -440,13 +458,28 @@ namespace Azure.Messaging.EventHubs
                                             CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(eventBatch, nameof(eventBatch));
-            AssertSinglePartitionReference(PartitionId, eventBatch.SendOptions.PartitionKey);
+            AssertSinglePartitionReference(eventBatch.SendOptions.PartitionId, eventBatch.SendOptions.PartitionKey);
+
+            // Determine the transport producer to delegate the send operation to.  Because sending to a specific
+            // partition requires a dedicated client, use (or create) that client if a partition was specified.  Otherwise
+            // the default gateway producer can be used to request automatic routing from the Event Hubs service gateway.
+
+            TransportProducer activeProducer;
+
+            if (String.IsNullOrEmpty(eventBatch.SendOptions.PartitionId))
+            {
+                activeProducer = GatewayProducer;
+            }
+            else
+            {
+                activeProducer = PartitionProducers.GetOrAdd(eventBatch.SendOptions.PartitionId, id => Connection.CreateTransportProducer(id, Options));
+            }
 
             using DiagnosticScope scope = CreateDiagnosticScope();
 
             try
             {
-                await InnerProducer.SendAsync(eventBatch, cancellationToken).ConfigureAwait(false);
+                await activeProducer.SendAsync(eventBatch, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -468,7 +501,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <returns>An <see cref="EventDataBatch" /> with the default batch options.</returns>
         ///
-        /// <seealso cref="CreateBatchAsync(BatchOptions, CancellationToken)" />
+        /// <seealso cref="CreateBatchAsync(CreateBatchOptions, CancellationToken)" />
         ///
         public virtual ValueTask<EventDataBatch> CreateBatchAsync(CancellationToken cancellationToken = default) => CreateBatchAsync(null, cancellationToken);
 
@@ -486,16 +519,15 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <returns>An <see cref="EventDataBatch" /> with the requested <paramref name="options"/>.</returns>
         ///
-        /// <seealso cref="CreateBatchAsync(BatchOptions, CancellationToken)" />
+        /// <seealso cref="CreateBatchAsync(CreateBatchOptions, CancellationToken)" />
         ///
-        public virtual async ValueTask<EventDataBatch> CreateBatchAsync(BatchOptions options,
+        public virtual async ValueTask<EventDataBatch> CreateBatchAsync(CreateBatchOptions options,
                                                                         CancellationToken cancellationToken = default)
         {
-            options = options?.Clone() ?? new BatchOptions();
+            options = options?.Clone() ?? new CreateBatchOptions();
+            AssertSinglePartitionReference(options.PartitionId, options.PartitionKey);
 
-            AssertSinglePartitionReference(PartitionId, options.PartitionKey);
-
-            TransportEventBatch transportBatch = await InnerProducer.CreateBatchAsync(options, cancellationToken).ConfigureAwait(false);
+            TransportEventBatch transportBatch = await GatewayProducer.CreateBatchAsync(options, cancellationToken).ConfigureAwait(false);
             return new EventDataBatch(transportBatch, options);
         }
 
@@ -509,21 +541,63 @@ namespace Azure.Messaging.EventHubs
         ///
         public virtual async Task CloseAsync(CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             Closed = true;
+
+            var identifier = GetHashCode().ToString();
+            EventHubsEventSource.Log.ClientCloseStart(typeof(EventHubProducerClient), EventHubName, identifier);
+
+            // Attempt to close the active transport producers.  In the event that an exception is encountered,
+            // it should not impact the attempt to close the connection, assuming ownership.
+
+            var transportProducerException = default(Exception);
 
             try
             {
-                await InnerProducer.CloseAsync(cancellationToken).ConfigureAwait(false);
+                await GatewayProducer.CloseAsync(cancellationToken).ConfigureAwait(false);
 
+                var pendingCloses = new List<Task>();
+
+                foreach (var producer in PartitionProducers.Values)
+                {
+                    pendingCloses.Add(producer.CloseAsync(CancellationToken.None));
+                }
+
+                PartitionProducers.Clear();
+                await Task.WhenAll(pendingCloses).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                EventHubsEventSource.Log.ClientCloseError(typeof(EventHubProducerClient), EventHubName, identifier, ex.Message);
+                transportProducerException = ex;
+            }
+
+            // An exception when closing the connection supersedes one observed when closing the
+            // individual transport clients.
+
+            try
+            {
                 if (OwnsConnection)
                 {
                     await Connection.CloseAsync().ConfigureAwait(false);
                 }
             }
-            catch (Exception ex) when (ex is TaskCanceledException || ex is OperationCanceledException)
+            catch (Exception ex)
             {
-                Closed = InnerProducer.Closed;
+                EventHubsEventSource.Log.ClientCloseError(typeof(EventHubProducerClient), EventHubName, identifier, ex.Message);
                 throw;
+            }
+            finally
+            {
+                EventHubsEventSource.Log.ClientCloseComplete(typeof(EventHubProducerClient), EventHubName, identifier);
+            }
+
+            // If there was an active exception pending from closing the individual
+            // transport producers, surface it now.
+
+            if (transportProducerException != default)
+            {
+                throw transportProducerException;
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducerClientOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducerClientOptions.cs
@@ -13,44 +13,11 @@ namespace Azure.Messaging.EventHubs
     ///
     public class EventHubProducerClientOptions
     {
-        /// <summary>The identifier of the partition that the producer will be bound to.</summary>
-        private string _partitionId = null;
-
         /// <summary>The set of options to use for configuring the connection to the Event Hubs service.</summary>
         private EventHubConnectionOptions _connectionOptions = new EventHubConnectionOptions();
 
         /// <summary>The set of options to govern retry behavior and try timeouts.</summary>
         private RetryOptions _retryOptions = new RetryOptions();
-
-        /// <summary>
-        ///   The identifier of the Event Hub partition that the <see cref="EventHubProducerClient" /> will be bound to,
-        ///   limiting it to sending events to only that partition.
-        ///
-        ///   If the identifier is not specified, the Event Hubs service will be responsible for routing events that
-        ///   are sent to an available partition.
-        /// </summary>
-        ///
-        /// <value>If the producer wishes the events to be automatically to partitions, <c>null</c>; otherwise, the identifier of the desired partition.</value>
-        ///
-        /// <remarks>
-        ///   Allowing automatic routing of partitions is recommended when:
-        ///   <para>- The sending of events needs to be highly available.</para>
-        ///   <para>- The event data should be evenly distributed among all available partitions.</para>
-        ///
-        ///   If no partition is specified, the following rules are used for automatically selecting one:
-        ///   <para>1) Distribute the events equally amongst all available partitions using a round-robin approach.</para>
-        ///   <para>2) If a partition becomes unavailable, the Event Hubs service will automatically detect it and forward the message to another available partition.</para>
-        /// </remarks>
-        ///
-        public string PartitionId
-        {
-            get => _partitionId;
-            set
-            {
-                Argument.AssertNotEmptyOrWhiteSpace(value, nameof(PartitionId));
-                _partitionId = value;
-            }
-        }
 
         /// <summary>
         ///   Gets or sets the options used for configuring the connection to the Event Hubs service.
@@ -120,7 +87,6 @@ namespace Azure.Messaging.EventHubs
         internal EventHubProducerClientOptions Clone() =>
             new EventHubProducerClientOptions
             {
-                _partitionId = PartitionId,
                 _connectionOptions = ConnectionOptions.Clone(),
                 _retryOptions = RetryOptions.Clone()
             };

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/SendOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/SendOptions.cs
@@ -27,9 +27,42 @@ namespace Azure.Messaging.EventHubs
         ///   specified directly when sending the batch.
         /// </summary>
         ///
-        /// <value>The partition hashing key to associate with the event or batch of events.</value>
+        /// <value>
+        ///   If the producer wishes to influence the automatic routing of events to partitions, the partition
+        ///   hashing key to associate with the event or batch of events; otherwise, <c>null</c>.
+        /// </value>
+        ///
+        /// <remarks>
+        ///   If the <see cref="SendOptions.PartitionKey" /> is specified, then no <see cref="SendOptions.PartitionId" />
+        ///   may be set when sending.
+        /// </remarks>
         ///
         public string PartitionKey { get; set; }
+
+        /// <summary>
+        ///   If the identifier is not specified, the Event Hubs service will be responsible for routing events automatically to
+        ///   to an available partition.  If specified, the sender is requesting that events be sent to this specific partition.
+        /// </summary>
+        ///
+        /// <value>
+        ///   If the producer wishes the events to be automatically to partitions, <c>null</c>; otherwise, the identifier
+        ///   of the desired partition.
+        /// </value>
+        ///
+        /// <remarks>
+        ///   If the <see cref="SendOptions.PartitionId" /> is specified, then no <see cref="SendOptions.PartitionKey" />
+        ///   may be set when sending.
+        ///
+        ///   <para>Allowing automatic routing of partitions is recommended when:</para>
+        ///   <para>- The sending of events needs to be highly available.</para>
+        ///   <para>- The event data should be evenly distributed among all available partitions.</para>
+        ///
+        ///   If no partition is specified, the following rules are used for automatically selecting one:
+        ///   <para>1) Distribute the events equally amongst all available partitions using a round-robin approach.</para>
+        ///   <para>2) If a partition becomes unavailable, the Event Hubs service will automatically detect it and forward the message to another available partition.</para>
+        /// </remarks>
+        ///
+        public string PartitionId { get; set; }
 
         /// <summary>
         ///   Determines whether the specified <see cref="System.Object" /> is equal to this instance.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpClientTests.cs
@@ -420,7 +420,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var client = new AmqpClient("my.eventhub.com", "somePath", credential.Object, new EventHubConnectionOptions());
             await client.CloseAsync(cancellationSource.Token);
 
-            Assert.That(() => client.CreateProducer(new EventHubProducerClientOptions()), Throws.InstanceOf<EventHubsClientClosedException>());
+            Assert.That(() => client.CreateProducer(null, new EventHubProducerClientOptions()), Throws.InstanceOf<EventHubsClientClosedException>());
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventBatchTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventBatchTests.cs
@@ -26,7 +26,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorValidatesTheMessageConverter()
         {
-            Assert.That(() => new AmqpEventBatch(null, new BatchOptions { MaximumSizeInBytes = 31 }), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpEventBatch(null, new CreateBatchOptions { MaximumSizeInBytes = 31 }), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 CreateBatchFromEventsHandler = (_e, _p) => Mock.Of<AmqpMessage>()
             };
 
-            Assert.That(() => new AmqpEventBatch(mockConverter, new BatchOptions { MaximumSizeInBytes = null }), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpEventBatch(mockConverter, new CreateBatchOptions { MaximumSizeInBytes = null }), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ConstructorSetsTheMaximumSize()
         {
             var maximumSize = 9943;
-            var options = new BatchOptions { MaximumSizeInBytes = maximumSize };
+            var options = new CreateBatchOptions { MaximumSizeInBytes = maximumSize };
 
             var mockConverter = new InjectableMockConverter
             {
@@ -96,7 +96,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(message => message.SerializedMessageSize)
                 .Returns(batchEnvelopeSize);
 
-            var batch = new AmqpEventBatch(mockConverter, new BatchOptions { MaximumSizeInBytes = 27 });
+            var batch = new AmqpEventBatch(mockConverter, new CreateBatchOptions { MaximumSizeInBytes = 27 });
             Assert.That(batch.SizeInBytes, Is.EqualTo(batchEnvelopeSize));
         }
 
@@ -113,7 +113,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 CreateBatchFromEventsHandler = (_e, _p) => Mock.Of<AmqpMessage>()
             };
 
-            var batch = new AmqpEventBatch(mockConverter, new BatchOptions { MaximumSizeInBytes = 25 });
+            var batch = new AmqpEventBatch(mockConverter, new CreateBatchOptions { MaximumSizeInBytes = 25 });
             Assert.That(() => batch.TryAdd(null), Throws.ArgumentNullException);
         }
 
@@ -130,7 +130,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 CreateBatchFromEventsHandler = (_e, _p) => Mock.Of<AmqpMessage>()
             };
 
-            var batch = new AmqpEventBatch(mockConverter, new BatchOptions { MaximumSizeInBytes = 25 });
+            var batch = new AmqpEventBatch(mockConverter, new CreateBatchOptions { MaximumSizeInBytes = 25 });
             batch.Dispose();
 
             Assert.That(() => batch.TryAdd(new EventData(new byte[0])), Throws.InstanceOf<ObjectDisposedException>());
@@ -146,7 +146,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var maximumSize = 50;
             var batchEnvelopeSize = 0;
-            var options = new BatchOptions { MaximumSizeInBytes = maximumSize };
+            var options = new CreateBatchOptions { MaximumSizeInBytes = maximumSize };
             var mockEnvelope = new Mock<AmqpMessage>();
             var mockEvent = new Mock<AmqpMessage>();
             var mockConverter = new InjectableMockConverter
@@ -178,7 +178,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var maximumSize = 50;
             var eventMessageSize = 40;
-            var options = new BatchOptions { MaximumSizeInBytes = maximumSize };
+            var options = new CreateBatchOptions { MaximumSizeInBytes = maximumSize };
             var mockEnvelope = new Mock<AmqpMessage>();
             var mockEvent = new Mock<AmqpMessage>();
             var mockConverter = new InjectableMockConverter
@@ -210,7 +210,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var currentIndex = -1;
             var maximumSize = 50;
-            var options = new BatchOptions { MaximumSizeInBytes = maximumSize };
+            var options = new CreateBatchOptions { MaximumSizeInBytes = maximumSize };
             var eventMessages = new AmqpMessage[5];
             var mockEnvelope = new Mock<AmqpMessage>();
             var mockConverter = new InjectableMockConverter
@@ -261,7 +261,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void TryAddSetsTheCount()
         {
             var currentIndex = -1;
-            var options = new BatchOptions { MaximumSizeInBytes = 5000 };
+            var options = new CreateBatchOptions { MaximumSizeInBytes = 5000 };
             var eventMessages = new AmqpMessage[5];
             var mockEnvelope = new Mock<AmqpMessage>();
             var mockConverter = new InjectableMockConverter
@@ -299,7 +299,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void AsEnumerableValidatesTheTypeParameter()
         {
-            var options = new BatchOptions { MaximumSizeInBytes = 5000 };
+            var options = new CreateBatchOptions { MaximumSizeInBytes = 5000 };
             var mockEnvelope = new Mock<AmqpMessage>();
             var mockConverter = new InjectableMockConverter
             {
@@ -324,7 +324,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var currentIndex = -1;
             var maximumSize = 5000;
-            var options = new BatchOptions { MaximumSizeInBytes = maximumSize };
+            var options = new CreateBatchOptions { MaximumSizeInBytes = maximumSize };
             var eventMessages = new AmqpMessage[5];
             var mockEnvelope = new Mock<AmqpMessage>();
             var mockConverter = new InjectableMockConverter
@@ -372,7 +372,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void DisposeCleansUpBatchMessages()
         {
             var currentIndex = -1;
-            var options = new BatchOptions { MaximumSizeInBytes = 5000 };
+            var options = new CreateBatchOptions { MaximumSizeInBytes = 5000 };
             var eventMessages = new AmqpMessage[5];
             var mockEnvelope = new Mock<AmqpMessage>();
             var mockConverter = new InjectableMockConverter
@@ -418,7 +418,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void DisposeClearsTheCount()
         {
             var currentIndex = -1;
-            var options = new BatchOptions { MaximumSizeInBytes = 5000 };
+            var options = new CreateBatchOptions { MaximumSizeInBytes = 5000 };
             var eventMessages = new AmqpMessage[5];
             var mockEnvelope = new Mock<AmqpMessage>();
             var mockConverter = new InjectableMockConverter
@@ -469,7 +469,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(message => message.SerializedMessageSize)
                 .Returns(9959);
 
-            var batch = new AmqpEventBatch(mockConverter, new BatchOptions { MaximumSizeInBytes = 99 });
+            var batch = new AmqpEventBatch(mockConverter, new CreateBatchOptions { MaximumSizeInBytes = 99 });
             batch.Dispose();
 
             Assert.That(batch.SizeInBytes, Is.EqualTo(0));

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
@@ -134,7 +134,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(Task.FromResult(new SendingAmqpLink(new AmqpLinkSettings())))
                 .Verifiable();
 
-            using TransportEventBatch batch = await producer.Object.CreateBatchAsync(new BatchOptions(), default);
+            using TransportEventBatch batch = await producer.Object.CreateBatchAsync(new CreateBatchOptions(), default);
             producer.VerifyAll();
         }
 
@@ -147,7 +147,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task CreateBatchAsyncDefaultsTheMaximumSizeWhenNotProvided()
         {
             var expectedMaximumSize = 512;
-            var options = new BatchOptions { MaximumSizeInBytes = null };
+            var options = new CreateBatchOptions { MaximumSizeInBytes = null };
             var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
@@ -178,7 +178,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task CreateBatchAsyncRespectsTheMaximumSizeWhenProvided()
         {
             var expectedMaximumSize = 512;
-            var options = new BatchOptions { MaximumSizeInBytes = expectedMaximumSize };
+            var options = new CreateBatchOptions { MaximumSizeInBytes = expectedMaximumSize };
             var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
@@ -209,7 +209,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CreateBatchAsyncVerifiesTheMaximumSize()
         {
             var linkMaximumSize = 512;
-            var options = new BatchOptions { MaximumSizeInBytes = 1024 };
+            var options = new CreateBatchOptions { MaximumSizeInBytes = 1024 };
             var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
@@ -238,7 +238,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task CreateBatchAsyncBuildsAnAmqpEventBatchWithTheOptions()
         {
-            var options = new BatchOptions { MaximumSizeInBytes = 512 };
+            var options = new CreateBatchOptions { MaximumSizeInBytes = 512 };
             var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
@@ -298,7 +298,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task SendEnumerableUsesThePartitionKey()
         {
             var expectedPartitionKey = "some key";
-            var options = new BatchOptions { PartitionKey = expectedPartitionKey };
+            var options = new CreateBatchOptions { PartitionKey = expectedPartitionKey };
             var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
@@ -429,7 +429,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task SendBatchEnsuresNotClosed()
         {
             var expectedMaximumSize = 512;
-            var options = new BatchOptions { MaximumSizeInBytes = null };
+            var options = new CreateBatchOptions { MaximumSizeInBytes = null };
             var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
@@ -462,7 +462,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var expectedMaximumSize = 512;
             var expectedPartitionKey = "some key";
-            var options = new BatchOptions { PartitionKey = expectedPartitionKey };
+            var options = new CreateBatchOptions { PartitionKey = expectedPartitionKey };
             var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
@@ -507,7 +507,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var messageFactory = default(Func<AmqpMessage>);
             var expectedMaximumSize = 512;
-            var options = new BatchOptions { PartitionKey = partitonKey };
+            var options = new CreateBatchOptions { PartitionKey = partitonKey };
             var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
@@ -556,7 +556,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task SendBatchDoesNotDisposeTheEventDataBatch()
         {
             var expectedMaximumSize = 512;
-            var options = new BatchOptions { MaximumSizeInBytes = null };
+            var options = new CreateBatchOptions { MaximumSizeInBytes = null };
             var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
@@ -601,7 +601,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task SendBatchDoesNotDisposeTheEventsInTheSourceBatch()
         {
             var expectedMaximumSize = 512;
-            var options = new BatchOptions { MaximumSizeInBytes = null };
+            var options = new CreateBatchOptions { MaximumSizeInBytes = null };
             var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
@@ -646,7 +646,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task SendBatchRespectsTheCancellationTokenIfSetWhenCalled()
         {
             var expectedMaximumSize = 512;
-            var options = new BatchOptions();
+            var options = new CreateBatchOptions();
             var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
@@ -680,7 +680,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SendBatchRespectsTheRetryPolicy(RetryOptions retryOptions)
         {
             var partitionKey = "testMe";
-            var options = new BatchOptions { PartitionKey = partitionKey };
+            var options = new CreateBatchOptions { PartitionKey = partitionKey };
             var retriableException = new EventHubsException(true, "Test");
             var retryPolicy = new BasicRetryPolicy(retryOptions);
             var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), options);
@@ -718,8 +718,8 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         /// <returns>The batch options.</returns>
         ///
-        private static BatchOptions GetEventBatchOptions(AmqpEventBatch batch) =>
-            (BatchOptions)
+        private static CreateBatchOptions GetEventBatchOptions(AmqpEventBatch batch) =>
+            (CreateBatchOptions)
                 typeof(AmqpEventBatch)
                     .GetProperty("Options", BindingFlags.Instance | BindingFlags.NonPublic)
                     .GetValue(batch);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
@@ -105,7 +105,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(Task.CompletedTask);
 
             transportMock
-                .Setup(m => m.CreateBatchAsync(It.IsAny<BatchOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(m => m.CreateBatchAsync(It.IsAny<CreateBatchOptions>(), It.IsAny<CancellationToken>()))
                 .Returns(new ValueTask<TransportEventBatch>(Task.FromResult(batchTransportMock.Object)));
 
             var producer = new EventHubProducerClient(fakeConnection, transportMock.Object);
@@ -202,7 +202,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(Task.CompletedTask);
 
             transportMock
-                .Setup(m => m.CreateBatchAsync(It.IsAny<BatchOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(m => m.CreateBatchAsync(It.IsAny<CreateBatchOptions>(), It.IsAny<CancellationToken>()))
                 .Returns(new ValueTask<TransportEventBatch>(Task.FromResult(batchTransportMock.Object)));
 
             var producer = new EventHubProducerClient(fakeConnection, transportMock.Object);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientLiveTests.cs
@@ -108,7 +108,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
+                    await using (var producer = new EventHubProducerClient(connection))
                     await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                     {
                         // Read the events.
@@ -123,7 +123,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                             if (!wereEventsPublished)
                             {
-                                await producer.SendAsync(eventBatch);
+                                await producer.SendAsync(eventBatch, new SendOptions { PartitionId = partition });
                                 wereEventsPublished = true;
                             }
 
@@ -176,7 +176,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
+                    await using (var producer = new EventHubProducerClient(connection))
                     await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                     {
                         /// Read the events.
@@ -191,7 +191,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                             if (!wereEventsPublished)
                             {
-                                await producer.SendAsync(eventBatch);
+                                await producer.SendAsync(eventBatch, new SendOptions { PartitionId = partition });
                                 wereEventsPublished = true;
                             }
 
@@ -246,7 +246,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
+                    await using (var producer = new EventHubProducerClient(connection))
                     await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     {
                         // Read the events.
@@ -261,7 +261,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                             if (!wereEventsPublished)
                             {
-                                await producer.SendAsync(eventSet);
+                                await producer.SendAsync(eventSet, new SendOptions { PartitionId = partition });
                                 wereEventsPublished = true;
                             }
 
@@ -319,7 +319,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var retryOptions = new RetryOptions { TryTimeout = TimeSpan.FromMinutes(5) };
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition, RetryOptions = retryOptions }))
+                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { RetryOptions = retryOptions }))
                     await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { RetryOptions = retryOptions }))
                     {
                         // Read the events.
@@ -334,7 +334,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                             if (!wereEventsPublished)
                             {
-                                await producer.SendAsync(eventBatch);
+                                await producer.SendAsync(eventBatch, new SendOptions { PartitionId = partition });
                                 wereEventsPublished = true;
                             }
 
@@ -396,7 +396,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
+                    await using (var producer = new EventHubProducerClient(connection))
                     await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     {
                         // Read the events.
@@ -411,7 +411,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                             if (!wereEventsPublished)
                             {
-                                await producer.SendAsync(eventBatch);
+                                await producer.SendAsync(eventBatch, new SendOptions { PartitionId = partition });
                                 wereEventsPublished = true;
                             }
 
@@ -466,7 +466,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var stampEvent = new EventData(new byte[1]);
                     stampEvent.Properties["stamp"] = Guid.NewGuid().ToString();
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
+                    await using (var producer = new EventHubProducerClient(connection))
                     await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     {
                         // Sending some events beforehand so the partition has some information.
@@ -483,7 +483,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                             if (!wereEventsPublished)
                             {
-                                await producer.SendAsync(stampEvent);
+                                await producer.SendAsync(stampEvent, new SendOptions { PartitionId = partition });
                                 wereEventsPublished = true;
                             }
 
@@ -522,12 +522,12 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
                     var expectedEventsCount = 10;
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
+                    await using (var producer = new EventHubProducerClient(connection))
                     await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     {
                         for (int i = 0; i < expectedEventsCount; i++)
                         {
-                            await producer.SendAsync(new EventData(new byte[1]));
+                            await producer.SendAsync(new EventData(new byte[1]), new SendOptions { PartitionId = partition });
                         }
 
                         // Read the events.
@@ -570,13 +570,13 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
+                    await using (var producer = new EventHubProducerClient(connection))
                     {
                         // Sending some events beforehand so the partition has some information.
 
                         for (var i = 0; i < 10; i++)
                         {
-                            await producer.SendAsync(new EventData(new byte[1]));
+                            await producer.SendAsync(new EventData(new byte[1]), new SendOptions { PartitionId = partition });
                         }
 
                         // Store last enqueued offset.
@@ -640,13 +640,13 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
+                    await using (var producer = new EventHubProducerClient(connection))
                     {
                         // Sending some events beforehand so the partition has some information.
 
                         for (var i = 0; i < 10; i++)
                         {
-                            await producer.SendAsync(new EventData(new byte[1]));
+                            await producer.SendAsync(new EventData(new byte[1]), new SendOptions { PartitionId = partition });
                         }
 
                         // Store last enqueued time.
@@ -708,7 +708,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
+                    await using (var producer = new EventHubProducerClient(connection))
                     {
                         // Sending some events beforehand so the partition has some information.
 
@@ -729,7 +729,7 @@ namespace Azure.Messaging.EventHubs.Tests
                             var stampEvent = new EventData(new byte[1]);
                             stampEvent.Properties["stamp"] = Guid.NewGuid().ToString();
 
-                            await producer.SendAsync(stampEvent);
+                            await producer.SendAsync(stampEvent, new SendOptions { PartitionId = partition });
 
                             // Read the events.
 
@@ -1443,7 +1443,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     using var cancellationSource = new CancellationTokenSource();
                     cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
 
-                    await using var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partitionIds[0] });
+                    await using var producer = new EventHubProducerClient(connection);
                     await using var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString);
 
                     var receivedEvents = new List<EventData>();
@@ -1461,7 +1461,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                             for (var batchesCount = 0; batchesCount < batches; batchesCount++)
                             {
-                                await producer.SendAsync(eventBatch);
+                                await producer.SendAsync(eventBatch, new SendOptions { PartitionId = partitionIds[0] });
                             }
 
                             wereEventsPublished = true;
@@ -1516,8 +1516,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     // Send the batch of events.
 
-                    await using var producer = new EventHubProducerClient(connectionString, new EventHubProducerClientOptions { PartitionId = partition });
-                    await producer.SendAsync(eventBatch);
+                    await using var producer = new EventHubProducerClient(connectionString);
+                    await producer.SendAsync(eventBatch, new SendOptions { PartitionId = partition });
 
                     // Read back the events from two different consumer groups.
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/PartitionReceiverLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/PartitionReceiverLiveTests.cs
@@ -7,10 +7,8 @@ using System.Linq;
 using System.Net;
 using System.Net.WebSockets;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Errors;
-using Azure.Messaging.EventHubs.Metadata;
 using Azure.Messaging.EventHubs.Tests.Infrastructure;
 using NUnit.Framework;
 
@@ -60,7 +58,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var producer = new EventHubProducerClient(connectionString, new EventHubProducerClientOptions { PartitionId = partition }))
+                    await using (var producer = new EventHubProducerClient(connectionString))
                     await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     {
@@ -71,7 +69,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         // Send the batch of events.
 
-                        await producer.SendAsync(eventSet);
+                        await producer.SendAsync(eventSet, new SendOptions { PartitionId = partition });
 
                         // Receive the events; because there is some non-determinism in the messaging flow, the
                         // sent events may not be immediately available.  Allow for a small number of attempts to receive, in order
@@ -127,13 +125,13 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
+                    await using (var producer = new EventHubProducerClient(connection))
                     await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     {
                         // Create the batch of events to publish.
 
-                        using EventDataBatch eventBatch = await producer.CreateBatchAsync();
+                        using EventDataBatch eventBatch = await producer.CreateBatchAsync(new CreateBatchOptions { PartitionId = partition });
 
                         foreach (EventData eventData in eventSet)
                         {
@@ -215,13 +213,13 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
+                    await using (var producer = new EventHubProducerClient(connection))
                     await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     {
                         // Create the batch of events to publish.
 
-                        using EventDataBatch eventBatch = await producer.CreateBatchAsync();
+                        using EventDataBatch eventBatch = await producer.CreateBatchAsync(new CreateBatchOptions { PartitionId = partition });
 
                         foreach (EventData eventData in eventSet)
                         {
@@ -297,7 +295,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
+                    await using (var producer = new EventHubProducerClient(connection))
                     await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     {
@@ -308,7 +306,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         // Send the batch of events.
 
-                        await producer.SendAsync(eventBatch);
+                        await producer.SendAsync(eventBatch, new SendOptions { PartitionId = partition });
 
                         // Receive the events; because there is some non-determinism in the messaging flow, the
                         // sent events may not be immediately available.  Allow for a small number of attempts to receive, in order
@@ -360,7 +358,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
+                    await using (var producer = new EventHubProducerClient(connection))
                     await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     {
@@ -371,7 +369,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         // Send the batch of events.
 
-                        await producer.SendAsync(eventBatch);
+                        await producer.SendAsync(eventBatch, new SendOptions { PartitionId = partition });
 
                         // Receive the events; because there is some non-determinism in the messaging flow, the
                         // sent events may not be immediately available.  Allow for a small number of attempts to receive, in order
@@ -425,7 +423,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
+                    await using (var producer = new EventHubProducerClient(connection))
                     await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     {
@@ -436,7 +434,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         // Send the set of events.
 
-                        await producer.SendAsync(eventSet);
+                        await producer.SendAsync(eventSet, new SendOptions { PartitionId = partition });
 
                         // Receive the events; because there is some non-determinism in the messaging flow, the
                         // sent events may not be immediately available.  Allow for a small number of attempts to receive, in order
@@ -493,7 +491,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var retryOptions = new RetryOptions { TryTimeout = TimeSpan.FromMinutes(5) };
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition, RetryOptions = retryOptions }))
+                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { RetryOptions = retryOptions }))
                     await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, new EventHubConsumerClientOptions { RetryOptions = retryOptions }))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     {
@@ -504,7 +502,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         // Send the batch of events.
 
-                        await producer.SendAsync(eventBatch);
+                        await producer.SendAsync(eventBatch, new SendOptions { PartitionId = partition });
 
                         // A short delay is necessary to persist the large event.
 
@@ -569,7 +567,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
+                    await using (var producer = new EventHubProducerClient(connection))
                     await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     {
@@ -580,7 +578,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         // Send the batch of events.
 
-                        await producer.SendAsync(eventBatch);
+                        await producer.SendAsync(eventBatch, new SendOptions { PartitionId = partition });
 
                         // Receive the events; because there is some non-determinism in the messaging flow, the
                         // sent events may not be immediately available.  Allow for a small number of attempts to receive, in order
@@ -627,7 +625,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
+                    await using (var producer = new EventHubProducerClient(connection))
                     await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     {
@@ -636,7 +634,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         for (int i = 0; i < 10; i++)
                         {
-                            await producer.SendAsync(new EventData(new byte[1]));
+                            await producer.SendAsync(new EventData(new byte[1]), new SendOptions { PartitionId = partition });
                         }
 
                         // Initiate an operation to force the consumer to connect and set its position at the
@@ -692,7 +690,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
                     await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
+                    await using (var producer = new EventHubProducerClient(connection))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Earliest))
                     {
                         // Sending some events beforehand so the partition has some information.
@@ -701,7 +699,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         for (int i = 0; i < expectedEventsCount; i++)
                         {
-                            await producer.SendAsync(new EventData(new byte[1]));
+                            await producer.SendAsync(new EventData(new byte[1]), new SendOptions { PartitionId = partition });
                         }
 
                         // Receive and validate the events; because there is some non-determinism in the messaging flow, the
@@ -738,13 +736,13 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
+                    await using (var producer = new EventHubProducerClient(connection))
                     {
                         // Sending some events beforehand so the partition has some information.
 
                         for (var i = 0; i < 10; i++)
                         {
-                            await producer.SendAsync(new EventData(new byte[1]));
+                            await producer.SendAsync(new EventData(new byte[1]), new SendOptions { PartitionId = partition });
                         }
 
                         // Store last enqueued offset.
@@ -802,13 +800,13 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
+                    await using (var producer = new EventHubProducerClient(connection))
                     {
                         // Sending some events beforehand so the partition has some information.
 
                         for (var i = 0; i < 10; i++)
                         {
-                            await producer.SendAsync(new EventData(new byte[1]));
+                            await producer.SendAsync(new EventData(new byte[1]), new SendOptions { PartitionId = partition });
                         }
 
                         // Store last enqueued time.
@@ -869,13 +867,13 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
+                    await using (var producer = new EventHubProducerClient(connection))
                     {
                         // Sending some events beforehand so the partition has some information.
 
                         for (var i = 0; i < 10; i++)
                         {
-                            await producer.SendAsync(new EventData(new byte[1]));
+                            await producer.SendAsync(new EventData(new byte[1]), new SendOptions { PartitionId = partition });
                         }
 
                         // Store last enqueued sequence number.
@@ -1010,7 +1008,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
+                    await using (var producer = new EventHubProducerClient(connection))
                     await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     await using (var receiver = consumer.CreatePartitionReceiver(partition, EventPosition.Latest))
                     {
@@ -1021,7 +1019,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         // Send the batch of events.
 
-                        await producer.SendAsync(eventBatch);
+                        await producer.SendAsync(eventBatch, new SendOptions { PartitionId = partition });
 
                         // Receive and validate the events.
 
@@ -1488,7 +1486,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partitionIds = await connection.GetPartitionIdsAsync(DefaultRetryPolicy);
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partitionIds[0] }))
+                    await using (var producer = new EventHubProducerClient(connection))
                     await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                     await using (var receiver = consumer.CreatePartitionReceiver(partitionIds[1], EventPosition.Latest))
                     {
@@ -1503,7 +1501,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         for (var batchesCount = 0; batchesCount < batches; batchesCount++)
                         {
-                            await producer.SendAsync(eventBatch);
+                            await producer.SendAsync(eventBatch, new SendOptions { PartitionId = partitionIds[0] });
                         }
 
                         // Receive and validate the events; because there is some non-determinism in the messaging flow, the
@@ -1549,7 +1547,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using var producer = new EventHubProducerClient(connectionString, new EventHubProducerClientOptions { PartitionId = partition });
+                    await using var producer = new EventHubProducerClient(connectionString);
                     await using var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString);
                     await using var anotherConsumer = new EventHubConsumerClient(customConsumerGroup, connection);
 
@@ -1564,7 +1562,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         // Send the batch of events.
 
-                        await producer.SendAsync(eventBatch);
+                        await producer.SendAsync(eventBatch, new SendOptions { PartitionId = partition });
 
                         // Receive and validate the events; because there is some non-determinism in the messaging flow, the
                         // sent events may not be immediately available.  Allow for a small number of attempts to receive, in order

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/PartitionReceiverTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/PartitionReceiverTests.cs
@@ -2,20 +2,12 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using System.Threading;
-using System.Threading.Channels;
 using System.Threading.Tasks;
-using Azure.Core;
-using Azure.Messaging.EventHubs.Authorization;
 using Azure.Messaging.EventHubs.Core;
-using Azure.Messaging.EventHubs.Errors;
-using Azure.Messaging.EventHubs.Metadata;
 using Moq;
 using NUnit.Framework;
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/CreateBatchOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/CreateBatchOptionsTests.cs
@@ -7,68 +7,70 @@ using NUnit.Framework;
 namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
-    ///   The suite of tests for the <see cref="BatchOptions" />
+    ///   The suite of tests for the <see cref="CreateBatchOptions" />
     ///   class.
     /// </summary>
     ///
     [TestFixture]
-    public class BatchOptionsTests
+    public class CreateBatchOptionsTests
     {
         /// <summary>
-        ///   Verifies functionality of the <see cref="BatchOptions.CloneToSend" />
+        ///   Verifies functionality of the <see cref="CreateBatchOptions.CloneToSend" />
         ///   method.
         /// </summary>
         ///
         [Test]
         public void CloneProducesACopy()
         {
-            var options = new BatchOptions
+            var options = new CreateBatchOptions
             {
+                PartitionId = "0",
                 PartitionKey = "some_partition_123",
                 MaximumSizeInBytes = (int.MaxValue + 122L)
             };
 
-            BatchOptions clone = options.Clone();
-            Assert.That(clone, Is.TypeOf<BatchOptions>(), "The clone should be a BatchOptions instance.");
+            CreateBatchOptions clone = options.Clone();
+            Assert.That(clone, Is.TypeOf<CreateBatchOptions>(), "The clone should be a BatchOptions instance.");
             Assert.That(clone, Is.Not.Null, "The clone should not be null.");
             Assert.That(clone, Is.Not.SameAs(options), "The clone should not the same reference as the options.");
+            Assert.That(clone.PartitionId, Is.EqualTo(options.PartitionId), "The partition identifier of the clone should match.");
             Assert.That(clone.PartitionKey, Is.EqualTo(options.PartitionKey), "The partition key of the clone should match.");
             Assert.That(clone.MaximumSizeInBytes, Is.EqualTo(options.MaximumSizeInBytes), "The maximum size should match.");
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="BatchOptions.MaximumSizeInBytes" />
+        ///   Verifies functionality of the <see cref="CreateBatchOptions.MaximumSizeInBytes" />
         ///   method.
         /// </summary>
         ///
         [Test]
         public void MaximumBatchSizeInBytesEnforcesMinimum()
         {
-            var options = new BatchOptions();
+            var options = new CreateBatchOptions();
             Assert.That(() => options.MaximumSizeInBytes = (EventHubProducerClient.MinimumBatchSizeLimit - 1), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="BatchOptions.MaximumSizeInBytes" />
+        ///   Verifies functionality of the <see cref="CreateBatchOptions.MaximumSizeInBytes" />
         ///   method.
         /// </summary>
         ///
         [Test]
         public void MaximumBatchSizeInBytesDoesNotLimitMaximum()
         {
-            var options = new BatchOptions();
+            var options = new CreateBatchOptions();
             Assert.That(() => options.MaximumSizeInBytes = int.MaxValue, Throws.Nothing);
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="BatchOptions.MaximumSizeInBytes" />
+        ///   Verifies functionality of the <see cref="CreateBatchOptions.MaximumSizeInBytes" />
         ///   method.
         /// </summary>
         ///
         [Test]
         public void MaximumBatchSizeInBytesAllowsNull()
         {
-            var options = new BatchOptions();
+            var options = new CreateBatchOptions();
             Assert.That(() => options.MaximumSizeInBytes = null, Throws.Nothing);
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientLiveTests.cs
@@ -31,8 +31,8 @@ namespace Azure.Messaging.EventHubs.Tests
     [Category(TestCategory.DisallowVisualStudioLiveUnitTesting)]
     public class EventHubProducerClientLiveTests
     {
-        /// <summary>The maximum number of times that the receive loop should iterate to collect the expected number of messages.</summary>
-        private const int ReceiveRetryLimit = 10;
+        /// <summary>The default retry policy to use when performing operations.</summary>
+        private readonly EventHubsRetryPolicy DefaultRetryPolicy = new RetryOptions().ToRetryPolicy();
 
         /// <summary>
         ///   Verifies that the <see cref="EventHubProducerClient" /> is able to
@@ -91,7 +91,6 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [Description("Partition Affinity Refactor")]
         public async Task ProducerCanSendToASpecificPartition()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
@@ -100,13 +99,12 @@ namespace Azure.Messaging.EventHubs.Tests
 
                 await using (var connection = new EventHubConnection(connectionString))
                 {
-                    var partition = (await connection.GetPartitionIdsAsync(new RetryOptions().ToRetryPolicy())).First();
-                    var producerOptions = new EventHubProducerClientOptions { PartitionId = partition };
+                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var producer = new EventHubProducerClient(connection, producerOptions))
+                    await using (var producer = new EventHubProducerClient(connection))
                     {
                         EventData[] events = new[] { new EventData(Encoding.UTF8.GetBytes("AWord")) };
-                        Assert.That(async () => await producer.SendAsync(events), Throws.Nothing);
+                        Assert.That(async () => await producer.SendAsync(events, new SendOptions { PartitionId = partition }), Throws.Nothing);
                     }
                 }
             }
@@ -212,7 +210,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     .Select(index => new EventData(Encoding.UTF8.GetBytes(new string('X', index + 5))));
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-                var batchOptions = new BatchOptions { PartitionKey = "some123key-!d" };
+                var batchOptions = new CreateBatchOptions { PartitionKey = "some123key-!d" };
 
                 await using (var producer = new EventHubProducerClient(connectionString))
                 {
@@ -512,10 +510,9 @@ namespace Azure.Messaging.EventHubs.Tests
 
                 await using (var connection = new EventHubConnection(connectionString))
                 {
-                    var partition = (await connection.GetPartitionIdsAsync(new RetryOptions().ToRetryPolicy())).First();
-                    var producerOptions = new EventHubProducerClientOptions { PartitionId = partition };
+                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
-                    await using (var producer = new EventHubProducerClient(connection, producerOptions))
+                    await using (var producer = new EventHubProducerClient(connection))
                     {
                         EventData[] events = new[]
                         {
@@ -524,7 +521,36 @@ namespace Azure.Messaging.EventHubs.Tests
                             new EventData(Encoding.UTF8.GetBytes("Do we need more messages"))
                         };
 
-                        Assert.That(async () => await producer.SendAsync(events), Throws.Nothing);
+                        Assert.That(async () => await producer.SendAsync(events, new SendOptions { PartitionId = partition }), Throws.Nothing);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubProducerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ProducerCanSendBatchToASpecificPartition()
+        {
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
+            {
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+                await using (var connection = new EventHubConnection(connectionString))
+                {
+                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
+
+                    await using (var producer = new EventHubProducerClient(connection))
+                    {
+                        using EventDataBatch batch = await producer.CreateBatchAsync(new CreateBatchOptions { PartitionId = partition });
+                        batch.TryAdd(new EventData(Encoding.UTF8.GetBytes("This is a message")));
+                        batch.TryAdd(new EventData(Encoding.UTF8.GetBytes("This is another message")));
+                        batch.TryAdd(new EventData(Encoding.UTF8.GetBytes("Do we need more messages")));
+
+                        Assert.That(async () => await producer.SendAsync(batch), Throws.Nothing);
                     }
                 }
             }
@@ -542,15 +568,10 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
-                await using (var connection = new EventHubConnection(connectionString))
+                await using (var producer = new EventHubProducerClient(connectionString))
                 {
-                    var producerOptions = new EventHubProducerClientOptions { PartitionId = null };
-
-                    await using (var producer = new EventHubProducerClient(connection, producerOptions))
-                    {
-                        EventData[] events = new[] { new EventData(Encoding.UTF8.GetBytes("Will it work")) };
-                        Assert.That(async () => await producer.SendAsync(events), Throws.Nothing);
-                    }
+                    EventData[] events = new[] { new EventData(Encoding.UTF8.GetBytes("Will it work")) };
+                    Assert.That(async () => await producer.SendAsync(events, new SendOptions { PartitionId = null }), Throws.Nothing);
                 }
             }
         }
@@ -608,9 +629,9 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     EventData[] events = new[] { new EventData(Encoding.UTF8.GetBytes("Lorem Ipsum")) };
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = invalidPartition }))
+                    await using (var producer = new EventHubProducerClient(connection))
                     {
-                        Assert.That(async () => await producer.SendAsync(events), Throws.TypeOf<ArgumentOutOfRangeException>());
+                        Assert.That(async () => await producer.SendAsync(events, new SendOptions { PartitionId = invalidPartition }), Throws.TypeOf<ArgumentOutOfRangeException>());
                     }
                 }
             }
@@ -622,7 +643,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task SendUpdatesPartitionProperties()
+        public async Task SendSetUpdatesPartitionProperties()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
@@ -630,14 +651,14 @@ namespace Azure.Messaging.EventHubs.Tests
 
                 await using (var connection = new EventHubConnection(connectionString))
                 {
-                    var partition = (await connection.GetPartitionIdsAsync(new RetryOptions().ToRetryPolicy())).First();
+                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
                     EventData[] events = new[] { new EventData(Encoding.UTF8.GetBytes("I should update stuff")) };
 
-                    await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partition }))
+                    await using (var producer = new EventHubProducerClient(connection))
                     {
                         // Sending events beforehand so the partition has some information.
 
-                        await producer.SendAsync(events);
+                        await producer.SendAsync(events, new SendOptions { PartitionId = partition });
 
                         PartitionProperties oldPartitionProperties = await producer.GetPartitionPropertiesAsync(partition);
 
@@ -670,6 +691,59 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        public async Task SendBatchUpdatesPartitionProperties()
+        {
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
+            {
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+                await using (var connection = new EventHubConnection(connectionString))
+                {
+                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
+
+                    await using (var producer = new EventHubProducerClient(connection))
+                    {
+                        // Sending events beforehand so the partition has some information.
+
+                        using var firstBatch = await producer.CreateBatchAsync(new CreateBatchOptions { PartitionId = partition });
+                        firstBatch.TryAdd(new EventData(Encoding.UTF8.GetBytes("I should update stuff")));
+
+                        await producer.SendAsync(firstBatch);
+
+                        PartitionProperties oldPartitionProperties = await producer.GetPartitionPropertiesAsync(partition);
+                        Assert.That(oldPartitionProperties, Is.Not.Null, "A set of partition properties should have been returned.");
+
+                        // Send another to force the updates.
+
+                        using var secondBatch = await producer.CreateBatchAsync(new CreateBatchOptions { PartitionId = partition });
+                        secondBatch.TryAdd(new EventData(Encoding.UTF8.GetBytes("I should update stuff")));
+
+                        await producer.SendAsync(secondBatch);
+
+                        PartitionProperties newPartitionProperties = await producer.GetPartitionPropertiesAsync(partition);
+                        Assert.That(newPartitionProperties, Is.Not.Null, "A set of partition properties should have been returned.");
+
+                        // The following properties should not have been altered.
+
+                        Assert.That(newPartitionProperties.Id, Is.EqualTo(oldPartitionProperties.Id));
+                        Assert.That(newPartitionProperties.EventHubName, Is.EqualTo(oldPartitionProperties.EventHubName));
+                        Assert.That(newPartitionProperties.BeginningSequenceNumber, Is.EqualTo(oldPartitionProperties.BeginningSequenceNumber));
+
+                        // The following properties should have been updated.
+
+                        Assert.That(newPartitionProperties.LastEnqueuedSequenceNumber, Is.GreaterThan(oldPartitionProperties.LastEnqueuedSequenceNumber));
+                        Assert.That(newPartitionProperties.LastEnqueuedOffset, Is.GreaterThan(oldPartitionProperties.LastEnqueuedOffset));
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubProducerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
         public async Task SendDoesNotUpdatePartitionPropertiesWhenSendingToDifferentPartition()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(2))
@@ -678,21 +752,21 @@ namespace Azure.Messaging.EventHubs.Tests
 
                 await using (var connection = new EventHubConnection(connectionString))
                 {
-                    var partitionIds = await connection.GetPartitionIdsAsync(new RetryOptions().ToRetryPolicy());
+                    var partitionIds = await connection.GetPartitionIdsAsync(DefaultRetryPolicy);
                     EventData[] events = new[] { new EventData(Encoding.UTF8.GetBytes("I should not update stuff")) };
 
-                    await using (var producer0 = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partitionIds[0] }))
-                    await using (var producer1 = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partitionIds[1] }))
+                    await using (var producer0 = new EventHubProducerClient(connection))
+                    await using (var producer1 = new EventHubProducerClient(connection))
                     {
                         // Sending events beforehand so the partition has some information.
 
-                        await producer0.SendAsync(events);
+                        await producer0.SendAsync(events, new SendOptions { PartitionId = partitionIds[0] });
 
                         PartitionProperties oldPartitionProperties = await producer0.GetPartitionPropertiesAsync(partitionIds[0]);
 
                         Assert.That(oldPartitionProperties, Is.Not.Null, "A set of partition properties should have been returned.");
 
-                        await producer1.SendAsync(events);
+                        await producer1.SendAsync(events, new SendOptions { PartitionId = partitionIds[1] });
 
                         PartitionProperties newPartitionProperties = await producer1.GetPartitionPropertiesAsync(partitionIds[0]);
 
@@ -716,11 +790,12 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [TestCase(true)]
-        [TestCase(false)]
-        public async Task ProducerDoesNotSendToSpecificPartitionWhenPartitionIdIsNotSpecified(bool nullPartition)
+        [TestCase("")]
+        [TestCase(null)]
+        public async Task ProducerDoesNotSendToSpecificPartitionWhenPartitionIdIsNotSpecified(string partitionId)
         {
             var partitions = 10;
+            var batchOptions = new CreateBatchOptions { PartitionId = partitionId };
 
             await using (EventHubScope scope = await EventHubScope.CreateAsync(partitions))
             {
@@ -728,65 +803,56 @@ namespace Azure.Messaging.EventHubs.Tests
 
                 await using (var connection = new EventHubConnection(connectionString))
                 {
-                    var producerOptions = new EventHubProducerClientOptions { };
-
-                    if (nullPartition)
-                    {
-                        producerOptions.PartitionId = null;
-                    }
-
-                    await using (var producer = new EventHubProducerClient(connection, producerOptions))
+                    await using (var producer = new EventHubProducerClient(connection))
+                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     {
                         var batches = 30;
+                        var eventsPerBatch = 5;
                         var partitionIds = await producer.GetPartitionIdsAsync();
                         var partitionsCount = 0;
-                        var consumers = new List<EventHubConsumerClient>();
-                        var receivers = new List<PartitionReceiver>();
 
-                        try
+                        // Send the batches of events.
+
+                        for (var index = 0; index < batches; index++)
                         {
-                            for (var index = 0; index < partitions; index++)
+                            using var batch = await producer.CreateBatchAsync(batchOptions);
+
+                            for (var eventIndex = 0; eventIndex < eventsPerBatch; ++eventIndex)
                             {
-                                consumers.Add(new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection));
-                                receivers.Add(consumers[index].CreatePartitionReceiver(partitionIds[index], EventPosition.Latest));
-
-                                // Initiate an operation to force the consumer to connect and set its position at the
-                                // end of the event stream.
-
-                                await receivers[index].ReceiveAsync(1, TimeSpan.Zero);
+                                batch.TryAdd(new EventData(Encoding.UTF8.GetBytes($"Event { eventIndex } in the batch")));
                             }
 
-                            // Send the batches of events.
-
-                            for (var index = 0; index < batches; index++)
-                            {
-                                await producer.SendAsync(new EventData(Encoding.UTF8.GetBytes("It's not healthy to send so many messages")));
-                            }
-
-                            // Receive the events; because there is some non-determinism in the messaging flow, the
-                            // sent events may not be immediately available.  Allow for a small number of attempts to receive, in order
-                            // to account for availability delays.
-
-                            foreach (PartitionReceiver receiver in receivers)
-                            {
-                                var receivedEvents = new List<EventData>();
-                                var index = 0;
-
-                                while (++index < ReceiveRetryLimit)
-                                {
-                                    receivedEvents.AddRange(await receiver.ReceiveAsync(batches + 10, TimeSpan.FromMilliseconds(25)));
-                                }
-
-                                if (receivedEvents.Count > 0)
-                                {
-                                    partitionsCount++;
-                                }
-                            }
+                            await producer.SendAsync(batch);
                         }
-                        finally
+
+                        // Read the events.
+
+                        using var cancellationSource = new CancellationTokenSource();
+                        cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
+
+                        foreach (string partition in partitionIds)
                         {
-                            await Task.WhenAll(receivers.Select(receiver => receiver.CloseAsync()));
-                            await Task.WhenAll(consumers.Select(consumer => consumer.CloseAsync()));
+                            var receivedEvents = new List<EventData>();
+                            var consecutiveEmpties = 0;
+                            var maximumConsecutiveEmpties = 5;
+
+                            await foreach (var partitionEvent in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.Earliest, TimeSpan.FromMilliseconds(50), cancellationSource.Token))
+                            {
+                                if (partitionEvent.Data != null)
+                                {
+                                    receivedEvents.Add(partitionEvent.Data);
+                                    consecutiveEmpties = 0;
+                                }
+                                else if (++consecutiveEmpties >= maximumConsecutiveEmpties)
+                                {
+                                    break;
+                                }
+                            }
+
+                            if (receivedEvents.Count > 0)
+                            {
+                                partitionsCount++;
+                            }
                         }
 
                         Assert.That(partitionsCount, Is.GreaterThan(1));
@@ -811,6 +877,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                 await using (var connection = new EventHubConnection(connectionString))
                 await using (var producer = new EventHubProducerClient(connection))
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                 {
                     var eventBatch = Enumerable
                         .Range(0, 30)
@@ -820,51 +887,40 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partitionIds = await producer.GetPartitionIdsAsync();
                     var partitionsCount = 0;
                     var receivedEventsCount = 0;
-                    var consumers = new List<EventHubConsumerClient>();
-                    var receivers = new List<PartitionReceiver>();
 
-                    try
+                    // Send the batch of events.
+
+                    await producer.SendAsync(eventBatch);
+
+                    // Read the events.
+
+                    using var cancellationSource = new CancellationTokenSource();
+                    cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
+
+                    foreach (string partition in partitionIds)
                     {
-                        for (var index = 0; index < partitions; index++)
+                        var receivedEvents = new List<EventData>();
+                        var consecutiveEmpties = 0;
+                        var maximumConsecutiveEmpties = 5;
+
+                        await foreach (var partitionEvent in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.Earliest, TimeSpan.FromMilliseconds(50), cancellationSource.Token))
                         {
-                            consumers.Add(new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection));
-                            receivers.Add(consumers[index].CreatePartitionReceiver(partitionIds[index], EventPosition.Latest));
-
-                            // Initiate an operation to force the consumer to connect and set its position at the
-                            // end of the event stream.
-
-                            await receivers[index].ReceiveAsync(1, TimeSpan.Zero);
-                        }
-
-                        // Send the batch of events.
-
-                        await producer.SendAsync(eventBatch);
-
-                        // Receive the events; because there is some non-determinism in the messaging flow, the
-                        // sent events may not be immediately available.  Allow for a small number of attempts to receive, in order
-                        // to account for availability delays.
-
-                        foreach (PartitionReceiver receiver in receivers)
-                        {
-                            var receivedEvents = new List<EventData>();
-                            var index = 0;
-
-                            while (++index < ReceiveRetryLimit)
+                            if (partitionEvent.Data != null)
                             {
-                                receivedEvents.AddRange(await receiver.ReceiveAsync(eventBatch.Count + 10, TimeSpan.FromMilliseconds(25)));
+                                receivedEvents.Add(partitionEvent.Data);
+                                consecutiveEmpties = 0;
                             }
-
-                            if (receivedEvents.Count > 0)
+                            else if (++consecutiveEmpties >= maximumConsecutiveEmpties)
                             {
-                                partitionsCount++;
-                                receivedEventsCount += receivedEvents.Count;
+                                break;
                             }
                         }
-                    }
-                    finally
-                    {
-                        await Task.WhenAll(receivers.Select(receiver => receiver.CloseAsync()));
-                        await Task.WhenAll(consumers.Select(consumer => consumer.CloseAsync()));
+
+                        if (receivedEvents.Count > 0)
+                        {
+                            partitionsCount++;
+                            receivedEventsCount += receivedEvents.Count;
+                        }
                     }
 
                     Assert.That(partitionsCount, Is.EqualTo(1));
@@ -890,66 +946,51 @@ namespace Azure.Messaging.EventHubs.Tests
 
                 await using (var connection = new EventHubConnection(connectionString))
                 await using (var producer = new EventHubProducerClient(connection))
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                 {
                     var batches = 5;
                     var partitionIds = await producer.GetPartitionIdsAsync();
                     var partitionsCount = 0;
                     var receivedEventsCount = 0;
-                    var consumers = new List<EventHubConsumerClient>();
-                    var receivers = new List<PartitionReceiver>();
 
-                    try
+                    // Send the batches of events.
+
+                    var batchOptions = new SendOptions { PartitionKey = partitionKey };
+
+                    for (var index = 0; index < batches; index++)
                     {
-                        for (var index = 0; index < partitions; index++)
-                        {
-                            consumers.Add(new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection));
-                            receivers.Add(consumers[index].CreatePartitionReceiver(partitionIds[index], EventPosition.Latest));
-
-                            // Initiate an operation to force the consumer to connect and set its position at the
-                            // end of the event stream.
-
-                            await receivers[index].ReceiveAsync(1, TimeSpan.Zero);
-                        }
-
-                        // Send the batches of events.
-
-                        var batchOptions = new SendOptions { PartitionKey = partitionKey };
-
-                        for (var index = 0; index < batches; index++)
-                        {
-                            await producer.SendAsync(new EventData(Encoding.UTF8.GetBytes($"Just a few messages ({ index })")), batchOptions);
-                        }
-
-                        // Receive the events; because there is some non-determinism in the messaging flow, the
-                        // sent events may not be immediately available.  Allow for a small number of attempts to receive, in order
-                        // to account for availability delays.
-
-                        foreach (PartitionReceiver receiver in receivers)
-                        {
-                            var receivedEvents = new List<EventData>();
-                            var index = 0;
-
-                            while (++index < ReceiveRetryLimit)
-                            {
-                                receivedEvents.AddRange(await receiver.ReceiveAsync(batches + 10, TimeSpan.FromMilliseconds(25)));
-                            }
-
-                            if (receivedEvents.Count > 0)
-                            {
-                                partitionsCount++;
-                                receivedEventsCount += receivedEvents.Count;
-
-                                foreach (EventData receivedEvent in receivedEvents)
-                                {
-                                    Assert.That(receivedEvent.PartitionKey, Is.EqualTo(partitionKey));
-                                }
-                            }
-                        }
+                        await producer.SendAsync(new EventData(Encoding.UTF8.GetBytes($"Just a few messages ({ index })")), batchOptions);
                     }
-                    finally
+
+                    // Read the events.
+
+                    using var cancellationSource = new CancellationTokenSource();
+                    cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
+
+                    foreach (string partition in partitionIds)
                     {
-                        await Task.WhenAll(receivers.Select(receiver => receiver.CloseAsync()));
-                        await Task.WhenAll(consumers.Select(consumer => consumer.CloseAsync()));
+                        var receivedEvents = new List<EventData>();
+                        var consecutiveEmpties = 0;
+                        var maximumConsecutiveEmpties = 5;
+
+                        await foreach (var partitionEvent in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.Earliest, TimeSpan.FromMilliseconds(50), cancellationSource.Token))
+                        {
+                            if (partitionEvent.Data != null)
+                            {
+                                receivedEvents.Add(partitionEvent.Data);
+                                consecutiveEmpties = 0;
+                            }
+                            else if (++consecutiveEmpties >= maximumConsecutiveEmpties)
+                            {
+                                break;
+                            }
+                        }
+
+                        if (receivedEvents.Count > 0)
+                        {
+                            partitionsCount++;
+                            receivedEventsCount += receivedEvents.Count;
+                        }
                     }
 
                     Assert.That(partitionsCount, Is.EqualTo(1));

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientOptionsTests.cs
@@ -24,7 +24,6 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubProducerClientOptions
             {
-                PartitionId = "some_partition_id_123",
                 ConnectionOptions = new EventHubConnectionOptions { TransportType = TransportType.AmqpWebSockets },
                 RetryOptions = new RetryOptions { TryTimeout = TimeSpan.FromMinutes(36) }
             };
@@ -32,36 +31,10 @@ namespace Azure.Messaging.EventHubs.Tests
             EventHubProducerClientOptions clone = options.Clone();
             Assert.That(clone, Is.Not.Null, "The clone should not be null.");
 
-            Assert.That(clone.PartitionId, Is.EqualTo(options.PartitionId), "The partition identifier of the clone should match.");
             Assert.That(clone.ConnectionOptions.TransportType, Is.EqualTo(options.ConnectionOptions.TransportType), "The connection options of the clone should copy properties.");
             Assert.That(clone.ConnectionOptions, Is.Not.SameAs(options.ConnectionOptions), "The connection options of the clone should be a copy, not the same instance.");
             Assert.That(clone.RetryOptions.IsEquivalentTo(options.RetryOptions), Is.True, "The retry options of the clone should be considered equal.");
             Assert.That(clone.RetryOptions, Is.Not.SameAs(options.RetryOptions), "The retry options of the clone should be a copy, not the same instance.");
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the <see cref="EventHubProducerClientOptions.PartitionId" />
-        ///   property.
-        /// </summary>
-        ///
-        [Test]
-        [TestCase("    ")]
-        [TestCase(" ")]
-        [TestCase("")]
-        public void PartitionIdIsValidated(string partition)
-        {
-            Assert.That(() => new EventHubProducerClientOptions { PartitionId = partition }, Throws.InstanceOf<ArgumentException>());
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the <see cref="EventHubProducerClientOptions.PartitionId" />
-        ///   property.
-        /// </summary>
-        ///
-        [Test]
-        public void PartitionIdAllowsNull()
-        {
-            Assert.That(() => new EventHubProducerClientOptions { PartitionId = null }, Throws.Nothing);
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientTests.cs
@@ -335,7 +335,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SendWithoutOptionsRequiresEvents()
         {
             var transportProducer = new ObservableTransportProducerMock();
-            var producer = new EventHubProducerClient(new MockConnection(transportProducer));
+            var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
             Assert.That(async () => await producer.SendAsync(default(IEnumerable<EventData>)), Throws.ArgumentNullException);
         }
@@ -349,7 +349,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SendRequiresEvents()
         {
             var transportProducer = new ObservableTransportProducerMock();
-            var producer = new EventHubProducerClient(new MockConnection(transportProducer));
+            var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
             Assert.That(async () => await producer.SendAsync(default(IEnumerable<EventData>), new SendOptions()), Throws.ArgumentNullException);
         }
@@ -363,7 +363,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SendRequiresTheBatch()
         {
             var transportProducer = new ObservableTransportProducerMock();
-            var producer = new EventHubProducerClient(new MockConnection(transportProducer));
+            var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
             Assert.That(async () => await producer.SendAsync(default(EventDataBatch)), Throws.ArgumentNullException);
         }
@@ -379,7 +379,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var sendOptions = new SendOptions { PartitionKey = "testKey" };
             var events = new[] { new EventData(new byte[] { 0x44, 0x66, 0x88 }) };
             var transportProducer = new ObservableTransportProducerMock();
-            var producer = new EventHubProducerClient(new MockConnection(transportProducer));
+            var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
             Assert.That(async () => await producer.SendAsync(events, sendOptions), Throws.Nothing);
         }
@@ -392,10 +392,10 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void SendAllowsAPartitionHashKeyWithABatch()
         {
-            var batchOptions = new BatchOptions { PartitionKey = "testKey" };
+            var batchOptions = new CreateBatchOptions { PartitionKey = "testKey" };
             var batch = new EventDataBatch(new MockTransportBatch(), batchOptions);
             var transportProducer = new ObservableTransportProducerMock();
-            var producer = new EventHubProducerClient(new MockConnection(transportProducer));
+            var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
             Assert.That(async () => await producer.SendAsync(batch), Throws.Nothing);
         }
@@ -408,10 +408,10 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void SendForASpecificPartitionDoesNotAllowAPartitionHashKey()
         {
-            var sendOptions = new SendOptions { PartitionKey = "testKey" };
+            var sendOptions = new SendOptions { PartitionKey = "testKey", PartitionId = "1" };
             var events = new[] { new EventData(new byte[] { 0x44, 0x66, 0x88 }) };
             var transportProducer = new ObservableTransportProducerMock();
-            var producer = new EventHubProducerClient(new MockConnection(transportProducer), new EventHubProducerClientOptions { PartitionId = "1" });
+            var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
             Assert.That(async () => await producer.SendAsync(events, sendOptions), Throws.InvalidOperationException);
         }
@@ -424,10 +424,10 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void SendForASpecificPartitionDoesNotAllowAPartitionHashKeyWithABatch()
         {
-            var batchOptions = new BatchOptions { PartitionKey = "testKey" };
+            var batchOptions = new CreateBatchOptions { PartitionKey = "testKey", PartitionId = "1" };
             var batch = new EventDataBatch(new MockTransportBatch(), batchOptions);
             var transportProducer = new ObservableTransportProducerMock();
-            var producer = new EventHubProducerClient(new MockConnection(transportProducer), new EventHubProducerClientOptions { PartitionId = "1" });
+            var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
             Assert.That(async () => await producer.SendAsync(batch), Throws.InvalidOperationException);
         }
@@ -442,7 +442,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var events = new EventData[0];
             var transportProducer = new ObservableTransportProducerMock();
-            var producer = new EventHubProducerClient(new MockConnection(transportProducer));
+            var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
             await producer.SendAsync(events);
 
@@ -463,7 +463,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var events = new EventData[0];
             var options = new SendOptions();
             var transportProducer = new ObservableTransportProducerMock();
-            var producer = new EventHubProducerClient(new MockConnection(transportProducer));
+            var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
             await producer.SendAsync(events, options);
 
@@ -481,10 +481,10 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task SendInvokesTheTransportProducerWithABatch()
         {
-            var batchOptions = new BatchOptions { PartitionKey = "testKey" };
+            var batchOptions = new CreateBatchOptions { PartitionKey = "testKey" };
             var batch = new EventDataBatch(new MockTransportBatch(), batchOptions);
             var transportProducer = new ObservableTransportProducerMock();
-            var producer = new EventHubProducerClient(new MockConnection(transportProducer));
+            var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
             await producer.SendAsync(batch);
             Assert.That(transportProducer.SendBatchCalledWith, Is.SameAs(batch), "The batch should be the same instance.");
@@ -498,9 +498,9 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void CreateBatchForASpecificPartitionDoesNotAllowAPartitionHashKey()
         {
-            var batchOptions = new BatchOptions { PartitionKey = "testKey" };
+            var batchOptions = new CreateBatchOptions { PartitionKey = "testKey", PartitionId = "1" };
             var transportProducer = new ObservableTransportProducerMock();
-            var producer = new EventHubProducerClient(new MockConnection(transportProducer), new EventHubProducerClientOptions { PartitionId = "1" });
+            var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
             Assert.That(async () => await producer.CreateBatchAsync(batchOptions), Throws.InvalidOperationException);
         }
@@ -513,9 +513,9 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task CreateBatchInvokesTheTransportProducer()
         {
-            var batchOptions = new BatchOptions { PartitionKey = "Hi", MaximumSizeInBytes = 9999 };
+            var batchOptions = new CreateBatchOptions { PartitionKey = "Hi", MaximumSizeInBytes = 9999 };
             var transportProducer = new ObservableTransportProducerMock();
-            var producer = new EventHubProducerClient(new MockConnection(transportProducer));
+            var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
             await producer.CreateBatchAsync(batchOptions);
 
@@ -533,9 +533,9 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task CreateBatchDefaultsBatchOptions()
         {
-            var expectedOptions = new BatchOptions();
+            var expectedOptions = new CreateBatchOptions();
             var transportProducer = new ObservableTransportProducerMock();
-            var producer = new EventHubProducerClient(new MockConnection(transportProducer));
+            var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
             await producer.CreateBatchAsync();
 
@@ -553,9 +553,9 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task CreateBatchSetsTheSendOptionsForTheEventBatch()
         {
-            var batchOptions = new BatchOptions { PartitionKey = "Hi", MaximumSizeInBytes = 9999 };
+            var batchOptions = new CreateBatchOptions { PartitionKey = "Hi", MaximumSizeInBytes = 9999 };
             var transportProducer = new ObservableTransportProducerMock();
-            var producer = new EventHubProducerClient(new MockConnection(transportProducer));
+            var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
             var eventBatch = await producer.CreateBatchAsync(batchOptions);
 
             Assert.That(eventBatch.SendOptions, Is.SameAs(transportProducer.CreateBatchCalledWith), "The batch options should have used for the send options.");
@@ -568,14 +568,42 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task CloseAsyncClosesTheTransportProducer()
+        public async Task CloseAsyncClosesTheTransportProducers()
         {
             var transportProducer = new ObservableTransportProducerMock();
-            var producer = new EventHubProducerClient(new MockConnection(transportProducer));
+            var mockFirstBatch = new EventDataBatch(new MockTransportBatch(), new SendOptions { PartitionId = "1" });
+            var mockSecondBatch = new EventDataBatch(new MockTransportBatch(), new SendOptions { PartitionId = "2" });
+            var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
+
+            try { await producer.SendAsync(mockFirstBatch); } catch {}
+            try { await producer.SendAsync(mockSecondBatch); } catch {}
 
             await producer.CloseAsync();
 
             Assert.That(transportProducer.WasCloseCalled, Is.True);
+            Assert.That(transportProducer.CloseCallCount, Is.EqualTo(3));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.CloseAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CloseAsyncSurfacesExceptionsForTransportConsumers()
+        {
+            var mockTransportProducer = new Mock<TransportProducer>();
+            var mockConnection = new MockConnection(() => mockTransportProducer.Object);
+            var mockBatch = new EventDataBatch(new MockTransportBatch(), new SendOptions { PartitionId = "1" });;
+            var producer = new EventHubProducerClient(mockConnection);
+
+            mockTransportProducer
+                .Setup(producer => producer.CloseAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromException(new InvalidCastException()));
+
+            try { await producer.SendAsync(mockBatch); } catch {}
+
+            Assert.That(async () => await producer.CloseAsync(), Throws.InstanceOf<InvalidCastException>());
         }
 
         /// <summary>
@@ -584,14 +612,42 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public void CloseClosesTheTransportProducer()
+        public async Task CloseClosesTheTransportProducers()
         {
             var transportProducer = new ObservableTransportProducerMock();
-            var producer = new EventHubProducerClient(new MockConnection(transportProducer));
+            var mockFirstBatch = new EventDataBatch(new MockTransportBatch(), new SendOptions { PartitionId = "1" });
+            var mockSecondBatch = new EventDataBatch(new MockTransportBatch(), new SendOptions { PartitionId = "2" });
+            var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
+
+            try { await producer.SendAsync(mockFirstBatch); } catch {}
+            try { await producer.SendAsync(mockSecondBatch); } catch {}
 
             producer.Close();
 
             Assert.That(transportProducer.WasCloseCalled, Is.True);
+            Assert.That(transportProducer.CloseCallCount, Is.EqualTo(3));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.Close" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CloseSurfacesExceptionsForTransportConsumers()
+        {
+            var mockTransportProducer = new Mock<TransportProducer>();
+            var mockConnection = new MockConnection(() => mockTransportProducer.Object);
+            var mockBatch = new EventDataBatch(new MockTransportBatch(), new SendOptions { PartitionId = "1" });;
+            var producer = new EventHubProducerClient(mockConnection);
+
+            mockTransportProducer
+                .Setup(producer => producer.CloseAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromException(new InvalidCastException()));
+
+            try { await producer.SendAsync(mockBatch); } catch {}
+
+            Assert.That(() => producer.Close(), Throws.InstanceOf<Exception>());
         }
 
         /// <summary>
@@ -637,7 +693,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task CloseAsyncDoesNotCloseTheConnectionWhenNotOwned()
         {
             var transportProducer = new ObservableTransportProducerMock();
-            var connection = new MockConnection(transportProducer);
+            var connection = new MockConnection(() => transportProducer);
             var producer = new EventHubProducerClient(connection);
 
             await producer.CloseAsync();
@@ -653,7 +709,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CloseDoesNotCloseTheConnectionWhenNotOwned()
         {
             var transportProducer = new ObservableTransportProducerMock();
-            var connection = new MockConnection(transportProducer);
+            var connection = new MockConnection(() => transportProducer);
             var producer = new EventHubProducerClient(connection);
 
             producer.Close();
@@ -686,10 +742,11 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         private class ObservableTransportProducerMock : TransportProducer
         {
+            public int CloseCallCount = 0;
             public bool WasCloseCalled = false;
             public (IEnumerable<EventData>, SendOptions) SendCalledWith;
             public EventDataBatch SendBatchCalledWith;
-            public BatchOptions CreateBatchCalledWith;
+            public CreateBatchOptions CreateBatchCalledWith;
 
             public override Task SendAsync(IEnumerable<EventData> events,
                                            SendOptions sendOptions,
@@ -705,7 +762,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 return Task.CompletedTask;
             }
 
-            public override ValueTask<TransportEventBatch> CreateBatchAsync(BatchOptions options,
+            public override ValueTask<TransportEventBatch> CreateBatchAsync(CreateBatchOptions options,
                                                                             CancellationToken cancellationToken)
             {
                 CreateBatchCalledWith = options;
@@ -715,6 +772,7 @@ namespace Azure.Messaging.EventHubs.Tests
             public override Task CloseAsync(CancellationToken cancellationToken)
             {
                 WasCloseCalled = true;
+                ++CloseCallCount;
                 return Task.CompletedTask;
             }
         }
@@ -728,7 +786,7 @@ namespace Azure.Messaging.EventHubs.Tests
             public EventHubsRetryPolicy GetPropertiesInvokedWith = null;
             public EventHubsRetryPolicy GetPartitionIdsInvokedWith = null;
             public EventHubsRetryPolicy GetPartitionPropertiesInvokedWith = null;
-            public TransportProducer TransportProducer = Mock.Of<TransportProducer>();
+            public Func<TransportProducer> TransportProducerFactory = () => Mock.Of<TransportProducer>();
 
             public bool WasClosed = false;
 
@@ -737,14 +795,14 @@ namespace Azure.Messaging.EventHubs.Tests
             {
             }
 
-            public MockConnection(TransportProducer transportProducer,
+            public MockConnection(Func<TransportProducer> transportProducerFactory,
                                   string namespaceName,
                                   string eventHubName) : this(namespaceName, eventHubName)
             {
-                TransportProducer = transportProducer;
+                TransportProducerFactory = transportProducerFactory;
             }
 
-            public MockConnection(TransportProducer transportProducer) : this(transportProducer, "fakeNamespace", "fakeEventHub")
+            public MockConnection(Func<TransportProducer> transportProducerFactory) : this(transportProducerFactory, "fakeNamespace", "fakeEventHub")
             {
             }
 
@@ -770,7 +828,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 return Task.FromResult(default(PartitionProperties));
             }
 
-            internal override TransportProducer CreateTransportProducer(EventHubProducerClientOptions producerOptions = default) => TransportProducer;
+            internal override TransportProducer CreateTransportProducer(string partitionId,
+                                                                        EventHubProducerClientOptions producerOptions = default) => TransportProducerFactory();
 
             internal override TransportClient CreateTransportClient(string fullyQualifiedNamespace, string eventHubName, EventHubTokenCredential credential, EventHubConnectionOptions options)
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventProcessorClient/EventProcessorClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventProcessorClient/EventProcessorClientLiveTests.cs
@@ -224,9 +224,9 @@ namespace Azure.Messaging.EventHubs.Tests
                             new EventData(Encoding.UTF8.GetBytes($"{ partitionId }: the end has come."))
                         };
 
-                        await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { PartitionId = partitionId }))
+                        await using (var producer = new EventHubProducerClient(connection))
                         {
-                            await producer.SendAsync(expectedEvents[partitionId]);
+                            await producer.SendAsync(expectedEvents[partitionId], new SendOptions { PartitionId = partitionId });
                         }
                     }
 


### PR DESCRIPTION
# Summary

The focus of these changes is to remove the ability to create an Event Hub Producer client that is bound to a specific partition.  Instead, the producer should allow requesting a specific partition during send, in the same manner that a partition hash key can be used.

Included in these changes is also removing the non-batch Send methods from thepublic scope, as they will not be part of the initial API surface.  Finally, the BatchOptions type has been renamed to CreateBatchOptions.

# Last Upstream Rebase

Wednesday, November 13, 4:09pm (EST)

# Related and Follow-Up Issues

- [Release Event Hubs Track 2 Library for .NET](https://github.com/Azure/azure-sdk-for-net/issues/8552) (#8552) 
- [ Remove partition affinity from Event Hub Producer Client ](https://github.com/Azure/azure-sdk-for-net/issues/8555) (#8555) 