### PR TITLE
[Event Hubs Client] Track Two (Read from all Partitions)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducerClient.cs
@@ -206,6 +206,7 @@ namespace Azure.Messaging.EventHubs
                                       EventHubProducerClientOptions producerOptions = default)
         {
             Argument.AssertNotNullOrEmpty(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace));
+            Argument.AssertNotNullOrEmpty(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace));
             Argument.AssertNotNullOrEmpty(eventHubName, nameof(eventHubName));
             Argument.AssertNotNull(credential, nameof(credential));
 
@@ -415,7 +416,7 @@ namespace Azure.Messaging.EventHubs
 
             TransportProducer activeProducer;
 
-            if (String.IsNullOrEmpty(options.PartitionId))
+            if (string.IsNullOrEmpty(options.PartitionId))
             {
                 activeProducer = GatewayProducer;
             }


### PR DESCRIPTION
# Summary

The focus of these changes is to add the `ReadEventsAsync` methods to the consumer client, allowing events for all partitions to be read from a single call and without explicit knowledge of the partitions.

# Last Upstream Rebase

Wednesday, November 20, 12:19pm (EST)

# Related and Follow-Up Issues

- [Release Event Hubs Track 2 Library for .NET](https://github.com/Azure/azure-sdk-for-net/issues/8552) (#8552) 
- [Implement ReadEvents on the Event Hub Consumer Client](https://github.com/Azure/azure-sdk-for-net/issues/8569) (#8569) 