### PR TITLE
[Event Hubs Client] Track Two (Board Review Client Types)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerClient.cs
@@ -82,12 +82,6 @@ namespace Azure.Messaging.EventHubs
         private bool OwnsConnection { get; } = true;
 
         /// <summary>
-        ///   The set of options used for creation of this consumer.
-        /// </summary>
-        ///
-        private EventHubConsumerClientOptions Options { get; }
-
-        /// <summary>
         ///   The policy to use for determining retry behavior for when an operation fails.
         /// </summary>
         ///
@@ -134,7 +128,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <param name="consumerGroup">The name of the consumer group this consumer is associated with.  Events are read in the context of this group.</param>
         /// <param name="connectionString">The connection string to use for connecting to the Event Hubs namespace; it is expected that the Event Hub name and SAS token are contained in this connection string.</param>
-        /// <param name="consumerOptions">The set of options to use for this consumer.</param>
+        /// <param name="clientOptions">The set of options to use for this consumer.</param>
         ///
         /// <remarks>
         ///   If the connection string is copied from the Event Hubs namespace, it will likely not contain the name of the desired Event Hub,
@@ -147,7 +141,7 @@ namespace Azure.Messaging.EventHubs
         ///
         public EventHubConsumerClient(string consumerGroup,
                                       string connectionString,
-                                      EventHubConsumerClientOptions consumerOptions) : this(consumerGroup, connectionString, null, consumerOptions)
+                                      EventHubConsumerClientOptions clientOptions) : this(consumerGroup, connectionString, null, clientOptions)
         {
         }
 
@@ -178,7 +172,7 @@ namespace Azure.Messaging.EventHubs
         /// <param name="consumerGroup">The name of the consumer group this consumer is associated with.  Events are read in the context of this group.</param>
         /// <param name="connectionString">The connection string to use for connecting to the Event Hubs namespace; it is expected that the Event Hub name and SAS token are contained in this connection string.</param>
         /// <param name="eventHubName">The name of the specific Event Hub to associate the consumer with.</param>
-        /// <param name="consumerOptions">A set of options to apply when configuring the consumer.</param>
+        /// <param name="clientOptions">A set of options to apply when configuring the consumer.</param>
         ///
         /// <remarks>
         ///   If the connection string is copied from the Event Hub itself, it will contain the name of the desired Event Hub,
@@ -189,18 +183,17 @@ namespace Azure.Messaging.EventHubs
         public EventHubConsumerClient(string consumerGroup,
                                       string connectionString,
                                       string eventHubName,
-                                      EventHubConsumerClientOptions consumerOptions)
+                                      EventHubConsumerClientOptions clientOptions)
         {
             Argument.AssertNotNullOrEmpty(consumerGroup, nameof(consumerGroup));
             Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
 
-            consumerOptions = consumerOptions?.Clone() ?? new EventHubConsumerClientOptions();
+            clientOptions = clientOptions?.Clone() ?? new EventHubConsumerClientOptions();
 
             OwnsConnection = true;
-            Connection = new EventHubConnection(connectionString, eventHubName, consumerOptions.ConnectionOptions);
+            Connection = new EventHubConnection(connectionString, eventHubName, clientOptions.ConnectionOptions);
             ConsumerGroup = consumerGroup;
-            Options = consumerOptions;
-            RetryPolicy = consumerOptions.RetryOptions.ToRetryPolicy();
+            RetryPolicy = clientOptions.RetryOptions.ToRetryPolicy();
         }
 
         /// <summary>
@@ -211,26 +204,25 @@ namespace Azure.Messaging.EventHubs
         /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace to connect to.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
         /// <param name="eventHubName">The name of the specific Event Hub to associate the consumer with.</param>
         /// <param name="credential">The Azure managed identity credential to use for authorization.  Access controls may be specified by the Event Hubs namespace or the requested Event Hub, depending on Azure configuration.</param>
