### PR TITLE
Modify cpk tests to use http

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,7 +116,7 @@ tools/*.dll
 *.keys
 !Azure.Security.KeyVault.Keys
 *.pfx
-sdk/storage/Azure.Storage.Common/tests/Shared/TestConfigurations.xml
+TestConfigurations.xml
 
 # Backup & report files from converting an old project file to a newer
 # Visual Studio version. Backup files are not needed, because we have git ;-)

--- a/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
@@ -141,7 +141,7 @@ namespace Azure.Storage.Blobs.Test
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(blobName));
             CustomerProvidedKey customerProvidedKey = GetCustomerProvidedKey();
             blob = InstrumentClient(new AppendBlobClient(
-                blob.Uri,
+                blob.Uri.ToHttp(),
                 blob.Pipeline,
                 blob.ClientDiagnostics,
                 customerProvidedKey));
@@ -360,7 +360,7 @@ namespace Azure.Storage.Blobs.Test
             AppendBlobClient httpBlob = InstrumentClient(test.Container.GetAppendBlobClient(blobName));
             CustomerProvidedKey customerProvidedKey = GetCustomerProvidedKey();
             httpBlob = InstrumentClient(new AppendBlobClient(
-                httpBlob.Uri,
+                httpBlob.Uri.ToHttp(),
                 httpBlob.Pipeline,
                 httpBlob.ClientDiagnostics,
                 customerProvidedKey));
@@ -637,7 +637,7 @@ namespace Azure.Storage.Blobs.Test
                 AppendBlobClient httpDestBlob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
                 CustomerProvidedKey customerProvidedKey = GetCustomerProvidedKey();
                 httpDestBlob = InstrumentClient(new AppendBlobClient(
-                    httpDestBlob.Uri,
+                    httpDestBlob.Uri.ToHttp(),
                     httpDestBlob.Pipeline,
                     httpDestBlob.ClientDiagnostics,
                     customerProvidedKey));

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -186,7 +186,7 @@ namespace Azure.Storage.Blobs.Test
             BlockBlobClient httpBlob = InstrumentClient(test.Container.GetBlockBlobClient(GetNewBlobName()));
             CustomerProvidedKey customerProvidedKey = GetCustomerProvidedKey();
             httpBlob = InstrumentClient(new BlockBlobClient(
-                httpBlob.Uri,
+                httpBlob.Uri.ToHttp(),
                 httpBlob.Pipeline,
                 httpBlob.ClientDiagnostics,
                 customerProvidedKey));
@@ -1260,7 +1260,7 @@ namespace Azure.Storage.Blobs.Test
             AppendBlobClient httpBlob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
             CustomerProvidedKey customerProvidedKey = GetCustomerProvidedKey();
             httpBlob = InstrumentClient(new AppendBlobClient(
-                httpBlob.Uri,
+                httpBlob.Uri.ToHttp(),
                 httpBlob.Pipeline,
                 httpBlob.ClientDiagnostics,
                 customerProvidedKey));
@@ -1661,7 +1661,7 @@ namespace Azure.Storage.Blobs.Test
             AppendBlobClient httpBlob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
             CustomerProvidedKey customerProvidedKey = GetCustomerProvidedKey();
             httpBlob = InstrumentClient(new AppendBlobClient(
-                httpBlob.Uri,
+                httpBlob.Uri.ToHttp(),
                 httpBlob.Pipeline,
                 httpBlob.ClientDiagnostics,
                 customerProvidedKey));
@@ -1781,7 +1781,7 @@ namespace Azure.Storage.Blobs.Test
             AppendBlobClient httpBlob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
             CustomerProvidedKey customerProvidedKey = GetCustomerProvidedKey();
             httpBlob = InstrumentClient(new AppendBlobClient(
-                httpBlob.Uri,
+                httpBlob.Uri.ToHttp(),
                 httpBlob.Pipeline,
                 httpBlob.ClientDiagnostics,
                 customerProvidedKey));

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
@@ -146,7 +146,7 @@ namespace Azure.Storage.Blobs.Test
             BlockBlobClient httpBlob = InstrumentClient(test.Container.GetBlockBlobClient(GetNewBlobName()));
             CustomerProvidedKey customerProvidedKey = GetCustomerProvidedKey();
             httpBlob = InstrumentClient(new BlockBlobClient(
-                httpBlob.Uri,
+                httpBlob.Uri.ToHttp(),
                 httpBlob.Pipeline,
                 httpBlob.ClientDiagnostics,
                 customerProvidedKey));
@@ -366,7 +366,7 @@ namespace Azure.Storage.Blobs.Test
             BlockBlobClient destBlob = InstrumentClient(test.Container.GetBlockBlobClient(GetNewBlobName()));
             CustomerProvidedKey customerProvidedKey = GetCustomerProvidedKey();
             destBlob = InstrumentClient(new BlockBlobClient(
-                destBlob.Uri,
+                destBlob.Uri.ToHttp(),
                 destBlob.Pipeline,
                 destBlob.ClientDiagnostics,
                 customerProvidedKey));
@@ -1180,7 +1180,7 @@ namespace Azure.Storage.Blobs.Test
             BlockBlobClient blob = InstrumentClient(test.Container.GetBlockBlobClient(GetNewBlobName()));
             CustomerProvidedKey customerProvidedKey = GetCustomerProvidedKey();
             blob = InstrumentClient(new BlockBlobClient(
-                blob.Uri,
+                blob.Uri.ToHttp(),
                 blob.Pipeline,
                 blob.ClientDiagnostics,
                 customerProvidedKey));

--- a/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
@@ -133,7 +133,7 @@ namespace Azure.Storage.Blobs.Test
             PageBlobClient blob = InstrumentClient(test.Container.GetPageBlobClient(blobName));
             CustomerProvidedKey customerProvidedKey = GetCustomerProvidedKey();
             blob = InstrumentClient(new PageBlobClient(
-                blob.Uri,
+                blob.Uri.ToHttp(),
                 blob.Pipeline,
                 blob.ClientDiagnostics,
                 customerProvidedKey));
@@ -345,7 +345,7 @@ namespace Azure.Storage.Blobs.Test
             PageBlobClient httpBlob = InstrumentClient(test.Container.GetPageBlobClient(blobName));
             CustomerProvidedKey customerProvidedKey = GetCustomerProvidedKey();
             httpBlob = InstrumentClient(new PageBlobClient(
-                httpBlob.Uri,
+                httpBlob.Uri.ToHttp(),
                 httpBlob.Pipeline,
                 httpBlob.ClientDiagnostics,
                 customerProvidedKey));
@@ -584,7 +584,7 @@ namespace Azure.Storage.Blobs.Test
             PageBlobClient httpBlob = InstrumentClient(test.Container.GetPageBlobClient(GetNewBlobName()));
             CustomerProvidedKey customerProvidedKey = GetCustomerProvidedKey();
             httpBlob = InstrumentClient(new PageBlobClient(
-                httpBlob.Uri,
+                httpBlob.Uri.ToHttp(),
                 httpBlob.Pipeline,
                 httpBlob.ClientDiagnostics,
                 customerProvidedKey));
@@ -1036,7 +1036,7 @@ namespace Azure.Storage.Blobs.Test
             PageBlobClient httpBlob = InstrumentClient(test.Container.GetPageBlobClient(GetNewBlobName()));
             CustomerProvidedKey customerProvidedKey = GetCustomerProvidedKey();
             httpBlob = InstrumentClient(new PageBlobClient(
-                httpBlob.Uri,
+                httpBlob.Uri.ToHttp(),
                 httpBlob.Pipeline,
                 httpBlob.ClientDiagnostics,
                 customerProvidedKey));
@@ -1608,7 +1608,7 @@ namespace Azure.Storage.Blobs.Test
             PageBlobClient httpDestBlob = InstrumentClient(test.Container.GetPageBlobClient(GetNewBlobName()));
             CustomerProvidedKey customerProvidedKey = GetCustomerProvidedKey();
             httpDestBlob = InstrumentClient(new PageBlobClient(
-                httpDestBlob.Uri,
+                httpDestBlob.Uri.ToHttp(),
                 httpDestBlob.Pipeline,
                 httpDestBlob.ClientDiagnostics,
                 customerProvidedKey));

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/TestExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/TestExtensions.cs
@@ -46,5 +46,20 @@ namespace Azure.Storage
             }
             throw new InvalidOperationException();
         }
+
+        /// <summary>
+        /// Returns a new Uri based on the supplied Uri, but with Http enabled.
+        /// </summary>
+        /// <param name="uri">Source Uri.</param>
+        /// <returns>Http Uri.</returns>
+        public static Uri ToHttp(this Uri uri)
+        {
+            var builder = new UriBuilder(uri)
+            {
+                Scheme = "http",
+                Port = 80
+            };
+            return builder.Uri;
+        }
     }
 }


### PR DESCRIPTION
Cpk tests that assert failures on http need to have the Uri modified to be http. We can't rely on the endpoint in the testconfig having http, as http is disabled for our test accounts.

Also update gitignore to no longer have the full path for TestConfigurations.