### PR TITLE
Fix live tests and samples

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/README.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/README.md
@@ -78,12 +78,6 @@ Once you've populated the **AZURE_CLIENT_ID**, **AZURE_CLIENT_SECRET** and **AZU
 // Create a new certificate client using the default credential from Azure.Identity using environment variables previously set,
 // including AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, and AZURE_TENANT_ID.
 var client = new CertificateClient(vaultUri: new Uri(keyVaultUrl), credential: new DefaultAzureCredential());
-
-// Create a certificate using the certificate client.
-CertificateOperation operation = client.StartCreateCertificate("MyCertificate", CertificatePolicy.Default);
-
-// Retrieve a certificate using the certificate client.
-KeyVaultCertificateWithPolicy certificate = client.GetCertificate("MyCertificate");
 ```
 
 ## Key concepts

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/README.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/README.md
@@ -174,7 +174,7 @@ is not enabled for the Key Vault, this operation permanently deletes the certifi
 ```C# Snippet:DeleteAndPurgeCertificate
 DeleteCertificateOperation operation = client.StartDeleteCertificate("MyCertificate");
 
-// You only need to wait for completion if you want to purge or recover the secret.
+// You only need to wait for completion if you want to purge or recover the certificate.
 // You should call `UpdateStatus` in another thread or after doing additional work like pumping messages.
 while (!operation.HasCompleted)
 {
@@ -219,7 +219,7 @@ By default, this loops indefinitely but you can cancel it by passing a `Cancella
 ```C# Snippet:DeleteAndPurgeCertificateAsync
 DeleteCertificateOperation operation = await client.StartDeleteCertificateAsync("MyCertificate");
 
-// You only need to wait for completion if you want to purge or recover the secret.
+// You only need to wait for completion if you want to purge or recover the certificate.
 await operation.WaitForCompletionAsync();
 
 DeletedCertificate secret = operation.Value;

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/samples/Sample1_HelloWorld.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/samples/Sample1_HelloWorld.md
@@ -76,7 +76,7 @@ The certificate is no longer needed, so delete it from the Key Vault.
 ```C# Snippet:CertificatesSample1DeleteCertificate
 DeleteCertificateOperation operation = client.StartDeleteCertificate(certName);
 
-// To ensure certificate is deleted on server side.
+// You only need to wait for completion if you want to purge or recover the certificate.
 while (!operation.HasCompleted)
 {
     Thread.Sleep(2000);

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/samples/Sample2_GetCertificates.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/samples/Sample2_GetCertificates.md
@@ -23,7 +23,7 @@ string certName1 = $"defaultCert-{Guid.NewGuid()}";
 CertificateOperation certOp1 = client.StartCreateCertificate(certName1, CertificatePolicy.Default);
 
 string certName2 = $"defaultCert-{Guid.NewGuid()}";
-CertificateOperation certOp2 = client.StartCreateCertificate(certName1, CertificatePolicy.Default);
+CertificateOperation certOp2 = client.StartCreateCertificate(certName2, CertificatePolicy.Default);
 
 while (!certOp1.HasCompleted)
 {

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/samples/Sample2_GetCertificates.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/samples/Sample2_GetCertificates.md
@@ -87,6 +87,7 @@ DeleteCertificateOperation operation1 = client.StartDeleteCertificate(certName1)
 DeleteCertificateOperation operation2 = client.StartDeleteCertificate(certName2);
 
 // To ensure certificates are deleted on server side.
+// You only need to wait for completion if you want to purge or recover the certificate.
 while (!operation1.HasCompleted || !operation2.HasCompleted)
 {
     Thread.Sleep(2000);

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificatesTestBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificatesTestBase.cs
@@ -15,6 +15,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
     {
         public const string AzureKeyVaultUrlEnvironmentVariable = "AZURE_KEYVAULT_URL";
         private readonly HashSet<string> _toCleanup = new HashSet<string>();
+        private readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
 
         public CertificateClient Client { get; set; }
 
@@ -48,9 +49,17 @@ namespace Azure.Security.KeyVault.Certificates.Tests
         {
             List<Task> cleanupTasks = new List<Task>();
 
-            foreach (string certName in _toCleanup)
+            _lock.EnterReadLock();
+            try
             {
-                cleanupTasks.Add(CleanupCertificate(certName));
+                foreach (string certName in _toCleanup)
+                {
+                    cleanupTasks.Add(CleanupCertificate(certName));
+                }
+            }
+            finally
+            {
+                _lock.ExitReadLock();
             }
 
             await Task.WhenAll(cleanupTasks);
@@ -61,7 +70,13 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             try
             {
                 await Client.StartDeleteCertificateAsync(name);
+            }
+            catch (RequestFailedException ex) when (ex.Status == 404)
+            {
+            }
 
+            try
+            {
                 await WaitForDeletedCertificate(name);
             }
             catch (RequestFailedException ex) when (ex.Status == 404)
@@ -158,9 +173,14 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 
         protected void RegisterForCleanup(string certificateName)
         {
-            lock (_toCleanup)
+            _lock.EnterWriteLock();
+            try
             {
                 _toCleanup.Add(certificateName);
+            }
+            finally
+            {
+                _lock.ExitWriteLock();
             }
         }
     }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample1_HelloWorld.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample1_HelloWorld.cs
@@ -14,6 +14,7 @@ namespace Azure.Security.KeyVault.Certificates.Samples
     /// This sample demonstrates how to create, get, update, and delete a certificate using the synchronous methods of the <see cref="CertificateClient">.
     /// </summary>
     [LiveOnly]
+    [NonParallelizable]
     public partial class HelloWorld
     {
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample1_HelloWorld.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample1_HelloWorld.cs
@@ -22,11 +22,7 @@ namespace Azure.Security.KeyVault.Certificates.Samples
         {
             // Environment variable with the Key Vault endpoint.
             string keyVaultUrl = Environment.GetEnvironmentVariable("AZURE_KEYVAULT_URL");
-            HelloWorldSync(keyVaultUrl);
-        }
 
-        public void HelloWorldSync(string keyVaultUrl)
-        {
             #region Snippet:CertificatesSample1CertificateClient
             var client = new CertificateClient(new Uri(keyVaultUrl), new DefaultAzureCredential());
             #endregion

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample1_HelloWorld.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample1_HelloWorld.cs
@@ -67,7 +67,7 @@ namespace Azure.Security.KeyVault.Certificates.Samples
             #region Snippet:CertificatesSample1DeleteCertificate
             DeleteCertificateOperation operation = client.StartDeleteCertificate(certName);
 
-            // To ensure certificate is deleted on server side.
+            // You only need to wait for completion if you want to purge or recover the certificate.
             while (!operation.HasCompleted)
             {
                 Thread.Sleep(2000);

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample1_HelloWorldAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample1_HelloWorldAsync.cs
@@ -63,7 +63,7 @@ namespace Azure.Security.KeyVault.Certificates.Samples
             // The certificate is no longer needed, need to delete it from the Key Vault.
             DeleteCertificateOperation operation = await client.StartDeleteCertificateAsync(certName);
 
-            // To ensure key is deleted on server side.
+            // You only need to wait for completion if you want to purge or recover the certificate.
             await operation.WaitForCompletionAsync();
 
             // If the keyvault is soft-delete enabled, then for permanent deletion, the deleted key needs to be purged.

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample2_GetCertificates.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample2_GetCertificates.cs
@@ -16,6 +16,7 @@ namespace Azure.Security.KeyVault.Certificates.Samples
     /// using the synchronous methods of the CertificateClient.
     /// </summary>
     [LiveOnly]
+    [NonParallelizable]
     public partial class GetCertificates
     {
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample2_GetCertificates.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample2_GetCertificates.cs
@@ -81,6 +81,7 @@ namespace Azure.Security.KeyVault.Certificates.Samples
             DeleteCertificateOperation operation2 = client.StartDeleteCertificate(certName2);
 
             // To ensure certificates are deleted on server side.
+            // You only need to wait for completion if you want to purge or recover the certificate.
             while (!operation1.HasCompleted || !operation2.HasCompleted)
             {
                 Thread.Sleep(2000);

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample2_GetCertificates.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample2_GetCertificates.cs
@@ -34,7 +34,7 @@ namespace Azure.Security.KeyVault.Certificates.Samples
             CertificateOperation certOp1 = client.StartCreateCertificate(certName1, CertificatePolicy.Default);
 
             string certName2 = $"defaultCert-{Guid.NewGuid()}";
-            CertificateOperation certOp2 = client.StartCreateCertificate(certName1, CertificatePolicy.Default);
+            CertificateOperation certOp2 = client.StartCreateCertificate(certName2, CertificatePolicy.Default);
 
             while (!certOp1.HasCompleted)
             {

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample2_GetCertificates.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample2_GetCertificates.cs
@@ -24,11 +24,7 @@ namespace Azure.Security.KeyVault.Certificates.Samples
         {
             // Environment variable with the Key Vault endpoint.
             string keyVaultUrl = Environment.GetEnvironmentVariable("AZURE_KEYVAULT_URL");
-            GetCertificatesSync(keyVaultUrl);
-        }
 
-        private void GetCertificatesSync(string keyVaultUrl)
-        {
             #region Snippet:CertificatesSample2CertificateClient
             var client = new CertificateClient(new Uri(keyVaultUrl), new DefaultAzureCredential());
             #endregion

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample2_GetCertificatesAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample2_GetCertificatesAsync.cs
@@ -68,7 +68,7 @@ namespace Azure.Security.KeyVault.Certificates.Samples
             DeleteCertificateOperation operation2 = await client.StartDeleteCertificateAsync(certName2);
 
             // To ensure certificates are deleted on server side.
-            Task.WaitAll(
+            await Task.WhenAll(
                 operation1.WaitForCompletionAsync().AsTask(),
                 operation2.WaitForCompletionAsync().AsTask());
 
@@ -79,7 +79,7 @@ namespace Azure.Security.KeyVault.Certificates.Samples
             }
 
             // If the keyvault is soft-delete enabled, then for permanent deletion, deleted keys needs to be purged.
-            Task.WaitAll(
+            await Task.WhenAll(
                 client.PurgeDeletedCertificateAsync(certName1),
                 client.PurgeDeletedCertificateAsync(certName2));
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample2_GetCertificatesAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample2_GetCertificatesAsync.cs
@@ -67,7 +67,7 @@ namespace Azure.Security.KeyVault.Certificates.Samples
             DeleteCertificateOperation operation1 = await client.StartDeleteCertificateAsync(certName1);
             DeleteCertificateOperation operation2 = await client.StartDeleteCertificateAsync(certName2);
 
-            // To ensure certificates are deleted on server side.
+            // You only need to wait for completion if you want to purge or recover the certificate.
             await Task.WhenAll(
                 operation1.WaitForCompletionAsync().AsTask(),
                 operation2.WaitForCompletionAsync().AsTask());

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample2_GetCertificatesAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample2_GetCertificatesAsync.cs
@@ -36,7 +36,7 @@ namespace Azure.Security.KeyVault.Certificates.Samples
 
             string certName2 = $"defaultCert-{Guid.NewGuid()}";
 
-            CertificateOperation certOp2 = await client.StartCreateCertificateAsync(certName1, CertificatePolicy.Default);
+            CertificateOperation certOp2 = await client.StartCreateCertificateAsync(certName2, CertificatePolicy.Default);
 
             // Next, let's wait on the certificate operation to complete. Note that certificate creation can last an indeterministic
             // amount of time, so applications should only wait on the operation to complete in the case the issuance time is well

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/SampleSnippets.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/SampleSnippets.cs
@@ -30,12 +30,6 @@ namespace Azure.Security.KeyVault.Certificates.Samples
             // Create a new certificate client using the default credential from Azure.Identity using environment variables previously set,
             // including AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, and AZURE_TENANT_ID.
             var client = new CertificateClient(vaultUri: new Uri(keyVaultUrl), credential: new DefaultAzureCredential());
-
-            // Create a certificate using the certificate client.
-            CertificateOperation operation = client.StartCreateCertificate("MyCertificate", CertificatePolicy.Default);
-
-            // Retrieve a certificate using the certificate client.
-            KeyVaultCertificateWithPolicy certificate = client.GetCertificate("MyCertificate");
             #endregion
 
             this.client = client;

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/SampleSnippets.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/SampleSnippets.cs
@@ -61,7 +61,7 @@ namespace Azure.Security.KeyVault.Certificates.Samples
             #endregion
         }
 
-        [Test]
+        [Ignore("The certificate was already created in the synchronous method.")]
         public async Task CreateCertificateAsync()
         {
             #region Snippet:CreateCertificateAsync

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/SampleSnippets.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/SampleSnippets.cs
@@ -139,7 +139,7 @@ namespace Azure.Security.KeyVault.Certificates.Samples
             #region Snippet:DeleteAndPurgeCertificateAsync
             DeleteCertificateOperation operation = await client.StartDeleteCertificateAsync("MyCertificate");
 
-            // You only need to wait for completion if you want to purge or recover the secret.
+            // You only need to wait for completion if you want to purge or recover the certificate.
             await operation.WaitForCompletionAsync();
 
             DeletedCertificate secret = operation.Value;
@@ -153,7 +153,7 @@ namespace Azure.Security.KeyVault.Certificates.Samples
             #region Snippet:DeleteAndPurgeCertificate
             DeleteCertificateOperation operation = client.StartDeleteCertificate("MyCertificate");
 
-            // You only need to wait for completion if you want to purge or recover the secret.
+            // You only need to wait for completion if you want to purge or recover the certificate.
             // You should call `UpdateStatus` in another thread or after doing additional work like pumping messages.
             while (!operation.HasCompleted)
             {

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/README.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/README.md
@@ -198,6 +198,7 @@ You will need to wait for the long-running operation to complete before trying t
 ```C# Snippet:DeleteAndPurgeKey
 DeleteKeyOperation operation = client.StartDeleteKey("key-name");
 
+// You only need to wait for completion if you want to purge or recover the key.
 while (!operation.HasCompleted)
 {
     Thread.Sleep(2000);

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample1_HelloWorld.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample1_HelloWorld.md
@@ -79,6 +79,7 @@ If the Key Vault is soft delete-enabled and you want to permanently delete the k
 the deleted key needs to be purged. Before it can be purged, you need to wait until the key is fully deleted.
 
 ```C# Snippet:KeysSample1PurgeKey
+// You only need to wait for completion if you want to purge or recover the key.
 while (!operation.HasCompleted)
 {
     Thread.Sleep(2000);
@@ -95,6 +96,7 @@ When writing asynchronous code, you can instead await `WaitForCompletionAsync` t
 You can optionally pass in a `CancellationToken` to cancel waiting after a certain period or time or any other trigger you require.
 
 ```C# Snippet:KeysSample1PurgeKeyAsync
+// You only need to wait for completion if you want to purge or recover the key.
 await operation.WaitForCompletionAsync();
 
 await client.PurgeDeletedKeyAsync(rsaKeyName);

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample3_GetKeys.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample3_GetKeys.md
@@ -90,6 +90,7 @@ You need to delete them from the Key Vault.
 DeleteKeyOperation rsaKeyOperation = client.StartDeleteKey(rsaKeyName);
 DeleteKeyOperation ecKeyOperation = client.StartDeleteKey(ecKeyName);
 
+// You only need to wait for completion if you want to purge or recover the key.
 while (!rsaKeyOperation.HasCompleted || !ecKeyOperation.HasCompleted)
 {
     Thread.Sleep(2000);

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientLiveTests.cs
@@ -288,7 +288,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
 
             KeyVaultKey key = await Client.CreateKeyAsync(keyName, KeyType.Ec);
 
-            RegisterForCleanup(key.Name, delete: false);
+            RegisterForCleanup(key.Name);
 
             DeleteKeyOperation operation = await Client.StartDeleteKeyAsync(keyName);
             DeletedKey deletedKey = operation.Value;
@@ -314,7 +314,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
 
             KeyVaultKey key = await Client.CreateKeyAsync(keyName, KeyType.Ec);
 
-            RegisterForCleanup(key.Name, delete: false);
+            RegisterForCleanup(key.Name);
 
             DeleteKeyOperation operation = await Client.StartDeleteKeyAsync(keyName);
             DeletedKey deletedKey = operation.Value;
@@ -354,7 +354,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             RecoverDeletedKeyOperation recoverOperation = await Client.StartRecoverDeletedKeyAsync(keyName);
             KeyVaultKey recoverKeyResult = recoverOperation.Value;
 
-            await PollForKey(keyName);
+            await WaitForKey(keyName);
 
             KeyVaultKey recoveredKey = await Client.GetKeyAsync(keyName);
 
@@ -456,7 +456,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
                 createdKeys.Add(Key);
                 await Client.StartDeleteKeyAsync(keyName + i);
 
-                RegisterForCleanup(Key.Name, delete: false);
+                RegisterForCleanup(Key.Name);
             }
 
             foreach (KeyVaultKey deletedKey in createdKeys)

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeysTestBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeysTestBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.Core.Testing;
@@ -18,7 +19,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
 
         public Uri VaultUri { get; set; }
 
-        private readonly Queue<(string Name, bool Delete)> _keysToCleanup = new Queue<(string, bool)>();
+        private readonly ConcurrentQueue<string> _keysToCleanup = new ConcurrentQueue<string>();
 
         protected KeysTestBase(bool isAsync) : base(isAsync)
         {
@@ -48,15 +49,12 @@ namespace Azure.Security.KeyVault.Keys.Tests
         {
             List<Task> cleanupTasks = new List<Task>();
 
-            foreach ((string name, bool delete) in _keysToCleanup)
+            foreach (string name in _keysToCleanup)
             {
-                if (delete)
-                {
-                    cleanupTasks.Add(CleanupKey(name));
-                }
-
-                await Task.WhenAll(cleanupTasks);
+                cleanupTasks.Add(CleanupKey(name));
             }
+
+            await Task.WhenAll(cleanupTasks);
         }
 
         protected async Task CleanupKey(string name)
@@ -64,7 +62,13 @@ namespace Azure.Security.KeyVault.Keys.Tests
             try
             {
                 await Client.StartDeleteKeyAsync(name);
+            }
+            catch (RequestFailedException ex) when (ex.Status == 404)
+            {
+            }
 
+            try
+            {
                 await WaitForDeletedKey(name);
             }
             catch (RequestFailedException ex) when (ex.Status == 404)
@@ -80,9 +84,9 @@ namespace Azure.Security.KeyVault.Keys.Tests
             }
         }
 
-        protected void RegisterForCleanup(string name, bool delete = true)
+        protected void RegisterForCleanup(string name)
         {
-            _keysToCleanup.Enqueue((name, delete));
+            _keysToCleanup.Enqueue(name);
         }
 
         protected void AssertKeyVaultKeysEqual(KeyVaultKey exp, KeyVaultKey act)
@@ -170,10 +174,10 @@ namespace Azure.Security.KeyVault.Keys.Tests
                 return TestRetryHelper.RetryAsync(async () => {
                     try
                     {
-                        await Client.GetDeletedKeyAsync(name);
-                        throw new InvalidOperationException("Key still exists");
+                        await Client.GetDeletedKeyAsync(name).ConfigureAwait(false);
+                        throw new InvalidOperationException($"Key {name} still exists");
                     }
-                    catch
+                    catch (RequestFailedException ex) when (ex.Status == 404)
                     {
                         return (Response)null;
                     }
@@ -181,7 +185,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             }
         }
 
-        protected Task PollForKey(string name)
+        protected Task WaitForKey(string name)
         {
             if (Mode == RecordedTestMode.Playback)
             {

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample1_HelloWorld.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample1_HelloWorld.cs
@@ -21,11 +21,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
         {
             // Environment variable with the Key Vault endpoint.
             string keyVaultUrl = Environment.GetEnvironmentVariable("AZURE_KEYVAULT_URL");
-            HelloWorldSync(keyVaultUrl);
-        }
 
-        private void HelloWorldSync(string keyVaultUrl)
-        {
             #region Snippet:KeysSample1KeyClient
             var client = new KeyClient(new Uri(keyVaultUrl), new DefaultAzureCredential());
             #endregion

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample1_HelloWorld.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample1_HelloWorld.cs
@@ -63,6 +63,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
             #endregion
 
             #region Snippet:KeysSample1PurgeKey
+            // You only need to wait for completion if you want to purge or recover the key.
             while (!operation.HasCompleted)
             {
                 Thread.Sleep(2000);

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample1_HelloWorldAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample1_HelloWorldAsync.cs
@@ -64,6 +64,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
             DeleteKeyOperation operation = await client.StartDeleteKeyAsync(rsaKeyName);
 
             #region Snippet:KeysSample1PurgeKeyAsync
+            // You only need to wait for completion if you want to purge or recover the key.
             await operation.WaitForCompletionAsync();
 
             await client.PurgeDeletedKeyAsync(rsaKeyName);

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample2_BackupAndRestore.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample2_BackupAndRestore.cs
@@ -22,11 +22,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
         {
             // Environment variable with the Key Vault endpoint.
             string keyVaultUrl = Environment.GetEnvironmentVariable("AZURE_KEYVAULT_URL");
-            BackupAndRestoreSync(keyVaultUrl);
-        }
 
-        private void BackupAndRestoreSync(string keyVaultUrl)
-        {
             #region Snippet:KeysSample2KeyClient
             var client = new KeyClient(new Uri(keyVaultUrl), new DefaultAzureCredential());
             #endregion
@@ -69,6 +65,18 @@ namespace Azure.Security.KeyVault.Keys.Samples
                 #endregion
 
                 AssertKeysEqual(storedKey.Properties, restoredKey.Properties);
+
+                // Delete and purge the restored key.
+                operation = client.StartDeleteKey(rsaKeyName);
+
+                while (!operation.HasCompleted)
+                {
+                    Thread.Sleep(2000);
+
+                    operation.UpdateStatus();
+                }
+
+                client.PurgeDeletedKey(rsaKeyName);
             }
         }
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample2_BackupAndRestore.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample2_BackupAndRestore.cs
@@ -69,6 +69,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
                 // Delete and purge the restored key.
                 operation = client.StartDeleteKey(rsaKeyName);
 
+                // You only need to wait for completion if you want to purge or recover the key.
                 while (!operation.HasCompleted)
                 {
                     Thread.Sleep(2000);

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample2_BackupAndRestoreAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample2_BackupAndRestoreAsync.cs
@@ -62,6 +62,13 @@ namespace Azure.Security.KeyVault.Keys.Samples
                 KeyVaultKey restoredKey = await client.RestoreKeyBackupAsync(memoryStream.ToArray());
 
                 AssertKeysEqual(storedKey.Properties, restoredKey.Properties);
+
+                // Delete and purge the restored key.
+                operation = await client.StartDeleteKeyAsync(rsaKeyName);
+
+                await operation.WaitForCompletionAsync();
+
+                await client.PurgeDeletedKeyAsync(rsaKeyName);
             }
         }
     }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample2_BackupAndRestoreAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample2_BackupAndRestoreAsync.cs
@@ -66,6 +66,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
                 // Delete and purge the restored key.
                 operation = await client.StartDeleteKeyAsync(rsaKeyName);
 
+                // You only need to wait for completion if you want to purge or recover the key.
                 await operation.WaitForCompletionAsync();
 
                 await client.PurgeDeletedKeyAsync(rsaKeyName);

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample3_GetKeys.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample3_GetKeys.cs
@@ -79,6 +79,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
             DeleteKeyOperation rsaKeyOperation = client.StartDeleteKey(rsaKeyName);
             DeleteKeyOperation ecKeyOperation = client.StartDeleteKey(ecKeyName);
 
+            // You only need to wait for completion if you want to purge or recover the key.
             while (!rsaKeyOperation.HasCompleted || !ecKeyOperation.HasCompleted)
             {
                 Thread.Sleep(2000);
@@ -96,6 +97,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
             }
             #endregion
 
+            // You only need to wait for completion if you want to purge or recover the key.
             // If the keyvault is soft-delete enabled, then for permanent deletion, deleted keys needs to be purged.
             client.PurgeDeletedKey(rsaKeyName);
             client.PurgeDeletedKey(ecKeyName);

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample3_GetKeys.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample3_GetKeys.cs
@@ -24,11 +24,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
         {
             // Environment variable with the Key Vault endpoint.
             string keyVaultUrl = Environment.GetEnvironmentVariable("AZURE_KEYVAULT_URL");
-            GetKeysSync(keyVaultUrl);
-        }
 
-        private void GetKeysSync(string keyVaultUrl)
-        {
             #region Snippet:KeysSample3KeyClient
             var client = new KeyClient(new Uri(keyVaultUrl), new DefaultAzureCredential());
             #endregion

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample3_GetKeysAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample3_GetKeysAsync.cs
@@ -82,7 +82,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
             DeleteKeyOperation rsaKeyOperation = await client.StartDeleteKeyAsync(rsaKeyName);
             DeleteKeyOperation ecKeyOperation = await client.StartDeleteKeyAsync(ecKeyName);
 
-            // To ensure the keys are deleted on server before we try to purge them.
+            // You only need to wait for completion if you want to purge or recover the key.
             await Task.WhenAll(
                 rsaKeyOperation.WaitForCompletionAsync().AsTask(),
                 ecKeyOperation.WaitForCompletionAsync().AsTask());

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample3_GetKeysAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample3_GetKeysAsync.cs
@@ -83,7 +83,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
             DeleteKeyOperation ecKeyOperation = await client.StartDeleteKeyAsync(ecKeyName);
 
             // To ensure the keys are deleted on server before we try to purge them.
-            Task.WaitAll(
+            await Task.WhenAll(
                 rsaKeyOperation.WaitForCompletionAsync().AsTask(),
                 ecKeyOperation.WaitForCompletionAsync().AsTask());
 
@@ -94,7 +94,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
             }
 
             // If the keyvault is soft-delete enabled, then for permanent deletion, deleted keys needs to be purged.
-            Task.WaitAll(
+            await Task.WhenAll(
                 client.PurgeDeletedKeyAsync(rsaKeyName),
                 client.PurgeDeletedKeyAsync(ecKeyName));
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample4_EncryptDecrypt.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample4_EncryptDecrypt.cs
@@ -23,11 +23,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
         {
             // Environment variable with the Key Vault endpoint.
             string keyVaultUrl = Environment.GetEnvironmentVariable("AZURE_KEYVAULT_URL");
-            EncryptDecryptSync(keyVaultUrl);
-        }
 
-        private void EncryptDecryptSync(string keyVaultUrl)
-        {
             #region Snippet:KeysSample4KeyClient
             var keyClient = new KeyClient(new Uri(keyVaultUrl), new DefaultAzureCredential());
             #endregion

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample4_EncryptDecrypt.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample4_EncryptDecrypt.cs
@@ -58,6 +58,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
             #region Snippet:KeysSample4DeleteKey
             DeleteKeyOperation operation = keyClient.StartDeleteKey(rsaKeyName);
 
+            // You only need to wait for completion if you want to purge or recover the key.
             while (!operation.HasCompleted)
             {
                 Thread.Sleep(2000);

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample4_EncryptDecryptAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample4_EncryptDecryptAsync.cs
@@ -59,7 +59,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
             // The Cloud RSA Key is no longer needed, need to delete it from the Key Vault.
             DeleteKeyOperation operation = await keyClient.StartDeleteKeyAsync(rsaKeyName);
 
-            // To ensure the key is deleted on server before we try to purge it.
+            // You only need to wait for completion if you want to purge or recover the key.
             await operation.WaitForCompletionAsync();
 
             // If the keyvault is soft-delete enabled, then for permanent deletion, deleted key needs to be purged.

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample5_SignVerify.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample5_SignVerify.cs
@@ -103,6 +103,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
             DeleteKeyOperation rsaKeyOperation = keyClient.StartDeleteKey(rsaKeyName);
             DeleteKeyOperation ecKeyOperation = keyClient.StartDeleteKey(ecKeyName);
 
+            // You only need to wait for completion if you want to purge or recover the key.
             while (!rsaKeyOperation.HasCompleted || !ecKeyOperation.HasCompleted)
             {
                 Thread.Sleep(2000);

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample5_SignVerify.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample5_SignVerify.cs
@@ -28,11 +28,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
 
             // Environment variable with the Key Vault endpoint.
             string keyVaultUrl = Environment.GetEnvironmentVariable("AZURE_KEYVAULT_URL");
-            SignVerifySync(keyVaultUrl);
-        }
 
-        private void SignVerifySync(string keyVaultUrl)
-        {
 #region Snippet:KeysSample5KeyClient
             var keyClient = new KeyClient(new Uri(keyVaultUrl), new DefaultAzureCredential());
 #endregion

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample5_SignVerify.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample5_SignVerify.cs
@@ -22,6 +22,10 @@ namespace Azure.Security.KeyVault.Keys.Samples
         [Test]
         public void SignVerifySync()
         {
+#if NET461
+            Assert.Ignore("Using CryptographyClient with EC keys is not supported on .NET Framework 4.6.1.");
+#endif
+
             // Environment variable with the Key Vault endpoint.
             string keyVaultUrl = Environment.GetEnvironmentVariable("AZURE_KEYVAULT_URL");
             SignVerifySync(keyVaultUrl);
@@ -29,11 +33,11 @@ namespace Azure.Security.KeyVault.Keys.Samples
 
         private void SignVerifySync(string keyVaultUrl)
         {
-            #region Snippet:KeysSample5KeyClient
+#region Snippet:KeysSample5KeyClient
             var keyClient = new KeyClient(new Uri(keyVaultUrl), new DefaultAzureCredential());
-            #endregion
+#endregion
 
-            #region Snippet:KeysSample5CreateKey
+#region Snippet:KeysSample5CreateKey
             string rsaKeyName = $"CloudRsaKey-{Guid.NewGuid()}";
             var rsaKey = new CreateRsaKeyOptions(rsaKeyName, hardwareProtected: false)
             {
@@ -51,15 +55,15 @@ namespace Azure.Security.KeyVault.Keys.Samples
 
             KeyVaultKey cloudEcKey = keyClient.CreateEcKey(ecKey);
             Debug.WriteLine($"Key is returned with name {cloudEcKey.Name} and type {cloudEcKey.KeyType}");
-            #endregion
+#endregion
 
-            #region Snippet:KeysSample5CryptographyClient
+#region Snippet:KeysSample5CryptographyClient
             var rsaCryptoClient = new CryptographyClient(cloudRsaKey.Id, new DefaultAzureCredential());
 
             var ecCryptoClient = new CryptographyClient(cloudEcKey.Id, new DefaultAzureCredential());
-            #endregion
+#endregion
 
-            #region Snippet:KeysSample5SignKey
+#region Snippet:KeysSample5SignKey
             byte[] data = Encoding.UTF8.GetBytes("This is some sample data which we will use to demonstrate sign and verify");
             byte[] digest = null;
 
@@ -73,33 +77,33 @@ namespace Azure.Security.KeyVault.Keys.Samples
 
             SignResult ecSignResult = ecCryptoClient.Sign(SignatureAlgorithm.ES256K, digest);
             Debug.WriteLine($"Signed digest using the algorithm {ecSignResult.Algorithm}, with key {ecSignResult.KeyId}. The resulting signature is {Convert.ToBase64String(ecSignResult.Signature)}");
-            #endregion
+#endregion
 
-            #region Snippet:KeysSample5VerifySign
+#region Snippet:KeysSample5VerifySign
             VerifyResult rsaVerifyResult = rsaCryptoClient.Verify(SignatureAlgorithm.RS256, digest, rsaSignResult.Signature);
             Debug.WriteLine($"Verified the signature using the algorithm {rsaVerifyResult.Algorithm}, with key {rsaVerifyResult.KeyId}. Signature is valid: {rsaVerifyResult.IsValid}");
 
             VerifyResult ecVerifyResult = ecCryptoClient.Verify(SignatureAlgorithm.ES256K, digest, ecSignResult.Signature);
             Debug.WriteLine($"Verified the signature using the algorithm {ecVerifyResult.Algorithm}, with key {ecVerifyResult.KeyId}. Signature is valid: {ecVerifyResult.IsValid}");
-            #endregion
+#endregion
 
-            #region Snippet:KeysSample5SignKeyWithSignData
+#region Snippet:KeysSample5SignKeyWithSignData
             SignResult rsaSignDataResult = rsaCryptoClient.SignData(SignatureAlgorithm.RS256, data);
             Debug.WriteLine($"Signed data using the algorithm {rsaSignDataResult.Algorithm}, with key {rsaSignDataResult.KeyId}. The resulting signature is {Convert.ToBase64String(rsaSignDataResult.Signature)}");
 
             SignResult ecSignDataResult = ecCryptoClient.SignData(SignatureAlgorithm.ES256K, data);
             Debug.WriteLine($"Signed data using the algorithm {ecSignDataResult.Algorithm}, with key {ecSignDataResult.KeyId}. The resulting signature is {Convert.ToBase64String(ecSignDataResult.Signature)}");
-            #endregion
+#endregion
 
-            #region Snippet:KeysSample5VerifyKeyWithData
+#region Snippet:KeysSample5VerifyKeyWithData
             VerifyResult rsaVerifyDataResult = rsaCryptoClient.VerifyData(SignatureAlgorithm.RS256, data, rsaSignDataResult.Signature);
             Debug.WriteLine($"Verified the signature using the algorithm {rsaVerifyDataResult.Algorithm}, with key {rsaVerifyDataResult.KeyId}. Signature is valid: {rsaVerifyDataResult.IsValid}");
 
             VerifyResult ecVerifyDataResult = ecCryptoClient.VerifyData(SignatureAlgorithm.ES256K, data, ecSignDataResult.Signature);
             Debug.WriteLine($"Verified the signature using the algorithm {ecVerifyDataResult.Algorithm}, with key {ecVerifyDataResult.KeyId}. Signature is valid: {ecVerifyDataResult.IsValid}");
-            #endregion
+#endregion
 
-            #region Snippet:KeysSample5DeleteKeys
+#region Snippet:KeysSample5DeleteKeys
             DeleteKeyOperation rsaKeyOperation = keyClient.StartDeleteKey(rsaKeyName);
             DeleteKeyOperation ecKeyOperation = keyClient.StartDeleteKey(ecKeyName);
 
@@ -110,7 +114,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
                 rsaKeyOperation.UpdateStatus();
                 ecKeyOperation.UpdateStatus();
             }
-            #endregion
+#endregion
 
             // If the keyvault is soft-delete enabled, then for permanent deletion, deleted keys needs to be purged.
             keyClient.PurgeDeletedKey(rsaKeyName);

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample5_SignVerifyAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample5_SignVerifyAsync.cs
@@ -115,12 +115,12 @@ namespace Azure.Security.KeyVault.Keys.Samples
             DeleteKeyOperation ecKeyOperation = await keyClient.StartDeleteKeyAsync(ecKeyName);
 
             // To ensure the key is deleted on server before we try to purge it.
-            Task.WaitAll(
+            await Task.WhenAll(
                 rsaKeyOperation.WaitForCompletionAsync().AsTask(),
                 ecKeyOperation.WaitForCompletionAsync().AsTask());
 
             // If the keyvault is soft-delete enabled, then for permanent deletion, deleted keys needs to be purged.
-            Task.WaitAll(
+            await Task.WhenAll(
                 keyClient.PurgeDeletedKeyAsync(rsaKeyName),
                 keyClient.PurgeDeletedKeyAsync(ecKeyName));
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample5_SignVerifyAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample5_SignVerifyAsync.cs
@@ -23,6 +23,10 @@ namespace Azure.Security.KeyVault.Keys.Samples
         [Test]
         public async Task SignVerifyAsync()
         {
+#if NET461
+            Assert.Ignore("Using CryptographyClient with EC keys is not supported on .NET Framework 4.6.1.");
+#endif
+
             // Environment variable with the Key Vault endpoint.
             string keyVaultUrl = Environment.GetEnvironmentVariable("AZURE_KEYVAULT_URL");
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample5_SignVerifyAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample5_SignVerifyAsync.cs
@@ -114,7 +114,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
             DeleteKeyOperation rsaKeyOperation = await keyClient.StartDeleteKeyAsync(rsaKeyName);
             DeleteKeyOperation ecKeyOperation = await keyClient.StartDeleteKeyAsync(ecKeyName);
 
-            // To ensure the key is deleted on server before we try to purge it.
+            // You only need to wait for completion if you want to purge or recover the key.
             await Task.WhenAll(
                 rsaKeyOperation.WaitForCompletionAsync().AsTask(),
                 ecKeyOperation.WaitForCompletionAsync().AsTask());

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample6_WrapUnwrap.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample6_WrapUnwrap.cs
@@ -24,11 +24,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
         {
             // Environment variable with the Key Vault endpoint.
             string keyVaultUrl = Environment.GetEnvironmentVariable("AZURE_KEYVAULT_URL");
-            WrapUnwrapSync(keyVaultUrl);
-        }
 
-        private void WrapUnwrapSync(string keyVaultUrl)
-        {
             #region Snippet:KeysSample6KeyClient
             var keyClient = new KeyClient(new Uri(keyVaultUrl), new DefaultAzureCredential());
             #endregion

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample6_WrapUnwrap.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample6_WrapUnwrap.cs
@@ -62,6 +62,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
             #region Snippet:KeysSample6DeleteKey
             DeleteKeyOperation operation = keyClient.StartDeleteKey(rsaKeyName);
 
+            // You only need to wait for completion if you want to purge or recover the key.
             while (!operation.HasCompleted)
             {
                 Thread.Sleep(2000);

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample6_WrapUnwrapAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample6_WrapUnwrapAsync.cs
@@ -58,7 +58,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
             // The Cloud RSA Key is no longer needed, need to delete it from the Key Vault.
             DeleteKeyOperation operation = await keyClient.StartDeleteKeyAsync(rsaKeyName);
 
-            // To ensure the key is deleted on server before we try to purge it.
+            // You only need to wait for completion if you want to purge or recover the key.
             await operation.WaitForCompletionAsync();
 
             // If the keyvault is soft-delete enabled, then for permanent deletion, deleted key needs to be purged.

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/SampleSnippets.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/SampleSnippets.cs
@@ -224,7 +224,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
 
             try
             {
-                // Deleting a key when soft delete is enabled may not happen immediately.
+                // You only need to wait for completion if you want to purge or recover the key.
                 await Task.WhenAll(
                     rsaKeyOperation.WaitForCompletionAsync().AsTask(),
                     ecKeyOperation.WaitForCompletionAsync().AsTask());
@@ -245,6 +245,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
             #region Snippet:DeleteAndPurgeKey
             DeleteKeyOperation operation = client.StartDeleteKey("key-name");
 
+            // You only need to wait for completion if you want to purge or recover the key.
             while (!operation.HasCompleted)
             {
                 Thread.Sleep(2000);

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/SampleSnippets.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/SampleSnippets.cs
@@ -225,11 +225,11 @@ namespace Azure.Security.KeyVault.Keys.Samples
             try
             {
                 // Deleting a key when soft delete is enabled may not happen immediately.
-                Task.WaitAll(
+                await Task.WhenAll(
                     rsaKeyOperation.WaitForCompletionAsync().AsTask(),
                     ecKeyOperation.WaitForCompletionAsync().AsTask());
 
-                Task.WaitAll(
+                await Task.WhenAll(
                     client.PurgeDeletedKeyAsync(rsaKeyOperation.Value.Name),
                     client.PurgeDeletedKeyAsync(ecKeyOperation.Value.Name));
             }

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample1_HelloWorld.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample1_HelloWorld.md
@@ -74,6 +74,7 @@ If the Key Vault is soft delete-enabled and you want to permanently delete the s
 the deleted secret needs to be purged. Before it can be purged, you need to wait until the secret is fully deleted.
 
 ```C# Snippet:SecretsSample1PurgeSecret
+// You only need to wait for completion if you want to purge or recover the secret.
 while (!operation.HasCompleted)
 {
     Thread.Sleep(2000);
@@ -90,6 +91,7 @@ When writing asynchronous code, you can instead await `WaitForCompletionAsync` t
 You can optionally pass in a `CancellationToken` to cancel waiting after a certain period or time or any other trigger you require.
 
 ```C# Snippet:SecretsSample1PurgeSecretAsync
+// You only need to wait for completion if you want to purge or recover the secret.
 await operation.WaitForCompletionAsync();
 
 await client.PurgeDeletedSecretAsync(secretName);

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample3_GetSecrets.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample3_GetSecrets.md
@@ -101,6 +101,7 @@ To list deleted secrets, we also need to wait until they are fully deleted.
 DeleteSecretOperation bankSecretOperation = client.StartDeleteSecret(bankSecretName);
 DeleteSecretOperation storageSecretOperation = client.StartDeleteSecret(storageSecretName);
 
+// You only need to wait for completion if you want to purge or recover the secret.
 while (!bankSecretOperation.HasCompleted || !storageSecretOperation.HasCompleted)
 {
     Thread.Sleep(2000);

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SecretClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SecretClientLiveTests.cs
@@ -83,7 +83,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
                     createdUpdatedConstraint = Is.InRange(now.AddMinutes(-5), now.AddMinutes(5));
                 }
 
-                RegisterForCleanup(secret.Name, delete: false);
+                RegisterForCleanup(secret.Name);
 
                 Assert.IsNotEmpty(setResult.Properties.Version);
                 Assert.AreEqual("password", setResult.Properties.ContentType);
@@ -301,7 +301,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
 
             KeyVaultSecret secret = await Client.SetSecretAsync(secretName, "value");
 
-            RegisterForCleanup(secret.Name, delete: false);
+            RegisterForCleanup(secret.Name);
 
             DeleteSecretOperation deleteOperation = await Client.StartDeleteSecretAsync(secretName);
             DeletedSecret deletedSecret = deleteOperation.Value;
@@ -326,7 +326,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
 
             KeyVaultSecret secret = await Client.SetSecretAsync(secretName, "value");
 
-            RegisterForCleanup(secret.Name, delete: false);
+            RegisterForCleanup(secret.Name);
 
             DeleteSecretOperation deleteOperation = await Client.StartDeleteSecretAsync(secretName);
             DeletedSecret deletedSecret = deleteOperation.Value;
@@ -366,7 +366,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
             RecoverDeletedSecretOperation operation = await Client.StartRecoverDeletedSecretAsync(secretName);
             SecretProperties recoverSecretResult = operation.Value;
 
-            await PollForSecret(secretName);
+            await WaitForSecret(secretName);
 
             KeyVaultSecret recoveredSecret = await Client.GetSecretAsync(secretName);
 
@@ -439,7 +439,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
                 deletedSecrets.Add(secret);
                 await Client.StartDeleteSecretAsync(secret.Name);
 
-                RegisterForCleanup(secret.Name, delete: false);
+                RegisterForCleanup(secret.Name);
             }
 
             foreach (KeyVaultSecret deletedSecret in deletedSecrets)

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SecretClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SecretClientLiveTests.cs
@@ -6,14 +6,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
-using Azure.Security.KeyVault.Secrets;
 using Azure.Core.Testing;
 using System.Text;
 using NUnit.Framework.Constraints;
 
-namespace Azure.Security.KeyVault.Test
+namespace Azure.Security.KeyVault.Secrets.Tests
 {
-    public class SecretClientLiveTests : KeyVaultTestBase
+    public class SecretClientLiveTests : SecretsTestBase
     {
         private const int PagedSecretCount = 50;
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SecretClientTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SecretClientTests.cs
@@ -4,10 +4,9 @@
 using System;
 using Azure.Core.Testing;
 using Azure.Identity;
-using Azure.Security.KeyVault.Secrets;
 using NUnit.Framework;
 
-namespace Azure.Security.KeyVault.Test
+namespace Azure.Security.KeyVault.Secrets.Tests
 {
     public class SecretClientTests: ClientTestBase
     {

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample1_HelloWorld.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample1_HelloWorld.cs
@@ -58,6 +58,7 @@ namespace Azure.Security.KeyVault.Secrets.Samples
             #endregion
 
             #region Snippet:SecretsSample1PurgeSecret
+            // You only need to wait for completion if you want to purge or recover the secret.
             while (!operation.HasCompleted)
             {
                 Thread.Sleep(2000);

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample1_HelloWorld.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample1_HelloWorld.cs
@@ -21,11 +21,7 @@ namespace Azure.Security.KeyVault.Secrets.Samples
         {
             // Environment variable with the Key Vault endpoint.
             string keyVaultUrl = Environment.GetEnvironmentVariable("AZURE_KEYVAULT_URL");
-            HelloWorldSync(keyVaultUrl);
-        }
 
-        private void HelloWorldSync(string keyVaultUrl)
-        {
             #region Snippet:SecretsSample1SecretClient
             var client = new SecretClient(new Uri(keyVaultUrl), new DefaultAzureCredential());
             #endregion

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample1_HelloWorldAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample1_HelloWorldAsync.cs
@@ -21,11 +21,7 @@ namespace Azure.Security.KeyVault.Secrets.Samples
         {
             // Environment variable with the Key Vault endpoint.
             string keyVaultUrl = Environment.GetEnvironmentVariable("AZURE_KEYVAULT_URL");
-            await HelloWorldAsync(keyVaultUrl);
-        }
 
-        private async Task HelloWorldAsync(string keyVaultUrl)
-        {
             var client = new SecretClient(new Uri(keyVaultUrl), new DefaultAzureCredential());
 
             string secretName = $"BankAccountPassword-{Guid.NewGuid()}";

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample1_HelloWorldAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample1_HelloWorldAsync.cs
@@ -46,6 +46,7 @@ namespace Azure.Security.KeyVault.Secrets.Samples
             DeleteSecretOperation operation = await client.StartDeleteSecretAsync(secretName);
 
             #region Snippet:SecretsSample1PurgeSecretAsync
+            // You only need to wait for completion if you want to purge or recover the secret.
             await operation.WaitForCompletionAsync();
 
             await client.PurgeDeletedSecretAsync(secretName);

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample2_BackupAndRestore.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample2_BackupAndRestore.cs
@@ -69,6 +69,7 @@ namespace Azure.Security.KeyVault.Secrets.Samples
             // Delete and purge the restored secret.
             operation = client.StartDeleteSecret(restoreSecret.Name);
 
+            // You only need to wait for completion if you want to purge or recover the secret.
             while (!operation.HasCompleted)
             {
                 Thread.Sleep(2000);

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample2_BackupAndRestore.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample2_BackupAndRestore.cs
@@ -22,11 +22,7 @@ namespace Azure.Security.KeyVault.Secrets.Samples
         {
             // Environment variable with the Key Vault endpoint.
             string keyVaultUrl = Environment.GetEnvironmentVariable("AZURE_KEYVAULT_URL");
-            BackupAndRestoreSync(keyVaultUrl);
-        }
 
-        private void BackupAndRestoreSync(string keyVaultUrl)
-        {
             #region Snippet:SecretsSample2SecretClient
             var client = new SecretClient(new Uri(keyVaultUrl), new DefaultAzureCredential());
             #endregion
@@ -69,6 +65,18 @@ namespace Azure.Security.KeyVault.Secrets.Samples
             #endregion
 
             AssertSecretsEqual(storedSecret.Properties, restoreSecret);
+
+            // Delete and purge the restored secret.
+            operation = client.StartDeleteSecret(restoreSecret.Name);
+
+            while (!operation.HasCompleted)
+            {
+                Thread.Sleep(2000);
+
+                operation.UpdateStatus();
+            }
+
+            client.PurgeDeletedSecret(restoreSecret.Name);
         }
 
         private static void AssertSecretsEqual(SecretProperties exp, SecretProperties act)

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample2_BackupAndRestoreAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample2_BackupAndRestoreAsync.cs
@@ -22,11 +22,6 @@ namespace Azure.Security.KeyVault.Secrets.Samples
         {
             // Environment variable with the Key Vault endpoint.
             string keyVaultUrl = Environment.GetEnvironmentVariable("AZURE_KEYVAULT_URL");
-            await BackupAndRestoreAsync(keyVaultUrl);
-        }
-
-        private async Task BackupAndRestoreAsync(string keyVaultUrl)
-        {
 
             var client = new SecretClient(new Uri(keyVaultUrl), new DefaultAzureCredential());
 
@@ -65,6 +60,13 @@ namespace Azure.Security.KeyVault.Secrets.Samples
             }
 
             AssertSecretsEqual(storedSecret.Properties, restoreSecret);
+
+            // Delete and purge the restored secret.
+            operation = await client.StartDeleteSecretAsync(restoreSecret.Name);
+
+            await operation.WaitForCompletionAsync();
+
+            await client.PurgeDeletedSecretAsync(restoreSecret.Name);
         }
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample2_BackupAndRestoreAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample2_BackupAndRestoreAsync.cs
@@ -64,6 +64,7 @@ namespace Azure.Security.KeyVault.Secrets.Samples
             // Delete and purge the restored secret.
             operation = await client.StartDeleteSecretAsync(restoreSecret.Name);
 
+            // You only need to wait for completion if you want to purge or recover the secret.
             await operation.WaitForCompletionAsync();
 
             await client.PurgeDeletedSecretAsync(restoreSecret.Name);

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample3_GetSecrets.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample3_GetSecrets.cs
@@ -91,6 +91,7 @@ namespace Azure.Security.KeyVault.Secrets.Samples
             DeleteSecretOperation bankSecretOperation = client.StartDeleteSecret(bankSecretName);
             DeleteSecretOperation storageSecretOperation = client.StartDeleteSecret(storageSecretName);
 
+            // You only need to wait for completion if you want to purge or recover the secret.
             while (!bankSecretOperation.HasCompleted || !storageSecretOperation.HasCompleted)
             {
                 Thread.Sleep(2000);

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample3_GetSecrets.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample3_GetSecrets.cs
@@ -22,11 +22,7 @@ namespace Azure.Security.KeyVault.Secrets.Samples
         {
             // Environment variable with the Key Vault endpoint.
             string keyVaultUrl = Environment.GetEnvironmentVariable("AZURE_KEYVAULT_URL");
-            GetSecretsSync(keyVaultUrl);
-        }
 
-        private void GetSecretsSync(string keyVaultUrl)
-        {
             #region Snippet:SecretsSample3SecretClient
             var client = new SecretClient(new Uri(keyVaultUrl), new DefaultAzureCredential());
             #endregion

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample3_GetSecretsAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample3_GetSecretsAsync.cs
@@ -83,6 +83,7 @@ namespace Azure.Security.KeyVault.Secrets.Samples
             DeleteSecretOperation bankSecretOperation = await client.StartDeleteSecretAsync(bankSecretName);
             DeleteSecretOperation storageSecretOperation = await client.StartDeleteSecretAsync(storageSecretName);
 
+            // You only need to wait for completion if you want to purge or recover the secret.
             await Task.WhenAll(
                 bankSecretOperation.WaitForCompletionAsync().AsTask(),
                 storageSecretOperation.WaitForCompletionAsync().AsTask());

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample3_GetSecretsAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample3_GetSecretsAsync.cs
@@ -25,11 +25,7 @@ namespace Azure.Security.KeyVault.Secrets.Samples
         {
             // Environment variable with the Key Vault endpoint.
             string keyVaultUrl = Environment.GetEnvironmentVariable("AZURE_KEYVAULT_URL");
-            await GetSecretsAsync(keyVaultUrl);
-        }
 
-        private async Task GetSecretsAsync(string keyVaultUrl)
-        {
             var client = new SecretClient(new Uri(keyVaultUrl), new DefaultAzureCredential());
 
             string bankSecretName = $"BankAccountPassword-{Guid.NewGuid()}";
@@ -87,7 +83,7 @@ namespace Azure.Security.KeyVault.Secrets.Samples
             DeleteSecretOperation bankSecretOperation = await client.StartDeleteSecretAsync(bankSecretName);
             DeleteSecretOperation storageSecretOperation = await client.StartDeleteSecretAsync(storageSecretName);
 
-            Task.WaitAll(
+            await Task.WhenAll(
                 bankSecretOperation.WaitForCompletionAsync().AsTask(),
                 storageSecretOperation.WaitForCompletionAsync().AsTask());
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample3_GetSecretsAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample3_GetSecretsAsync.cs
@@ -93,7 +93,7 @@ namespace Azure.Security.KeyVault.Secrets.Samples
             }
 
             // If the Key Vault is soft delete-enabled, then for permanent deletion, deleted secret needs to be purged.
-            Task.WaitAll(
+            await Task.WhenAll(
                 client.PurgeDeletedSecretAsync(bankSecretName),
                 client.PurgeDeletedSecretAsync(storageSecretName));
         }


### PR DESCRIPTION
Now that samples are running as part of our live nightly runs, there were a few conflicts that needed to be resolved. This should also solve the problem(s) of artifacts not being properly deleted and purged from a soft delete-enabled vault.