-        /// <param name="consumerOptions">A set of options to apply when configuring the consumer.</param>
+        /// <param name="clientOptions">A set of options to apply when configuring the consumer.</param>
         ///
         public EventHubConsumerClient(string consumerGroup,
                                       string fullyQualifiedNamespace,
                                       string eventHubName,
                                       TokenCredential credential,
-                                      EventHubConsumerClientOptions consumerOptions = default)
+                                      EventHubConsumerClientOptions clientOptions = default)
         {
             Argument.AssertNotNullOrEmpty(consumerGroup, nameof(consumerGroup));
             Argument.AssertNotNullOrEmpty(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace));
             Argument.AssertNotNullOrEmpty(eventHubName, nameof(eventHubName));
             Argument.AssertNotNull(credential, nameof(credential));
 
-            consumerOptions = consumerOptions?.Clone() ?? new EventHubConsumerClientOptions();
+            clientOptions = clientOptions?.Clone() ?? new EventHubConsumerClientOptions();
 
             OwnsConnection = true;
-            Connection = new EventHubConnection(fullyQualifiedNamespace, eventHubName, credential, consumerOptions.ConnectionOptions);
+            Connection = new EventHubConnection(fullyQualifiedNamespace, eventHubName, credential, clientOptions.ConnectionOptions);
             ConsumerGroup = consumerGroup;
-            Options = consumerOptions;
-            RetryPolicy = consumerOptions.RetryOptions.ToRetryPolicy();
+            RetryPolicy = clientOptions.RetryOptions.ToRetryPolicy();
         }
 
         /// <summary>
@@ -239,21 +231,20 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <param name="consumerGroup">The name of the consumer group this consumer is associated with.  Events are read in the context of this group.</param>
         /// <param name="connection">The <see cref="EventHubConnection" /> connection to use for communication with the Event Hubs service.</param>
-        /// <param name="consumerOptions">A set of options to apply when configuring the consumer.</param>
+        /// <param name="clientOptions">A set of options to apply when configuring the consumer.</param>
         ///
         public EventHubConsumerClient(string consumerGroup,
                                       EventHubConnection connection,
-                                      EventHubConsumerClientOptions consumerOptions = default)
+                                      EventHubConsumerClientOptions clientOptions = default)
         {
             Argument.AssertNotNullOrEmpty(consumerGroup, nameof(consumerGroup));
             Argument.AssertNotNull(connection, nameof(connection));
-            consumerOptions = consumerOptions?.Clone() ?? new EventHubConsumerClientOptions();
+            clientOptions = clientOptions?.Clone() ?? new EventHubConsumerClientOptions();
 
             OwnsConnection = false;
             Connection = connection;
             ConsumerGroup = consumerGroup;
-            Options = consumerOptions;
-            RetryPolicy = consumerOptions.RetryOptions.ToRetryPolicy();
+            RetryPolicy = clientOptions.RetryOptions.ToRetryPolicy();
         }
 
         /// <summary>
@@ -653,14 +644,6 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
-        ///   Closes the consumer.
-        /// </summary>
-        ///
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        ///
-        public virtual void Close(CancellationToken cancellationToken = default) => CloseAsync(cancellationToken).GetAwaiter().GetResult();
-
-        /// <summary>
         ///   Performs the task needed to clean up resources used by the <see cref="EventHubConsumerClient" />,
         ///   including ensuring that the client itself has been closed.
         /// </summary>
@@ -792,12 +775,25 @@ namespace Azure.Messaging.EventHubs
                     throw new EventHubsException(false, EventHubName, String.Format(CultureInfo.CurrentCulture, Resources.FailedToCreateReader, EventHubName, partitionId, ConsumerGroup));
                 }
 
