### PR TITLE
[HDInsight] Hotfix for deprecating Dv1 series: change Dv1-series to related Dv2

### DIFF
--- a/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/src/Customizations/Converters/DefaultVmSizes.cs
+++ b/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/src/Customizations/Converters/DefaultVmSizes.cs
@@ -19,8 +19,8 @@ namespace Microsoft.Azure.Management.HDInsight
 
             private static readonly Dictionary<string, string> DefaultSizes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
-                {"hadoop", "Standard_D3"},
-                {"spark", "Standard_D12"},
+                {"hadoop", "Standard_D3_v2"},
+                {"spark", "Standard_D12_v2"},
                 {"rserver", "Standard_D12_v2"},
                 {"mlservices", "Standard_D12_v2"},
                 {"InteractiveHive", "Standard_D13_v2"},
@@ -40,11 +40,11 @@ namespace Microsoft.Azure.Management.HDInsight
 
         public static class WorkerNode
         {
-            private const string DefaultSizeIfNotSpecified = "Standard_D3";
+            private const string DefaultSizeIfNotSpecified = "Standard_D3_v2";
 
             private static readonly Dictionary<string, string> DefaultSizes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
-                {"spark", "Standard_D12"},
+                {"spark", "Standard_D12_v2"},
                 {"rserver", "Standard_D4_v2"},
                 {"mlservices", "Standard_D4_v2"},
                 {"InteractiveHive", "Standard_D13_v2"},

--- a/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/src/Microsoft.Azure.Management.HDInsight.csproj
+++ b/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/src/Microsoft.Azure.Management.HDInsight.csproj
@@ -7,14 +7,12 @@
 		<PackageId>Microsoft.Azure.Management.HDInsight</PackageId>
 		<Description>Azure HDInsight Management SDK Library</Description>
 		<AssemblyName>Microsoft.Azure.Management.HDInsight</AssemblyName>
-		<Version>5.1.0</Version>
+		<Version>5.2.0</Version>
 		<PackageTags>Microsoft Azure HDInsight Management;HDInsight;HDInsight Management</PackageTags>
 		<PackageReleaseNotes>
 			<![CDATA[
-This release adds a few new features:
-1) Added a new API, LocationsOperationsExtensions.GetCapabilities, to get capabilities for a specific location/region.
-2) Add a new API, LocationsOperationsExtensions.ListBillingSpecs, to list billing specs for a specific location/region.
-3) Added support for creating clusters with Autoscale (load-based and schedule-based) applied to the workernode role. For more details, please see the definition of Microsoft.Azure.Management.HDInsight.Models.Role.AutoscaleConfiguration.
+This release is a hotfix for Disabling D-series vm.
+changing default size from D3 to D3_v2, D12 to D12_v2
       ]]>
 		</PackageReleaseNotes>
     

--- a/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/src/Microsoft.Azure.Management.HDInsight.csproj
+++ b/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/src/Microsoft.Azure.Management.HDInsight.csproj
@@ -7,7 +7,7 @@
 		<PackageId>Microsoft.Azure.Management.HDInsight</PackageId>
 		<Description>Azure HDInsight Management SDK Library</Description>
 		<AssemblyName>Microsoft.Azure.Management.HDInsight</AssemblyName>
-		<Version>5.2.0</Version>
+		<Version>5.1.1</Version>
 		<PackageTags>Microsoft Azure HDInsight Management;HDInsight;HDInsight Management</PackageTags>
 		<PackageReleaseNotes>
 			<![CDATA[

--- a/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/src/Properties/AssemblyInfo.cs
+++ b/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/src/Properties/AssemblyInfo.cs
@@ -22,7 +22,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("Microsoft Azure HDInsight Management Library")]
 [assembly: AssemblyDescription("Provides management functionality for Microsoft Azure HDInsight.")]
 [assembly: AssemblyVersion("5.0.0.0")]
-[assembly: AssemblyFileVersion("5.1.0.0")]
+[assembly: AssemblyFileVersion("5.2.0.0")]
 
 [assembly: InternalsVisibleTo("Microsoft.Azure.Management.HDInsight.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
 

--- a/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/src/Properties/AssemblyInfo.cs
+++ b/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/src/Properties/AssemblyInfo.cs
@@ -22,7 +22,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("Microsoft Azure HDInsight Management Library")]
 [assembly: AssemblyDescription("Provides management functionality for Microsoft Azure HDInsight.")]
 [assembly: AssemblyVersion("5.0.0.0")]
-[assembly: AssemblyFileVersion("5.2.0.0")]
+[assembly: AssemblyFileVersion("5.1.1.0")]
 
 [assembly: InternalsVisibleTo("Microsoft.Azure.Management.HDInsight.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
 


### PR DESCRIPTION
change D3 to D3_v2, D12 to D12_v2.
there is no related swagger spec pr.