### PR TITLE
[Event Hubs Client] Track Two (Credential Fix)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Authorization/SharedAccessSignature.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Authorization/SharedAccessSignature.cs
@@ -158,17 +158,19 @@ namespace Azure.Messaging.EventHubs.Authorization
         /// <param name="value">The shared access signature to be used for authorization.</param>
         /// <param name="signatureExpiration">The date and time that the shared access signature expires, in UTC.</param>
         ///
-        /// <remarks>
-        ///     This constructor is intended to support cloning of the signature and internal testing,
-        ///     allowing for direct setting of the property values without validation or adjustment.
-        /// </remarks>
-        ///
-        internal SharedAccessSignature(string eventHubResource,
-                                       string sharedAccessKeyName,
-                                       string sharedAccessKey,
-                                       string value,
-                                       DateTimeOffset signatureExpiration)
+        public SharedAccessSignature(string eventHubResource,
+                                     string sharedAccessKeyName,
+                                     string sharedAccessKey,
+                                     string value,
+                                     DateTimeOffset signatureExpiration)
         {
+            Argument.AssertNotNullOrEmpty(eventHubResource, nameof(eventHubResource));
+            Argument.AssertNotNullOrEmpty(sharedAccessKeyName, nameof(sharedAccessKeyName));
+            Argument.AssertNotNullOrEmpty(sharedAccessKey, nameof(sharedAccessKey));
+
+            Argument.AssertNotTooLong(sharedAccessKeyName, MaximumKeyNameLength, nameof(sharedAccessKeyName));
+            Argument.AssertNotTooLong(sharedAccessKey, MaximumKeyLength, nameof(sharedAccessKey));
+
             Resource = eventHubResource;
             SharedAccessKeyName = sharedAccessKeyName;
             SharedAccessKey = sharedAccessKey;
@@ -177,14 +179,14 @@ namespace Azure.Messaging.EventHubs.Authorization
         }
 
         /// <summary>
-        ///   Extends the period for which the shared access signature is considered valid by adjusting the
-        ///   calculated expiration time.  Upon successful extension, the <see cref="Value" /> of the signature will
-        ///   be updated with the new expiration.
+        ///   Creates a new signature with the specified period for which the shared access signature is considered valid.
         /// </summary>
         ///
         /// <param name="signatureValidityDuration">The duration that the signature should be considered valid.</param>
         ///
-        public void ExtendExpiration(TimeSpan signatureValidityDuration)
+        /// <returns>A new <see cref="SharedAccessSignature" /> based on the same key, but with a new expiration time.</returns>
+        ///
+        public SharedAccessSignature CloneWithNewExpiration(TimeSpan signatureValidityDuration)
         {
             Argument.AssertNotNegative(signatureValidityDuration, nameof(signatureValidityDuration));
 
@@ -195,29 +197,8 @@ namespace Azure.Messaging.EventHubs.Authorization
                 throw new InvalidOperationException(Resources.SharedAccessKeyIsRequired);
             }
 
-            SignatureExpiration = DateTimeOffset.UtcNow.Add(signatureValidityDuration);
-            Value = BuildSignature(Resource, SharedAccessKeyName, SharedAccessKey, SignatureExpiration);
+            return new SharedAccessSignature(Resource, SharedAccessKeyName, SharedAccessKey, signatureValidityDuration);
         }
-
-        /// <summary>
-        ///   Returns a hash code for this instance.
-        /// </summary>
-        ///
-        /// <returns>A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.</returns>
-        ///
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public override int GetHashCode() => base.GetHashCode();
-
-        /// <summary>
-        ///   Determines whether the specified <see cref="System.Object" /> is equal to this instance.
-        /// </summary>
-        ///
-        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
-        ///
-        /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.</returns>
-        ///
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public override bool Equals(object obj) => base.Equals(obj);
 
         /// <summary>
         ///   Converts the instance to string representation.
@@ -226,15 +207,6 @@ namespace Azure.Messaging.EventHubs.Authorization
         /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
         ///
         public override string ToString() => Value;