+                void exceptionCallback(Exception ex)
+                {
+                    // Ignore the known exception cases that present during cancellation across
+                    // background publishing for multiple partitions.
+
+                    if ((ex is ChannelClosedException) || (ex is TaskCanceledException))
+                    {
+                        return;
+                    }
+
+                    observedException = ex;
+                }
+
                 publishingTask = StartBackgroundChannelPublishingAsync
                 (
                     transportConsumer,
                     channel,
                     new PartitionContext(partitionId, transportConsumer),
-                    ex => { observedException = ex; },
+                    exceptionCallback,
                     publishingCancellationSource.Token
                 );
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducerClient.cs
@@ -73,12 +73,6 @@ namespace Azure.Messaging.EventHubs
         private bool OwnsConnection { get; } = true;
 
         /// <summary>
-        ///   The set of options used for creation of this producer.
-        /// </summary>
-        ///
-        private EventHubProducerClientOptions Options { get; }
-
-        /// <summary>
         ///   The policy to use for determining retry behavior for when an operation fails.
         /// </summary>
         ///
@@ -129,7 +123,7 @@ namespace Azure.Messaging.EventHubs
         /// </summary>
         ///
         /// <param name="connectionString">The connection string to use for connecting to the Event Hubs namespace; it is expected that the Event Hub name and SAS token are contained in this connection string.</param>
-        /// <param name="producerOptions">The set of options to use for this consumer.</param>
+        /// <param name="clientOptions">The set of options to use for this consumer.</param>
         ///
         /// <remarks>
         ///   If the connection string is copied from the Event Hubs namespace, it will likely not contain the name of the desired Event Hub,
@@ -141,7 +135,7 @@ namespace Azure.Messaging.EventHubs
         /// </remarks>
         ///
         public EventHubProducerClient(string connectionString,
-                                      EventHubProducerClientOptions producerOptions) : this(connectionString, null, producerOptions)
+                                      EventHubProducerClientOptions clientOptions) : this(connectionString, null, clientOptions)
         {
         }
 
@@ -169,7 +163,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <param name="connectionString">The connection string to use for connecting to the Event Hubs namespace; it is expected that the Event Hub name and SAS token are contained in this connection string.</param>
         /// <param name="eventHubName">The name of the specific Event Hub to associate the producer with.</param>
-        /// <param name="producerOptions">A set of options to apply when configuring the producer.</param>
+        /// <param name="clientOptions">A set of options to apply when configuring the producer.</param>
         ///
         /// <remarks>
         ///   If the connection string is copied from the Event Hub itself, it will contain the name of the desired Event Hub,
@@ -179,15 +173,14 @@ namespace Azure.Messaging.EventHubs
         ///
         public EventHubProducerClient(string connectionString,
                                       string eventHubName,
-                                      EventHubProducerClientOptions producerOptions)
+                                      EventHubProducerClientOptions clientOptions)
         {
             Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
-            producerOptions = producerOptions?.Clone() ?? new EventHubProducerClientOptions();
+            clientOptions = clientOptions?.Clone() ?? new EventHubProducerClientOptions();
 
             OwnsConnection = true;
-            Connection = new EventHubConnection(connectionString, eventHubName, producerOptions.ConnectionOptions);
-            Options = producerOptions;
-            RetryPolicy = producerOptions.RetryOptions.ToRetryPolicy();
+            Connection = new EventHubConnection(connectionString, eventHubName, clientOptions.ConnectionOptions);
+            RetryPolicy = clientOptions.RetryOptions.ToRetryPolicy();
             GatewayProducer = Connection.CreateTransportProducer(null, RetryPolicy);
         }
 
@@ -198,24 +191,23 @@ namespace Azure.Messaging.EventHubs
         /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace to connect to.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
         /// <param name="eventHubName">The name of the specific Event Hub to associated the producer with.</param>
         /// <param name="credential">The Azure managed identity credential to use for authorization.  Access controls may be specified by the Event Hubs namespace or the requested Event Hub, depending on Azure configuration.</param>
