### PR TITLE
Update ShareFileRangeInfo to use HttpRange

### DIFF
--- a/sdk/storage/Azure.Storage.Files.Shares/api/Azure.Storage.Files.Shares.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/api/Azure.Storage.Files.Shares.netstandard2.0.cs
@@ -224,12 +224,6 @@ namespace Azure.Storage.Files.Shares.Models
         internal PermissionInfo() { }
         public string FilePermissionKey { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
     }
-    public partial class Range
-    {
-        internal Range() { }
-        public long End { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
-        public long Start { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
-    }
     public partial class ShareAccessPolicy
     {
         internal ShareAccessPolicy() { }
@@ -449,11 +443,11 @@ namespace Azure.Storage.Files.Shares.Models
     }
     public partial class ShareFileRangeInfo
     {
-        public ShareFileRangeInfo() { }
-        public Azure.ETag ETag { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
-        public long FileContentLength { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
-        public System.DateTimeOffset LastModified { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
-        public System.Collections.Generic.IEnumerable<Azure.Storage.Files.Shares.Models.Range> Ranges { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
+        internal ShareFileRangeInfo() { }
+        public Azure.ETag ETag { get { throw null; } }
+        public long FileContentLength { get { throw null; } }
+        public System.DateTimeOffset LastModified { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<Azure.HttpRange> Ranges { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
     }
     public enum ShareFileRangeWriteType
     {
@@ -492,10 +486,9 @@ namespace Azure.Storage.Files.Shares.Models
     public static partial class ShareModelFactory
     {
         public static Azure.Storage.Files.Shares.Models.PermissionInfo PermissionInfo(string filePermissionKey) { throw null; }
-        public static Azure.Storage.Files.Shares.Models.Range Range(long start, long end) { throw null; }
         public static Azure.Storage.Files.Shares.Models.ShareFileCopyInfo ShareFileCopyInfo(Azure.ETag eTag, System.DateTimeOffset lastModified, string copyId, Azure.Storage.Files.Shares.Models.CopyStatus copyStatus) { throw null; }
         public static Azure.Storage.Files.Shares.Models.ShareFileHandle ShareFileHandle(string handleId, string path, string fileId, string sessionId, string clientIp, string parentId = null, System.DateTimeOffset? openedOn = default(System.DateTimeOffset?), System.DateTimeOffset? lastReconnectedOn = default(System.DateTimeOffset?)) { throw null; }
-        public static Azure.Storage.Files.Shares.Models.ShareFileRangeInfo ShareFileRangeInfo(System.DateTimeOffset lastModified, Azure.ETag eTag, long fileContentLength, System.Collections.Generic.IEnumerable<Azure.Storage.Files.Shares.Models.Range> ranges) { throw null; }
+        public static Azure.Storage.Files.Shares.Models.ShareFileRangeInfo ShareFileRangeInfo(System.DateTimeOffset lastModified, Azure.ETag eTag, long fileContentLength, System.Collections.Generic.IEnumerable<Azure.HttpRange> ranges) { throw null; }
         public static Azure.Storage.Files.Shares.Models.ShareFileUploadInfo ShareFileUploadInfo(Azure.ETag eTag, System.DateTimeOffset lastModified, byte[] contentHash, bool isServerEncrypted) { throw null; }
         public static Azure.Storage.Files.Shares.Models.ShareInfo ShareInfo(Azure.ETag eTag, System.DateTimeOffset lastModified) { throw null; }
         public static Azure.Storage.Files.Shares.Models.ShareItem ShareItem(string name, Azure.Storage.Files.Shares.Models.ShareProperties properties, string snapshot = null) { throw null; }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Generated/FileRestClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Generated/FileRestClient.cs
@@ -5193,8 +5193,8 @@ namespace Azure.Storage.Files.Shares
             /// <param name="clientDiagnostics">The ClientDiagnostics instance used for operation reporting.</param>
             /// <param name="operationName">Operation name.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response{Azure.Storage.Files.Shares.Models.ShareFileRangeInfo}</returns>
-            public static async System.Threading.Tasks.ValueTask<Azure.Response<Azure.Storage.Files.Shares.Models.ShareFileRangeInfo>> GetRangeListAsync(
+            /// <returns>Azure.Response{Azure.Storage.Files.Shares.Models.ShareFileRangeInfoInternal}</returns>
+            public static async System.Threading.Tasks.ValueTask<Azure.Response<Azure.Storage.Files.Shares.Models.ShareFileRangeInfoInternal>> GetRangeListAsync(
                 Azure.Core.Pipeline.ClientDiagnostics clientDiagnostics,
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -5288,8 +5288,8 @@ namespace Azure.Storage.Files.Shares
             /// Create the File.GetRangeListAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The File.GetRangeListAsync Azure.Response{Azure.Storage.Files.Shares.Models.ShareFileRangeInfo}.</returns>
-            internal static Azure.Response<Azure.Storage.Files.Shares.Models.ShareFileRangeInfo> GetRangeListAsync_CreateResponse(
+            /// <returns>The File.GetRangeListAsync Azure.Response{Azure.Storage.Files.Shares.Models.ShareFileRangeInfoInternal}.</returns>
+            internal static Azure.Response<Azure.Storage.Files.Shares.Models.ShareFileRangeInfoInternal> GetRangeListAsync_CreateResponse(
                 Azure.Response response)
             {
                 // Process the response
@@ -5299,7 +5299,7 @@ namespace Azure.Storage.Files.Shares
                     {
                         // Create the result
                         System.Xml.Linq.XDocument _xml = System.Xml.Linq.XDocument.Load(response.ContentStream, System.Xml.Linq.LoadOptions.PreserveWhitespace);
-                        Azure.Storage.Files.Shares.Models.ShareFileRangeInfo _value = new Azure.Storage.Files.Shares.Models.ShareFileRangeInfo();
+                        Azure.Storage.Files.Shares.Models.ShareFileRangeInfoInternal _value = new Azure.Storage.Files.Shares.Models.ShareFileRangeInfoInternal();
                         _value.Ranges =
                             System.Linq.Enumerable.ToList(
                                 System.Linq.Enumerable.Select(
@@ -5326,7 +5326,7 @@ namespace Azure.Storage.Files.Shares
                     }
                     case 304:
                     {
-                        return new Azure.NoBodyResponse<Azure.Storage.Files.Shares.Models.ShareFileRangeInfo>(response);
+                        return new Azure.NoBodyResponse<Azure.Storage.Files.Shares.Models.ShareFileRangeInfoInternal>(response);
                     }
                     default:
                     {
@@ -6687,7 +6687,7 @@ namespace Azure.Storage.Files.Shares.Models
     /// <summary>
     /// An Azure Storage file range.
     /// </summary>
-    public partial class Range
+    internal partial class Range
     {
         /// <summary>
         /// Start of the range.
@@ -6730,26 +6730,6 @@ namespace Azure.Storage.Files.Shares.Models
         }
 
         static partial void CustomizeFromXml(System.Xml.Linq.XElement element, Azure.Storage.Files.Shares.Models.Range value);
-    }
-
-    /// <summary>
-    /// ShareModelFactory provides utilities for mocking.
-    /// </summary>
-    public static partial class ShareModelFactory
-    {
-        /// <summary>
-        /// Creates a new Range instance for mocking.
-        /// </summary>
-        public static Range Range(
-            long start,
-            long end)
-        {
-            return new Range()
-            {
-                Start = start,
-                End = end,
-            };
-        }
     }
 }
 #endregion class Range
@@ -7907,13 +7887,13 @@ namespace Azure.Storage.Files.Shares.Models
 }
 #endregion class ShareFileHandle
 
-#region class ShareFileRangeInfo
+#region class ShareFileRangeInfoInternal
 namespace Azure.Storage.Files.Shares.Models
 {
     /// <summary>
-    /// ShareFileRangeInfo
+    /// ShareFileRangeInfoInternal
     /// </summary>
-    public partial class ShareFileRangeInfo
+    internal partial class ShareFileRangeInfoInternal
     {
         /// <summary>
         /// The date/time that the file was last modified. Any operation that modifies the file, including an update of the file's metadata or properties, changes the file's last modified time.
@@ -7936,39 +7916,15 @@ namespace Azure.Storage.Files.Shares.Models
         public System.Collections.Generic.IEnumerable<Azure.Storage.Files.Shares.Models.Range> Ranges { get; internal set; }
 
         /// <summary>
-        /// Creates a new ShareFileRangeInfo instance
+        /// Creates a new ShareFileRangeInfoInternal instance
         /// </summary>
-        public ShareFileRangeInfo()
+        public ShareFileRangeInfoInternal()
         {
             Ranges = new System.Collections.Generic.List<Azure.Storage.Files.Shares.Models.Range>();
         }
     }
-
-    /// <summary>
-    /// ShareModelFactory provides utilities for mocking.
-    /// </summary>
-    public static partial class ShareModelFactory
-    {
-        /// <summary>
-        /// Creates a new ShareFileRangeInfo instance for mocking.
-        /// </summary>
-        public static ShareFileRangeInfo ShareFileRangeInfo(
-            System.DateTimeOffset lastModified,
-            Azure.ETag eTag,
-            long fileContentLength,
-            System.Collections.Generic.IEnumerable<Azure.Storage.Files.Shares.Models.Range> ranges)
-        {
-            return new ShareFileRangeInfo()
-            {
-                LastModified = lastModified,
-                ETag = eTag,
-                FileContentLength = fileContentLength,
-                Ranges = ranges,
-            };
-        }
-    }
 }
-#endregion class ShareFileRangeInfo
+#endregion class ShareFileRangeInfoInternal
 
 #region enum ShareFileRangeWriteType
 namespace Azure.Storage.Files.Shares.Models

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Models/ShareFileRangeInfo.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Models/ShareFileRangeInfo.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma warning disable SA1402  // File may only contain a single type
+
+using System.Collections.Generic;
+
+namespace Azure.Storage.Files.Shares.Models
+{
+    /// <summary>
+    /// Contains file share range information returned from the ShareFileClient.GetRangeList operations.
+    /// </summary>
+    public class ShareFileRangeInfo
+    {
+        /// <summary>
+        /// Model type expected by the protocol layer.
+        /// </summary>
+        private readonly ShareFileRangeInfoInternal _shareFileRangeInfoInternal;
+
+        /// <summary>
+        /// The date/time that the file was last modified. Any operation that modifies the file, including an update of the file's metadata or properties, changes the file's last modified time.
+        /// </summary>
+        public System.DateTimeOffset LastModified => _shareFileRangeInfoInternal.LastModified;
+
+        /// <summary>
+        /// The ETag contains a value which represents the version of the file, in quotes.
+        /// </summary>
+        public ETag ETag => _shareFileRangeInfoInternal.ETag;
+
+        /// <summary>
+        /// The size of the file in bytes.
+        /// </summary>
+        public long FileContentLength => _shareFileRangeInfoInternal.FileContentLength;
+
+        /// <summary>
+        /// A list of non-overlapping valid ranges, sorted by increasing address range.
+        /// </summary>
+        public IEnumerable<HttpRange> Ranges { get; internal set; }
+
+        /// <summary>
+        /// Creates a new PageRangesInfo instance
+        /// </summary>
+        internal ShareFileRangeInfo(ShareFileRangeInfoInternal rangesInfoInternal)
+        {
+            _shareFileRangeInfoInternal = rangesInfoInternal;
+
+            // convert from internal Range type to HttpRange
+            var ranges = new List<HttpRange>();
+            foreach (Range range in rangesInfoInternal.Ranges)
+            {
+                ranges.Add(new HttpRange(range.Start, range.End - range.Start + 1));
+            }
+            Ranges = ranges;
+        }
+    }
+
+    /// <summary>
+    /// ShareModelFactory provides utilities for mocking.
+    /// </summary>
+    public static partial class ShareModelFactory
+    {
+        /// <summary>
+        /// Creates a new ShareFileRangeInfo instance for mocking.
+        /// </summary>
+        public static ShareFileRangeInfo ShareFileRangeInfo(
+            System.DateTimeOffset lastModified,
+            Azure.ETag eTag,
+            long fileContentLength,
+            IEnumerable<HttpRange> ranges)
+        {
+            var shareFileRangeInfo =
+                new ShareFileRangeInfo(
+                    new ShareFileRangeInfoInternal()
+                    {
+                        LastModified = lastModified,
+                        ETag = eTag,
+                        FileContentLength = fileContentLength
+                    }
+                )
+                {
+                    Ranges = ranges
+                };
+            return shareFileRangeInfo;
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
@@ -2219,7 +2219,7 @@ namespace Azure.Storage.Files.Shares
                     $"{nameof(Uri)}: {Uri}");
                 try
                 {
-                    return await FileRestClient.File.GetRangeListAsync(
+                    Response<ShareFileRangeInfoInternal> response = await FileRestClient.File.GetRangeListAsync(
                         ClientDiagnostics,
                         Pipeline,
                         Uri,
@@ -2228,6 +2228,7 @@ namespace Azure.Storage.Files.Shares
                         cancellationToken: cancellationToken,
                         operationName: Constants.File.GetRangeListOperationName)
                         .ConfigureAwait(false);
+                    return Response.FromValue(new ShareFileRangeInfo(response.Value), response.GetRawResponse());
                 }
                 catch (Exception ex)
                 {

--- a/sdk/storage/Azure.Storage.Files.Shares/swagger/readme.md
+++ b/sdk/storage/Azure.Storage.Files.Shares/swagger/readme.md
@@ -534,7 +534,8 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{shareName}/{directory}/{fileName}?comp=rangelist"]
   transform: >
-    $.get.responses["200"]["x-az-response-name"] = "ShareFileRangeInfo";
+    $.get.responses["200"]["x-az-response-name"] = "ShareFileRangeInfoInternal";
+    $.get.responses["200"]["x-az-public"] = false;
     $.get.responses["200"]["x-az-response-schema-name"] = "Ranges";
 ```
 
@@ -750,5 +751,13 @@ directive:
     $.put.parameters[3]["x-ms-enum"].name = "ShareFileRangeWriteType";
 ```
 
+### Hide ranges
+``` yaml
+directive:
+- from: swagger-document
+  where: $.definitions
+  transform: >
+    $.Range["x-az-public"] = false;
+```
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsdk%2Fstorage%2FAzure.Storage.Files%2Fswagger%2Freadme.png)
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsdk%2Fstorage%2FAzure.Storage.Files.Shares%2Fswagger%2Freadme.png)

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
@@ -846,6 +846,9 @@ namespace Azure.Storage.Files.Shares.Test
             Response<ShareFileRangeInfo> response = await file.GetRangeListAsync(range: new HttpRange(0, Constants.MB));
 
             Assert.IsNotNull(response);
+            Assert.AreNotEqual("<null>", response.Value.ETag.ToString());
+            Assert.AreNotEqual(default(DateTimeOffset), response.Value.LastModified);
+            Assert.IsTrue(response.Value.FileContentLength > 0);
         }
 
         [Test]


### PR DESCRIPTION
Hide the File.Shares Range type and instead use HttpRange from Core.