-
-        /// <summary>
-        ///   Creates a new copy of the current <see cref="SharedAccessSignature" />, cloning its attributes into a new instance.
-        /// </summary>
-        ///
-        /// <returns>A new copy of <see cref="SharedAccessSignature" />.</returns>
-        ///
-        internal SharedAccessSignature Clone() =>
-            new SharedAccessSignature(Resource, SharedAccessKeyName, SharedAccessKey, Value, SignatureExpiration);
 
         /// <summary>
         ///   Parses a shared access signature into its component parts.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/CbsTokenProviderTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/CbsTokenProviderTests.cs
@@ -66,7 +66,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task GetTokenAsyncSetsTheCorrectTypeForSharedAccessSignatureTokens()
         {
             var value = "TOkEn!";
-            var signature = new SharedAccessSignature(string.Empty, "keyName", "key", value, DateTimeOffset.Parse("2015-10-27T00:00:00Z"));
+            var signature = new SharedAccessSignature("hub", "keyName", "key", value, DateTimeOffset.Parse("2015-10-27T00:00:00Z"));
             var sasCredential = new SharedAccessSignatureCredential(signature);
             var credential = new EventHubTokenCredential(sasCredential, "test");
             var provider = new CbsTokenProvider(credential, default);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/EventHubSharedKeyCredentialTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/EventHubSharedKeyCredentialTests.cs
@@ -51,10 +51,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var name = "KeyName";
             var value = "KeyValue";
             var credential = new EventHubSharedKeyCredential(name, value);
-
-            var initializedValue = typeof(EventHubSharedKeyCredential)
-                .GetProperty("SharedAccessKey", BindingFlags.Instance | BindingFlags.NonPublic)
-                .GetValue(credential, null);
+            var initializedValue = GetSharedAccessKey(credential);
 
             Assert.That(credential.SharedAccessKeyName, Is.EqualTo(name), "The shared key name should have been set.");
             Assert.That(initializedValue, Is.EqualTo(value), "The shared key should have been set.");
@@ -93,14 +90,44 @@ namespace Azure.Messaging.EventHubs.Tests
             var validSpan = TimeSpan.FromHours(4);
             var signature = new SharedAccessSignature(resource, keyName, keyValue, validSpan);
             var keyCredential = new EventHubSharedKeyCredential(keyName, keyValue);
-            SharedAccessSignatureCredential sasCredential = keyCredential.ConvertToSharedAccessSignatureCredential(resource, validSpan);
+            var sasCredential = keyCredential.ConvertToSharedAccessSignatureCredential(resource, validSpan);
 
             Assert.That(sasCredential, Is.Not.Null, "A shared access signature credential should have been created.");
-            Assert.That(sasCredential.SharedAccessSignature, Is.Not.Null, "The SAS credential should contain a shared access signature.");
-            Assert.That(sasCredential.SharedAccessSignature.Resource, Is.EqualTo(signature.Resource), "The resource should match.");
-            Assert.That(sasCredential.SharedAccessSignature.SharedAccessKeyName, Is.EqualTo(signature.SharedAccessKeyName), "The shared access key name should match.");
-            Assert.That(sasCredential.SharedAccessSignature.SharedAccessKey, Is.EqualTo(signature.SharedAccessKey), "The shared access key should match.");
-            Assert.That(sasCredential.SharedAccessSignature.SignatureExpiration, Is.EqualTo(signature.SignatureExpiration).Within(TimeSpan.FromSeconds(5)), "The expiration should match.");
+
+            var credentialSignature = GetSharedAccessSignature(sasCredential);
+            Assert.That(credentialSignature, Is.Not.Null, "The SAS credential should contain a shared access signature.");
+            Assert.That(credentialSignature.Resource, Is.EqualTo(signature.Resource), "The resource should match.");
+            Assert.That(credentialSignature.SharedAccessKeyName, Is.EqualTo(signature.SharedAccessKeyName), "The shared access key name should match.");
+            Assert.That(credentialSignature.SharedAccessKey, Is.EqualTo(signature.SharedAccessKey), "The shared access key should match.");
+            Assert.That(credentialSignature.SignatureExpiration, Is.EqualTo(signature.SignatureExpiration).Within(TimeSpan.FromSeconds(5)), "The expiration should match.");
         }