-        /// <param name="producerOptions">A set of options to apply when configuring the producer.</param>
+        /// <param name="clientOptions">A set of options to apply when configuring the producer.</param>
         ///
         public EventHubProducerClient(string fullyQualifiedNamespace,
                                       string eventHubName,
                                       TokenCredential credential,
-                                      EventHubProducerClientOptions producerOptions = default)
+                                      EventHubProducerClientOptions clientOptions = default)
         {
             Argument.AssertNotNullOrEmpty(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace));
             Argument.AssertNotNullOrEmpty(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace));
             Argument.AssertNotNullOrEmpty(eventHubName, nameof(eventHubName));
             Argument.AssertNotNull(credential, nameof(credential));
 
-            producerOptions = producerOptions?.Clone() ?? new EventHubProducerClientOptions();
+            clientOptions = clientOptions?.Clone() ?? new EventHubProducerClientOptions();
 
             OwnsConnection = true;
-            Connection = new EventHubConnection(fullyQualifiedNamespace, eventHubName, credential, producerOptions.ConnectionOptions);
-            Options = producerOptions;
-            RetryPolicy = producerOptions.RetryOptions.ToRetryPolicy();
+            Connection = new EventHubConnection(fullyQualifiedNamespace, eventHubName, credential, clientOptions.ConnectionOptions);
+            RetryPolicy = clientOptions.RetryOptions.ToRetryPolicy();
             GatewayProducer = Connection.CreateTransportProducer(null, RetryPolicy);
         }
 
@@ -224,18 +216,17 @@ namespace Azure.Messaging.EventHubs
         /// </summary>
         ///
         /// <param name="connection">The <see cref="EventHubConnection" /> connection to use for communication with the Event Hubs service.</param>
-        /// <param name="producerOptions">A set of options to apply when configuring the producer.</param>
+        /// <param name="clientOptions">A set of options to apply when configuring the producer.</param>
         ///
         public EventHubProducerClient(EventHubConnection connection,
-                                      EventHubProducerClientOptions producerOptions = default)
+                                      EventHubProducerClientOptions clientOptions = default)
         {
             Argument.AssertNotNull(connection, nameof(connection));
-            producerOptions = producerOptions?.Clone() ?? new EventHubProducerClientOptions();
+            clientOptions = clientOptions?.Clone() ?? new EventHubProducerClientOptions();
 
             OwnsConnection = false;
             Connection = connection;
-            Options = producerOptions;
-            RetryPolicy = producerOptions.RetryOptions.ToRetryPolicy();
+            RetryPolicy = clientOptions.RetryOptions.ToRetryPolicy();
             GatewayProducer = Connection.CreateTransportProducer(null, RetryPolicy);
         }
 
@@ -601,14 +592,6 @@ namespace Azure.Messaging.EventHubs
                 throw transportProducerException;
             }
         }
-
-        /// <summary>
-        ///   Closes the producer.
-        /// </summary>
-        ///
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        ///
-        public virtual void Close(CancellationToken cancellationToken = default) => CloseAsync(cancellationToken).GetAwaiter().GetResult();
 
         /// <summary>
         ///   Performs the task needed to clean up resources used by the <see cref="EventHubProducerClient" />,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientLiveTests.cs
@@ -1111,9 +1111,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [TestCase(true)]
-        [TestCase(false)]
-        public async Task ConsumerCannotReadWhenClosed(bool sync)
+        public async Task ConsumerCannotReadWhenClosed()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
@@ -1138,14 +1136,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                                 if ((count == countBeforeClose) && (!closeCalled))
                                 {
-                                    if (sync)
-                                    {
-                                        consumer.Close();
-                                    }
-                                    else
-                                    {
-                                        await consumer.CloseAsync();
-                                    }
+                                    await consumer.CloseAsync();
                                 }
 
                                 if (count >= maximumCount)
@@ -2130,9 +2121,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [TestCase(true)]
-        [TestCase(false)]
-        public async Task ConsumerCannotRetrieveMetadataWhenClosed(bool sync)
+        public async Task ConsumerCannotRetrieveMetadataWhenClosed()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
@@ -2145,15 +2134,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     Assert.That(async () => await consumer.GetEventHubPropertiesAsync(), Throws.Nothing);
                     Assert.That(async () => await consumer.GetPartitionPropertiesAsync(partition), Throws.Nothing);
 
