### PR TITLE
Code checks

### DIFF
--- a/eng/CodeChecks.ps1
+++ b/eng/CodeChecks.ps1
@@ -72,18 +72,19 @@ try {
         & $PSScriptRoot\Update-Snippets.ps1 @script:PSBoundParameters
     }
 
-    Write-Host "Re-generating lisgings"
+    Write-Host "Re-generating listings"
     Invoke-Block {
         & $PSScriptRoot\Export-API.ps1 @script:PSBoundParameters
     }
 
     Write-Host "Re-generating clients"
     Invoke-Block {
-        # https://github.com/Azure/azure-sdk-for-net/issues/8584
-        # & $repoRoot\storage\generate.ps1
+        & $repoRoot\storage\generate.ps1
     }
 
     Write-Host "git diff"
+    # prevent warning related to EOL differences which triggers an exception for some reason
+    & git config core.safecrlf false
     & git diff --ignore-space-at-eol --exit-code
     if ($LastExitCode -ne 0) {
         $status = git status -s | Out-String

--- a/eng/CodeChecks.ps1
+++ b/eng/CodeChecks.ps1
@@ -84,8 +84,7 @@ try {
 
     Write-Host "git diff"
     # prevent warning related to EOL differences which triggers an exception for some reason
-    & git config core.safecrlf false
-    & git diff --ignore-space-at-eol --exit-code
+    & git -c core.safecrlf=false diff --ignore-space-at-eol --exit-code
     if ($LastExitCode -ne 0) {
         $status = git status -s | Out-String
         $status = $status -replace "`n","`n    "

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -85,7 +85,8 @@ jobs:
         condition: and(succeededOrFailed(), ne(variables['Build.Reason'],'PullRequest'))
       - task: NodeTool@0
         inputs:
-          versionSpec: '12.x'
+          # AutoRest doesn't work with versions 12.x
+          versionSpec: '10.15.0'
         displayName: 'Install NodeJS'
       - task: PowerShell@2
         displayName: "Verify generated code"
@@ -93,7 +94,6 @@ jobs:
           DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
           DOTNET_CLI_TELEMETRY_OPTOUT: 1
           DOTNET_MULTILEVEL_LOOKUP: 0
-          NODE_OPTIONS: "--max-old-space-size=4096"
         inputs:
           filePath: "eng/CodeChecks.ps1"
           pwsh: true

--- a/sdk/storage/Azure.Storage.Common/swagger/Generator/package-lock.json
+++ b/sdk/storage/Azure.Storage.Common/swagger/Generator/package-lock.json
@@ -59,12 +59,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "autorest": {
-      "version": "3.0.5231",
-      "resolved": "https://registry.npmjs.org/autorest/-/autorest-3.0.5231.tgz",
-      "integrity": "sha512-zuhiWJtz/mg/aEDwHLJtRSLeQp++C4Sl8MbrRYN/bA9WaiwOTg42nSbtwZFDNCpVAmclG8lkD9WQft/AEj7jXg==",
-      "dev": true
-    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",

--- a/sdk/storage/Azure.Storage.Common/swagger/Generator/package.json
+++ b/sdk/storage/Azure.Storage.Common/swagger/Generator/package.json
@@ -20,7 +20,6 @@
     "@types/mocha": "5.2.5",
     "@types/node": "10.12.19",
     "@types/semver": "5.5.0",
-    "autorest": "^3.0.5231",
     "mocha": "5.2.0",
     "mocha-typescript": "1.1.17",
     "tslint": "^5.11.0",

--- a/sdk/storage/generate.ps1
+++ b/sdk/storage/generate.ps1
@@ -1,16 +1,17 @@
 pushd $PSScriptRoot/Azure.Storage.Common/swagger/Generator/
 npm install
+npm install -g autorest@beta
 
 cd $PSScriptRoot/Azure.Storage.Blobs/swagger/
-npx autorest --use=$PSScriptRoot/Azure.Storage.Common/swagger/Generator/ --verbose
+autorest --use=$PSScriptRoot/Azure.Storage.Common/swagger/Generator/ --verbose
 
 cd $PSScriptRoot/Azure.Storage.Files.Shares/swagger/
-npx autorest --use=$PSScriptRoot/Azure.Storage.Common/swagger/Generator/ --verbose
+autorest --use=$PSScriptRoot/Azure.Storage.Common/swagger/Generator/ --verbose
 
 cd $PSScriptRoot/Azure.Storage.Queues/swagger/
-npx autorest --use=$PSScriptRoot/Azure.Storage.Common/swagger/Generator/ --verbose
+autorest --use=$PSScriptRoot/Azure.Storage.Common/swagger/Generator/ --verbose
 
 cd $PSScriptRoot/Azure.Storage.Files.DataLake/swagger/
-npx autorest --use=$PSScriptRoot/Azure.Storage.Common/swagger/Generator/ --verbose
+autorest --use=$PSScriptRoot/Azure.Storage.Common/swagger/Generator/ --verbose
 
 popd


### PR DESCRIPTION
Get storage client generation working as part of CI:
- Use Node 10.15.0 instead of 12.x.
- Update Generate script to install and use global autorest@beta.
- Prevent git EOL warnings which were triggering exceptions in CodeChecks