+
+        /// <summary>
+        ///   Retrieves the shared access key from the credential using its private accessor.
+        /// </summary>
+        ///
+        /// <param name="instance">The instance to retrieve the key from.</param>
+        ///
+        /// <returns>The shared access key.</returns>
+        ///
+        private static string GetSharedAccessKey(EventHubSharedKeyCredential instance) =>
+            (string)
+                typeof(EventHubSharedKeyCredential)
+                .GetProperty("SharedAccessKey", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(instance, null);
+
+        /// <summary>
+        ///   Retrieves the shared access signature from the credential using its private accessor.
+        /// </summary>
+        ///
+        /// <param name="instance">The instance to retrieve the key from.</param>
+        ///
+        /// <returns>The shared access key.</returns>
+        ///
+        private static SharedAccessSignature GetSharedAccessSignature(SharedAccessSignatureCredential instance) =>
+            (SharedAccessSignature)
+                typeof(SharedAccessSignatureCredential)
+                .GetProperty("SharedAccessSignature", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(instance, null);
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/EventHubTokenCredentialTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/EventHubTokenCredentialTests.cs
@@ -29,7 +29,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public static IEnumerable<object[]> SharedAccessSignatureCredentialTestCases()
         {
             TokenCredential credentialMock = Mock.Of<TokenCredential>();
-            var signature = new SharedAccessSignature(string.Empty, "keyName", "key", "TOkEn!", DateTimeOffset.UtcNow.AddHours(4));
+            var signature = new SharedAccessSignature("hub", "keyName", "key", "TOkEn!", DateTimeOffset.UtcNow.AddHours(4));
 
             yield return new object[] { new SharedAccessSignatureCredential(signature), true };
             yield return new object[] { new EventHubSharedKeyCredential("blah", "foo"), true };

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/SharedAccessSignatureCredentialTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/SharedAccessSignatureCredentialTests.cs
@@ -34,13 +34,13 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public void ConstructorValidatesInitializesProperties()
+        public void ConstructorInitializesProperties()
         {
             var value = "TOkEn!";
-            var signature = new SharedAccessSignature(string.Empty, "keyName", "key", value, DateTimeOffset.UtcNow.AddHours(4));
+            var signature = new SharedAccessSignature("hub-name", "keyName", "key", value, DateTimeOffset.UtcNow.AddHours(4));
             var credential = new SharedAccessSignatureCredential(signature);
 
-            Assert.That(credential.SharedAccessSignature, Is.SameAs(signature), "The credential should allow the signature to be accessed.");
+            Assert.That(GetSharedAccessSignature(credential), Is.SameAs(signature), "The credential should allow the signature to be accessed.");
         }
 
         /// <summary>
@@ -51,7 +51,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void GetTokenReturnsTheSignatureValue()
         {
             var value = "TOkEn!";
-            var signature = new SharedAccessSignature(string.Empty, "keyName", "key", value, DateTimeOffset.UtcNow.AddHours(4));
+            var signature = new SharedAccessSignature("hub-name", "keyName", "key", value, DateTimeOffset.UtcNow.AddHours(4));
             var credential = new SharedAccessSignatureCredential(signature);
 
             Assert.That(credential.GetToken(new TokenRequestContext(), default).Token, Is.SameAs(signature.Value), "The credential should return the signature as the token.");
@@ -65,7 +65,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void GetTokenIgnoresScopeAndCancellationToken()
         {
             var value = "TOkEn!";
-            var signature = new SharedAccessSignature(string.Empty, "keyName", "key", value, DateTimeOffset.UtcNow.AddHours(4));
+            var signature = new SharedAccessSignature("hub-name", "keyName", "key", value, DateTimeOffset.UtcNow.AddHours(4));
             var credential = new SharedAccessSignatureCredential(signature);
 
             Assert.That(credential.GetToken(new TokenRequestContext(new[] { "test", "this" }), CancellationToken.None).Token, Is.SameAs(signature.Value), "The credential should return the signature as the token.");
@@ -79,7 +79,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task GetTokenAsyncReturnsTheSignatureValue()
         {
             var value = "TOkEn!";
-            var signature = new SharedAccessSignature(string.Empty, "keyName", "key", value, DateTimeOffset.UtcNow.AddHours(4));
+            var signature = new SharedAccessSignature("hub-name", "keyName", "key", value, DateTimeOffset.UtcNow.AddHours(4));
             var credential = new SharedAccessSignatureCredential(signature);
             var cancellation = new CancellationTokenSource();
             AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(), cancellation.Token);
@@ -95,7 +95,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task GetTokenAsyncIgnoresScopeAndCancellationToken()
         {
             var value = "TOkEn!";
-            var signature = new SharedAccessSignature(string.Empty, "keyName", "key", value, DateTimeOffset.UtcNow.AddHours(4));
+            var signature = new SharedAccessSignature("hub-name", "keyName", "key", value, DateTimeOffset.UtcNow.AddHours(4));
             var credential = new SharedAccessSignatureCredential(signature);
             var cancellation = new CancellationTokenSource();
             AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new string[0]), cancellation.Token);
@@ -111,7 +111,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void GetTokenExtendsAnExpiredToken()
         {
             var value = "TOkEn!";
-            var signature = new SharedAccessSignature(string.Empty, "keyName", "key", value, DateTimeOffset.UtcNow.Subtract(TimeSpan.FromHours(2)));
+            var signature = new SharedAccessSignature("hub-name", "keyName", "key", value, DateTimeOffset.UtcNow.Subtract(TimeSpan.FromHours(2)));
             var credential = new SharedAccessSignatureCredential(signature);
 
             var expectedExpiration = DateTimeOffset.Now.Add(GetSignatureExtensionDuration());
@@ -127,12 +127,26 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var value = "TOkEn!";
             var tokenExpiration = DateTimeOffset.UtcNow.Add(TimeSpan.FromSeconds(GetSignatureRefreshBuffer().TotalSeconds / 2));
-            var signature = new SharedAccessSignature(string.Empty, "keyName", "key", value, tokenExpiration);
+            var signature = new SharedAccessSignature("hub-name", "keyName", "key", value, tokenExpiration);
             var credential = new SharedAccessSignatureCredential(signature);
 
             var expectedExpiration = DateTimeOffset.Now.Add(GetSignatureExtensionDuration());
             Assert.That(credential.GetToken(new TokenRequestContext(), default).ExpiresOn, Is.EqualTo(expectedExpiration).Within(TimeSpan.FromMinutes(1)));
         }
+
+        /// <summary>
+        ///   Retrieves the shared access signature from the credential using its private accessor.
+        /// </summary>
+        ///
+        /// <param name="instance">The instance to retrieve the key from.</param>
+        ///
+        /// <returns>The shared access key</returns>
+        ///
+        private static SharedAccessSignature GetSharedAccessSignature(SharedAccessSignatureCredential instance) =>
+            (SharedAccessSignature)
+                typeof(SharedAccessSignatureCredential)
+                .GetProperty("SharedAccessSignature", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(instance, null);
 
         /// <summary>
         ///   Gets the refresh buffer for the <see cref="SharedAccessSignatureCredential" /> using


### PR DESCRIPTION
# Summary

The focus of these changes is to provide better synchronization for the shared access signature credential used for connection string-provided credentials to ensure that the signature and expiration date are in-sync when the expiration is extended.

# Last Upstream Rebase

Thursday, November 14, 3:01pm (EST)

# Related and Follow-Up Issues

- [Release Event Hubs Track 2 Library for .NET](https://github.com/Azure/azure-sdk-for-net/issues/8552) (#8552) 
- [Setup the local stress client and perform periodic prolonged runs ](https://github.com/Azure/azure-sdk-for-net/issues/8573) (#8573) 