-                    if (sync)
-                    {
-                        consumer.Close();
-                    }
-                    else
-                    {
-                        await consumer.CloseAsync();
-                    }
-
+                    await consumer.CloseAsync();
                     await Task.Delay(TimeSpan.FromSeconds(5));
 
                     Assert.That(async () => await consumer.GetPartitionIdsAsync(), Throws.TypeOf<EventHubsClientClosedException>());

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientLiveTests.cs
@@ -585,9 +585,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [TestCase(true)]
-        [TestCase(false)]
-        public async Task ProducerCannotSendWhenClosed(bool sync)
+        public async Task ProducerCannotSendWhenClosed()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
@@ -598,15 +596,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     EventData[] events = new[] { new EventData(Encoding.UTF8.GetBytes("Dummy event")) };
                     Assert.That(async () => await producer.SendAsync(events), Throws.Nothing);
 
-                    if (sync)
-                    {
-                        producer.Close();
-                    }
-                    else
-                    {
-                        await producer.CloseAsync();
-                    }
-
+                    await producer.CloseAsync();
                     Assert.That(async () => await producer.SendAsync(events), Throws.TypeOf<EventHubsClientClosedException>());
                 }
             }
@@ -1127,9 +1117,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [TestCase(true)]
-        [TestCase(false)]
-        public async Task ProducerCannotRetrieveMetadataWhenClosed(bool sync)
+        public async Task ProducerCannotRetrieveMetadataWhenClosed()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
@@ -1142,15 +1130,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     Assert.That(async () => await producer.GetEventHubPropertiesAsync(), Throws.Nothing);
                     Assert.That(async () => await producer.GetPartitionPropertiesAsync(partition), Throws.Nothing);
 
