### PR TITLE
[Event Hubs Client] Track Two (Consumer Options Refactor)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample08_ConsumeEvents.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample08_ConsumeEvents.cs
@@ -78,15 +78,20 @@ namespace Azure.Messaging.EventHubs.Samples
                 // we're expecting only the one event, we will exit the loop when we receive it.  To be sure that we do not block forever
                 // waiting on an event that is not published, we will request cancellation after a fairly long interval.
 
-                PartitionEvent receivedEvent;
-
-                Stopwatch watch = Stopwatch.StartNew();
-                bool wereEventsPublished = false;
-
                 CancellationTokenSource cancellationSource = new CancellationTokenSource();
                 cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
 
-                await foreach (PartitionEvent currentEvent in consumerClient.ReadEventsFromPartitionAsync(firstPartition, EventPosition.Latest, TimeSpan.FromMilliseconds(150), cancellationSource.Token))
+                ReadOptions readOptions = new ReadOptions
+                {
+                    MaximumWaitTime = TimeSpan.FromMilliseconds(150)
+                };
+
+                PartitionEvent receivedEvent;
+                bool wereEventsPublished = false;
+
+                Stopwatch watch = Stopwatch.StartNew();
+
+                await foreach (PartitionEvent currentEvent in consumerClient.ReadEventsFromPartitionAsync(firstPartition, EventPosition.Latest, readOptions, cancellationSource.Token))
                 {
                     if (!wereEventsPublished)
                     {
@@ -98,6 +103,7 @@ namespace Azure.Messaging.EventHubs.Samples
                             await producerClient.SendAsync(eventBatch);
                             wereEventsPublished = true;
 
+                            await Task.Delay(250);
                             Console.WriteLine("The event batch has been published.");
                         }
                     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample10_ConsumeEventsFromAKnownPosition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample10_ConsumeEventsFromAKnownPosition.cs
@@ -88,13 +88,18 @@ namespace Azure.Messaging.EventHubs.Samples
 
                     // We will consume the events until all of the published events have been received.
 
-                    List<EventData> receivedEvents = new List<EventData>();
-                    bool wereEventsPublished = false;
-
                     CancellationTokenSource cancellationSource = new CancellationTokenSource();
                     cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
 
-                    await foreach (PartitionEvent currentEvent in initialConsumerClient.ReadEventsFromPartitionAsync(firstPartition, EventPosition.Latest, TimeSpan.FromMilliseconds(150), cancellationSource.Token))
+                    ReadOptions readOptions = new ReadOptions
+                    {
+                         MaximumWaitTime = TimeSpan.FromMilliseconds(150)
+                    };
+
+                    List<EventData> receivedEvents = new List<EventData>();
+                    bool wereEventsPublished = false;
+
+                    await foreach (PartitionEvent currentEvent in initialConsumerClient.ReadEventsFromPartitionAsync(firstPartition, EventPosition.Latest, readOptions, cancellationSource.Token))
                     {
                         if (!wereEventsPublished)
                         {
@@ -110,6 +115,7 @@ namespace Azure.Messaging.EventHubs.Samples
                                 await producerClient.SendAsync(eventBatch);
                                 wereEventsPublished = true;
 
+                                await Task.Delay(250);
                                 Console.WriteLine($"The event batch with { eventBatchSize } events has been published.");
                             }
                         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample12_AuthenticateWithClientSecretCredential.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample12_AuthenticateWithClientSecretCredential.cs
@@ -96,13 +96,18 @@ namespace Azure.Messaging.EventHubs.Samples
 
                 PartitionEvent receivedEvent;
 
+                ReadOptions readOptions = new ReadOptions
+                {
+                    MaximumWaitTime = TimeSpan.FromMilliseconds(150)
+                };
+
                 Stopwatch watch = Stopwatch.StartNew();
                 bool wereEventsPublished = false;
 
                 CancellationTokenSource cancellationSource = new CancellationTokenSource();
                 cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
 
-                await foreach (PartitionEvent currentEvent in consumerClient.ReadEventsFromPartitionAsync(firstPartition, EventPosition.Latest, TimeSpan.FromMilliseconds(150), cancellationSource.Token))
+                await foreach (PartitionEvent currentEvent in consumerClient.ReadEventsFromPartitionAsync(firstPartition, EventPosition.Latest, readOptions, cancellationSource.Token))
                 {
                     if (!wereEventsPublished)
                     {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
@@ -358,12 +358,12 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// </summary>
         ///
         /// <param name="partitionId">The identifier of the partition to which the transport producer should be bound; if <c>null</c>, the producer is unbound.</param>
-        /// <param name="producerOptions">The set of options to apply when creating the producer.</param>
+        /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
         ///
         /// <returns>A <see cref="TransportProducer"/> configured in the requested manner.</returns>
         ///
         public override TransportProducer CreateProducer(string partitionId,
-                                                         EventHubProducerClientOptions producerOptions)
+                                                         EventHubsRetryPolicy retryPolicy)
         {
             Argument.AssertNotClosed(_closed, nameof(AmqpClient));
 
@@ -373,7 +373,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                 partitionId,
                 ConnectionScope,
                 MessageConverter,
-                producerOptions.RetryOptions.ToRetryPolicy()
+                retryPolicy
             );
         }
 
@@ -390,21 +390,27 @@ namespace Azure.Messaging.EventHubs.Amqp
         ///   group to be actively reading events from the partition.  These non-exclusive consumers are
         ///   sometimes referred to as "Non-epoch Consumers."
         ///
-        ///   Designating a consumer as exclusive may be specified in the <paramref name="consumerOptions" />.
-        ///   By default, consumers are created as non-exclusive.
+        ///   Designating a consumer as exclusive may be specified by setting the <paramref name="ownerLevel" />.
+        ///   When <c>null</c>, consumers are created as non-exclusive.
         /// </summary>
         ///
         /// <param name="consumerGroup">The name of the consumer group this consumer is associated with.  Events are read in the context of this group.</param>
         /// <param name="partitionId">The identifier of the Event Hub partition from which events will be received.</param>
         /// <param name="eventPosition">The position within the partition where the consumer should begin reading events.</param>
-        /// <param name="consumerOptions">The set of options to apply when creating the consumer.</param>
+        /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
+        /// <param name="trackLastEnqueuedEventInformation">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
+        /// <param name="ownerLevel">The relative priority to associate with the link; for a non-exclusive link, this value should be <c>null</c>.</param>
+        /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.  If <c>null</c> a default will be used.</param>
         ///
         /// <returns>A <see cref="TransportConsumer" /> configured in the requested manner.</returns>
         ///
         public override TransportConsumer CreateConsumer(string consumerGroup,
                                                          string partitionId,
                                                          EventPosition eventPosition,
-                                                         EventHubConsumerClientOptions consumerOptions)
+                                                         EventHubsRetryPolicy retryPolicy,
+                                                         bool trackLastEnqueuedEventInformation,
+                                                         long? ownerLevel,
+                                                         uint? prefetchCount)
         {
             Argument.AssertNotClosed(_closed, nameof(AmqpClient));
 
@@ -414,10 +420,12 @@ namespace Azure.Messaging.EventHubs.Amqp
                 consumerGroup,
                 partitionId,
                 eventPosition,
-                consumerOptions,
+                trackLastEnqueuedEventInformation,
+                ownerLevel,
+                prefetchCount,
                 ConnectionScope,
                 MessageConverter,
-                consumerOptions.RetryOptions.ToRetryPolicy()
+                retryPolicy
             );
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
@@ -230,7 +230,9 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// <param name="consumerGroup">The name of the consumer group in the context of which events should be received.</param>
         /// <param name="partitionId">The identifier of the Event Hub partition from which events should be received.</param>
         /// <param name="eventPosition">The position of the event in the partition where the link should be filtered to.</param>
-        /// <param name="consumerOptions">The set of active options for the consumer that will make use of the link.</param>
+        /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.</param>
+        /// <param name="ownerLevel">The relative priority to associate with the link; for a non-exclusive link, this value should be <c>null</c>.</param>
+        /// <param name="trackLastEnqueuedEventInformation">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
         /// <param name="timeout">The timeout to apply when creating the link.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
@@ -239,13 +241,14 @@ namespace Azure.Messaging.EventHubs.Amqp
         public virtual async Task<ReceivingAmqpLink> OpenConsumerLinkAsync(string consumerGroup,
                                                                            string partitionId,
                                                                            EventPosition eventPosition,
-                                                                           EventHubConsumerClientOptions consumerOptions,
                                                                            TimeSpan timeout,
+                                                                           uint prefetchCount,
+                                                                           long? ownerLevel,
+                                                                           bool trackLastEnqueuedEventInformation,
                                                                            CancellationToken cancellationToken)
         {
             Argument.AssertNotNullOrEmpty(consumerGroup, nameof(consumerGroup));
             Argument.AssertNotNullOrEmpty(partitionId, nameof(partitionId));
-            Argument.AssertNotNull(consumerOptions, nameof(consumerOptions));
 
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
@@ -255,7 +258,17 @@ namespace Azure.Messaging.EventHubs.Amqp
             var connection = await ActiveConnection.GetOrCreateAsync(timeout).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
-            var link = await CreateReceivingLinkAsync(connection, consumerEndpoint, eventPosition, consumerOptions, timeout.CalculateRemaining(stopWatch.Elapsed), cancellationToken).ConfigureAwait(false);
+            var link = await CreateReceivingLinkAsync(
+                connection,
+                consumerEndpoint,
+                eventPosition,
+                timeout.CalculateRemaining(stopWatch.Elapsed),
+                prefetchCount,
+                ownerLevel,
+                trackLastEnqueuedEventInformation,
+                cancellationToken
+            ).ConfigureAwait(false);
+
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
             await OpenAmqpObjectAsync(link, timeout.CalculateRemaining(stopWatch.Elapsed)).ConfigureAwait(false);
@@ -441,7 +454,9 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// <param name="connection">The active and opened AMQP connection to use for this link.</param>
         /// <param name="endpoint">The fully qualified endpoint to open the link for.</param>
         /// <param name="eventPosition">The position of the event in the partition where the link should be filtered to.</param>
-        /// <param name="consumerOptions">The set of active options for the consumer that will make use of the link.</param>
+        /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.</param>
+        /// <param name="ownerLevel">The relative priority to associate with the link; for a non-exclusive link, this value should be <c>null</c>.</param>
+        /// <param name="trackLastEnqueuedEventInformation">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
         /// <param name="timeout">The timeout to apply when creating the link.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
@@ -450,8 +465,10 @@ namespace Azure.Messaging.EventHubs.Amqp
         protected virtual async Task<ReceivingAmqpLink> CreateReceivingLinkAsync(AmqpConnection connection,
                                                                                  Uri endpoint,
                                                                                  EventPosition eventPosition,
-                                                                                 EventHubConsumerClientOptions consumerOptions,
                                                                                  TimeSpan timeout,
+                                                                                 uint prefetchCount,
+                                                                                 long? ownerLevel,
+                                                                                 bool trackLastEnqueuedEventInformation,
                                                                                  CancellationToken cancellationToken)
         {
             Argument.AssertNotDisposed(IsDisposed, nameof(AmqpConnectionScope));
@@ -484,8 +501,8 @@ namespace Azure.Messaging.EventHubs.Amqp
                 var linkSettings = new AmqpLinkSettings
                 {
                     Role = true,
-                    TotalLinkCredit = (uint)consumerOptions.PrefetchCount,
-                    AutoSendFlow = consumerOptions.PrefetchCount > 0,
+                    TotalLinkCredit = prefetchCount,
+                    AutoSendFlow = prefetchCount > 0,
                     SettleType = SettleMode.SettleOnSend,
                     Source = new Source { Address = endpoint.AbsolutePath, FilterSet = filters },
                     Target = new Target { Address = Guid.NewGuid().ToString() }
@@ -493,12 +510,12 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                 linkSettings.AddProperty(AmqpProperty.EntityType, (int)AmqpProperty.Entity.ConsumerGroup);
 
-                if (consumerOptions.OwnerLevel.HasValue)
+                if (ownerLevel.HasValue)
                 {
-                    linkSettings.AddProperty(AmqpProperty.OwnerLevel, consumerOptions.OwnerLevel.Value);
+                    linkSettings.AddProperty(AmqpProperty.OwnerLevel, ownerLevel.Value);
                 }
 
-                if (consumerOptions.TrackLastEnqueuedEventInformation)
+                if (trackLastEnqueuedEventInformation)
                 {
                     linkSettings.DesiredCapabilities = new Multiple<AmqpSymbol>(new List<AmqpSymbol>
                     {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
@@ -25,6 +25,9 @@ namespace Azure.Messaging.EventHubs.Amqp
     ///
     internal class AmqpConsumer : TransportConsumer
     {
+        /// <summary>The default prefetch count to use for the consumer.</summary>
+        private const uint DefaultPrefetchCount = 300;
+
         /// <summary>Indicates whether or not this instance has been closed.</summary>
         private bool _closed = false;
 
@@ -59,10 +62,13 @@ namespace Azure.Messaging.EventHubs.Amqp
         private string PartitionId { get; }
 
         /// <summary>
-        ///   The set of options which govern the behavior of this consumer instance.
+        ///   Indicates whether or not the consumer should request information on the last enqueued event on the partition
+        ///   associated with a given event, and track that information as events are received.
         /// </summary>
         ///
-        private EventHubConsumerClientOptions Options { get; }
+        /// <value><c>true</c> if information about a partition's last event should be requested and tracked; otherwise, <c>false</c>.</value>
+        ///
+        private bool TrackLastEnqueuedEventInformation { get; }
 
         /// <summary>
         ///   The policy to use for determining retry behavior for when an operation fails.
@@ -96,8 +102,10 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// <param name="eventHubName">The name of the Event Hub from which events will be consumed.</param>
         /// <param name="consumerGroup">The name of the consumer group this consumer is associated with.  Events are read in the context of this group.</param>
         /// <param name="partitionId">The identifier of the Event Hub partition from which events will be received.</param>
-        /// <param name="consumerOptions">The set of active options for the consumer that will make use of the link.</param>
         /// <param name="eventPosition">The position of the event in the partition where the consumer should begin reading.</param>
+        /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.  If <c>null</c> a default will be used.</param>
+        /// <param name="ownerLevel">The relative priority to associate with the link; for a non-exclusive link, this value should be <c>null</c>.</param>
+        /// <param name="trackLastEnqueuedEventInformation">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
         /// <param name="connectionScope">The AMQP connection context for operations .</param>
         /// <param name="messageConverter">The converter to use for translating between AMQP messages and client types.</param>
         /// <param name="retryPolicy">The retry policy to consider when an operation fails.</param>
@@ -115,7 +123,9 @@ namespace Azure.Messaging.EventHubs.Amqp
                             string consumerGroup,
                             string partitionId,
                             EventPosition eventPosition,
-                            EventHubConsumerClientOptions consumerOptions,
+                            bool trackLastEnqueuedEventInformation,
+                            long? ownerLevel,
+                            uint? prefetchCount,
                             AmqpConnectionScope connectionScope,
                             AmqpMessageConverter messageConverter,
                             EventHubsRetryPolicy retryPolicy)
@@ -123,7 +133,6 @@ namespace Azure.Messaging.EventHubs.Amqp
             Argument.AssertNotNullOrEmpty(eventHubName, nameof(eventHubName));
             Argument.AssertNotNullOrEmpty(consumerGroup, nameof(consumerGroup));
             Argument.AssertNotNullOrEmpty(partitionId, nameof(partitionId));
-            Argument.AssertNotNull(consumerOptions, nameof(EventHubConsumerClientOptions));
             Argument.AssertNotNull(connectionScope, nameof(connectionScope));
             Argument.AssertNotNull(messageConverter, nameof(messageConverter));
             Argument.AssertNotNull(retryPolicy, nameof(retryPolicy));
@@ -131,11 +140,22 @@ namespace Azure.Messaging.EventHubs.Amqp
             EventHubName = eventHubName;
             ConsumerGroup = consumerGroup;
             PartitionId = partitionId;
-            Options = consumerOptions;
+            TrackLastEnqueuedEventInformation = trackLastEnqueuedEventInformation;
             ConnectionScope = connectionScope;
             RetryPolicy = retryPolicy;
             MessageConverter = messageConverter;
-            ReceiveLink = new FaultTolerantAmqpObject<ReceivingAmqpLink>(timeout => ConnectionScope.OpenConsumerLinkAsync(consumerGroup, partitionId, eventPosition, consumerOptions, timeout, CancellationToken.None), link => link.SafeClose());
+
+            ReceiveLink = new FaultTolerantAmqpObject<ReceivingAmqpLink>(timeout =>
+                ConnectionScope.OpenConsumerLinkAsync(
+                    consumerGroup,
+                    partitionId,
+                    eventPosition,
+                    timeout,
+                    prefetchCount ?? DefaultPrefetchCount,
+                    ownerLevel,
+                    trackLastEnqueuedEventInformation,
+                    CancellationToken.None),
+                link => link.SafeClose());
         }
 
         /// <summary>
@@ -202,7 +222,7 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                             receivedEventCount = receivedEvents.Count;
 
-                            if ((Options.TrackLastEnqueuedEventInformation) && (receivedEventCount > 0))
+                            if ((TrackLastEnqueuedEventInformation) && (receivedEventCount > 0))
                             {
                                 LastReceivedEvent = receivedEvents[receivedEventCount - 1];
                             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportClient.cs
@@ -67,12 +67,12 @@ namespace Azure.Messaging.EventHubs.Core
         /// </summary>
         ///
         /// <param name="partitionId">The identifier of the partition to which the transport producer should be bound; if <c>null</c>, the producer is unbound.</param>
-        /// <param name="producerOptions">The set of options to apply when creating the producer.</param>
+        /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
         ///
         /// <returns>A <see cref="TransportProducer"/> configured in the requested manner.</returns>
         ///
         public abstract TransportProducer CreateProducer(string partitionId,
-                                                         EventHubProducerClientOptions producerOptions);
+                                                         EventHubsRetryPolicy retryPolicy);
 
         /// <summary>
         ///   Creates a consumer strongly aligned with the active protocol and transport, responsible
@@ -87,21 +87,27 @@ namespace Azure.Messaging.EventHubs.Core
         ///   group to be actively reading events from the partition.  These non-exclusive consumers are
         ///   sometimes referred to as "Non-epoch Consumers."
         ///
-        ///   Designating a consumer as exclusive may be specified in the <paramref name="consumerOptions" />.
-        ///   By default, consumers are created as non-exclusive.
+        ///   Designating a consumer as exclusive may be specified by setting the <paramref name="ownerLevel" />.
+        ///   When <c>null</c>, consumers are created as non-exclusive.
         /// </summary>
         ///
         /// <param name="consumerGroup">The name of the consumer group this consumer is associated with.  Events are read in the context of this group.</param>
         /// <param name="partitionId">The identifier of the Event Hub partition from which events will be received.</param>
         /// <param name="eventPosition">The position within the partition where the consumer should begin reading events.</param>
-        /// <param name="consumerOptions">The set of options to apply when creating the consumer.</param>
+        /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
+        /// <param name="trackLastEnqueuedEventInformation">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
+        /// <param name="ownerLevel">The relative priority to associate with the link; for a non-exclusive link, this value should be <c>null</c>.</param>
+        /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.  If <c>null</c> a default will be used.</param>
         ///
         /// <returns>A <see cref="TransportConsumer" /> configured in the requested manner.</returns>
         ///
         public abstract TransportConsumer CreateConsumer(string consumerGroup,
                                                          string partitionId,
                                                          EventPosition eventPosition,
-                                                         EventHubConsumerClientOptions consumerOptions);
+                                                         EventHubsRetryPolicy retryPolicy,
+                                                         bool trackLastEnqueuedEventInformation,
+                                                         long? ownerLevel,
+                                                         uint? prefetchCount);
 
         /// <summary>
         ///   Closes the connection to the transport client instance.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportConsumer.cs
@@ -32,7 +32,7 @@ namespace Azure.Messaging.EventHubs.Core
         /// </summary>
         ///
         /// <value>
-        ///   <c>null</c>, if the <see cref="EventHubConsumerClientOptions.TrackLastEnqueuedEventInformation" /> was not requested; otherwise,
+        ///   <c>null</c>, if the tracking of the last enqueued event information was not requested; otherwise,
         ///   the most recently received event.
         /// </value>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Errors/ConsumerDisconnectedException.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Errors/ConsumerDisconnectedException.cs
@@ -7,7 +7,7 @@ namespace Azure.Messaging.EventHubs.Errors
 {
     /// <summary>
     ///   An exception which occurs when an <see cref="EventHubConsumerClient" /> is forcefully disconnected
-    ///   from an Event Hub instance.  This typically occurs when another consumer with higher <see cref="EventHubConsumerClient.OwnerLevel" />
+    ///   from an Event Hub instance.  This typically occurs when another consumer with higher <see cref="ReadOptions.OwnerLevel" />
     ///   asserts ownership over the partition and consumer group.
     /// </summary>
     ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -129,8 +129,8 @@ namespace Azure.Messaging.EventHubs
         /// </summary>
         ///
         /// <remarks>
-        ///   This property is only populated for events received using an <see cref="EventHubConsumerClient" /> which was created when
-        ///   <see cref="EventHubConsumerClientOptions.TrackLastEnqueuedEventInformation" /> is enabled.
+        ///   This property is only populated for events received using an reader specifying
+        ///   <see cref="ReadOptions.TrackLastEnqueuedEventInformation" /> as enabled.
         /// </remarks>
         ///
         internal long? LastPartitionSequenceNumber { get; }
@@ -141,8 +141,8 @@ namespace Azure.Messaging.EventHubs
         /// </summary>
         ///
         /// <remarks>
-        ///   This property is only populated for events received using an <see cref="EventHubConsumerClient" /> which was created when
-        ///   <see cref="EventHubConsumerClientOptions.TrackLastEnqueuedEventInformation" /> is enabled.
+        ///   This property is only populated for events received using an reader specifying
+        ///   <see cref="ReadOptions.TrackLastEnqueuedEventInformation" /> as enabled.
         /// </remarks>
         ///
         internal long? LastPartitionOffset { get; }
@@ -153,8 +153,8 @@ namespace Azure.Messaging.EventHubs
         /// </summary>
         ///
         /// <remarks>
-        ///   This property is only populated for events received using an <see cref="EventHubConsumerClient" /> which was created when
-        ///   <see cref="EventHubConsumerClientOptions.TrackLastEnqueuedEventInformation" /> is enabled.
+        ///   This property is only populated for events received using an reader specifying
+        ///   <see cref="ReadOptions.TrackLastEnqueuedEventInformation" /> as enabled.
         /// </remarks>
         ///
         internal DateTimeOffset? LastPartitionEnqueuedTime { get; }
@@ -165,8 +165,8 @@ namespace Azure.Messaging.EventHubs
         /// </summary>
         ///
         /// <remarks>
-        ///   This property is only populated for events received using an <see cref="EventHubConsumerClient" /> which was created when
-        ///   <see cref="EventHubConsumerClientOptions.TrackLastEnqueuedEventInformation" /> is enabled.
+        ///   This property is only populated for events received using an reader specifying
+        ///   <see cref="ReadOptions.TrackLastEnqueuedEventInformation" /> as enabled.
         /// </remarks>
         ///
         internal DateTimeOffset? LastPartitionInformationRetrievalTime { get; }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnection.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnection.cs
@@ -350,13 +350,16 @@ namespace Azure.Messaging.EventHubs
         /// </summary>
         ///
         /// <param name="partitionId">The identifier of the partition to which the transport producer should be bound; if <c>null</c>, the producer is unbound.</param>
-        /// <param name="producerOptions">The set of options to apply when creating the producer.</param>
+        /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
         ///
         /// <returns>A <see cref="TransportProducer"/> configured in the requested manner.</returns>
         ///
         internal virtual TransportProducer CreateTransportProducer(string partitionId,
-                                                                   EventHubProducerClientOptions producerOptions = default) =>
-            InnerClient.CreateProducer(partitionId, producerOptions?.Clone() ?? new EventHubProducerClientOptions());
+                                                                   EventHubsRetryPolicy retryPolicy)
+        {
+            Argument.AssertNotNull(retryPolicy, nameof(retryPolicy));
+            return InnerClient.CreateProducer(partitionId, retryPolicy);
+        }
 
         /// <summary>
         ///   Creates a consumer strongly aligned with the active protocol and transport, responsible
@@ -371,26 +374,33 @@ namespace Azure.Messaging.EventHubs
         ///   group to be actively reading events from the partition.  These non-exclusive consumers are
         ///   sometimes referred to as "Non-epoch Consumers."
         ///
-        ///   Designating a consumer as exclusive may be specified in the <paramref name="consumerOptions" />.
-        ///   By default, consumers are created as non-exclusive.
+        ///   Designating a consumer as exclusive may be specified by setting the <paramref name="ownerLevel" />.
+        ///   When <c>null</c>, consumers are created as non-exclusive.
         /// </summary>
         ///
         /// <param name="consumerGroup">The name of the consumer group this consumer is associated with.  Events are read in the context of this group.</param>
         /// <param name="partitionId">The identifier of the Event Hub partition from which events will be received.</param>
         /// <param name="eventPosition">The position within the partition where the consumer should begin reading events.</param>
-        /// <param name="consumerOptions">The set of options to apply when creating the consumer.</param>
+        /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
+        /// <param name="trackLastEnqueuedEventInformation">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
+        /// <param name="ownerLevel">The relative priority to associate with the link; for a non-exclusive link, this value should be <c>null</c>.</param>
+        /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.  If <c>null</c> a default will be used.</param>
         ///
-        /// <returns>A <see cref="TransportConsumer"/> configured in the requested manner.</returns>
+        /// <returns>A <see cref="TransportConsumer" /> configured in the requested manner.</returns>
         ///
         internal virtual TransportConsumer CreateTransportConsumer(string consumerGroup,
                                                                    string partitionId,
                                                                    EventPosition eventPosition,
-                                                                   EventHubConsumerClientOptions consumerOptions = default)
+                                                                   EventHubsRetryPolicy retryPolicy,
+                                                                   bool trackLastEnqueuedEventInformation = true,
+                                                                   long? ownerLevel = default,
+                                                                   uint? prefetchCount = default)
         {
             Argument.AssertNotNullOrEmpty(consumerGroup, nameof(consumerGroup));
             Argument.AssertNotNullOrEmpty(partitionId, nameof(partitionId));
+            Argument.AssertNotNull(retryPolicy, nameof(retryPolicy));
 
-            return InnerClient.CreateConsumer(consumerGroup, partitionId, eventPosition, consumerOptions?.Clone() ?? new EventHubConsumerClientOptions());
+            return InnerClient.CreateConsumer(consumerGroup, partitionId, eventPosition, retryPolicy, trackLastEnqueuedEventInformation, ownerLevel, prefetchCount);
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerClientOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerClientOptions.cs
@@ -15,95 +15,11 @@ namespace Azure.Messaging.EventHubs
     ///
     public class EventHubConsumerClientOptions
     {
-        /// <summary>The minimum value allowed for the prefetch count of the consumer.</summary>
-        internal const int MinimumPrefetchCount = 10;
-
-        /// <summary>The maximum length, in characters, for the identifier assigned to a consumer.</summary>
-        internal const int MaximumIdentifierLength = 64;
-
-        /// <summary>The amount of time to wait for messages when receiving.</summary>
-        private TimeSpan? _maximumReceiveWaitTime = TimeSpan.FromMinutes(1);
-
-        /// <summary>The prefetch count to use for the consumer.</summary>
-        private int _prefetchCount = 300;
-
         /// <summary>The set of options to use for configuring the connection to the Event Hubs service.</summary>
         private EventHubConnectionOptions _connectionOptions = new EventHubConnectionOptions();
 
         /// <summary>The set of options to govern retry behavior and try timeouts.</summary>
         private RetryOptions _retryOptions = new RetryOptions();
-
-        /// <summary>
-        ///   When populated, the owner level indicates that a consumer is intended to be the only reader of events for the
-        ///   requested partition and an associated consumer group.  To do so, this consumer will attempt to assert ownership
-        ///   over the partition; in the case where more than one exclusive consumer attempts to assert ownership for the same
-        ///   partition/consumer group pair, the one having a larger <see cref="OwnerLevel"/> value will "win."
-        ///
-        ///   When an exclusive consumer is used, other consumers which are non-exclusive or which have a lower owner level will either
-        ///   not be allowed to be created, if they already exist, will encounter an exception during the next attempted operation.
-        /// </summary>
-        ///
-        /// <value>The relative priority to associate with an exclusive consumer; for a non-exclusive consumer, this value should be <c>null</c>.</value>
-        ///
-        public long? OwnerLevel { get; set; }
-
-        /// <summary>
-        ///   The default amount of time to wait for the requested amount of messages when receiving; if this
-        ///   period elapses before the requested amount of messages were available or received, then the set of
-        ///   messages that were received will be returned.
-        /// </summary>
-        ///
-        /// <value>If not specified, the <see cref="RetryOptions.TryTimeout" /> specified by the active retry policy will be used.</value>
-        ///
-        internal TimeSpan? DefaultMaximumReceiveWaitTime
-        {
-            get => _maximumReceiveWaitTime;
-
-            set
-            {
-                ValidateMaximumReceiveWaitTime(value);
-                _maximumReceiveWaitTime = value;
-            }
-        }
-
-        /// <summary>
-        ///   Normalizes the specified wait time value, returning the timeout period or the
-        ///   a <c>null</c> value if no wait time was specified.
-        /// </summary>
-        ///
-        internal TimeSpan? MaximumReceiveWaitTimeOrDefault => (_maximumReceiveWaitTime == TimeSpan.Zero) ? null : _maximumReceiveWaitTime;
-
-        /// <summary>
-        ///   The count used by the consumer to control the number of events this consumer will actively receive
-        ///   and queue locally without regard to whether a receive operation is currently active.
-        /// </summary>
-        ///
-        public int PrefetchCount
-        {
-            get => _prefetchCount;
-
-            set
-            {
-                Argument.AssertInRange(value, MinimumPrefetchCount, int.MaxValue, nameof(PrefetchCount));
-                _prefetchCount = value;
-            }
-        }
-
-        /// <summary>
-        ///     Indicates whether or not the consumer should request information on the last enqueued event on the partition
-        ///     associated with a given event, and track that information as events are received.
-        /// </summary>
-        ///
-        /// <value><c>true</c> if information about a partition's last event should be requested and tracked; otherwise, <c>false</c>.</value>
-        ///
-        /// <remarks>
-        ///   When information about a partition's last enqueued event is being tracked, each event received from the Event Hubs
-        ///   service will carry metadata about the partition that it otherwise would not. This results in a small amount of
-        ///   additional network bandwidth consumption that is generally a favorable trade-off when considered
-        ///   against periodically making requests for partition properties using one of the Event Hub clients.
-        /// </remarks>
-        ///
-        public bool TrackLastEnqueuedEventInformation { get; set; } = true;
 
         /// <summary>
         ///   Gets or sets the options used for configuring the connection to the Event Hubs service.
@@ -173,42 +89,8 @@ namespace Azure.Messaging.EventHubs
         internal EventHubConsumerClientOptions Clone() =>
             new EventHubConsumerClientOptions
             {
-                OwnerLevel = OwnerLevel,
-                TrackLastEnqueuedEventInformation = TrackLastEnqueuedEventInformation,
-                _prefetchCount = _prefetchCount,
-                _maximumReceiveWaitTime = _maximumReceiveWaitTime,
                 _connectionOptions = ConnectionOptions.Clone(),
                 _retryOptions = RetryOptions.Clone()
             };
-
-        /// <summary>
-        ///   Validates that the identifier requested for the consumer can be used, throwing an <see cref="ArgumentException" /> if
-        ///   it is not valid.
-        /// </summary>
-        ///
-        /// <param name="identifier">The identifier to validate.</param>
-        ///
-        private void ValidateIdentifier(string identifier)
-        {
-            if ((!string.IsNullOrEmpty(identifier)) && (identifier.Length > MaximumIdentifierLength))
-            {
-                throw new ArgumentException(nameof(identifier), string.Format(CultureInfo.CurrentCulture, Resources.ConsumerIdentifierOverMaxValue, MaximumIdentifierLength));
-            }
-        }
-
-        /// <summary>
-        ///   Validates the time period specified as the maximum time to wait when receiving, throwing an <see cref="ArgumentException" /> if
-        ///   it is not valid.
-        /// </summary>
-        ///
-        /// <param name="maximumWaitTime">The time period to validate.</param>
-        ///
-        private void ValidateMaximumReceiveWaitTime(TimeSpan? maximumWaitTime)
-        {
-            if (maximumWaitTime < TimeSpan.Zero)
-            {
-                throw new ArgumentException(Resources.TimeoutMustBePositive, nameof(DefaultMaximumReceiveWaitTime));
-            }
-        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducerClient.cs
@@ -188,7 +188,7 @@ namespace Azure.Messaging.EventHubs
             Connection = new EventHubConnection(connectionString, eventHubName, producerOptions.ConnectionOptions);
             Options = producerOptions;
             RetryPolicy = producerOptions.RetryOptions.ToRetryPolicy();
-            GatewayProducer = Connection.CreateTransportProducer(null, producerOptions);
+            GatewayProducer = Connection.CreateTransportProducer(null, RetryPolicy);
         }
 
         /// <summary>
@@ -215,7 +215,7 @@ namespace Azure.Messaging.EventHubs
             Connection = new EventHubConnection(fullyQualifiedNamespace, eventHubName, credential, producerOptions.ConnectionOptions);
             Options = producerOptions;
             RetryPolicy = producerOptions.RetryOptions.ToRetryPolicy();
-            GatewayProducer = Connection.CreateTransportProducer(null, producerOptions);
+            GatewayProducer = Connection.CreateTransportProducer(null, RetryPolicy);
         }
 
         /// <summary>
@@ -235,7 +235,7 @@ namespace Azure.Messaging.EventHubs
             Connection = connection;
             Options = producerOptions;
             RetryPolicy = producerOptions.RetryOptions.ToRetryPolicy();
-            GatewayProducer = Connection.CreateTransportProducer(null, producerOptions);
+            GatewayProducer = Connection.CreateTransportProducer(null, RetryPolicy);
         }
 
         /// <summary>
@@ -421,7 +421,7 @@ namespace Azure.Messaging.EventHubs
             }
             else
             {
-                activeProducer = PartitionProducers.GetOrAdd(options.PartitionId, id => Connection.CreateTransportProducer(id, Options));
+                activeProducer = PartitionProducers.GetOrAdd(options.PartitionId, id => Connection.CreateTransportProducer(id, RetryPolicy));
             }
 
             using DiagnosticScope scope = CreateDiagnosticScope();
@@ -472,7 +472,7 @@ namespace Azure.Messaging.EventHubs
             }
             else
             {
-                activeProducer = PartitionProducers.GetOrAdd(eventBatch.SendOptions.PartitionId, id => Connection.CreateTransportProducer(id, Options));
+                activeProducer = PartitionProducers.GetOrAdd(eventBatch.SendOptions.PartitionId, id => Connection.CreateTransportProducer(id, RetryPolicy));
             }
 
             using DiagnosticScope scope = CreateDiagnosticScope();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/PartitionContext.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/PartitionContext.cs
@@ -29,9 +29,9 @@ namespace Azure.Messaging.EventHubs
         private WeakReference<TransportConsumer> SourceConsumer { get; }
 
         /// <summary>
-        ///   A set of information about the last enqueued event of a partition, as observed by the <see cref="EventHubConsumerClient" />
+        ///   A set of information about the last enqueued event of a partition, as observed by the associated EventHubs client
         ///   associated with this context as events are received from the Event Hubs service.  This is only available if the consumer was
-        ///   created with <see cref="EventHubConsumerClientOptions.TrackLastEnqueuedEventInformation" /> set.
+        ///   created with <see cref="ReadOptions.TrackLastEnqueuedEventInformation" /> set.
         /// </summary>
         ///
         /// <remarks>
@@ -41,8 +41,8 @@ namespace Azure.Messaging.EventHubs
         ///   against periodically making requests for partition properties using an Event Hub client.
         /// </remarks>
         ///
-        /// <exception cref="EventHubsClientClosedException">Occurs when the <see cref="EventHubConsumerClient" /> needed to read this information is no longer available.</exception>
-        /// <exception cref="InvalidOperationException">Occurs when this method is invoked without <see cref="EventHubConsumerClientOptions.TrackLastEnqueuedEventInformation" /> set.</exception>
+        /// <exception cref="EventHubsClientClosedException">Occurs when the Event Hubs client needed to read this information is no longer available.</exception>
+        /// <exception cref="InvalidOperationException">Occurs when this method is invoked without <see cref="ReadOptions.TrackLastEnqueuedEventInformation" /> set.</exception>
         ///
         public virtual LastEnqueuedEventProperties ReadLastEnqueuedEventInformation()
         {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/EventProcessorBase.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/EventProcessorBase.cs
@@ -709,17 +709,22 @@ namespace Azure.Messaging.EventHubs.Processor
 
                 PartitionContexts.TryGetValue(partitionId, out var context);
 
-                var options = new EventHubConsumerClientOptions
+                var clientOptions = new EventHubConsumerClientOptions
                 {
-                    RetryOptions = retryOptions,
+                    RetryOptions = retryOptions
+                };
+
+                var readOptions = new ReadOptions
+                {
+                    MaximumWaitTime = maximumReceiveWaitTime,
                     TrackLastEnqueuedEventInformation = trackLastEnqueuedEventInformation
                 };
 
                 await using var connection = CreateConnection();
 
-                await using (var consumer = new EventHubConsumerClient(ConsumerGroup, connection, options))
+                await using (var consumer = new EventHubConsumerClient(ConsumerGroup, connection, clientOptions))
                 {
-                    await foreach (var partitionEvent in consumer.ReadEventsFromPartitionAsync(partitionId, startingPosition, maximumReceiveWaitTime, taskCancellationToken))
+                    await foreach (var partitionEvent in consumer.ReadEventsFromPartitionAsync(partitionId, startingPosition, readOptions, taskCancellationToken))
                     {
                         using DiagnosticScope diagnosticScope = EventDataInstrumentation.ClientDiagnostics.CreateScope(DiagnosticProperty.EventProcessorProcessingActivityName);
                         diagnosticScope.AddAttribute("kind", "server");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/ReadOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/ReadOptions.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ComponentModel;
+using Azure.Core;
+
+namespace Azure.Messaging.EventHubs
+{
+    /// <summary>
+    ///   The set of options that can be specified to configure behavior when reading events from an
+    ///   <see cref="EventHubConsumerClient" />.
+    /// </summary>
+    ///
+    public class ReadOptions
+    {
+        /// <summary>The maximum amount of time to wait to for an event to be available before emitting an empty item; if <c>null</c>, empty items will not be emitted.</summary>
+        private TimeSpan? _maximumWaitTime = null;
+
+        /// <summary>
+        ///   When populated, the owner level indicates that a reading is intended to be performed exclusively for events in the
+        ///   requested partition and an for the associated consumer group.  To do so, reading will attempt to assert ownership
+        ///   over the partition; in the case where more than one exclusive reader attempts to assert ownership for the same
+        ///   partition/consumer group pair, the one having a larger <see cref="OwnerLevel"/> value will "win."
+        ///
+        ///   When an exclusive reader is used, other readers which are non-exclusive or which have a lower owner level will either
+        ///   not be allowed to be created, if they already exist, will encounter an exception during the next attempted operation.
+        /// </summary>
+        ///
+        /// <value>The relative priority to associate with an exclusive reader; for a non-exclusive reader, this value should be <c>null</c>.</value>
+        ///
+        public long? OwnerLevel { get; set; }
+
+        /// <summary>
+        ///   Indicates whether or not the reader should request information on the last enqueued event on the partition
+        ///   associated with a given event, and track that information as events are read.
+        /// </summary>
+        ///
+        /// <value><c>true</c> if information about a partition's last event should be requested and tracked; otherwise, <c>false</c>.</value>
+        ///
+        /// <remarks>
+        ///   When information about a partition's last enqueued event is being tracked, each event received from the Event Hubs
+        ///   service will carry metadata about the partition that it otherwise would not. This results in a small amount of
+        ///   additional network bandwidth consumption that is generally a favorable trade-off when considered
+        ///   against periodically making requests for partition properties using one of the Event Hub clients.
+        /// </remarks>
+        ///
+        public bool TrackLastEnqueuedEventInformation { get; set; } = true;
+
+        /// <summary>
+        ///   The maximum amount of time to wait to for an event to be available when reading before reading an empty
+        ///   event.
+        /// </summary>
+        ///
+        /// <value>
+        ///   If specified, should there be no events available before this waiting period expires, an empty event will be returned,
+        ///   allowing control to return to the reader that was waiting.
+        ///
+        ///   If <c>null</c>, the reader will wait forever for items to be available unless reading is canceled. Empty items will
+        ///   not be returned.
+        /// </value>
+        ///
+        public TimeSpan? MaximumWaitTime
+        {
+            get => _maximumWaitTime;
+
+            set
+            {
+                if (value.HasValue)
+                {
+                    Argument.AssertNotNegative(value.Value, nameof(MaximumWaitTime));
+                }
+
+                _maximumWaitTime = value;
+            }
+        }
+
+        /// <summary>
+        ///   Determines whether the specified <see cref="System.Object" /> is equal to this instance.
+        /// </summary>
+        ///
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+        ///
+        /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => base.Equals(obj);
+
+        /// <summary>
+        ///   Returns a hash code for this instance.
+        /// </summary>
+        ///
+        /// <returns>A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => base.GetHashCode();
+
+        /// <summary>
+        ///   Converts the instance to string representation.
+        /// </summary>
+        ///
+        /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override string ToString() => base.ToString();
+
+        /// <summary>
+        ///   Creates a new copy of the current <see cref="ReadOptions" />, cloning its attributes into a new instance.
+        /// </summary>
+        ///
+        /// <returns>A new copy of <see cref="ReadOptions" />.</returns>
+        ///
+        internal ReadOptions Clone() =>
+            new ReadOptions
+            {
+                OwnerLevel = OwnerLevel,
+                TrackLastEnqueuedEventInformation = TrackLastEnqueuedEventInformation,
+                MaximumWaitTime = MaximumWaitTime
+            };
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpClientTests.cs
@@ -403,7 +403,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var client = new AmqpClient("my.eventhub.com", "somePath", credential.Object, new EventHubConnectionOptions());
             await client.CloseAsync(cancellationSource.Token);
 
-            Assert.That(() => client.CreateConsumer("group", "0", EventPosition.Earliest, new EventHubConsumerClientOptions()), Throws.InstanceOf<EventHubsClientClosedException>());
+            Assert.That(() => client.CreateConsumer("group", "0", EventPosition.Earliest, Mock.Of<EventHubsRetryPolicy>(), false, null, null), Throws.InstanceOf<EventHubsClientClosedException>());
         }
 
         /// <summary>
@@ -420,7 +420,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var client = new AmqpClient("my.eventhub.com", "somePath", credential.Object, new EventHubConnectionOptions());
             await client.CloseAsync(cancellationSource.Token);
 
-            Assert.That(() => client.CreateProducer(null, new EventHubProducerClientOptions()), Throws.InstanceOf<EventHubsClientClosedException>());
+            Assert.That(() => client.CreateProducer(null, Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<EventHubsClientClosedException>());
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
@@ -41,7 +41,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorRequiresTheEventHubName(string eventHub)
         {
-            Assert.That(() => new AmqpConsumer(eventHub, "$DEFAULT", "0", EventPosition.Earliest, new EventHubConsumerClientOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new AmqpConsumer(eventHub, "$DEFAULT", "0", EventPosition.Earliest, true, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorRequiresTheConsumerGroup(string group)
         {
-            Assert.That(() => new AmqpConsumer("myHub", group, "0", EventPosition.Earliest, new EventHubConsumerClientOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new AmqpConsumer("myHub", group, "0", EventPosition.Earliest, true, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -65,17 +65,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorRequiresThePartition(string partition)
         {
-            Assert.That(() => new AmqpConsumer("aHub", "$DEFAULT", partition, EventPosition.Earliest, new EventHubConsumerClientOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the constructor.
-        /// </summary>
-        ///
-        [Test]
-        public void ConstructorRequiresTheOptions()
-        {
-            Assert.That(() => new AmqpConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.FromOffset(1), null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpConsumer("aHub", "$DEFAULT", partition, EventPosition.Earliest, true, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -85,7 +75,17 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorRequiresTheConnectionScope()
         {
-            Assert.That(() => new AmqpConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.FromSequenceNumber(123), new EventHubConsumerClientOptions(), null, Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.FromSequenceNumber(123), true, null, null, null, Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>()), Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorRequiresTheMessageConverter()
+        {
+            Assert.That(() => new AmqpConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.FromSequenceNumber(123), true, null, null, Mock.Of<AmqpConnectionScope>(), null, Mock.Of<EventHubsRetryPolicy>()), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorRequiresTheRetryPolicy()
         {
-            Assert.That(() => new AmqpConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.Latest, new EventHubConsumerClientOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), null), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpConsumer("theMostAwesomeHubEvar", "$DEFAULT", "0", EventPosition.Latest, true, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), null), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task CloseMarksTheConsumerAsClosed()
         {
-            var consumer = new AmqpConsumer("aHub", "$DEFAULT", "0", EventPosition.Earliest, new EventHubConsumerClientOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>());
+            var consumer = new AmqpConsumer("aHub", "$DEFAULT", "0", EventPosition.Earliest, true, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>());
             Assert.That(consumer.IsClosed, Is.False, "The consumer should not be closed on creation");
 
             await consumer.CloseAsync(CancellationToken.None);
@@ -121,7 +121,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void CloseRespectsTheCancellationToken()
         {
-            var consumer = new AmqpConsumer("aHub", "$DEFAULT", "0", EventPosition.Earliest, new EventHubConsumerClientOptions(), Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>());
+            var consumer = new AmqpConsumer("aHub", "$DEFAULT", "0", EventPosition.Earliest, true, null, null, Mock.Of<AmqpConnectionScope>(), Mock.Of<AmqpMessageConverter>(), Mock.Of<EventHubsRetryPolicy>());
             using var cancellationSource = new CancellationTokenSource();
 
             cancellationSource.Cancel();
@@ -144,7 +144,6 @@ namespace Azure.Messaging.EventHubs.Tests
             var consumerGroup = "$DEFAULT";
             var partition = "3";
             var eventPosition = EventPosition.FromOffset(123);
-            var options = new EventHubConsumerClientOptions();
             var retryPolicy = new BasicRetryPolicy(new RetryOptions());
             var retriableException = new EventHubsException(true, "Test");
             var mockConverter = new Mock<AmqpMessageConverter>();
@@ -153,7 +152,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             using var cancellationSource = new CancellationTokenSource();
 
-            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, options, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, true, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             Assert.That(async () => await consumer.ReceiveAsync(count, null, cancellationSource.Token), Throws.InstanceOf<ArgumentException>());
         }
 
@@ -169,7 +168,6 @@ namespace Azure.Messaging.EventHubs.Tests
             var consumerGroup = "$DEFAULT";
             var partition = "3";
             var eventPosition = EventPosition.FromOffset(123);
-            var options = new EventHubConsumerClientOptions();
             var retryPolicy = new BasicRetryPolicy(new RetryOptions());
             var retriableException = new EventHubsException(true, "Test");
             var mockConverter = new Mock<AmqpMessageConverter>();
@@ -179,7 +177,7 @@ namespace Azure.Messaging.EventHubs.Tests
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();
 
-            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, options, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, true, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
         }
 
@@ -197,7 +195,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var consumerGroup = "$DEFAULT";
             var partition = "3";
             var eventPosition = EventPosition.FromOffset(123);
-            var options = new EventHubConsumerClientOptions();
+            var trackLastEnqueued = false;
+            var ownerLevel = 123L;
             var tokenValue = "123ABC";
             var retryPolicy = new BasicRetryPolicy(retryOptions);
             var retriableException = new EventHubsException(true, "Test");
@@ -216,12 +215,14 @@ namespace Azure.Messaging.EventHubs.Tests
                    It.IsAny<string>(),
                    It.IsAny<string>(),
                    It.IsAny<EventPosition>(),
-                   It.IsAny<EventHubConsumerClientOptions>(),
                    It.IsAny<TimeSpan>(),
+                   It.IsAny<uint>(),
+                   It.IsAny<long?>(),
+                   It.IsAny<bool>(),
                    It.IsAny<CancellationToken>()))
                .Throws(retriableException);
 
-            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, options, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, trackLastEnqueued, ownerLevel, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf(retriableException.GetType()));
 
             mockScope
@@ -229,8 +230,10 @@ namespace Azure.Messaging.EventHubs.Tests
                     It.Is<string>(value => value == consumerGroup),
                     It.Is<string>(value => value == partition),
                     It.Is<EventPosition>(value => value == eventPosition),
-                    It.Is<EventHubConsumerClientOptions>(value => value == options),
                     It.IsAny<TimeSpan>(),
+                    It.IsAny<uint>(),
+                    It.Is<long?>(value => value == ownerLevel),
+                    It.Is<bool>(value => value == trackLastEnqueued),
                     It.IsAny<CancellationToken>()),
                 Times.Exactly(1 + retryOptions.MaximumRetries));
         }
@@ -256,7 +259,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             using var cancellationSource = new CancellationTokenSource();
 
-            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, options, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, true, null, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
             await consumer.CloseAsync(cancellationSource.Token);
 
             Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf<EventHubsClientClosedException>());

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
@@ -303,7 +303,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 });
 
             var connectionMock = new Mock<EventHubConnection>("namespace", "eventHubName", Mock.Of<TokenCredential>(), new EventHubConnectionOptions());
-            connectionMock.Setup(c => c.CreateTransportConsumer("cg", "pid", It.IsAny<EventPosition>(), It.IsAny<EventHubConsumerClientOptions>())).Returns(consumerMock.Object);
+            connectionMock.Setup(c => c.CreateTransportConsumer("cg", "pid", It.IsAny<EventPosition>(), It.IsAny<EventHubsRetryPolicy>(), It.IsAny<bool>(), It.IsAny<long?>(), It.IsAny<uint?>())).Returns(consumerMock.Object);
 
             Func<EventProcessorEvent, ValueTask> processEventAsync = processorEvent =>
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientOptionsTests.cs
@@ -24,64 +24,17 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubConsumerClientOptions
             {
-                OwnerLevel = 99,
-                TrackLastEnqueuedEventInformation = false,
                 RetryOptions = new RetryOptions { Mode = RetryMode.Fixed },
-                ConnectionOptions = new EventHubConnectionOptions { TransportType = TransportType.AmqpWebSockets },
-                DefaultMaximumReceiveWaitTime = TimeSpan.FromMinutes(65)
+                ConnectionOptions = new EventHubConnectionOptions { TransportType = TransportType.AmqpWebSockets }
             };
 
             EventHubConsumerClientOptions clone = options.Clone();
             Assert.That(clone, Is.Not.Null, "The clone should not be null.");
 
-            Assert.That(clone.OwnerLevel, Is.EqualTo(options.OwnerLevel), "The owner level of the clone should match.");
-            Assert.That(clone.TrackLastEnqueuedEventInformation, Is.EqualTo(options.TrackLastEnqueuedEventInformation), "The tracking of last event information of the clone should match.");
-            Assert.That(clone.DefaultMaximumReceiveWaitTime, Is.EqualTo(options.DefaultMaximumReceiveWaitTime), "The default maximum wait time of the clone should match.");
             Assert.That(clone.ConnectionOptions.TransportType, Is.EqualTo(options.ConnectionOptions.TransportType), "The connection options of the clone should copy properties.");
             Assert.That(clone.ConnectionOptions, Is.Not.SameAs(options.ConnectionOptions), "The connection options of the clone should be a copy, not the same instance.");
             Assert.That(clone.RetryOptions.IsEquivalentTo(options.RetryOptions), Is.True, "The retry options of the clone should be considered equal.");
             Assert.That(clone.RetryOptions, Is.Not.SameAs(options.RetryOptions), "The retry options of the clone should be a copy, not the same instance.");
-        }
-
-        /// <summary>
-        ///  Verifies that setting the <see cref="EventHubConsumerClientOptions.PrefetchCount" /> is
-        ///  validated.
-        /// </summary>
-        ///
-        [Test]
-        public void PrefetchIsValidated()
-        {
-            var options = new MockOptions();
-            Assert.That(() => options.PrefetchCount = (options.MinPrefixCount - 1), Throws.InstanceOf<ArgumentOutOfRangeException>());
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the <see cref="EventHubConsumerClientOptions.DefaultMaximumReceiveWaitTime" />
-        ///   property.
-        /// </summary>
-        ///
-        [Test]
-        public void DefaultMaximumReceiveWaitTimeIsValidated()
-        {
-            Assert.That(() => new EventHubConsumerClientOptions { DefaultMaximumReceiveWaitTime = TimeSpan.FromMilliseconds(-1) }, Throws.ArgumentException);
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the <see cref="EventHubProducerClientOptions.Timeout" />
-        ///   property.
-        /// </summary>
-        ///
-        [Test]
-        [TestCase(null)]
-        [TestCase(0)]
-        public void DefaultMaximumReceiveWaitTimeUsesNormalizedValueIfNotSpecified(int? noTimeoutValue)
-        {
-            var options = new EventHubConsumerClientOptions();
-            TimeSpan? timeoutValue = (noTimeoutValue.HasValue) ? TimeSpan.Zero : (TimeSpan?)null;
-
-            options.DefaultMaximumReceiveWaitTime = timeoutValue;
-            Assert.That(options.DefaultMaximumReceiveWaitTime, Is.EqualTo(timeoutValue), "The value supplied by the caller should be preserved.");
-            Assert.That(options.MaximumReceiveWaitTimeOrDefault, Is.Null, "The maximum wait value should be normalized to null internally.");
         }
 
         /// <summary>
@@ -104,17 +57,6 @@ namespace Azure.Messaging.EventHubs.Tests
         public void RetryOptionsAreValidated()
         {
             Assert.That(() => new EventHubConsumerClientOptions { RetryOptions = null }, Throws.ArgumentNullException);
-        }
-
-        /// <summary>
-        ///   A mock of the <see cref="EventHubConsumerClientOptions" /> to allow the protected validation
-        ///   constants to be referenced.
-        /// </summary>
-        ///
-        private class MockOptions : EventHubConsumerClientOptions
-        {
-            public int MinPrefixCount => EventHubConsumerClientOptions.MinimumPrefetchCount;
-            public int MaxIdentifierLength => EventHubConsumerClientOptions.MaximumIdentifierLength;
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/ReadOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/ReadOptionsTests.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="ReadOptions" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class ReadOptionsTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ReadOptions.Clone" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CloneProducesACopy()
+        {
+            var options = new ReadOptions
+            {
+                OwnerLevel = 99,
+                TrackLastEnqueuedEventInformation = false,
+                MaximumWaitTime = TimeSpan.FromMinutes(65)
+            };
+
+            ReadOptions clone = options.Clone();
+            Assert.That(clone, Is.Not.Null, "The clone should not be null.");
+
+            Assert.That(clone.OwnerLevel, Is.EqualTo(options.OwnerLevel), "The owner level of the clone should match.");
+            Assert.That(clone.TrackLastEnqueuedEventInformation, Is.EqualTo(options.TrackLastEnqueuedEventInformation), "The tracking of last event information of the clone should match.");
+            Assert.That(clone.MaximumWaitTime, Is.EqualTo(options.MaximumWaitTime), "The default maximum wait time of the clone should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ReadOptions.MaximumWaitTime" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void MaximumWaitTimeIsValidated()
+        {
+            Assert.That(() => new ReadOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(-1) }, Throws.InstanceOf<ArgumentException>());
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientLiveTests.cs
@@ -34,6 +34,9 @@ namespace Azure.Messaging.EventHubs.Tests
         /// <summary>The default retry policy to use when performing operations.</summary>
         private readonly EventHubsRetryPolicy DefaultRetryPolicy = new RetryOptions().ToRetryPolicy();
 
+        /// <summary>The default set of options for reading, allowing a small wait time.</summary>
+        private readonly ReadOptions DefaultReadOptions = new ReadOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(50) };
+
         /// <summary>
         ///   Verifies that the <see cref="EventHubProducerClient" /> is able to
         ///   connect to the Event Hubs service and perform operations.
@@ -836,7 +839,7 @@ namespace Azure.Messaging.EventHubs.Tests
                             var consecutiveEmpties = 0;
                             var maximumConsecutiveEmpties = 5;
 
-                            await foreach (var partitionEvent in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.Earliest, TimeSpan.FromMilliseconds(50), cancellationSource.Token))
+                            await foreach (var partitionEvent in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.Earliest, DefaultReadOptions, cancellationSource.Token))
                             {
                                 if (partitionEvent.Data != null)
                                 {
@@ -903,7 +906,7 @@ namespace Azure.Messaging.EventHubs.Tests
                         var consecutiveEmpties = 0;
                         var maximumConsecutiveEmpties = 5;
 
-                        await foreach (var partitionEvent in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.Earliest, TimeSpan.FromMilliseconds(50), cancellationSource.Token))
+                        await foreach (var partitionEvent in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.Earliest, DefaultReadOptions, cancellationSource.Token))
                         {
                             if (partitionEvent.Data != null)
                             {
@@ -973,7 +976,7 @@ namespace Azure.Messaging.EventHubs.Tests
                         var consecutiveEmpties = 0;
                         var maximumConsecutiveEmpties = 5;
 
-                        await foreach (var partitionEvent in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.Earliest, TimeSpan.FromMilliseconds(50), cancellationSource.Token))
+                        await foreach (var partitionEvent in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.Earliest, DefaultReadOptions, cancellationSource.Token))
                         {
                             if (partitionEvent.Data != null)
                             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientTests.cs
@@ -829,7 +829,7 @@ namespace Azure.Messaging.EventHubs.Tests
             }
 
             internal override TransportProducer CreateTransportProducer(string partitionId,
-                                                                        EventHubProducerClientOptions producerOptions = default) => TransportProducerFactory();
+                                                                        EventHubsRetryPolicy retryPolicy) => TransportProducerFactory();
 
             internal override TransportClient CreateTransportClient(string fullyQualifiedNamespace, string eventHubName, EventHubTokenCredential credential, EventHubConnectionOptions options)
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventProcessorClient/EventProcessorClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventProcessorClient/EventProcessorClientLiveTests.cs
@@ -619,6 +619,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        [Ignore("Unstable test. (Tracked by: #7458)")]
         public async Task PartitionProcessorCanCreateACheckpoint()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))


### PR DESCRIPTION
# Summary

The focus of these changes is to refactor the scope of the options used with an Event Hub Consumer client, moving the owner level and tracking of last enqueued event information to the reader level.   This allows for them to differ for each active reader, rather than having the client bound to the specified values.

Also included are tweaks to test timings with the goal of improving test stability and determinism after the large overhaul.

# Last Upstream Rebase

Wednesday, November 20, 8:41apm (EST)

# Related and Follow-Up Issues

- [Release Event Hubs Track 2 Library for .NET](https://github.com/Azure/azure-sdk-for-net/issues/8552) (#8552) 
- [Incorporate review feedback](https://github.com/Azure/azure-sdk-for-net/issues/8583) (#8583) 