-                    if (sync)
-                    {
-                        producer.Close();
-                    }
-                    else
-                    {
-                        await producer.CloseAsync();
-                    }
-
+                    await producer.CloseAsync();
                     await Task.Delay(TimeSpan.FromSeconds(5));
 
                     Assert.That(async () => await producer.GetPartitionIdsAsync(), Throws.TypeOf<EventHubsClientClosedException>());

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientTests.cs
@@ -607,50 +607,6 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="EventHubProducerClient.Close" />
-        ///   method.
-        /// </summary>
-        ///
-        [Test]
-        public async Task CloseClosesTheTransportProducers()
-        {
-            var transportProducer = new ObservableTransportProducerMock();
-            var mockFirstBatch = new EventDataBatch(new MockTransportBatch(), new SendOptions { PartitionId = "1" });
-            var mockSecondBatch = new EventDataBatch(new MockTransportBatch(), new SendOptions { PartitionId = "2" });
-            var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
-
-            try { await producer.SendAsync(mockFirstBatch); } catch {}
-            try { await producer.SendAsync(mockSecondBatch); } catch {}
-
-            producer.Close();
-
-            Assert.That(transportProducer.WasCloseCalled, Is.True);
-            Assert.That(transportProducer.CloseCallCount, Is.EqualTo(3));
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the <see cref="EventHubProducerClient.Close" />
-        ///   method.
-        /// </summary>
-        ///
-        [Test]
-        public async Task CloseSurfacesExceptionsForTransportConsumers()
-        {
-            var mockTransportProducer = new Mock<TransportProducer>();
-            var mockConnection = new MockConnection(() => mockTransportProducer.Object);
-            var mockBatch = new EventDataBatch(new MockTransportBatch(), new SendOptions { PartitionId = "1" });;
-            var producer = new EventHubProducerClient(mockConnection);
-
-            mockTransportProducer
-                .Setup(producer => producer.CloseAsync(It.IsAny<CancellationToken>()))
-                .Returns(Task.FromException(new InvalidCastException()));
-
-            try { await producer.SendAsync(mockBatch); } catch {}
-
-            Assert.That(() => producer.Close(), Throws.InstanceOf<Exception>());
-        }
-
-        /// <summary>
         ///   Verifies functionality of the <see cref="EventHubProducerClient.CloseAsync" />
         ///   method.
         /// </summary>
@@ -662,23 +618,6 @@ namespace Azure.Messaging.EventHubs.Tests
             var producer = new EventHubProducerClient(connectionString);
 
             await producer.CloseAsync();
-
-            var connection = GetConnection(producer);
-            Assert.That(connection.IsClosed, Is.True);
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the <see cref="EventHubProducerClient.Close" />
-        ///   method.
-        /// </summary>
-        ///
-        [Test]
-        public void CloseClosesTheConnectionWhenOwned()
-        {
-            var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
-            var producer = new EventHubProducerClient(connectionString);
-
-            producer.Close();
 
             var connection = GetConnection(producer);
             Assert.That(connection.IsClosed, Is.True);
@@ -697,22 +636,6 @@ namespace Azure.Messaging.EventHubs.Tests
             var producer = new EventHubProducerClient(connection);
 
             await producer.CloseAsync();
-            Assert.That(connection.IsClosed, Is.False);
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the <see cref="EventHubProducerClient.Close" />
-        ///   method.
-        /// </summary>
-        ///
-        [Test]
-        public void CloseDoesNotCloseTheConnectionWhenNotOwned()
-        {
-            var transportProducer = new ObservableTransportProducerMock();
-            var connection = new MockConnection(() => transportProducer);
-            var producer = new EventHubProducerClient(connection);
-
-            producer.Close();
             Assert.That(connection.IsClosed, Is.False);
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventProcessorClient/EventProcessorClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventProcessorClient/EventProcessorClientTests.cs
@@ -389,24 +389,6 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="EventProcessorClient.Close" />
-        ///   method.
-        /// </summary>
-        ///
-        [Test]
-        [Ignore("Event Processor does not have a single connection anymore.")]
-        public void CloseClosesTheConnectionWhenOwned()
-        {
-            var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
-            var processor = new EventProcessorClient(EventHubConsumerClient.DefaultConsumerGroupName, Mock.Of<PartitionManager>(), connectionString);
-
-            processor.Close();
-
-            var connection = GetConnection(processor);
-            Assert.That(connection.IsClosed, Is.True);
-        }
-
-        /// <summary>
         ///   Verifies functionality of the <see cref="EventProcessorClient.CloseAsync" />
         ///   method.
         /// </summary>
@@ -418,21 +400,6 @@ namespace Azure.Messaging.EventHubs.Tests
             var processor = new EventProcessorClient(EventHubConsumerClient.DefaultConsumerGroupName, Mock.Of<PartitionManager>(), connection, default);
 
             await processor.CloseAsync();
-            Assert.That(connection.IsClosed, Is.False);
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the <see cref="EventHubProducer.Close" />
-        ///   method.
-        /// </summary>
-        ///
-        [Test]
-        public void CloseDoesNotCloseTheConnectionWhenNotOwned()
-        {
-            var connection = new MockConnection();
-            var processor = new EventProcessorClient(EventHubConsumerClient.DefaultConsumerGroupName, Mock.Of<PartitionManager>(), connection, default);
-
-            processor.Close();
             Assert.That(connection.IsClosed, Is.False);
         }
 


### PR DESCRIPTION
# Summary

The focus of these changes is to perform minor cleanup on the Event Hubs client types and to incorporate feedback from the architecture board for the final review.  The following items are included:

- Client type constructors accepting options have had parameters renamed to `clientOptions` to conform to guidelines.
- The synchonous `Close` method has been removed from clients.
- Clients holding their constructor options in a private member but no longer actively using them have had the member removed.

# Last Upstream Rebase

Thursday, November 21, 10:37am (EST)

# Related and Follow-Up Issues

- [Release Event Hubs Track 2 Library for .NET](https://github.com/Azure/azure-sdk-for-net/issues/8552) (#8552) 
- [Incorporate architecture board review feedback](https://github.com/Azure/azure-sdk-for-net/issues/8583) (#8583) 