### PR TITLE
[Event Hubs Client] Track Two (Board Review Naming Revisions)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample02_ClientWithCustomOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample02_ClientWithCustomOptions.cs
@@ -57,11 +57,11 @@ namespace Azure.Messaging.EventHubs.Samples
             {
                ConnectionOptions = new EventHubConnectionOptions
                 {
-                    TransportType = TransportType.AmqpWebSockets,
+                    TransportType = EventHubsTransportType.AmqpWebSockets,
                     Proxy = (IWebProxy)null
                 },
 
-                RetryOptions = new RetryOptions
+                RetryOptions = new EventHubsRetryOptions
                 {
                    MaximumRetries = 5,
                    TryTimeout = TimeSpan.FromMinutes(1)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample08_ConsumeEvents.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample08_ConsumeEvents.cs
@@ -81,7 +81,7 @@ namespace Azure.Messaging.EventHubs.Samples
                 CancellationTokenSource cancellationSource = new CancellationTokenSource();
                 cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
 
-                ReadOptions readOptions = new ReadOptions
+                ReadEventOptions readOptions = new ReadEventOptions
                 {
                     MaximumWaitTime = TimeSpan.FromMilliseconds(150)
                 };

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample09_ConsumeEventsWithMaximumWaitTime.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample09_ConsumeEventsWithMaximumWaitTime.cs
@@ -90,7 +90,7 @@ namespace Azure.Messaging.EventHubs.Samples
                 CancellationTokenSource cancellationSource = new CancellationTokenSource();
                 cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
 
-                ReadOptions readOptions = new ReadOptions
+                ReadEventOptions readOptions = new ReadEventOptions
                 {
                     MaximumWaitTime = TimeSpan.FromMilliseconds(250)
                 };

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample10_ConsumeEventsFromAKnownPosition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample10_ConsumeEventsFromAKnownPosition.cs
@@ -91,7 +91,7 @@ namespace Azure.Messaging.EventHubs.Samples
                     CancellationTokenSource cancellationSource = new CancellationTokenSource();
                     cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
 
-                    ReadOptions readOptions = new ReadOptions
+                    ReadEventOptions readOptions = new ReadEventOptions
                     {
                          MaximumWaitTime = TimeSpan.FromMilliseconds(150)
                     };

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample12_AuthenticateWithClientSecretCredential.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample12_AuthenticateWithClientSecretCredential.cs
@@ -96,7 +96,7 @@ namespace Azure.Messaging.EventHubs.Samples
 
                 PartitionEvent receivedEvent;
 
-                ReadOptions readOptions = new ReadOptions
+                ReadEventOptions readOptions = new ReadEventOptions
                 {
                     MaximumWaitTime = TimeSpan.FromMilliseconds(150)
                 };

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
@@ -397,7 +397,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// <param name="partitionId">The identifier of the Event Hub partition from which events will be received.</param>
         /// <param name="eventPosition">The position within the partition where the consumer should begin reading events.</param>
         /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
-        /// <param name="trackLastEnqueuedEventInformation">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
+        /// <param name="trackLastEnqueuedEventProperties">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
         /// <param name="ownerLevel">The relative priority to associate with the link; for a non-exclusive link, this value should be <c>null</c>.</param>
         /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.  If <c>null</c> a default will be used.</param>
         ///
@@ -407,7 +407,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                                                          string partitionId,
                                                          EventPosition eventPosition,
                                                          EventHubsRetryPolicy retryPolicy,
-                                                         bool trackLastEnqueuedEventInformation,
+                                                         bool trackLastEnqueuedEventProperties,
                                                          long? ownerLevel,
                                                          uint? prefetchCount)
         {
@@ -419,7 +419,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                 consumerGroup,
                 partitionId,
                 eventPosition,
-                trackLastEnqueuedEventInformation,
+                trackLastEnqueuedEventProperties,
                 ownerLevel,
                 prefetchCount,
                 ConnectionScope,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
@@ -134,7 +134,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         ///   The type of transport to use for communication.
         /// </summary>
         ///
-        private TransportType Transport { get; }
+        private EventHubsTransportType Transport { get; }
 
         /// <summary>
         ///   The proxy, if any, which should be used for communication.
@@ -162,7 +162,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         public AmqpConnectionScope(Uri serviceEndpoint,
                                    string eventHubName,
                                    EventHubTokenCredential credential,
-                                   TransportType transport,
+                                   EventHubsTransportType transport,
                                    IWebProxy proxy,
                                    string identifier = default)
         {
@@ -232,7 +232,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// <param name="eventPosition">The position of the event in the partition where the link should be filtered to.</param>
         /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.</param>
         /// <param name="ownerLevel">The relative priority to associate with the link; for a non-exclusive link, this value should be <c>null</c>.</param>
-        /// <param name="trackLastEnqueuedEventInformation">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
+        /// <param name="trackLastEnqueuedEventProperties">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
         /// <param name="timeout">The timeout to apply when creating the link.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
@@ -244,7 +244,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                                                                            TimeSpan timeout,
                                                                            uint prefetchCount,
                                                                            long? ownerLevel,
-                                                                           bool trackLastEnqueuedEventInformation,
+                                                                           bool trackLastEnqueuedEventProperties,
                                                                            CancellationToken cancellationToken)
         {
             Argument.AssertNotNullOrEmpty(consumerGroup, nameof(consumerGroup));
@@ -265,7 +265,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                 timeout.CalculateRemaining(stopWatch.Elapsed),
                 prefetchCount,
                 ownerLevel,
-                trackLastEnqueuedEventInformation,
+                trackLastEnqueuedEventProperties,
                 cancellationToken
             ).ConfigureAwait(false);
 
@@ -345,7 +345,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         ///
         protected virtual async Task<AmqpConnection> CreateAndOpenConnectionAsync(Version amqpVersion,
                                                                                   Uri serviceEndpoint,
-                                                                                  TransportType transportType,
+                                                                                  EventHubsTransportType transportType,
                                                                                   IWebProxy proxy,
                                                                                   string scopeIdentifier,
                                                                                   TimeSpan timeout)
@@ -456,7 +456,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// <param name="eventPosition">The position of the event in the partition where the link should be filtered to.</param>
         /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.</param>
         /// <param name="ownerLevel">The relative priority to associate with the link; for a non-exclusive link, this value should be <c>null</c>.</param>
-        /// <param name="trackLastEnqueuedEventInformation">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
+        /// <param name="trackLastEnqueuedEventProperties">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
         /// <param name="timeout">The timeout to apply when creating the link.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
@@ -468,7 +468,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                                                                                  TimeSpan timeout,
                                                                                  uint prefetchCount,
                                                                                  long? ownerLevel,
-                                                                                 bool trackLastEnqueuedEventInformation,
+                                                                                 bool trackLastEnqueuedEventProperties,
                                                                                  CancellationToken cancellationToken)
         {
             Argument.AssertNotDisposed(IsDisposed, nameof(AmqpConnectionScope));
@@ -515,11 +515,11 @@ namespace Azure.Messaging.EventHubs.Amqp
                     linkSettings.AddProperty(AmqpProperty.OwnerLevel, ownerLevel.Value);
                 }
 
-                if (trackLastEnqueuedEventInformation)
+                if (trackLastEnqueuedEventProperties)
                 {
                     linkSettings.DesiredCapabilities = new Multiple<AmqpSymbol>(new List<AmqpSymbol>
                     {
-                        AmqpProperty.TrackLastEnqueuedEventInformation
+                        AmqpProperty.TrackLastEnqueuedEventProperties
                     });
                 }
 
@@ -929,9 +929,9 @@ namespace Azure.Messaging.EventHubs.Amqp
         ///
         /// <param name="transport">The transport to validate.</param>
         ///
-        private static void ValidateTransport(TransportType transport)
+        private static void ValidateTransport(EventHubsTransportType transport)
         {
-            if ((transport != TransportType.AmqpTcp) && (transport != TransportType.AmqpWebSockets))
+            if ((transport != EventHubsTransportType.AmqpTcp) && (transport != EventHubsTransportType.AmqpWebSockets))
             {
                 throw new ArgumentException(nameof(transport), string.Format(CultureInfo.CurrentCulture, Resources.UnknownConnectionType, transport));
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
@@ -68,7 +68,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         ///
         /// <value><c>true</c> if information about a partition's last event should be requested and tracked; otherwise, <c>false</c>.</value>
         ///
-        private bool TrackLastEnqueuedEventInformation { get; }
+        private bool TrackLastEnqueuedEventProperties { get; }
 
         /// <summary>
         ///   The policy to use for determining retry behavior for when an operation fails.
@@ -105,7 +105,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// <param name="eventPosition">The position of the event in the partition where the consumer should begin reading.</param>
         /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.  If <c>null</c> a default will be used.</param>
         /// <param name="ownerLevel">The relative priority to associate with the link; for a non-exclusive link, this value should be <c>null</c>.</param>
-        /// <param name="trackLastEnqueuedEventInformation">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
+        /// <param name="trackLastEnqueuedEventProperties">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
         /// <param name="connectionScope">The AMQP connection context for operations .</param>
         /// <param name="messageConverter">The converter to use for translating between AMQP messages and client types.</param>
         /// <param name="retryPolicy">The retry policy to consider when an operation fails.</param>
@@ -123,7 +123,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                             string consumerGroup,
                             string partitionId,
                             EventPosition eventPosition,
-                            bool trackLastEnqueuedEventInformation,
+                            bool trackLastEnqueuedEventProperties,
                             long? ownerLevel,
                             uint? prefetchCount,
                             AmqpConnectionScope connectionScope,
@@ -140,7 +140,7 @@ namespace Azure.Messaging.EventHubs.Amqp
             EventHubName = eventHubName;
             ConsumerGroup = consumerGroup;
             PartitionId = partitionId;
-            TrackLastEnqueuedEventInformation = trackLastEnqueuedEventInformation;
+            TrackLastEnqueuedEventProperties = trackLastEnqueuedEventProperties;
             ConnectionScope = connectionScope;
             RetryPolicy = retryPolicy;
             MessageConverter = messageConverter;
@@ -153,7 +153,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                     timeout,
                     prefetchCount ?? DefaultPrefetchCount,
                     ownerLevel,
-                    trackLastEnqueuedEventInformation,
+                    trackLastEnqueuedEventProperties,
                     CancellationToken.None),
                 link => link.SafeClose());
         }
@@ -222,7 +222,7 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                             receivedEventCount = receivedEvents.Count;
 
-                            if ((TrackLastEnqueuedEventInformation) && (receivedEventCount > 0))
+                            if ((TrackLastEnqueuedEventProperties) && (receivedEventCount > 0))
                             {
                                 LastReceivedEvent = receivedEvents[receivedEventCount - 1];
                             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
@@ -138,7 +138,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         public override async Task SendAsync(IEnumerable<EventData> events,
-                                             SendOptions sendOptions,
+                                             SendEventOptions sendOptions,
                                              CancellationToken cancellationToken)
         {
             Argument.AssertNotNull(events, nameof(events));

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProperty.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProperty.cs
@@ -29,7 +29,7 @@ namespace Azure.Messaging.EventHubs
         ///   The capability for tracking the last event enqueued in a partition, to associate with a link.
         /// </summary>
         ///
-        public static AmqpSymbol TrackLastEnqueuedEventInformation { get; } = AmqpConstants.Vendor + ":enable-receiver-runtime-metric";
+        public static AmqpSymbol TrackLastEnqueuedEventProperties { get; } = AmqpConstants.Vendor + ":enable-receiver-runtime-metric";
 
         /// <summary>
         ///   The timeout to associate with a link.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Authorization/EventHubSharedKeyCredential.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Authorization/EventHubSharedKeyCredential.cs
@@ -15,14 +15,14 @@ namespace Azure.Messaging.EventHubs.Authorization
     ///
     /// <seealso cref="Azure.Core.TokenCredential" />
     ///
-    public sealed class EventHubSharedKeyCredential : TokenCredential
+    internal sealed class EventHubSharedKeyCredential : TokenCredential
     {
         /// <summary>
         ///   The name of the shared access key to be used for authorization, as
         ///   reported by the Azure portal.
         /// </summary>
         ///
-        public string SharedAccessKeyName { get; }
+        private string SharedAccessKeyName { get; }
 
         /// <summary>
         ///   The value of the shared access key to be used for authorization, as

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/BasicRetryPolicy.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/BasicRetryPolicy.cs
@@ -13,10 +13,10 @@ namespace Azure.Messaging.EventHubs.Core
 {
     /// <summary>
     ///   The default retry policy for the Event Hubs client library, respecting the
-    ///   configuration specified as a set of <see cref="RetryOptions" />.
+    ///   configuration specified as a set of <see cref="EventHubsRetryOptions" />.
     /// </summary>
     ///
-    /// <seealso cref="RetryOptions"/>
+    /// <seealso cref="EventHubsRetryOptions"/>
     ///
     internal class BasicRetryPolicy : EventHubsRetryPolicy
     {
@@ -31,7 +31,7 @@ namespace Azure.Messaging.EventHubs.Core
         ///   behavior.
         /// </summary>
         ///
-        public RetryOptions Options { get; }
+        public EventHubsRetryOptions Options { get; }
 
         /// <summary>
         ///   The factor to apply to the base delay for use as a base jitter value.
@@ -47,7 +47,7 @@ namespace Azure.Messaging.EventHubs.Core
         ///
         /// <param name="retryOptions">The options which control the retry approach.</param>
         ///
-        public BasicRetryPolicy(RetryOptions retryOptions)
+        public BasicRetryPolicy(EventHubsRetryOptions retryOptions)
         {
             Argument.AssertNotNull(retryOptions, nameof(retryOptions));
             Options = retryOptions;
@@ -89,8 +89,8 @@ namespace Azure.Messaging.EventHubs.Core
 
             TimeSpan retryDelay = Options.Mode switch
             {
-                RetryMode.Fixed => CalculateFixedDelay(Options.Delay.TotalSeconds, baseJitterSeconds, RandomNumberGenerator.Value),
-                RetryMode.Exponential => CalculateExponentialDelay(attemptCount, Options.Delay.TotalSeconds, baseJitterSeconds, RandomNumberGenerator.Value),
+                EventHubsRetryMode.Fixed => CalculateFixedDelay(Options.Delay.TotalSeconds, baseJitterSeconds, RandomNumberGenerator.Value),
+                EventHubsRetryMode.Exponential => CalculateExponentialDelay(attemptCount, Options.Delay.TotalSeconds, baseJitterSeconds, RandomNumberGenerator.Value),
                 _ => throw new NotSupportedException(string.Format(CultureInfo.CurrentCulture, Resources.UnknownRetryMode, Options.Mode.ToString())),
             };
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportClient.cs
@@ -95,7 +95,7 @@ namespace Azure.Messaging.EventHubs.Core
         /// <param name="partitionId">The identifier of the Event Hub partition from which events will be received.</param>
         /// <param name="eventPosition">The position within the partition where the consumer should begin reading events.</param>
         /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
-        /// <param name="trackLastEnqueuedEventInformation">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
+        /// <param name="trackLastEnqueuedEventProperties">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
         /// <param name="ownerLevel">The relative priority to associate with the link; for a non-exclusive link, this value should be <c>null</c>.</param>
         /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.  If <c>null</c> a default will be used.</param>
         ///
@@ -105,7 +105,7 @@ namespace Azure.Messaging.EventHubs.Core
                                                          string partitionId,
                                                          EventPosition eventPosition,
                                                          EventHubsRetryPolicy retryPolicy,
-                                                         bool trackLastEnqueuedEventInformation,
+                                                         bool trackLastEnqueuedEventProperties,
                                                          long? ownerLevel,
                                                          uint? prefetchCount);
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportProducer.cs
@@ -36,7 +36,7 @@ namespace Azure.Messaging.EventHubs.Core
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         public abstract Task SendAsync(IEnumerable<EventData> events,
-                                       SendOptions sendOptions,
+                                       SendEventOptions sendOptions,
                                        CancellationToken cancellationToken);
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportTypeExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportTypeExtensions.cs
@@ -7,7 +7,7 @@ using System.Globalization;
 namespace Azure.Messaging.EventHubs.Core
 {
     /// <summary>
-    ///   The set of extension methods for the <see cref="TransportType" /> enumeration.
+    ///   The set of extension methods for the <see cref="EventHubsTransportType" /> enumeration.
     /// </summary>
     ///
     internal static class TransportTypeExtensions
@@ -23,12 +23,12 @@ namespace Azure.Messaging.EventHubs.Core
         ///
         /// <returns>The scheme that should be used for the given connection type when forming an associated URI.</returns>
         ///
-        public static string GetUriScheme(this TransportType instance)
+        public static string GetUriScheme(this EventHubsTransportType instance)
         {
             switch (instance)
             {
-                case TransportType.AmqpTcp:
-                case TransportType.AmqpWebSockets:
+                case EventHubsTransportType.AmqpTcp:
+                case EventHubsTransportType.AmqpWebSockets:
                     return AmqpUriScheme;
 
                 default:
@@ -44,6 +44,6 @@ namespace Azure.Messaging.EventHubs.Core
         ///
         /// <returns><c>true</c> if the transport uses web sockets; otherwise, <c>false</c>.</returns>
         ///
-        public static bool IsWebSocketTransport(this TransportType instance) => (instance == TransportType.AmqpWebSockets);
+        public static bool IsWebSocketTransport(this EventHubsTransportType instance) => (instance == EventHubsTransportType.AmqpWebSockets);
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/CreateBatchOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/CreateBatchOptions.cs
@@ -108,12 +108,12 @@ namespace Azure.Messaging.EventHubs
 
         /// <summary>
         ///   Converts the <see cref="CreateBatchOptions" /> into an equivalent
-        ///   <see cref="SendOptions" /> instance.
+        ///   <see cref="SendEventOptions" /> instance.
         /// </summary>
         ///
         /// <returns>A set of sending options equivalent to those represented by the batch options.</returns>
         ///
-        internal SendOptions ToSendOptions() => new SendOptions(PartitionId, PartitionKey);
+        internal SendEventOptions ToSendOptions() => new SendEventOptions(PartitionId, PartitionKey);
 
         /// <summary>
         ///   Determines whether the specified <see cref="System.Object" /> is equal to this instance.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Errors/ConsumerDisconnectedException.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Errors/ConsumerDisconnectedException.cs
@@ -7,7 +7,7 @@ namespace Azure.Messaging.EventHubs.Errors
 {
     /// <summary>
     ///   An exception which occurs when an <see cref="EventHubConsumerClient" /> is forcefully disconnected
-    ///   from an Event Hub instance.  This typically occurs when another consumer with higher <see cref="ReadOptions.OwnerLevel" />
+    ///   from an Event Hub instance.  This typically occurs when another consumer with higher <see cref="ReadEventOptions.OwnerLevel" />
     ///   asserts ownership over the partition and consumer group.
     /// </summary>
     ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -130,7 +130,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <remarks>
         ///   This property is only populated for events received using an reader specifying
-        ///   <see cref="ReadOptions.TrackLastEnqueuedEventInformation" /> as enabled.
+        ///   <see cref="ReadEventOptions.TrackLastEnqueuedEventProperties" /> as enabled.
         /// </remarks>
         ///
         internal long? LastPartitionSequenceNumber { get; }
@@ -142,7 +142,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <remarks>
         ///   This property is only populated for events received using an reader specifying
-        ///   <see cref="ReadOptions.TrackLastEnqueuedEventInformation" /> as enabled.
+        ///   <see cref="ReadEventOptions.TrackLastEnqueuedEventProperties" /> as enabled.
         /// </remarks>
         ///
         internal long? LastPartitionOffset { get; }
@@ -154,7 +154,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <remarks>
         ///   This property is only populated for events received using an reader specifying
-        ///   <see cref="ReadOptions.TrackLastEnqueuedEventInformation" /> as enabled.
+        ///   <see cref="ReadEventOptions.TrackLastEnqueuedEventProperties" /> as enabled.
         /// </remarks>
         ///
         internal DateTimeOffset? LastPartitionEnqueuedTime { get; }
@@ -166,7 +166,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <remarks>
         ///   This property is only populated for events received using an reader specifying
-        ///   <see cref="ReadOptions.TrackLastEnqueuedEventInformation" /> as enabled.
+        ///   <see cref="ReadEventOptions.TrackLastEnqueuedEventProperties" /> as enabled.
         /// </remarks>
         ///
         internal DateTimeOffset? LastPartitionInformationRetrievalTime { get; }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventDataBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventDataBatch.cs
@@ -40,7 +40,7 @@ namespace Azure.Messaging.EventHubs
         ///   The set of options that should be used when publishing the batch.
         /// </summary>
         ///
-        internal SendOptions SendOptions { get; }
+        internal SendEventOptions SendOptions { get; }
 
         /// <summary>
         ///   The transport-specific batch responsible for performing the batch operations
@@ -66,7 +66,7 @@ namespace Azure.Messaging.EventHubs
         /// </remarks>
         ///
         internal EventDataBatch(TransportEventBatch transportBatch,
-                                SendOptions sendOptions)
+                                SendEventOptions sendOptions)
         {
             Argument.AssertNotNull(transportBatch, nameof(transportBatch));
             Argument.AssertNotNull(sendOptions, nameof(sendOptions));

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnection.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnection.cs
@@ -382,7 +382,7 @@ namespace Azure.Messaging.EventHubs
         /// <param name="partitionId">The identifier of the Event Hub partition from which events will be received.</param>
         /// <param name="eventPosition">The position within the partition where the consumer should begin reading events.</param>
         /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
-        /// <param name="trackLastEnqueuedEventInformation">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
+        /// <param name="trackLastEnqueuedEventProperties">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
         /// <param name="ownerLevel">The relative priority to associate with the link; for a non-exclusive link, this value should be <c>null</c>.</param>
         /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.  If <c>null</c> a default will be used.</param>
         ///
@@ -392,7 +392,7 @@ namespace Azure.Messaging.EventHubs
                                                                    string partitionId,
                                                                    EventPosition eventPosition,
                                                                    EventHubsRetryPolicy retryPolicy,
-                                                                   bool trackLastEnqueuedEventInformation = true,
+                                                                   bool trackLastEnqueuedEventProperties = true,
                                                                    long? ownerLevel = default,
                                                                    uint? prefetchCount = default)
         {
@@ -400,7 +400,7 @@ namespace Azure.Messaging.EventHubs
             Argument.AssertNotNullOrEmpty(partitionId, nameof(partitionId));
             Argument.AssertNotNull(retryPolicy, nameof(retryPolicy));
 
-            return InnerClient.CreateConsumer(consumerGroup, partitionId, eventPosition, retryPolicy, trackLastEnqueuedEventInformation, ownerLevel, prefetchCount);
+            return InnerClient.CreateConsumer(consumerGroup, partitionId, eventPosition, retryPolicy, trackLastEnqueuedEventProperties, ownerLevel, prefetchCount);
         }
 
         /// <summary>
@@ -430,8 +430,8 @@ namespace Azure.Messaging.EventHubs
         {
             switch (options.TransportType)
             {
-                case TransportType.AmqpTcp:
-                case TransportType.AmqpWebSockets:
+                case EventHubsTransportType.AmqpTcp:
+                case EventHubsTransportType.AmqpWebSockets:
                     return new AmqpClient(fullyQualifiedNamespace, eventHubName, credential, options);
 
                 default:
@@ -449,7 +449,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <returns>The value to use as the audience of the signature.</returns>
         ///
-        private static string BuildAudienceResource(TransportType transportType,
+        private static string BuildAudienceResource(EventHubsTransportType transportType,
                                                     string fullyQualifiedNamespace,
                                                     string eventHubName)
         {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnectionOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnectionOptions.cs
@@ -18,7 +18,7 @@ namespace Azure.Messaging.EventHubs
         ///   service.
         /// </summary>
         ///
-        public TransportType TransportType { get; set; } = TransportType.AmqpTcp;
+        public EventHubsTransportType TransportType { get; set; } = EventHubsTransportType.AmqpTcp;
 
         /// <summary>
         ///   The proxy to use for communication over web sockets.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerClient.cs
@@ -329,7 +329,7 @@ namespace Azure.Messaging.EventHubs
         ///   process, rather than competing for them.
         /// </remarks>
         ///
-        /// <seealso cref="ReadEventsFromPartitionAsync(string, EventPosition, ReadOptions, CancellationToken)"/>
+        /// <seealso cref="ReadEventsFromPartitionAsync(string, EventPosition, ReadEventOptions, CancellationToken)"/>
         ///
         public virtual IAsyncEnumerable<PartitionEvent> ReadEventsFromPartitionAsync(string partitionId,
                                                                                      EventPosition startingPosition,
@@ -341,7 +341,7 @@ namespace Azure.Messaging.EventHubs
         ///
         ///   This enumerator may block for an indeterminate amount of time for an <c>await</c> if events are not available on the partition, requiring
         ///   cancellation via the <paramref name="cancellationToken"/> to be requested in order to return control.  It is recommended to set the
-        ///   <see cref="ReadOptions.MaximumWaitTime" /> for scenarios where a more deterministic maximum waiting period is desired.
+        ///   <see cref="ReadEventOptions.MaximumWaitTime" /> for scenarios where a more deterministic maximum waiting period is desired.
         /// </summary>
         ///
         /// <param name="partitionId">The identifier of the Event Hub partition from which events will be received.</param>
@@ -360,7 +360,7 @@ namespace Azure.Messaging.EventHubs
         ///
         public virtual async IAsyncEnumerable<PartitionEvent> ReadEventsFromPartitionAsync(string partitionId,
                                                                                            EventPosition startingPosition,
-                                                                                           ReadOptions readOptions,
+                                                                                           ReadEventOptions readOptions,
                                                                                            [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             Argument.AssertNotClosed(IsClosed, nameof(EventHubConsumerClient));
@@ -370,14 +370,14 @@ namespace Azure.Messaging.EventHubs
 
             var cancelPublishingAsync = default(Func<Task>);
             var eventChannel = default(Channel<PartitionEvent>);
-            var options = readOptions?.Clone() ?? new ReadOptions();
+            var options = readOptions?.Clone() ?? new ReadEventOptions();
 
             using var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
             try
             {
                 eventChannel = CreateEventChannel((BackgroundPublishReceiveBatchSize * 4));
-                cancelPublishingAsync = await PublishPartitionEventsToChannelAsync(partitionId, startingPosition, options.TrackLastEnqueuedEventInformation, options.OwnerLevel, eventChannel, cancellationSource).ConfigureAwait(false);
+                cancelPublishingAsync = await PublishPartitionEventsToChannelAsync(partitionId, startingPosition, options.TrackLastEnqueuedEventProperties, options.OwnerLevel, eventChannel, cancellationSource).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -415,7 +415,7 @@ namespace Azure.Messaging.EventHubs
         ///
         ///   This enumerator may block for an indeterminate amount of time for an <c>await</c> if events are not available on the partition, requiring
         ///   cancellation via the <paramref name="cancellationToken"/> to be requested in order to return control.  It is recommended to set the
-        ///   <see cref="ReadOptions.MaximumWaitTime" /> for scenarios where a more deterministic maximum waiting period is desired.
+        ///   <see cref="ReadEventOptions.MaximumWaitTime" /> for scenarios where a more deterministic maximum waiting period is desired.
         /// </summary>
         ///
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
@@ -435,7 +435,7 @@ namespace Azure.Messaging.EventHubs
         /// </remarks>
         ///
         /// <seealso cref="EventProcessorClient" />
-        /// <seealso cref="ReadEventsAsync(ReadOptions, CancellationToken)"/>
+        /// <seealso cref="ReadEventsAsync(ReadEventOptions, CancellationToken)"/>
         ///
         public virtual IAsyncEnumerable<PartitionEvent> ReadEventsAsync(CancellationToken cancellationToken = default) => ReadEventsAsync(null, cancellationToken);
 
@@ -445,7 +445,7 @@ namespace Azure.Messaging.EventHubs
         ///
         ///   This enumerator may block for an indeterminate amount of time for an <c>await</c> if events are not available on the partition, requiring
         ///   cancellation via the <paramref name="cancellationToken"/> to be requested in order to return control.  It is recommended to set the
-        ///   <see cref="ReadOptions.MaximumWaitTime" /> for scenarios where a more deterministic maximum waiting period is desired.
+        ///   <see cref="ReadEventOptions.MaximumWaitTime" /> for scenarios where a more deterministic maximum waiting period is desired.
         /// </summary>
         ///
         /// <param name="readOptions">The set of options to use for configuring read behavior; if not specified the defaults will be used.</param>
@@ -468,7 +468,7 @@ namespace Azure.Messaging.EventHubs
         /// <seealso cref="EventProcessorClient" />
         /// <seealso cref="ReadEventsAsync(CancellationToken)"/>
         ///
-        public virtual IAsyncEnumerable<PartitionEvent> ReadEventsAsync(ReadOptions readOptions,
+        public virtual IAsyncEnumerable<PartitionEvent> ReadEventsAsync(ReadEventOptions readOptions,
                                                                         CancellationToken cancellationToken = default) => ReadEventsAsync(true, readOptions, cancellationToken);
 
         /// <summary>
@@ -477,7 +477,7 @@ namespace Azure.Messaging.EventHubs
         ///
         ///   This enumerator may block for an indeterminate amount of time for an <c>await</c> if events are not available on the partition, requiring
         ///   cancellation via the <paramref name="cancellationToken"/> to be requested in order to return control.  It is recommended to set the
-        ///   <see cref="ReadOptions.MaximumWaitTime" /> for scenarios where a more deterministic maximum waiting period is desired.
+        ///   <see cref="ReadEventOptions.MaximumWaitTime" /> for scenarios where a more deterministic maximum waiting period is desired.
         /// </summary>
         ///
         /// <param name="startReadingAtEarliestEvent"><c>true</c> to begin reading at the first events available in each partition; otherwise, reading will begin at the end of each partition seeing only new events as they are published.</param>
@@ -500,10 +500,10 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <seealso cref="EventProcessorClient" />
         /// <seealso cref="ReadEventsAsync(CancellationToken)"/>
-        /// <seealso cref="ReadEventsAsync(ReadOptions, CancellationToken)"/>
+        /// <seealso cref="ReadEventsAsync(ReadEventOptions, CancellationToken)"/>
         ///
         public virtual async IAsyncEnumerable<PartitionEvent> ReadEventsAsync(bool startReadingAtEarliestEvent,
-                                                                              ReadOptions readOptions = default,
+                                                                              ReadEventOptions readOptions = default,
                                                                               [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             Argument.AssertNotClosed(IsClosed, nameof(EventHubConsumerClient));
@@ -513,7 +513,7 @@ namespace Azure.Messaging.EventHubs
 
             var cancelPublishingAsync = default(Func<Task>);
             var eventChannel = default(Channel<PartitionEvent>);
-            var options = readOptions?.Clone() ?? new ReadOptions();
+            var options = readOptions?.Clone() ?? new ReadEventOptions();
             var startingPosition = startReadingAtEarliestEvent ? EventPosition.Earliest : EventPosition.Latest;
 
             using var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -531,7 +531,7 @@ namespace Azure.Messaging.EventHubs
 
                 for (var index = 0; index < partitions.Length; ++index)
                 {
-                    publishingTasks[index] = PublishPartitionEventsToChannelAsync(partitions[index], startingPosition, options.TrackLastEnqueuedEventInformation, options.OwnerLevel, eventChannel, cancellationSource);
+                    publishingTasks[index] = PublishPartitionEventsToChannelAsync(partitions[index], startingPosition, options.TrackLastEnqueuedEventProperties, options.OwnerLevel, eventChannel, cancellationSource);
                 }
 
                 // Capture the callbacks to cancel publishing for all events.
@@ -689,7 +689,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <param name="partitionId">The identifier of the partition from which events should be read.</param>
         /// <param name="startingPosition">The position within the partition's event stream that reading should begin from.</param>
-        /// <param name="trackLastEnqueuedEventInformation">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
+        /// <param name="trackLastEnqueuedEventProperties">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
         /// <param name="ownerLevel">The relative priority to associate with the link; for a non-exclusive link, this value should be <c>null</c>.</param>
         /// <param name="channel">The channel to which events should be published.</param>
         /// <param name="publishingCancellationSource">A cancellation source which can be used for signaling publication to stop.</param>
@@ -703,7 +703,7 @@ namespace Azure.Messaging.EventHubs
         ///
         private async Task<Func<Task>> PublishPartitionEventsToChannelAsync(string partitionId,
                                                                             EventPosition startingPosition,
-                                                                            bool trackLastEnqueuedEventInformation,
+                                                                            bool trackLastEnqueuedEventProperties,
                                                                             long? ownerLevel,
                                                                             Channel<PartitionEvent> channel,
                                                                             CancellationTokenSource publishingCancellationSource)
@@ -766,7 +766,7 @@ namespace Azure.Messaging.EventHubs
 
             try
             {
-                transportConsumer = Connection.CreateTransportConsumer(ConsumerGroup, partitionId, startingPosition, RetryPolicy, trackLastEnqueuedEventInformation, ownerLevel);
+                transportConsumer = Connection.CreateTransportConsumer(ConsumerGroup, partitionId, startingPosition, RetryPolicy, trackLastEnqueuedEventProperties, ownerLevel);
 
                 if (!ActiveConsumers.TryAdd(publisherId, transportConsumer))
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerClientOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerClientOptions.cs
@@ -19,7 +19,7 @@ namespace Azure.Messaging.EventHubs
         private EventHubConnectionOptions _connectionOptions = new EventHubConnectionOptions();
 
         /// <summary>The set of options to govern retry behavior and try timeouts.</summary>
-        private RetryOptions _retryOptions = new RetryOptions();
+        private EventHubsRetryOptions _retryOptions = new EventHubsRetryOptions();
 
         /// <summary>
         ///   Gets or sets the options used for configuring the connection to the Event Hubs service.
@@ -41,7 +41,7 @@ namespace Azure.Messaging.EventHubs
         ///   amount of time allowed for publishing events and other interactions with the Event Hubs service.
         /// </summary>
         ///
-        public RetryOptions RetryOptions
+        public EventHubsRetryOptions RetryOptions
         {
             get => _retryOptions;
             set

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducerClient.cs
@@ -39,7 +39,7 @@ namespace Azure.Messaging.EventHubs
         internal const int MinimumBatchSizeLimit = 24;
 
         /// <summary>The set of default publishing options to use when no specific options are requested.</summary>
-        private static readonly SendOptions DefaultSendOptions = new SendOptions();
+        private static readonly SendEventOptions DefaultSendOptions = new SendEventOptions();
 
         /// <summary>
         ///   The fully qualified Event Hubs namespace that the producer is associated with.  This is likely
@@ -325,9 +325,9 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///
-        /// <seealso cref="SendAsync(EventData, SendOptions, CancellationToken)" />
+        /// <seealso cref="SendAsync(EventData, SendEventOptions, CancellationToken)" />
         /// <seealso cref="SendAsync(IEnumerable{EventData}, CancellationToken)" />
-        /// <seealso cref="SendAsync(IEnumerable{EventData}, SendOptions, CancellationToken)" />
+        /// <seealso cref="SendAsync(IEnumerable{EventData}, SendEventOptions, CancellationToken)" />
         /// <seealso cref="SendAsync(EventDataBatch, CancellationToken)" />
         ///
         internal virtual Task SendAsync(EventData eventData,
@@ -350,11 +350,11 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <seealso cref="SendAsync(EventData, CancellationToken)" />
         /// <seealso cref="SendAsync(IEnumerable{EventData}, CancellationToken)" />
-        /// <seealso cref="SendAsync(IEnumerable{EventData}, SendOptions, CancellationToken)" />
+        /// <seealso cref="SendAsync(IEnumerable{EventData}, SendEventOptions, CancellationToken)" />
         /// <seealso cref="SendAsync(EventDataBatch, CancellationToken)" />
         ///
         internal virtual Task SendAsync(EventData eventData,
-                                        SendOptions options,
+                                        SendEventOptions options,
                                         CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(eventData, nameof(eventData));
@@ -371,7 +371,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///
-        /// <seealso cref="SendAsync(IEnumerable{EventData}, SendOptions, CancellationToken)"/>
+        /// <seealso cref="SendAsync(IEnumerable{EventData}, SendEventOptions, CancellationToken)"/>
         ///
         internal virtual Task SendAsync(IEnumerable<EventData> events,
                                         CancellationToken cancellationToken = default) => SendAsync(events, null, cancellationToken);
@@ -388,12 +388,12 @@ namespace Azure.Messaging.EventHubs
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///
         /// <seealso cref="SendAsync(EventData, CancellationToken)" />
-        /// <seealso cref="SendAsync(EventData, SendOptions, CancellationToken)" />
+        /// <seealso cref="SendAsync(EventData, SendEventOptions, CancellationToken)" />
         /// <seealso cref="SendAsync(IEnumerable{EventData}, CancellationToken)" />
         /// <seealso cref="SendAsync(EventDataBatch, CancellationToken)" />
         ///
         internal virtual async Task SendAsync(IEnumerable<EventData> events,
-                                              SendOptions options,
+                                              SendEventOptions options,
                                               CancellationToken cancellationToken = default)
         {
             options ??= DefaultSendOptions;
@@ -442,9 +442,9 @@ namespace Azure.Messaging.EventHubs
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///
         /// <seealso cref="SendAsync(EventData, CancellationToken)" />
-        /// <seealso cref="SendAsync(EventData, SendOptions, CancellationToken)" />
+        /// <seealso cref="SendAsync(EventData, SendEventOptions, CancellationToken)" />
         /// <seealso cref="SendAsync(IEnumerable{EventData}, CancellationToken)" />
-        /// <seealso cref="SendAsync(IEnumerable{EventData}, SendOptions, CancellationToken)" />
+        /// <seealso cref="SendAsync(IEnumerable{EventData}, SendEventOptions, CancellationToken)" />
         ///
         public virtual async Task SendAsync(EventDataBatch eventBatch,
                                             CancellationToken cancellationToken = default)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducerClientOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducerClientOptions.cs
@@ -17,7 +17,7 @@ namespace Azure.Messaging.EventHubs
         private EventHubConnectionOptions _connectionOptions = new EventHubConnectionOptions();
 
         /// <summary>The set of options to govern retry behavior and try timeouts.</summary>
-        private RetryOptions _retryOptions = new RetryOptions();
+        private EventHubsRetryOptions _retryOptions = new EventHubsRetryOptions();
 
         /// <summary>
         ///   Gets or sets the options used for configuring the connection to the Event Hubs service.
@@ -39,7 +39,7 @@ namespace Azure.Messaging.EventHubs
         ///   amount of time allowed for publishing events and other interactions with the Event Hubs service.
         /// </summary>
         ///
-        public RetryOptions RetryOptions
+        public EventHubsRetryOptions RetryOptions
         {
             get => _retryOptions;
             set

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsRetryMode.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsRetryMode.cs
@@ -8,7 +8,7 @@ namespace Azure.Messaging.EventHubs
     ///   between retry attempts.
     /// </summary>
     ///
-    public enum RetryMode
+    public enum EventHubsRetryMode
     {
         /// <summary>Retry attempts happen at fixed intervals; each delay is a consistent duration.</summary>
         Fixed,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsRetryOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsRetryOptions.cs
@@ -12,7 +12,7 @@ namespace Azure.Messaging.EventHubs
     ///    retry attempts are made, and a failure is eligible to be retried.
     /// </summary>
     ///
-    public class RetryOptions
+    public class EventHubsRetryOptions
     {
         /// <summary>The maximum number of retry attempts before considering the associated operation to have failed.</summary>
         private int _maximumRetries = 3;
@@ -30,7 +30,7 @@ namespace Azure.Messaging.EventHubs
         ///   The approach to use for calculating retry delays.
         /// </summary>
         ///
-        public RetryMode Mode { get; set; } = RetryMode.Exponential;
+        public EventHubsRetryMode Mode { get; set; } = EventHubsRetryMode.Exponential;
 
         /// <summary>
         ///   The maximum number of retry attempts before considering the associated operation
@@ -112,13 +112,13 @@ namespace Azure.Messaging.EventHubs
         public EventHubsRetryPolicy CustomRetryPolicy { get; set; }
 
         /// <summary>
-        ///   Creates a new copy of the current <see cref="RetryOptions" />, cloning its attributes into a new instance.
+        ///   Creates a new copy of the current <see cref="EventHubsRetryOptions" />, cloning its attributes into a new instance.
         /// </summary>
         ///
-        /// <returns>A new copy of <see cref="RetryOptions" />.</returns>
+        /// <returns>A new copy of <see cref="EventHubsRetryOptions" />.</returns>
         ///
-        internal RetryOptions Clone() =>
-            new RetryOptions
+        internal EventHubsRetryOptions Clone() =>
+            new EventHubsRetryOptions
             {
                 Mode = Mode,
                 CustomRetryPolicy = CustomRetryPolicy,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsRetryPolicy.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsRetryPolicy.cs
@@ -16,7 +16,7 @@ namespace Azure.Messaging.EventHubs
     ///   retry options when creating one of the Event Hubs clients.
     /// </remarks>
     ///
-    /// <seealso cref="RetryOptions"/>
+    /// <seealso cref="EventHubsRetryOptions"/>
     ///
     public abstract class EventHubsRetryPolicy
     {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsTransportType.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsTransportType.cs
@@ -8,7 +8,7 @@ namespace Azure.Messaging.EventHubs
     ///   Azure Event Hubs.
     /// </summary>
     ///
-    public enum TransportType
+    public enum EventHubsTransportType
     {
         /// <summary>The connection uses the AMQP protocol over TCP.</summary>
         AmqpTcp,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventProcessorClient.cs
@@ -383,7 +383,7 @@ namespace Azure.Messaging.EventHubs
                 // processing task that's not RunPartitionProcessingAsync, how would the base stop it?  It would not have a cancellation
                 // token to do so.
 
-                ActivePartitionProcessors[context.PartitionId] = RunPartitionProcessingAsync(context.PartitionId, startingPosition, Options.MaximumReceiveWaitTime, Options.RetryOptions, Options.TrackLastEnqueuedEventInformation);
+                ActivePartitionProcessors[context.PartitionId] = RunPartitionProcessingAsync(context.PartitionId, startingPosition, Options.MaximumReceiveWaitTime, Options.RetryOptions, Options.TrackLastEnqueuedEventProperties);
             }
             catch (Exception)
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventProcessorClientOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventProcessorClientOptions.cs
@@ -21,7 +21,7 @@ namespace Azure.Messaging.EventHubs
         private EventHubConnectionOptions _connectionOptions = new EventHubConnectionOptions();
 
         /// <summary>The set of options to govern retry behavior and try timeouts.</summary>
-        private RetryOptions _retryOptions = new RetryOptions();
+        private EventHubsRetryOptions _retryOptions = new EventHubsRetryOptions();
 
         /// <summary>
         ///   The maximum amount of time to wait for an event to become available for a given partition before emitting
@@ -62,7 +62,7 @@ namespace Azure.Messaging.EventHubs
         ///   against periodically making requests for partition properties using one of the Event Hub clients.
         /// </remarks>
         ///
-        public bool TrackLastEnqueuedEventInformation { get; set; } = true;
+        public bool TrackLastEnqueuedEventProperties { get; set; } = true;
 
         /// <summary>
         ///   Gets or sets the options used for configuring the connection to the Event Hubs service.
@@ -84,7 +84,7 @@ namespace Azure.Messaging.EventHubs
         ///   amount of time allowed for publishing events and other interactions with the Event Hubs service.
         /// </summary>
         ///
-        public RetryOptions RetryOptions
+        public EventHubsRetryOptions RetryOptions
         {
             get => _retryOptions;
             set
@@ -137,7 +137,7 @@ namespace Azure.Messaging.EventHubs
         internal EventProcessorClientOptions Clone() =>
             new EventProcessorClientOptions
             {
-                TrackLastEnqueuedEventInformation = TrackLastEnqueuedEventInformation,
+                TrackLastEnqueuedEventProperties = TrackLastEnqueuedEventProperties,
                 _maximumReceiveWaitTime = _maximumReceiveWaitTime,
                 _connectionOptions = ConnectionOptions.Clone(),
                 _retryOptions = RetryOptions.Clone()

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/PartitionContext.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/PartitionContext.cs
@@ -31,7 +31,7 @@ namespace Azure.Messaging.EventHubs
         /// <summary>
         ///   A set of information about the last enqueued event of a partition, as observed by the associated EventHubs client
         ///   associated with this context as events are received from the Event Hubs service.  This is only available if the consumer was
-        ///   created with <see cref="ReadOptions.TrackLastEnqueuedEventInformation" /> set.
+        ///   created with <see cref="ReadEventOptions.TrackLastEnqueuedEventProperties" /> set.
         /// </summary>
         ///
         /// <remarks>
@@ -42,9 +42,9 @@ namespace Azure.Messaging.EventHubs
         /// </remarks>
         ///
         /// <exception cref="EventHubsClientClosedException">Occurs when the Event Hubs client needed to read this information is no longer available.</exception>
-        /// <exception cref="InvalidOperationException">Occurs when this method is invoked without <see cref="ReadOptions.TrackLastEnqueuedEventInformation" /> set.</exception>
+        /// <exception cref="InvalidOperationException">Occurs when this method is invoked without <see cref="ReadEventOptions.TrackLastEnqueuedEventProperties" /> set.</exception>
         ///
-        public virtual LastEnqueuedEventProperties ReadLastEnqueuedEventInformation()
+        public virtual LastEnqueuedEventProperties ReadLastEnqueuedEventProperties()
         {
             var consumer = default(TransportConsumer);
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/EventProcessorBase.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/EventProcessorBase.cs
@@ -678,7 +678,7 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="startingPosition">The position within the partition where the task should begin reading events.</param>
         /// <param name="maximumReceiveWaitTime">The maximum amount of time to wait to for an event to be available before emitting an empty item; if <c>null</c>, empty items will not be published.</param>
         /// <param name="retryOptions">The set of options to use for determining whether a failed operation should be retried and, if so, the amount of time to wait between retry attempts.</param>
-        /// <param name="trackLastEnqueuedEventInformation">Indicates whether or not the task should request information on the last enqueued event on the partition associated with a given event, and track that information as events are received.</param>
+        /// <param name="trackLastEnqueuedEventProperties">Indicates whether or not the task should request information on the last enqueued event on the partition associated with a given event, and track that information as events are received.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>The running task that is currently receiving and processing events in the context of the specified partition.</returns>
@@ -686,8 +686,8 @@ namespace Azure.Messaging.EventHubs.Processor
         protected virtual Task RunPartitionProcessingAsync(string partitionId,
                                                            EventPosition startingPosition,
                                                            TimeSpan? maximumReceiveWaitTime,
-                                                           RetryOptions retryOptions,
-                                                           bool trackLastEnqueuedEventInformation,
+                                                           EventHubsRetryOptions retryOptions,
+                                                           bool trackLastEnqueuedEventProperties,
                                                            CancellationToken cancellationToken = default)
         {
             // TODO: should the retry options used here be the same for the abstract RetryPolicy property?
@@ -714,10 +714,10 @@ namespace Azure.Messaging.EventHubs.Processor
                     RetryOptions = retryOptions
                 };
 
-                var readOptions = new ReadOptions
+                var readOptions = new ReadEventOptions
                 {
                     MaximumWaitTime = maximumReceiveWaitTime,
-                    TrackLastEnqueuedEventInformation = trackLastEnqueuedEventInformation
+                    TrackLastEnqueuedEventProperties = trackLastEnqueuedEventProperties
                 };
 
                 await using var connection = CreateConnection();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/ReadEventOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/ReadEventOptions.cs
@@ -12,7 +12,7 @@ namespace Azure.Messaging.EventHubs
     ///   <see cref="EventHubConsumerClient" />.
     /// </summary>
     ///
-    public class ReadOptions
+    public class ReadEventOptions
     {
         /// <summary>The maximum amount of time to wait to for an event to be available before emitting an empty item; if <c>null</c>, empty items will not be emitted.</summary>
         private TimeSpan? _maximumWaitTime = null;
@@ -45,7 +45,7 @@ namespace Azure.Messaging.EventHubs
         ///   against periodically making requests for partition properties using one of the Event Hub clients.
         /// </remarks>
         ///
-        public bool TrackLastEnqueuedEventInformation { get; set; } = true;
+        public bool TrackLastEnqueuedEventProperties { get; set; } = true;
 
         /// <summary>
         ///   The maximum amount of time to wait to for an event to be available when reading before reading an empty
@@ -105,16 +105,16 @@ namespace Azure.Messaging.EventHubs
         public override string ToString() => base.ToString();
 
         /// <summary>
-        ///   Creates a new copy of the current <see cref="ReadOptions" />, cloning its attributes into a new instance.
+        ///   Creates a new copy of the current <see cref="ReadEventOptions" />, cloning its attributes into a new instance.
         /// </summary>
         ///
-        /// <returns>A new copy of <see cref="ReadOptions" />.</returns>
+        /// <returns>A new copy of <see cref="ReadEventOptions" />.</returns>
         ///
-        internal ReadOptions Clone() =>
-            new ReadOptions
+        internal ReadEventOptions Clone() =>
+            new ReadEventOptions
             {
                 OwnerLevel = OwnerLevel,
-                TrackLastEnqueuedEventInformation = TrackLastEnqueuedEventInformation,
+                TrackLastEnqueuedEventProperties = TrackLastEnqueuedEventProperties,
                 MaximumWaitTime = MaximumWaitTime
             };
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.Designer.cs
@@ -322,11 +322,11 @@ namespace Azure.Messaging.EventHubs {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This information is only available when TrackLastEnqueuedEventInformation is set on the Event Hub consumer options..
+        ///   Looks up a localized string similar to This information is only available when TrackLastEnqueuedEventProperties is set on the Event Hub consumer options..
         /// </summary>
-        internal static string TrackLastEnqueuedEventInformationNotSet {
+        internal static string TrackLastEnqueuedEventPropertiesNotSet {
             get {
-                return ResourceManager.GetString("TrackLastEnqueuedEventInformationNotSet", resourceCulture);
+                return ResourceManager.GetString("TrackLastEnqueuedEventPropertiesNotSet", resourceCulture);
             }
         }
         

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.resx
@@ -219,8 +219,8 @@
   <data name="ClosedConnectionCannotPerformOperation" xml:space="preserve">
     <value>{0} has already been closed and cannot perform the requested operation.</value>
   </data>
-  <data name="TrackLastEnqueuedEventInformationNotSet" xml:space="preserve">
-    <value>This information is only available when TrackLastEnqueuedEventInformation is set on the Event Hub consumer options.</value>
+  <data name="TrackLastEnqueuedEventPropertiesNotSet" xml:space="preserve">
+    <value>This information is only available when TrackLastEnqueuedEventProperties is set on the Event Hub consumer options.</value>
   </data>
   <data name="CannotStartEventProcessorWithoutHandler" xml:space="preserve">
     <value>Cannot begin processing without {0} handler set.</value>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/SendEventOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/SendEventOptions.cs
@@ -10,7 +10,7 @@ namespace Azure.Messaging.EventHubs
     ///   are sent to the Event Hubs service.
     /// </summary>
     ///
-    internal class SendOptions
+    internal class SendEventOptions
     {
         /// <summary>
         ///   Allows a hashing key to be provided for the batch of events, which instructs the Event Hubs
@@ -33,7 +33,7 @@ namespace Azure.Messaging.EventHubs
         /// </value>
         ///
         /// <remarks>
-        ///   If the <see cref="SendOptions.PartitionKey" /> is specified, then no <see cref="SendOptions.PartitionId" />
+        ///   If the <see cref="SendEventOptions.PartitionKey" /> is specified, then no <see cref="SendEventOptions.PartitionId" />
         ///   may be set when sending.
         /// </remarks>
         ///
@@ -50,7 +50,7 @@ namespace Azure.Messaging.EventHubs
         /// </value>
         ///
         /// <remarks>
-        ///   If the <see cref="SendOptions.PartitionId" /> is specified, then no <see cref="SendOptions.PartitionKey" />
+        ///   If the <see cref="SendEventOptions.PartitionId" /> is specified, then no <see cref="SendEventOptions.PartitionKey" />
         ///   may be set when sending.
         ///
         ///   <para>Allowing automatic routing of partitions is recommended when:</para>
@@ -65,21 +65,21 @@ namespace Azure.Messaging.EventHubs
         public string PartitionId { get; set; }
 
         /// <summary>
-        ///   Initializes a new instance of the <see cref="SendOptions"/> class.
+        ///   Initializes a new instance of the <see cref="SendEventOptions"/> class.
         /// </summary>
         ///
-        public SendOptions()
+        public SendEventOptions()
         {
         }
 
         /// <summary>
-        ///   Initializes a new instance of the <see cref="SendOptions"/> class.
+        ///   Initializes a new instance of the <see cref="SendEventOptions"/> class.
         /// </summary>
         ///
         /// <param name="partitionId">The identifier of the partition to which events should be sent.</param>
         /// <param name="partitionKey">The hashing key to use for influencing the partition to which the events are routed.</param>
         ///
-        internal SendOptions(string partitionId,
+        internal SendEventOptions(string partitionId,
                              string partitionKey)
         {
             PartitionId = partitionId;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpClientTests.cs
@@ -31,8 +31,8 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         public static IEnumerable<object[]> RetryOptionTestCases()
         {
-            yield return new object[] { new RetryOptions { MaximumRetries = 3, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = RetryMode.Fixed } };
-            yield return new object[] { new RetryOptions { MaximumRetries = 0, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = RetryMode.Fixed } };
+            yield return new object[] { new EventHubsRetryOptions { MaximumRetries = 3, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = EventHubsRetryMode.Fixed } };
+            yield return new object[] { new EventHubsRetryOptions { MaximumRetries = 0, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = EventHubsRetryMode.Fixed } };
         }
 
         /// <summary>
@@ -220,7 +220,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         [Test]
         [TestCaseSource(nameof(RetryOptionTestCases))]
-        public void GetPropertiesAsyncRespectsTheRetryPolicy(RetryOptions retryOptions)
+        public void GetPropertiesAsyncRespectsTheRetryPolicy(EventHubsRetryOptions retryOptions)
         {
             var eventHubName = "myName";
             var tokenValue = "123ABC";
@@ -358,7 +358,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         [Test]
         [TestCaseSource(nameof(RetryOptionTestCases))]
-        public void GetPartitionPropertiesAsyncRespectsTheRetryPolicy(RetryOptions retryOptions)
+        public void GetPartitionPropertiesAsyncRespectsTheRetryPolicy(EventHubsRetryOptions retryOptions)
         {
             var eventHubName = "myName";
             var partitionId = "Barney";

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConnectionScopeTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConnectionScopeTests.cs
@@ -36,7 +36,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ConstructorValidatesTheEndpoint()
         {
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            Assert.That(() => new AmqpConnectionScope(null, "hub", credential.Object, TransportType.AmqpTcp, null), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpConnectionScope(null, "hub", credential.Object, EventHubsTransportType.AmqpTcp, null), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ConstructorValidatesTheEventHubName()
         {
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            Assert.That(() => new AmqpConnectionScope(new Uri("amqp://some.place.com"), null, credential.Object, TransportType.AmqpWebSockets, Mock.Of<IWebProxy>()), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpConnectionScope(new Uri("amqp://some.place.com"), null, credential.Object, EventHubsTransportType.AmqpWebSockets, Mock.Of<IWebProxy>()), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorValidatesTheCredential()
         {
-            Assert.That(() => new AmqpConnectionScope(new Uri("amqp://some.place.com"), "hub", null, TransportType.AmqpWebSockets, null), Throws.ArgumentNullException);
+            Assert.That(() => new AmqpConnectionScope(new Uri("amqp://some.place.com"), "hub", null, EventHubsTransportType.AmqpWebSockets, null), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorValidatesTheTransport()
         {
-            var invalidTransport = (TransportType)(-2);
+            var invalidTransport = (EventHubsTransportType)(-2);
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
             Assert.That(() => new AmqpConnectionScope(new Uri("amqp://some.place.com"), "hun", credential.Object, invalidTransport, Mock.Of<IWebProxy>()), Throws.ArgumentException);
         }
@@ -82,7 +82,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var endpoint = new Uri("amqp://test.service.gov");
             var eventHub = "myHub";
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            TransportType transport = TransportType.AmqpTcp;
+            EventHubsTransportType transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
             var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
 
@@ -96,7 +96,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
                     ItExpr.IsAny<Version>(),
                     ItExpr.Is<Uri>(value => value == endpoint),
-                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<EventHubsTransportType>(value => value == transport),
                     ItExpr.Is<IWebProxy>(value => value == null),
                     ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<TimeSpan>())
@@ -120,7 +120,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var endpoint = new Uri("amqp://test.service.gov");
             var eventHub = "myHub";
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            TransportType transport = TransportType.AmqpTcp;
+            EventHubsTransportType transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
 
             using var scope = new AmqpConnectionScope(endpoint, eventHub, credential.Object, transport, null, identifier);
@@ -142,7 +142,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var endpoint = new Uri("amqp://test.service.gov");
             var eventHub = "myHub";
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            TransportType transport = TransportType.AmqpTcp;
+            EventHubsTransportType transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
 
             var scope = new AmqpConnectionScope(endpoint, eventHub, credential.Object, transport, null, identifier);
@@ -162,7 +162,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var endpoint = new Uri("amqp://test.service.gov");
             var eventHub = "myHub";
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            TransportType transport = TransportType.AmqpTcp;
+            EventHubsTransportType transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
             var cancellationSource = new CancellationTokenSource();
             var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
@@ -179,7 +179,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
                     ItExpr.IsAny<Version>(),
                     ItExpr.Is<Uri>(value => value == endpoint),
-                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<EventHubsTransportType>(value => value == transport),
                     ItExpr.Is<IWebProxy>(value => value == null),
                     ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<TimeSpan>())
@@ -220,7 +220,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var endpoint = new Uri("amqp://test.service.gov");
             var eventHub = "myHub";
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var transport = TransportType.AmqpTcp;
+            var transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
             var cancellationSource = new CancellationTokenSource();
             var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
@@ -235,7 +235,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
                     ItExpr.IsAny<Version>(),
                     ItExpr.Is<Uri>(value => value == endpoint),
-                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<EventHubsTransportType>(value => value == transport),
                     ItExpr.Is<IWebProxy>(value => value == null),
                     ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<TimeSpan>())
@@ -280,7 +280,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var partitionId = "0";
             var position = EventPosition.Latest;
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var transport = TransportType.AmqpTcp;
+            var transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
 
             using var scope = new AmqpConnectionScope(endpoint, eventHub, credential.Object, transport, null, identifier);
@@ -302,7 +302,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var consumerGroup = "$Default";
             var position = EventPosition.Latest;
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var transport = TransportType.AmqpTcp;
+            var transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
 
             using var scope = new AmqpConnectionScope(endpoint, eventHub, credential.Object, transport, null, identifier);
@@ -323,7 +323,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var partitionId = "0";
             var position = EventPosition.Latest;
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var transport = TransportType.AmqpTcp;
+            var transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
 
             using var scope = new AmqpConnectionScope(endpoint, eventHub, credential.Object, transport, null, identifier);
@@ -348,7 +348,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var partitionId = "0";
             var position = EventPosition.Latest;
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var transport = TransportType.AmqpTcp;
+            var transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
 
             var scope = new AmqpConnectionScope(endpoint, eventHub, credential.Object, transport, null, identifier);
@@ -374,7 +374,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var trackLastEvent = false;
             var position = EventPosition.Latest;
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var transport = TransportType.AmqpTcp;
+            var transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
             var cancellationSource = new CancellationTokenSource();
             var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
@@ -391,7 +391,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
                     ItExpr.IsAny<Version>(),
                     ItExpr.Is<Uri>(value => value == endpoint),
-                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<EventHubsTransportType>(value => value == transport),
                     ItExpr.Is<IWebProxy>(value => value == null),
                     ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<TimeSpan>())
@@ -443,7 +443,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var trackLastEvent = true;
             var position = EventPosition.Latest;
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var transport = TransportType.AmqpTcp;
+            var transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
             var cancellationSource = new CancellationTokenSource();
             var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
@@ -459,7 +459,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
                     ItExpr.IsAny<Version>(),
                     ItExpr.Is<Uri>(value => value == endpoint),
-                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<EventHubsTransportType>(value => value == transport),
                     ItExpr.Is<IWebProxy>(value => value == null),
                     ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<TimeSpan>())
@@ -497,7 +497,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(link.GetSettingPropertyOrDefault<long>(AmqpProperty.OwnerLevel, -1), Is.EqualTo(ownerLevel), "The owner level should have been used.");
 
             Assert.That(link.Settings.DesiredCapabilities, Is.Not.Null, "There should have been a set of desired capabilities created.");
-            Assert.That(link.Settings.DesiredCapabilities.Contains(AmqpProperty.TrackLastEnqueuedEventInformation), Is.True, "Last event tracking should be requested.");
+            Assert.That(link.Settings.DesiredCapabilities.Contains(AmqpProperty.TrackLastEnqueuedEventProperties), Is.True, "Last event tracking should be requested.");
         }
 
         /// <summary>
@@ -517,7 +517,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var trackLastEvent = false;
             var position = EventPosition.Latest;
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var transport = TransportType.AmqpTcp;
+            var transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
             var cancellationSource = new CancellationTokenSource();
             var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
@@ -533,7 +533,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
                     ItExpr.IsAny<Version>(),
                     ItExpr.Is<Uri>(value => value == endpoint),
-                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<EventHubsTransportType>(value => value == transport),
                     ItExpr.Is<IWebProxy>(value => value == null),
                     ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<TimeSpan>())
@@ -580,7 +580,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var trackLastEvent = false;
             var position = EventPosition.Latest;
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var transport = TransportType.AmqpTcp;
+            var transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
             var cancellationSource = new CancellationTokenSource();
             var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
@@ -596,7 +596,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
                     ItExpr.IsAny<Version>(),
                     ItExpr.Is<Uri>(value => value == endpoint),
-                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<EventHubsTransportType>(value => value == transport),
                     ItExpr.Is<IWebProxy>(value => value == null),
                     ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<TimeSpan>())
@@ -643,7 +643,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var trackLastEvent = false;
             var position = EventPosition.Latest;
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var transport = TransportType.AmqpTcp;
+            var transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
             var cancellationSource = new CancellationTokenSource();
             var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
@@ -659,7 +659,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
                     ItExpr.IsAny<Version>(),
                     ItExpr.Is<Uri>(value => value == endpoint),
-                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<EventHubsTransportType>(value => value == transport),
                     ItExpr.Is<IWebProxy>(value => value == null),
                     ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<TimeSpan>())
@@ -716,7 +716,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var partitionId = "0";
             var position = EventPosition.Latest;
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var transport = TransportType.AmqpTcp;
+            var transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
             var cancellationSource = new CancellationTokenSource();
             var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
@@ -732,7 +732,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
                     ItExpr.IsAny<Version>(),
                     ItExpr.Is<Uri>(value => value == endpoint),
-                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<EventHubsTransportType>(value => value == transport),
                     ItExpr.Is<IWebProxy>(value => value == null),
                     ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<TimeSpan>())
@@ -815,7 +815,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var partitionId = "0";
             var position = EventPosition.Latest;
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var transport = TransportType.AmqpTcp;
+            var transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
             var cancellationSource = new CancellationTokenSource();
             var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
@@ -831,7 +831,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
                     ItExpr.IsAny<Version>(),
                     ItExpr.Is<Uri>(value => value == endpoint),
-                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<EventHubsTransportType>(value => value == transport),
                     ItExpr.Is<IWebProxy>(value => value == null),
                     ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<TimeSpan>())
@@ -935,7 +935,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var eventHub = "myHub";
             var partitionId = "0";
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var transport = TransportType.AmqpTcp;
+            var transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
 
             using var scope = new AmqpConnectionScope(endpoint, eventHub, credential.Object, transport, null, identifier);
@@ -957,7 +957,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var endpoint = new Uri("amqp://test.service.gov");
             var eventHub = "myHub";
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var transport = TransportType.AmqpTcp;
+            var transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
 
             var scope = new AmqpConnectionScope(endpoint, eventHub, credential.Object, transport, null, identifier);
@@ -978,7 +978,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var eventHub = "myHub";
             var partitionId = "0";
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var transport = TransportType.AmqpTcp;
+            var transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
             var cancellationSource = new CancellationTokenSource();
             var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
@@ -995,7 +995,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
                     ItExpr.IsAny<Version>(),
                     ItExpr.Is<Uri>(value => value == endpoint),
-                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<EventHubsTransportType>(value => value == transport),
                     ItExpr.Is<IWebProxy>(value => value == null),
                     ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<TimeSpan>())
@@ -1038,7 +1038,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var eventHub = "myHub";
             var partitionId = "00_partition_00";
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var transport = TransportType.AmqpTcp;
+            var transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
             var cancellationSource = new CancellationTokenSource();
             var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
@@ -1054,7 +1054,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
                     ItExpr.IsAny<Version>(),
                     ItExpr.Is<Uri>(value => value == endpoint),
-                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<EventHubsTransportType>(value => value == transport),
                     ItExpr.Is<IWebProxy>(value => value == null),
                     ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<TimeSpan>())
@@ -1098,7 +1098,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var endpoint = new Uri("amqp://test.service.gov");
             var eventHub = "myHub";
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var transport = TransportType.AmqpTcp;
+            var transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
             var cancellationSource = new CancellationTokenSource();
             var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
@@ -1114,7 +1114,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
                     ItExpr.IsAny<Version>(),
                     ItExpr.Is<Uri>(value => value == endpoint),
-                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<EventHubsTransportType>(value => value == transport),
                     ItExpr.Is<IWebProxy>(value => value == null),
                     ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<TimeSpan>())
@@ -1168,7 +1168,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var endpoint = new Uri("amqp://test.service.gov");
             var eventHub = "myHub";
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var transport = TransportType.AmqpTcp;
+            var transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
             var cancellationSource = new CancellationTokenSource();
             var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
@@ -1184,7 +1184,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
                     ItExpr.IsAny<Version>(),
                     ItExpr.Is<Uri>(value => value == endpoint),
-                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<EventHubsTransportType>(value => value == transport),
                     ItExpr.Is<IWebProxy>(value => value == null),
                     ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<TimeSpan>())
@@ -1264,7 +1264,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var endpoint = new Uri("amqp://test.service.gov");
             var eventHub = "myHub";
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var transport = TransportType.AmqpTcp;
+            var transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
             var cancellationSource = new CancellationTokenSource();
             var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
@@ -1280,7 +1280,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
                     ItExpr.IsAny<Version>(),
                     ItExpr.Is<Uri>(value => value == endpoint),
-                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<EventHubsTransportType>(value => value == transport),
                     ItExpr.Is<IWebProxy>(value => value == null),
                     ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<TimeSpan>())
@@ -1383,7 +1383,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var endpoint = new Uri("amqp://test.service.gov");
             var eventHub = "myHub";
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var transport = TransportType.AmqpTcp;
+            var transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
             var scope = new AmqpConnectionScope(endpoint, eventHub, credential.Object, transport, null, identifier);
             var cancellation = GetOperationCancellationSource(scope);
@@ -1405,7 +1405,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var endpoint = new Uri("amqp://test.service.gov");
             var eventHub = "myHub";
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            TransportType transport = TransportType.AmqpTcp;
+            EventHubsTransportType transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
             var connectionClosed = false;
             var cancellationSource = new CancellationTokenSource();
@@ -1425,7 +1425,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
                     ItExpr.IsAny<Version>(),
                     ItExpr.Is<Uri>(value => value == endpoint),
-                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<EventHubsTransportType>(value => value == transport),
                     ItExpr.Is<IWebProxy>(value => value == null),
                     ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<TimeSpan>())
@@ -1471,7 +1471,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var partitionId = "0";
             var position = EventPosition.Latest;
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var transport = TransportType.AmqpTcp;
+            var transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
             var cancellationSource = new CancellationTokenSource();
             var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
@@ -1487,7 +1487,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
                     ItExpr.IsAny<Version>(),
                     ItExpr.Is<Uri>(value => value == endpoint),
-                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<EventHubsTransportType>(value => value == transport),
                     ItExpr.Is<IWebProxy>(value => value == null),
                     ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<TimeSpan>())
@@ -1544,7 +1544,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var partitionId = "0";
             var position = EventPosition.Latest;
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var transport = TransportType.AmqpTcp;
+            var transport = EventHubsTransportType.AmqpTcp;
             var identifier = "customIdentIFIER";
             var cancellationSource = new CancellationTokenSource();
             var mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
@@ -1560,7 +1560,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup<Task<AmqpConnection>>("CreateAndOpenConnectionAsync",
                     ItExpr.IsAny<Version>(),
                     ItExpr.Is<Uri>(value => value == endpoint),
-                    ItExpr.Is<TransportType>(value => value == transport),
+                    ItExpr.Is<EventHubsTransportType>(value => value == transport),
                     ItExpr.Is<IWebProxy>(value => value == null),
                     ItExpr.Is<string>(value => value == identifier),
                     ItExpr.IsAny<TimeSpan>())

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
@@ -28,8 +28,8 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         public static IEnumerable<object[]> RetryOptionTestCases()
         {
-            yield return new object[] { new RetryOptions { MaximumRetries = 3, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = RetryMode.Fixed } };
-            yield return new object[] { new RetryOptions { MaximumRetries = 0, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = RetryMode.Fixed } };
+            yield return new object[] { new EventHubsRetryOptions { MaximumRetries = 3, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = EventHubsRetryMode.Fixed } };
+            yield return new object[] { new EventHubsRetryOptions { MaximumRetries = 0, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = EventHubsRetryMode.Fixed } };
         }
 
         /// <summary>
@@ -144,7 +144,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var consumerGroup = "$DEFAULT";
             var partition = "3";
             var eventPosition = EventPosition.FromOffset(123);
-            var retryPolicy = new BasicRetryPolicy(new RetryOptions());
+            var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
             var retriableException = new EventHubsException(true, "Test");
             var mockConverter = new Mock<AmqpMessageConverter>();
             var mockCredential = new Mock<TokenCredential>();
@@ -168,7 +168,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var consumerGroup = "$DEFAULT";
             var partition = "3";
             var eventPosition = EventPosition.FromOffset(123);
-            var retryPolicy = new BasicRetryPolicy(new RetryOptions());
+            var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
             var retriableException = new EventHubsException(true, "Test");
             var mockConverter = new Mock<AmqpMessageConverter>();
             var mockCredential = new Mock<TokenCredential>();
@@ -189,7 +189,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         [Test]
         [TestCaseSource(nameof(RetryOptionTestCases))]
-        public void ReceiveAsyncRespectsTheRetryPolicy(RetryOptions retryOptions)
+        public void ReceiveAsyncRespectsTheRetryPolicy(EventHubsRetryOptions retryOptions)
         {
             var eventHub = "eventHubName";
             var consumerGroup = "$DEFAULT";
@@ -251,7 +251,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var partition = "3";
             var eventPosition = EventPosition.FromOffset(123);
             var options = new EventHubConsumerClientOptions();
-            var retryPolicy = new BasicRetryPolicy(new RetryOptions());
+            var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
             var retriableException = new EventHubsException(true, "Test");
             var mockConverter = new Mock<AmqpMessageConverter>();
             var mockCredential = new Mock<TokenCredential>();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
@@ -31,8 +31,8 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         public static IEnumerable<object[]> RetryOptionTestCases()
         {
-            yield return new object[] { new RetryOptions { MaximumRetries = 3, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = RetryMode.Fixed } };
-            yield return new object[] { new RetryOptions { MaximumRetries = 0, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = RetryMode.Fixed } };
+            yield return new object[] { new EventHubsRetryOptions { MaximumRetries = 3, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = EventHubsRetryMode.Fixed } };
+            yield return new object[] { new EventHubsRetryOptions { MaximumRetries = 0, Delay = TimeSpan.FromMilliseconds(1), MaximumDelay = TimeSpan.FromMilliseconds(10), Mode = EventHubsRetryMode.Fixed } };
         }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task CreateBatchAsyncEnsuresMaximumMessageSizeIsPopulated()
         {
-            var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+            var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
             {
                 CallBase = true
@@ -148,7 +148,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var expectedMaximumSize = 512;
             var options = new CreateBatchOptions { MaximumSizeInBytes = null };
-            var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+            var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
             {
@@ -179,7 +179,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var expectedMaximumSize = 512;
             var options = new CreateBatchOptions { MaximumSizeInBytes = expectedMaximumSize };
-            var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+            var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
             {
@@ -210,7 +210,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var linkMaximumSize = 512;
             var options = new CreateBatchOptions { MaximumSizeInBytes = 1024 };
-            var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+            var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
             {
@@ -239,7 +239,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task CreateBatchAsyncBuildsAnAmqpEventBatchWithTheOptions()
         {
             var options = new CreateBatchOptions { MaximumSizeInBytes = 512 };
-            var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+            var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
             {
@@ -272,7 +272,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SendEnumerableValidatesTheEvents()
         {
             var producer = new AmqpProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubsRetryPolicy>());
-            Assert.That(async () => await producer.SendAsync(null, new SendOptions(), CancellationToken.None), Throws.ArgumentNullException);
+            Assert.That(async () => await producer.SendAsync(null, new SendEventOptions(), CancellationToken.None), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -286,7 +286,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var producer = new AmqpProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubsRetryPolicy>());
             await producer.CloseAsync(CancellationToken.None);
 
-            Assert.That(async () => await producer.SendAsync(Enumerable.Empty<EventData>(), new SendOptions(), CancellationToken.None), Throws.InstanceOf<EventHubsClientClosedException>());
+            Assert.That(async () => await producer.SendAsync(Enumerable.Empty<EventData>(), new SendEventOptions(), CancellationToken.None), Throws.InstanceOf<EventHubsClientClosedException>());
         }
 
         /// <summary>
@@ -298,8 +298,8 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task SendEnumerableUsesThePartitionKey()
         {
             var expectedPartitionKey = "some key";
-            var options = new SendOptions { PartitionKey = expectedPartitionKey };
-            var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+            var options = new SendEventOptions { PartitionKey = expectedPartitionKey };
+            var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
             {
@@ -347,7 +347,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Callback<Func<AmqpMessage>, string, CancellationToken>((factory, key, token) => messageFactory = factory)
                 .Returns(Task.CompletedTask);
 
-            await producer.Object.SendAsync(events, new SendOptions { PartitionKey = partitonKey }, CancellationToken.None);
+            await producer.Object.SendAsync(events, new SendEventOptions { PartitionKey = partitonKey }, CancellationToken.None);
             Assert.That(messageFactory, Is.Not.Null, "The batch message factory should have been set.");
 
             using var batchMessage = new AmqpMessageConverter().CreateBatchFromEvents(events, partitonKey);
@@ -368,7 +368,7 @@ namespace Azure.Messaging.EventHubs.Tests
             cancellationSource.Cancel();
 
             var producer = new AmqpProducer("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), Mock.Of<EventHubsRetryPolicy>());
-            Assert.That(async () => await producer.SendAsync(new[] { new EventData(new byte[] { 0x15 }) }, new SendOptions(), cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
+            Assert.That(async () => await producer.SendAsync(new[] { new EventData(new byte[] { 0x15 }) }, new SendEventOptions(), cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
         }
 
         /// <summary>
@@ -378,7 +378,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         [Test]
         [TestCaseSource(nameof(RetryOptionTestCases))]
-        public void SendEnumerableRespectsTheRetryPolicy(RetryOptions retryOptions)
+        public void SendEnumerableRespectsTheRetryPolicy(EventHubsRetryOptions retryOptions)
         {
             var partitionId = "testMe";
             var retriableException = new EventHubsException(true, "Test");
@@ -398,7 +398,7 @@ namespace Azure.Messaging.EventHubs.Tests
                  .Throws(retriableException);
 
             using CancellationTokenSource cancellationSource = new CancellationTokenSource();
-            Assert.That(async () => await producer.Object.SendAsync(new[] { new EventData(new byte[] { 0x65 }) }, new SendOptions(), cancellationSource.Token), Throws.InstanceOf(retriableException.GetType()));
+            Assert.That(async () => await producer.Object.SendAsync(new[] { new EventData(new byte[] { 0x65 }) }, new SendEventOptions(), cancellationSource.Token), Throws.InstanceOf(retriableException.GetType()));
 
             producer
                 .Protected()
@@ -430,7 +430,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var expectedMaximumSize = 512;
             var options = new CreateBatchOptions { MaximumSizeInBytes = null };
-            var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+            var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
             {
@@ -449,7 +449,7 @@ namespace Azure.Messaging.EventHubs.Tests
             using TransportEventBatch batch = await producer.Object.CreateBatchAsync(options, default);
 
             await producer.Object.CloseAsync(CancellationToken.None);
-            Assert.That(async () => await producer.Object.SendAsync(new EventDataBatch(batch, new SendOptions()), CancellationToken.None), Throws.InstanceOf<EventHubsClientClosedException>());
+            Assert.That(async () => await producer.Object.SendAsync(new EventDataBatch(batch, new SendEventOptions()), CancellationToken.None), Throws.InstanceOf<EventHubsClientClosedException>());
         }
 
         /// <summary>
@@ -463,7 +463,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedMaximumSize = 512;
             var expectedPartitionKey = "some key";
             var options = new CreateBatchOptions { PartitionKey = expectedPartitionKey };
-            var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+            var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
             {
@@ -508,7 +508,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var messageFactory = default(Func<AmqpMessage>);
             var expectedMaximumSize = 512;
             var options = new CreateBatchOptions { PartitionKey = partitonKey };
-            var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+            var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
             {
@@ -557,7 +557,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var expectedMaximumSize = 512;
             var options = new CreateBatchOptions { MaximumSizeInBytes = null };
-            var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+            var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
             {
@@ -602,7 +602,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var expectedMaximumSize = 512;
             var options = new CreateBatchOptions { MaximumSizeInBytes = null };
-            var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+            var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
             {
@@ -647,7 +647,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var expectedMaximumSize = 512;
             var options = new CreateBatchOptions();
-            var retryPolicy = new BasicRetryPolicy(new RetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+            var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
             {
@@ -677,7 +677,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         [Test]
         [TestCaseSource(nameof(RetryOptionTestCases))]
-        public void SendBatchRespectsTheRetryPolicy(RetryOptions retryOptions)
+        public void SendBatchRespectsTheRetryPolicy(EventHubsRetryOptions retryOptions)
         {
             var partitionKey = "testMe";
             var options = new CreateBatchOptions { PartitionKey = partitionKey };

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/EventHubSharedKeyCredentialTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/EventHubSharedKeyCredentialTests.cs
@@ -53,7 +53,6 @@ namespace Azure.Messaging.EventHubs.Tests
             var credential = new EventHubSharedKeyCredential(name, value);
             var initializedValue = GetSharedAccessKey(credential);
 
-            Assert.That(credential.SharedAccessKeyName, Is.EqualTo(name), "The shared key name should have been set.");
             Assert.That(initializedValue, Is.EqualTo(value), "The shared key should have been set.");
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ConnectionTypeExtensionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ConnectionTypeExtensionTests.cs
@@ -20,9 +20,9 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [TestCase(TransportType.AmqpTcp)]
-        [TestCase(TransportType.AmqpWebSockets)]
-        public void GetUriSchemeUnderstandsAmqpConnectionTypes(TransportType transportType)
+        [TestCase(EventHubsTransportType.AmqpTcp)]
+        [TestCase(EventHubsTransportType.AmqpWebSockets)]
+        public void GetUriSchemeUnderstandsAmqpConnectionTypes(EventHubsTransportType transportType)
         {
             var scheme = transportType.GetUriScheme();
 
@@ -38,7 +38,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void GetUriSchemeUDisallowsUnknownConnectionTypes()
         {
-            var invalidConnectionType = (TransportType)int.MinValue;
+            var invalidConnectionType = (EventHubsTransportType)int.MinValue;
             Assert.That(() => invalidConnectionType.GetUriScheme(), Throws.ArgumentException);
         }
 
@@ -48,9 +48,9 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [TestCase(TransportType.AmqpTcp, false)]
-        [TestCase(TransportType.AmqpWebSockets, true)]
-        public void IsWebSocketTransportRecognizesSocketTransports(TransportType transportType,
+        [TestCase(EventHubsTransportType.AmqpTcp, false)]
+        [TestCase(EventHubsTransportType.AmqpWebSockets, true)]
+        public void IsWebSocketTransportRecognizesSocketTransports(EventHubsTransportType transportType,
                                                                    bool expectedResult)
         {
             Assert.That(transportType.IsWebSocketTransport(), Is.EqualTo(expectedResult));

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/PartitionContextTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/PartitionContextTests.cs
@@ -44,12 +44,12 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="PartitionContext.ReadLastEnqueuedEventInformation" />
+        ///   Verifies functionality of the <see cref="PartitionContext.ReadLastEnqueuedEventProperties" />
         ///   method.
         /// </summary>
         ///
         [Test]
-        public void ReadLastEnqueuedEventInformationDelegatesToTheConsumer()
+        public void ReadLastEnqueuedEventPropertiesDelegatesToTheConsumer()
         {
             var lastEvent = new EventData
             (
@@ -63,7 +63,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var partitionId = "id-value";
             var mockConsumer = new LastEventConsumerMock(lastEvent);
             var context = new PartitionContext(partitionId, mockConsumer);
-            var information = context.ReadLastEnqueuedEventInformation();
+            var information = context.ReadLastEnqueuedEventProperties();
 
             Assert.That(information.SequenceNumber, Is.EqualTo(lastEvent.LastPartitionSequenceNumber), "The sequence number should match.");
             Assert.That(information.Offset, Is.EqualTo(lastEvent.LastPartitionOffset), "The offset should match.");
@@ -72,7 +72,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="PartitionContext.ReadLastEnqueuedEventInformation" />
+        ///   Verifies functionality of the <see cref="PartitionContext.ReadLastEnqueuedEventProperties" />
         ///   method.
         /// </summary>
         ///
@@ -102,7 +102,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                 try
                 {
-                    Assert.That(() => context.ReadLastEnqueuedEventInformation(), Throws.TypeOf<EventHubsClientClosedException>());
+                    Assert.That(() => context.ReadLastEnqueuedEventProperties(), Throws.TypeOf<EventHubsClientClosedException>());
                 }
                 catch (AssertionException)
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
@@ -54,7 +54,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var transportMock = new Mock<TransportProducer>();
 
             transportMock
-                .Setup(m => m.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(m => m.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             var producer = new EventHubProducerClient(fakeConnection, transportMock.Object);
@@ -102,7 +102,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var transportMock = new Mock<TransportProducer>();
 
             transportMock
-                .Setup(m => m.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(m => m.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             transportMock
@@ -147,8 +147,8 @@ namespace Azure.Messaging.EventHubs.Tests
             EventData[] writtenEventsData = null;
 
             transportMock
-                .Setup(m => m.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendOptions>(), It.IsAny<CancellationToken>()))
-                .Callback<IEnumerable<EventData>, SendOptions, CancellationToken>((e, _, __) => writtenEventsData = e.ToArray())
+                .Setup(m => m.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
+                .Callback<IEnumerable<EventData>, SendEventOptions, CancellationToken>((e, _, __) => writtenEventsData = e.ToArray())
                 .Returns(Task.CompletedTask);
 
             var producer = new EventHubProducerClient(fakeConnection, transportMock.Object);
@@ -199,7 +199,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 });
 
             transportMock
-                .Setup(m => m.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(m => m.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             transportMock

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConnection/EventHubConnectionLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConnection/EventHubConnectionLiveTests.cs
@@ -130,9 +130,9 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [TestCase(TransportType.AmqpTcp)]
-        [TestCase(TransportType.AmqpWebSockets)]
-        public async Task ConnectionTransportCanRetrieveProperties(TransportType transportType)
+        [TestCase(EventHubsTransportType.AmqpTcp)]
+        [TestCase(EventHubsTransportType.AmqpWebSockets)]
+        public async Task ConnectionTransportCanRetrieveProperties(EventHubsTransportType transportType)
         {
             var partitionCount = 4;
 
@@ -158,9 +158,9 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [TestCase(TransportType.AmqpTcp)]
-        [TestCase(TransportType.AmqpWebSockets)]
-        public async Task ConnectionTransportCanRetrievePartitionProperties(TransportType transportType)
+        [TestCase(EventHubsTransportType.AmqpTcp)]
+        [TestCase(EventHubsTransportType.AmqpWebSockets)]
+        public async Task ConnectionTransportCanRetrievePartitionProperties(EventHubsTransportType transportType)
         {
             var partitionCount = 4;
 
@@ -296,12 +296,12 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-                var retryOptions = new RetryOptions { TryTimeout = TimeSpan.FromMinutes(2) };
+                var retryOptions = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromMinutes(2) };
 
                 var clientOptions = new EventHubConnectionOptions
                 {
                     Proxy = new WebProxy("http://1.2.3.4:9999"),
-                    TransportType = TransportType.AmqpWebSockets
+                    TransportType = EventHubsTransportType.AmqpWebSockets
                 };
 
                 await using (var connection = new TestConnectionWithTransport(connectionString))
@@ -326,7 +326,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         private class TestConnectionWithTransport : EventHubConnection
         {
-            public EventHubsRetryPolicy RetryPolicy { get; set; } = new BasicRetryPolicy(new RetryOptions());
+            public EventHubsRetryPolicy RetryPolicy { get; set; } = new BasicRetryPolicy(new EventHubsRetryOptions());
 
             public TestConnectionWithTransport(string connectionString,
                                                EventHubConnectionOptions connectionOptions = default) : base(connectionString, connectionOptions)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConnection/EventHubConnectionOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConnection/EventHubConnectionOptionsTests.cs
@@ -25,7 +25,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubConnectionOptions
             {
-                TransportType = TransportType.AmqpWebSockets,
+                TransportType = EventHubsTransportType.AmqpWebSockets,
                 Proxy = Mock.Of<IWebProxy>()
             };
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConnection/EventHubConnectionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConnection/EventHubConnectionTests.cs
@@ -65,7 +65,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var options = new EventHubConnectionOptions
             {
-                TransportType = TransportType.AmqpWebSockets,
+                TransportType = EventHubsTransportType.AmqpWebSockets,
                 Proxy = Mock.Of<IWebProxy>()
             };
 
@@ -79,8 +79,8 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         public static IEnumerable<object[]> ValidConnectionTypeCases()
         {
-            yield return new object[] { TransportType.AmqpTcp };
-            yield return new object[] { TransportType.AmqpWebSockets };
+            yield return new object[] { EventHubsTransportType.AmqpTcp };
+            yield return new object[] { EventHubsTransportType.AmqpWebSockets };
         }
 
         /// <summary>
@@ -277,7 +277,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ConstructorWithConnectionStringValidatesOptions()
         {
             var fakeConnection = "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake";
-            var invalidOptions = new EventHubConnectionOptions { TransportType = TransportType.AmqpTcp, Proxy = Mock.Of<IWebProxy>() };
+            var invalidOptions = new EventHubConnectionOptions { TransportType = EventHubsTransportType.AmqpTcp, Proxy = Mock.Of<IWebProxy>() };
 
             Assert.That(() => new EventHubConnection(fakeConnection, invalidOptions), Throws.ArgumentException, "The connection string constructor should validate client options");
         }
@@ -291,7 +291,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ConstructorWithExpandedArgumentsValidatesOptions()
         {
             var token = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var invalidOptions = new EventHubConnectionOptions { TransportType = TransportType.AmqpTcp, Proxy = Mock.Of<IWebProxy>() };
+            var invalidOptions = new EventHubConnectionOptions { TransportType = EventHubsTransportType.AmqpTcp, Proxy = Mock.Of<IWebProxy>() };
             Assert.That(() => new EventHubConnection("fullyQualifiedNamespace", "path", Mock.Of<TokenCredential>(), invalidOptions), Throws.ArgumentException, "The expanded argument constructor should validate client options");
         }
 
@@ -320,7 +320,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var keyName = "aWonderfulKey";
             var key = "ABC4223";
             var resource = $"amqps://{ fullyQualifiedNamespace }/{ path }";
-            var options = new EventHubConnectionOptions { TransportType = TransportType.AmqpTcp };
+            var options = new EventHubConnectionOptions { TransportType = EventHubsTransportType.AmqpTcp };
             var signature = new SharedAccessSignature(resource, keyName, key);
             var client = new EventHubConnection(fullyQualifiedNamespace, path, new SharedAccessSignatureCredential(signature), options);
 
@@ -372,7 +372,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         [Test]
         [TestCaseSource(nameof(ValidConnectionTypeCases))]
-        public void BuildTransportClientAllowsLegalConnectionTypes(TransportType connectionType)
+        public void BuildTransportClientAllowsLegalConnectionTypes(EventHubsTransportType connectionType)
         {
             var fullyQualifiedNamespace = "my.eventhubs.com";
             var path = "some-hub";
@@ -401,7 +401,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var keyName = "aWonderfulKey";
             var key = "ABC4223";
             var resource = $"amqps://{ fullyQualifiedNamespace }/{ path }";
-            var connectionType = (TransportType)int.MinValue;
+            var connectionType = (EventHubsTransportType)int.MinValue;
             var options = new EventHubConnectionOptions { TransportType = connectionType };
             var signature = new SharedAccessSignature(resource, keyName, key);
             var credential = new SharedAccessSignatureCredential(signature);
@@ -554,7 +554,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var transportClient = new ObservableTransportClientMock();
             var client = new InjectableTransportClientMock(transportClient, "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake");
-            var options = new EventHubProducerClientOptions { RetryOptions = new RetryOptions { MaximumRetries = 6, TryTimeout = TimeSpan.FromMinutes(4) } };
+            var options = new EventHubProducerClientOptions { RetryOptions = new EventHubsRetryOptions { MaximumRetries = 6, TryTimeout = TimeSpan.FromMinutes(4) } };
             var expectedRetry = options.RetryOptions.ToRetryPolicy();
 
             client.CreateTransportProducer(null, expectedRetry);
@@ -578,7 +578,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedPosition = EventPosition.FromOffset(65);
             var expectedPartition = "2123";
             var expectedConsumerGroup = EventHubConsumerClient.DefaultConsumerGroupName;
-            var expectedRetryPolicy = new RetryOptions { MaximumRetries = 67 }.ToRetryPolicy();
+            var expectedRetryPolicy = new EventHubsRetryOptions { MaximumRetries = 67 }.ToRetryPolicy();
             var expectedTrackLastEnqueued = false;
             var expectedPrefetch = 99U;
             var expectedOwnerLevel = 123L;
@@ -639,7 +639,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var path = "someHub/";
             var transportClient = new ObservableTransportClientMock();
             var client = new InjectableTransportClientMock(transportClient, "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake");
-            var resource = BuildResource(client, TransportType.AmqpWebSockets, fullyQualifiedNamespace, path);
+            var resource = BuildResource(client, EventHubsTransportType.AmqpWebSockets, fullyQualifiedNamespace, path);
 
             Assert.That(resource, Is.Not.Null.Or.Empty, "The resource should have been populated.");
             Assert.That(resource, Is.EqualTo(resource.ToLowerInvariant()), "The resource should have been normalized to lower case.");
@@ -663,7 +663,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var transportClient = new ObservableTransportClientMock();
             var client = new InjectableTransportClientMock(transportClient, "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake");
             var expectedPath = $"/{ path.ToLowerInvariant() }";
-            var resource = BuildResource(client, TransportType.AmqpTcp, fullyQualifiedNamespace, path);
+            var resource = BuildResource(client, EventHubsTransportType.AmqpTcp, fullyQualifiedNamespace, path);
 
             Assert.That(resource, Is.Not.Null.Or.Empty, "The resource should have been populated.");
 
@@ -683,7 +683,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// <returns>The credential with which the client was created.</returns>
         ///
         private string BuildResource(EventHubConnection client,
-                                     TransportType transportType,
+                                     EventHubsTransportType transportType,
                                      string fullyQualifiedNamespace,
                                      string eventHubName) =>
              typeof(EventHubConnection)
@@ -844,11 +844,11 @@ namespace Azure.Messaging.EventHubs.Tests
                                                              string partitionId,
                                                              EventPosition eventPosition,
                                                              EventHubsRetryPolicy retryPolicy,
-                                                             bool trackLastEnqueuedEventInformation = true,
+                                                             bool trackLastEnqueuedEventProperties = true,
                                                              long? ownerLevel = default,
                                                              uint? prefetchCount = default)
             {
-                CreateConsumerCalledWith = (consumerGroup, partitionId, eventPosition, retryPolicy, trackLastEnqueuedEventInformation, ownerLevel, prefetchCount);
+                CreateConsumerCalledWith = (consumerGroup, partitionId, eventPosition, retryPolicy, trackLastEnqueuedEventProperties, ownerLevel, prefetchCount);
                 return default;
             }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientLiveTests.cs
@@ -32,10 +32,10 @@ namespace Azure.Messaging.EventHubs.Tests
     public class EventHubConsumerClientLiveTests
     {
         /// <summary>The default retry policy to use when performing operations.</summary>
-        private readonly EventHubsRetryPolicy DefaultRetryPolicy = new RetryOptions().ToRetryPolicy();
+        private readonly EventHubsRetryPolicy DefaultRetryPolicy = new EventHubsRetryOptions().ToRetryPolicy();
 
         /// <summary>The default set of options for reading, allowing a small wait time.</summary>
-        private readonly ReadOptions DefaultReadOptions = new ReadOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(250) };
+        private readonly ReadEventOptions DefaultReadOptions = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(250) };
 
         /// <summary>
         ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
@@ -43,9 +43,9 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [TestCase(TransportType.AmqpTcp)]
-        [TestCase(TransportType.AmqpWebSockets)]
-        public async Task ConsumerWithNoOptionsCanReceive(TransportType transportType)
+        [TestCase(EventHubsTransportType.AmqpTcp)]
+        [TestCase(EventHubsTransportType.AmqpWebSockets)]
+        public async Task ConsumerWithNoOptionsCanReceive(EventHubsTransportType transportType)
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
@@ -69,14 +69,14 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [TestCase(TransportType.AmqpTcp)]
-        [TestCase(TransportType.AmqpWebSockets)]
-        public async Task ConsumerWithOptionsCanReceive(TransportType transportType)
+        [TestCase(EventHubsTransportType.AmqpTcp)]
+        [TestCase(EventHubsTransportType.AmqpWebSockets)]
+        public async Task ConsumerWithOptionsCanReceive(EventHubsTransportType transportType)
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-                var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { MaximumRetries = 7 } };
+                var options = new EventHubConsumerClientOptions { RetryOptions = new EventHubsRetryOptions { MaximumRetries = 7 } };
 
                 await using (var connection = new EventHubConnection(connectionString, new EventHubConnectionOptions { TransportType = transportType }))
                 {
@@ -126,7 +126,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                             if (!wereEventsPublished)
                             {
-                                await producer.SendAsync(eventBatch, new SendOptions { PartitionId = partition });
+                                await producer.SendAsync(eventBatch, new SendEventOptions { PartitionId = partition });
 
                                 wereEventsPublished = true;
                                 continue;
@@ -196,7 +196,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                             if (!wereEventsPublished)
                             {
-                                await producer.SendAsync(eventBatch, new SendOptions { PartitionId = partition });
+                                await producer.SendAsync(eventBatch, new SendEventOptions { PartitionId = partition });
 
                                 wereEventsPublished = true;
                                 continue;
@@ -268,7 +268,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                             if (!wereEventsPublished)
                             {
-                                await producer.SendAsync(eventSet, new SendOptions { PartitionId = partition });
+                                await producer.SendAsync(eventSet, new SendEventOptions { PartitionId = partition });
 
                                 wereEventsPublished = true;
                                 continue;
@@ -325,7 +325,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                 await using (var connection = new EventHubConnection(connectionString))
                 {
-                    var retryOptions = new RetryOptions { TryTimeout = TimeSpan.FromMinutes(5) };
+                    var retryOptions = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromMinutes(5) };
                     var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
 
                     await using (var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions { RetryOptions = retryOptions }))
@@ -336,7 +336,7 @@ namespace Azure.Messaging.EventHubs.Tests
                         var receivedEvents = new List<EventData>();
                         var consecutiveEmpties = 0;
                         var wereEventsPublished = false;
-                        var readOptions = new ReadOptions { MaximumWaitTime = TimeSpan.FromSeconds(2) };
+                        var readOptions = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromSeconds(2) };
 
                         await foreach (var partitionEvent in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.Latest, readOptions))
                         {
@@ -344,7 +344,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                             if (!wereEventsPublished)
                             {
-                                await producer.SendAsync(eventBatch, new SendOptions { PartitionId = partition });
+                                await producer.SendAsync(eventBatch, new SendEventOptions { PartitionId = partition });
 
                                 wereEventsPublished = true;
                                 continue;
@@ -423,7 +423,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                             if (!wereEventsPublished)
                             {
-                                await producer.SendAsync(eventBatch, new SendOptions { PartitionId = partition });
+                                await producer.SendAsync(eventBatch, new SendEventOptions { PartitionId = partition });
 
                                 wereEventsPublished = true;
                                 continue;
@@ -497,7 +497,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                             if (!wereEventsPublished)
                             {
-                                await producer.SendAsync(stampEvent, new SendOptions { PartitionId = partition });
+                                await producer.SendAsync(stampEvent, new SendEventOptions { PartitionId = partition });
 
                                 wereEventsPublished = true;
                                 continue;
@@ -543,7 +543,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     {
                         for (int i = 0; i < expectedEventsCount; i++)
                         {
-                            await producer.SendAsync(new EventData(new byte[1]), new SendOptions { PartitionId = partition });
+                            await producer.SendAsync(new EventData(new byte[1]), new SendEventOptions { PartitionId = partition });
                         }
 
                         // Read the events.
@@ -592,7 +592,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         for (var i = 0; i < 10; i++)
                         {
-                            await producer.SendAsync(new EventData(new byte[1]), new SendOptions { PartitionId = partition });
+                            await producer.SendAsync(new EventData(new byte[1]), new SendEventOptions { PartitionId = partition });
                         }
 
                         // Store last enqueued offset.
@@ -613,7 +613,7 @@ namespace Azure.Messaging.EventHubs.Tests
                             var expectedEventsCount = 2;
                             var consecutiveEmpties = 0;
                             var receivedEvents = new List<EventData>();
-                            var readOptions = new ReadOptions { MaximumWaitTime = TimeSpan.FromSeconds(1) };
+                            var readOptions = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromSeconds(1) };
 
                             await foreach (var partitionEvent in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.FromOffset(offset), readOptions))
                             {
@@ -658,7 +658,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         for (var i = 0; i < 10; i++)
                         {
-                            await producer.SendAsync(new EventData(new byte[1]), new SendOptions { PartitionId = partition });
+                            await producer.SendAsync(new EventData(new byte[1]), new SendEventOptions { PartitionId = partition });
                         }
 
                         // Store last enqueued time.
@@ -680,7 +680,7 @@ namespace Azure.Messaging.EventHubs.Tests
                             var expectedEventsCount = 1;
                             var consecutiveEmpties = 0;
                             var receivedEvents = new List<EventData>();
-                            var readOptions = new ReadOptions { MaximumWaitTime = TimeSpan.FromSeconds(1) };
+                            var readOptions = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromSeconds(1) };
 
                             await foreach (var partitionEvent in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.FromEnqueuedTime(enqueuedTime), readOptions))
                             {
@@ -741,14 +741,14 @@ namespace Azure.Messaging.EventHubs.Tests
                             var stampEvent = new EventData(new byte[1]);
                             stampEvent.Properties["stamp"] = Guid.NewGuid().ToString();
 
-                            await producer.SendAsync(stampEvent, new SendOptions { PartitionId = partition });
+                            await producer.SendAsync(stampEvent, new SendEventOptions { PartitionId = partition });
 
                             // Read the events.
 
                             var expectedEventsCount = isInclusive ? 2 : 1;
                             var consecutiveEmpties = 0;
                             var receivedEvents = new List<EventData>();
-                            var readOptions = new ReadOptions { MaximumWaitTime = TimeSpan.FromSeconds(1) };
+                            var readOptions = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromSeconds(1) };
 
                             await foreach (var partitionEvent in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.FromSequenceNumber(sequenceNumber, isInclusive), readOptions))
                             {
@@ -896,7 +896,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     await publishEvents();
 
-                    await foreach (var partitionEvent in consumer.ReadEventsAsync(false, new ReadOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(50) }, cancellationSource.Token))
+                    await foreach (var partitionEvent in consumer.ReadEventsAsync(false, new ReadEventOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(50) }, cancellationSource.Token))
                     {
                         if (partitionEvent.Data != null)
                         {
@@ -1849,7 +1849,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                             for (var batchesCount = 0; batchesCount < batches; batchesCount++)
                             {
-                                await producer.SendAsync(eventBatch, new SendOptions { PartitionId = partitionIds[0] });
+                                await producer.SendAsync(eventBatch, new SendEventOptions { PartitionId = partitionIds[0] });
                             }
 
                             wereEventsPublished = true;
@@ -1906,7 +1906,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     // Send the batch of events.
 
                     await using var producer = new EventHubProducerClient(connectionString);
-                    await producer.SendAsync(eventBatch, new SendOptions { PartitionId = partition });
+                    await producer.SendAsync(eventBatch, new SendEventOptions { PartitionId = partition });
 
                     // Read back the events from two different consumer groups.
 
@@ -1914,7 +1914,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var consecutiveEmpties = 0;
                     var consumerReceivedEvents = new List<EventData>();
                     var anotherReceivedEvents = new List<EventData>();
-                    var readOptions = new ReadOptions { MaximumWaitTime = TimeSpan.FromSeconds(1) };
+                    var readOptions = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromSeconds(1) };
 
 
                     await foreach (var consumerEvent in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.Earliest, readOptions, cancellationSource.Token))
@@ -1976,7 +1976,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     var startTime = DateTime.UtcNow;
                     var elapsedTime = 0.0;
-                    var readOptions = new ReadOptions { MaximumWaitTime = TimeSpan.FromSeconds(maximumWaitTimeInSecs) };
+                    var readOptions = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromSeconds(maximumWaitTimeInSecs) };
 
                     await foreach (var partitionEvent in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.Latest, readOptions, cancellationSource.Token))
                     {
@@ -2008,18 +2008,18 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     var options = new EventHubConsumerClientOptions
                     {
-                        RetryOptions = new RetryOptions { TryTimeout = TimeSpan.FromMinutes(2) },
+                        RetryOptions = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromMinutes(2) },
 
                         ConnectionOptions = new EventHubConnectionOptions
                         {
                             Proxy = new WebProxy("http://1.2.3.4:9999"),
-                            TransportType = TransportType.AmqpWebSockets
+                            TransportType = EventHubsTransportType.AmqpWebSockets
                         }
                     };
 
                     await using (var invalidProxyConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString, options))
                     {
-                        var readOptions = new ReadOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(250) };
+                        var readOptions = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(250) };
                         Assert.That(async () => await ReadNothingAsync(invalidProxyConsumer, partition, EventPosition.Latest, readOptions), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
                     }
                 }
@@ -2032,9 +2032,9 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [TestCase(TransportType.AmqpTcp)]
-        [TestCase(TransportType.AmqpWebSockets)]
-        public async Task ConsumerCanRetrieveEventHubProperties(TransportType transportType)
+        [TestCase(EventHubsTransportType.AmqpTcp)]
+        [TestCase(EventHubsTransportType.AmqpWebSockets)]
+        public async Task ConsumerCanRetrieveEventHubProperties(EventHubsTransportType transportType)
         {
             var partitionCount = 4;
 
@@ -2061,9 +2061,9 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [TestCase(TransportType.AmqpTcp)]
-        [TestCase(TransportType.AmqpWebSockets)]
-        public async Task ConsumerCanRetrievePartitionProperties(TransportType transportType)
+        [TestCase(EventHubsTransportType.AmqpTcp)]
+        [TestCase(EventHubsTransportType.AmqpWebSockets)]
+        public async Task ConsumerCanRetrievePartitionProperties(EventHubsTransportType transportType)
         {
             var partitionCount = 4;
 
@@ -2181,12 +2181,12 @@ namespace Azure.Messaging.EventHubs.Tests
 
                 var invalidProxyOptions = new EventHubConsumerClientOptions
                 {
-                    RetryOptions = new RetryOptions { TryTimeout = TimeSpan.FromMinutes(2) },
+                    RetryOptions = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromMinutes(2) },
 
                     ConnectionOptions = new EventHubConnectionOptions
                     {
                         Proxy = new WebProxy("http://1.2.3.4:9999"),
-                        TransportType = TransportType.AmqpWebSockets
+                        TransportType = EventHubsTransportType.AmqpWebSockets
                     }
                 };
 
@@ -2214,10 +2214,10 @@ namespace Azure.Messaging.EventHubs.Tests
         private async Task ReadNothingAsync(EventHubConsumerClient consumer,
                                             string partition,
                                             EventPosition startingPosition,
-                                            ReadOptions readOptions = default,
+                                            ReadEventOptions readOptions = default,
                                             int iterationCount = 5)
         {
-            readOptions ??= new ReadOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(150) };
+            readOptions ??= new ReadEventOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(150) };
 
             await foreach (var item in consumer.ReadEventsFromPartitionAsync(partition, startingPosition, readOptions))
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientOptionsTests.cs
@@ -24,8 +24,8 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubConsumerClientOptions
             {
-                RetryOptions = new RetryOptions { Mode = RetryMode.Fixed },
-                ConnectionOptions = new EventHubConnectionOptions { TransportType = TransportType.AmqpWebSockets }
+                RetryOptions = new EventHubsRetryOptions { Mode = EventHubsRetryMode.Fixed },
+                ConnectionOptions = new EventHubConnectionOptions { TransportType = EventHubsTransportType.AmqpWebSockets }
             };
 
             EventHubConsumerClientOptions clone = options.Clone();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientTests.cs
@@ -137,7 +137,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ConnectionStringConstructorSetsTheRetryPolicy()
         {
             var expected = Mock.Of<EventHubsRetryPolicy>();
-            var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = expected } };
+            var options = new EventHubConsumerClientOptions { RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = expected } };
             var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString, options);
 
@@ -153,7 +153,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var expected = Mock.Of<EventHubsRetryPolicy>();
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = expected } };
+            var options = new EventHubConsumerClientOptions { RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = expected } };
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, "namespace", "hub", credential.Object, options);
 
             Assert.That(GetRetryPolicy(consumer), Is.SameAs(expected));
@@ -167,7 +167,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ConnectionConstructorSetsTheRetryPolicy()
         {
             var expected = Mock.Of<EventHubsRetryPolicy>();
-            var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = expected } };
+            var options = new EventHubConsumerClientOptions { RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = expected } };
             var mockConnection = new MockConnection();
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection, options);
 
@@ -313,7 +313,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var mockConnection = new MockConnection();
             var retryPolicy = Mock.Of<EventHubsRetryPolicy>();
-            var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = retryPolicy } };
+            var options = new EventHubConsumerClientOptions { RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = retryPolicy } };
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection, options);
 
             await consumer.GetEventHubPropertiesAsync();
@@ -330,7 +330,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var mockConnection = new MockConnection();
             var retryPolicy = Mock.Of<EventHubsRetryPolicy>();
-            var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = retryPolicy } };
+            var options = new EventHubConsumerClientOptions { RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = retryPolicy } };
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection, options);
 
             await consumer.GetPartitionIdsAsync();
@@ -347,7 +347,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var mockConnection = new MockConnection();
             var retryPolicy = Mock.Of<EventHubsRetryPolicy>();
-            var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = retryPolicy } };
+            var options = new EventHubConsumerClientOptions { RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = retryPolicy } };
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection, options);
 
             await consumer.GetPartitionPropertiesAsync("1");
@@ -365,7 +365,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var transportConsumer = new ObservableTransportConsumerMock();
             var mockConnection = new MockConnection(() => transportConsumer);
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
-            var options = new ReadOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(25) };
+            var options = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(25) };
 
             await using var firstIterator = consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(23), options).GetAsyncEnumerator();
             await using var secondIterator = consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(23), options).GetAsyncEnumerator();
@@ -395,7 +395,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             try
             {
-                var options = new ReadOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(25) };
+                var options = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(25) };
 
                 await using var iterator = consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(23), options).GetAsyncEnumerator();
                 await iterator.MoveNextAsync();
@@ -443,7 +443,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockConnection = new MockConnection(() => transportConsumer);
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
 
-            var options = new ReadOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(25) };
+            var options = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(25) };
             var enumerable = consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(12), options);
 
             Assert.That(enumerable, Is.Not.Null, "An enumerable should have been returned.");
@@ -827,7 +827,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 new EventData(Encoding.UTF8.GetBytes("Five"))
             };
 
-            var options = new ReadOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(5) };
+            var options = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(5) };
             var partition = "0";
             var position = EventPosition.FromOffset(22);
             var mockConnection = new MockConnection(() => new PublishingTransportConsumerMock(events));
@@ -926,7 +926,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task ReadEventsFromPartitionAsyncPublishesEventsWithMultipleIteratorsAndMultipleBatches()
         {
-            var options = new ReadOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(5) };
+            var options = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(5) };
             var events = new List<EventData>();
             var partition = "0";
             var position = EventPosition.FromSequenceNumber(453);
@@ -1007,7 +1007,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var maxWaitTime = TimeSpan.FromMilliseconds(50);
             var publishDelay = maxWaitTime.Add(TimeSpan.FromMilliseconds(15));
-            var options = new ReadOptions { MaximumWaitTime = maxWaitTime };
+            var options = new ReadEventOptions { MaximumWaitTime = maxWaitTime };
             var transportConsumer = new PublishingTransportConsumerMock(events, () => publishDelay);
             var mockConnection = new MockConnection(() => transportConsumer);
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
@@ -1147,7 +1147,7 @@ namespace Azure.Messaging.EventHubs.Tests
             };
 
             var mockRetryPolicy = new Mock<EventHubsRetryPolicy>();
-            var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = mockRetryPolicy.Object } };
+            var options = new EventHubConsumerClientOptions { RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = mockRetryPolicy.Object } };
             var transportConsumer = new ReceiveCallbackTransportConsumerMock(receiveCallback);
             var mockConnection = new MockConnection(() => transportConsumer);
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection, options);
@@ -1192,7 +1192,7 @@ namespace Azure.Messaging.EventHubs.Tests
             };
 
             var mockRetryPolicy = new Mock<EventHubsRetryPolicy>();
-            var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = mockRetryPolicy.Object } };
+            var options = new EventHubConsumerClientOptions { RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = mockRetryPolicy.Object } };
             var transportConsumer = new ReceiveCallbackTransportConsumerMock(receiveCallback);
             var mockConnection = new MockConnection(() => transportConsumer);
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection, options);
@@ -1255,7 +1255,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockConnection = new MockConnection(() => transportConsumer);
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
 
-            var options = new ReadOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(25) };
+            var options = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(25) };
             IAsyncEnumerable<PartitionEvent> enumerable = consumer.ReadEventsAsync(options);
 
             Assert.That(enumerable, Is.Not.Null, "An enumerable should have been returned.");
@@ -1751,7 +1751,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var maxWaitTime = TimeSpan.FromMilliseconds(50);
             var publishDelay = maxWaitTime.Add(TimeSpan.FromMilliseconds(15));
-            var options = new ReadOptions { MaximumWaitTime = maxWaitTime };
+            var options = new ReadEventOptions { MaximumWaitTime = maxWaitTime };
             var transportConsumer = new PublishingTransportConsumerMock(events, () => publishDelay);
             var mockConnection = new MockConnection(() => transportConsumer);
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
@@ -1941,7 +1941,7 @@ namespace Azure.Messaging.EventHubs.Tests
             };
 
             var mockRetryPolicy = new Mock<EventHubsRetryPolicy>();
-            var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = mockRetryPolicy.Object } };
+            var options = new EventHubConsumerClientOptions { RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = mockRetryPolicy.Object } };
             var mockConnection = new MockConnection(() => new ReceiveCallbackTransportConsumerMock(receiveCallback));
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection, options);
             var partitions = await consumer.GetPartitionIdsAsync();
@@ -1987,7 +1987,7 @@ namespace Azure.Messaging.EventHubs.Tests
             };
 
             var mockRetryPolicy = new Mock<EventHubsRetryPolicy>();
-            var options = new EventHubConsumerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = mockRetryPolicy.Object } };
+            var options = new EventHubConsumerClientOptions { RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = mockRetryPolicy.Object } };
             var transportConsumer = new ReceiveCallbackTransportConsumerMock(receiveCallback);
             var mockConnection = new MockConnection(() => transportConsumer);
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection, options);
@@ -2247,7 +2247,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 return Task.FromResult(default(PartitionProperties));
             }
 
-            internal override TransportConsumer CreateTransportConsumer(string consumerGroup, string partitionId, EventPosition eventPosition, EventHubsRetryPolicy retryPolicy, bool trackLastEnqueuedEventInformation = true, long? ownerLevel = default, uint? prefetchCount = default) => TransportConsumerFactory();
+            internal override TransportConsumer CreateTransportConsumer(string consumerGroup, string partitionId, EventPosition eventPosition, EventHubsRetryPolicy retryPolicy, bool trackLastEnqueuedEventProperties = true, long? ownerLevel = default, uint? prefetchCount = default) => TransportConsumerFactory();
 
             internal override TransportClient CreateTransportClient(string fullyQualifiedNamespace, string eventHubName, EventHubTokenCredential credential, EventHubConnectionOptions options)
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/ReadOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/ReadOptionsTests.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
-    ///   The suite of tests for the <see cref="ReadOptions" />
+    ///   The suite of tests for the <see cref="ReadEventOptions" />
     ///   class.
     /// </summary>
     ///
@@ -15,37 +15,37 @@ namespace Azure.Messaging.EventHubs.Tests
     public class ReadOptionsTests
     {
         /// <summary>
-        ///   Verifies functionality of the <see cref="ReadOptions.Clone" />
+        ///   Verifies functionality of the <see cref="ReadEventOptions.Clone" />
         ///   method.
         /// </summary>
         ///
         [Test]
         public void CloneProducesACopy()
         {
-            var options = new ReadOptions
+            var options = new ReadEventOptions
             {
                 OwnerLevel = 99,
-                TrackLastEnqueuedEventInformation = false,
+                TrackLastEnqueuedEventProperties = false,
                 MaximumWaitTime = TimeSpan.FromMinutes(65)
             };
 
-            ReadOptions clone = options.Clone();
+            ReadEventOptions clone = options.Clone();
             Assert.That(clone, Is.Not.Null, "The clone should not be null.");
 
             Assert.That(clone.OwnerLevel, Is.EqualTo(options.OwnerLevel), "The owner level of the clone should match.");
-            Assert.That(clone.TrackLastEnqueuedEventInformation, Is.EqualTo(options.TrackLastEnqueuedEventInformation), "The tracking of last event information of the clone should match.");
+            Assert.That(clone.TrackLastEnqueuedEventProperties, Is.EqualTo(options.TrackLastEnqueuedEventProperties), "The tracking of last event information of the clone should match.");
             Assert.That(clone.MaximumWaitTime, Is.EqualTo(options.MaximumWaitTime), "The default maximum wait time of the clone should match.");
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="ReadOptions.MaximumWaitTime" />
+        ///   Verifies functionality of the <see cref="ReadEventOptions.MaximumWaitTime" />
         ///   property.
         /// </summary>
         ///
         [Test]
         public void MaximumWaitTimeIsValidated()
         {
-            Assert.That(() => new ReadOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(-1) }, Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new ReadEventOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(-1) }, Throws.InstanceOf<ArgumentException>());
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/CreateBatchOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/CreateBatchOptionsTests.cs
@@ -55,7 +55,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var sendOptions = options.ToSendOptions();
             Assert.That(sendOptions, Is.Not.Null, "The send options should not be null.");
-            Assert.That(sendOptions, Is.TypeOf<SendOptions>(), "The send options should be a SendOptions instance.");
+            Assert.That(sendOptions, Is.TypeOf<SendEventOptions>(), "The send options should be a SendOptions instance.");
             Assert.That(sendOptions, Is.Not.SameAs(options), "The send options should not the same reference as the options.");
             Assert.That(sendOptions.PartitionId, Is.EqualTo(options.PartitionId), "The partition identifier of the send options should match.");
             Assert.That(sendOptions.PartitionKey, Is.EqualTo(options.PartitionKey), "The partition key of the send options should match.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventDataBatchTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventDataBatchTests.cs
@@ -23,7 +23,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         public void ConstructorVerifiesTheTransportBatch()
         {
-            Assert.That(() => new EventDataBatch(null, new SendOptions()), Throws.ArgumentNullException);
+            Assert.That(() => new EventDataBatch(null, new SendEventOptions()), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         public void ConstructorUpdatesState()
         {
-            var sendOptions = new SendOptions();
+            var sendOptions = new SendEventOptions();
             var mockBatch = new MockTransportBatch();
             var batch = new EventDataBatch(new MockTransportBatch(), null);
 
@@ -59,7 +59,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void PropertyAccessIsDelegatedToTheTransportClient()
         {
             var mockBatch = new MockTransportBatch();
-            var batch = new EventDataBatch(mockBatch, new SendOptions());
+            var batch = new EventDataBatch(mockBatch, new SendEventOptions());
 
             Assert.That(batch.MaximumSizeInBytes, Is.EqualTo(mockBatch.MaximumSizeInBytes), "The maximum size should have been delegated.");
             Assert.That(batch.SizeInBytes, Is.EqualTo(mockBatch.SizeInBytes), "The size should have been delegated.");
@@ -74,7 +74,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void TryAddIsDelegatedToTheTransportClient()
         {
             var mockBatch = new MockTransportBatch();
-            var batch = new EventDataBatch(mockBatch, new SendOptions());
+            var batch = new EventDataBatch(mockBatch, new SendEventOptions());
             var eventData = new EventData(new byte[] { 0x21 });
 
             Assert.That(batch.TryAdd(eventData), Is.True, "The event should have been accepted.");
@@ -89,7 +89,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void AsEnumerableIsDelegatedToTheTransportClient()
         {
             var mockBatch = new MockTransportBatch();
-            var batch = new EventDataBatch(mockBatch, new SendOptions());
+            var batch = new EventDataBatch(mockBatch, new SendEventOptions());
 
             batch.AsEnumerable<string>();
             Assert.That(mockBatch.AsEnumerableCalledWith, Is.EqualTo(typeof(string)), "The enumerable should delegated the requested type parameter.");
@@ -103,7 +103,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void DisposeIsDelegatedToTheTransportClient()
         {
             var mockBatch = new MockTransportBatch();
-            var batch = new EventDataBatch(mockBatch, new SendOptions());
+            var batch = new EventDataBatch(mockBatch, new SendEventOptions());
 
             batch.Dispose();
             Assert.That(mockBatch.DisposeInvoked, Is.True);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientLiveTests.cs
@@ -32,10 +32,10 @@ namespace Azure.Messaging.EventHubs.Tests
     public class EventHubProducerClientLiveTests
     {
         /// <summary>The default retry policy to use when performing operations.</summary>
-        private readonly EventHubsRetryPolicy DefaultRetryPolicy = new RetryOptions().ToRetryPolicy();
+        private readonly EventHubsRetryPolicy DefaultRetryPolicy = new EventHubsRetryOptions().ToRetryPolicy();
 
         /// <summary>The default set of options for reading, allowing a small wait time.</summary>
-        private readonly ReadOptions DefaultReadOptions = new ReadOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(50) };
+        private readonly ReadEventOptions DefaultReadOptions = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(50) };
 
         /// <summary>
         ///   Verifies that the <see cref="EventHubProducerClient" /> is able to
@@ -43,9 +43,9 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [TestCase(TransportType.AmqpTcp)]
-        [TestCase(TransportType.AmqpWebSockets)]
-        public async Task ProducerWithNoOptionsCanSend(TransportType transportType)
+        [TestCase(EventHubsTransportType.AmqpTcp)]
+        [TestCase(EventHubsTransportType.AmqpWebSockets)]
+        public async Task ProducerWithNoOptionsCanSend(EventHubsTransportType transportType)
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
@@ -66,9 +66,9 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [TestCase(TransportType.AmqpTcp)]
-        [TestCase(TransportType.AmqpWebSockets)]
-        public async Task ProducerWithOptionsCanSend(TransportType transportType)
+        [TestCase(EventHubsTransportType.AmqpTcp)]
+        [TestCase(EventHubsTransportType.AmqpWebSockets)]
+        public async Task ProducerWithOptionsCanSend(EventHubsTransportType transportType)
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
@@ -76,7 +76,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                 var producerOptions = new EventHubProducerClientOptions
                 {
-                    RetryOptions = new RetryOptions { MaximumRetries = 5 },
+                    RetryOptions = new EventHubsRetryOptions { MaximumRetries = 5 },
                     ConnectionOptions = new EventHubConnectionOptions { TransportType = transportType }
                 };
 
@@ -107,7 +107,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     await using (var producer = new EventHubProducerClient(connection))
                     {
                         EventData[] events = new[] { new EventData(Encoding.UTF8.GetBytes("AWord")) };
-                        Assert.That(async () => await producer.SendAsync(events, new SendOptions { PartitionId = partition }), Throws.Nothing);
+                        Assert.That(async () => await producer.SendAsync(events, new SendEventOptions { PartitionId = partition }), Throws.Nothing);
                     }
                 }
             }
@@ -164,7 +164,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                 await using (var producer = new EventHubProducerClient(connectionString))
                 {
-                    var batchOptions = new SendOptions { PartitionKey = "some123key-!d" };
+                    var batchOptions = new SendEventOptions { PartitionKey = "some123key-!d" };
                     Assert.That(async () => await producer.SendAsync(events, batchOptions), Throws.Nothing);
                 }
             }
@@ -180,7 +180,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(2))
             {
-                var batchOptions = new SendOptions { PartitionKey = "some123key-!d" };
+                var batchOptions = new SendEventOptions { PartitionKey = "some123key-!d" };
 
                 for (var index = 0; index < 5; ++index)
                 {
@@ -261,7 +261,7 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
-                await using (var producer = new EventHubProducerClient(connectionString, new EventHubProducerClientOptions { RetryOptions = new RetryOptions { TryTimeout = TimeSpan.FromMinutes(5) } }))
+                await using (var producer = new EventHubProducerClient(connectionString, new EventHubProducerClientOptions { RetryOptions = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromMinutes(5) } }))
                 {
                     // Actual limit is 1046520 for a single event.
                     var singleEvent = new EventData(new byte[100000]);
@@ -283,7 +283,7 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
-                await using (var producer = new EventHubProducerClient(connectionString, new EventHubProducerClientOptions { RetryOptions = new RetryOptions { TryTimeout = TimeSpan.FromMinutes(5) } }))
+                await using (var producer = new EventHubProducerClient(connectionString, new EventHubProducerClientOptions { RetryOptions = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromMinutes(5) } }))
                 {
                     // Actual limit is 1046520 for a single event.
                     EventData[] eventSet = new[] { new EventData(new byte[100000]) };
@@ -381,7 +381,7 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
-                await using (var producer = new EventHubProducerClient(connectionString, new EventHubProducerClientOptions { RetryOptions = new RetryOptions { TryTimeout = TimeSpan.FromMinutes(5) } }))
+                await using (var producer = new EventHubProducerClient(connectionString, new EventHubProducerClientOptions { RetryOptions = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromMinutes(5) } }))
                 {
                     // Actual limit is 1046520 for a single event.
                     EventData[] events = new[]
@@ -457,7 +457,7 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
-                await using (var producer = new EventHubProducerClient(connectionString, new EventHubProducerClientOptions { RetryOptions = new RetryOptions { TryTimeout = TimeSpan.FromMinutes(5) } }))
+                await using (var producer = new EventHubProducerClient(connectionString, new EventHubProducerClientOptions { RetryOptions = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromMinutes(5) } }))
                 {
                     using EventDataBatch batch = await producer.CreateBatchAsync();
 
@@ -524,7 +524,7 @@ namespace Azure.Messaging.EventHubs.Tests
                             new EventData(Encoding.UTF8.GetBytes("Do we need more messages"))
                         };
 
-                        Assert.That(async () => await producer.SendAsync(events, new SendOptions { PartitionId = partition }), Throws.Nothing);
+                        Assert.That(async () => await producer.SendAsync(events, new SendEventOptions { PartitionId = partition }), Throws.Nothing);
                     }
                 }
             }
@@ -574,7 +574,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 await using (var producer = new EventHubProducerClient(connectionString))
                 {
                     EventData[] events = new[] { new EventData(Encoding.UTF8.GetBytes("Will it work")) };
-                    Assert.That(async () => await producer.SendAsync(events, new SendOptions { PartitionId = null }), Throws.Nothing);
+                    Assert.That(async () => await producer.SendAsync(events, new SendEventOptions { PartitionId = null }), Throws.Nothing);
                 }
             }
         }
@@ -624,7 +624,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     await using (var producer = new EventHubProducerClient(connection))
                     {
-                        Assert.That(async () => await producer.SendAsync(events, new SendOptions { PartitionId = invalidPartition }), Throws.TypeOf<ArgumentOutOfRangeException>());
+                        Assert.That(async () => await producer.SendAsync(events, new SendEventOptions { PartitionId = invalidPartition }), Throws.TypeOf<ArgumentOutOfRangeException>());
                     }
                 }
             }
@@ -651,7 +651,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     {
                         // Sending events beforehand so the partition has some information.
 
-                        await producer.SendAsync(events, new SendOptions { PartitionId = partition });
+                        await producer.SendAsync(events, new SendEventOptions { PartitionId = partition });
 
                         PartitionProperties oldPartitionProperties = await producer.GetPartitionPropertiesAsync(partition);
 
@@ -753,13 +753,13 @@ namespace Azure.Messaging.EventHubs.Tests
                     {
                         // Sending events beforehand so the partition has some information.
 
-                        await producer0.SendAsync(events, new SendOptions { PartitionId = partitionIds[0] });
+                        await producer0.SendAsync(events, new SendEventOptions { PartitionId = partitionIds[0] });
 
                         PartitionProperties oldPartitionProperties = await producer0.GetPartitionPropertiesAsync(partitionIds[0]);
 
                         Assert.That(oldPartitionProperties, Is.Not.Null, "A set of partition properties should have been returned.");
 
-                        await producer1.SendAsync(events, new SendOptions { PartitionId = partitionIds[1] });
+                        await producer1.SendAsync(events, new SendEventOptions { PartitionId = partitionIds[1] });
 
                         PartitionProperties newPartitionProperties = await producer1.GetPartitionPropertiesAsync(partitionIds[0]);
 
@@ -948,7 +948,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     // Send the batches of events.
 
-                    var batchOptions = new SendOptions { PartitionKey = partitionKey };
+                    var batchOptions = new SendEventOptions { PartitionKey = partitionKey };
 
                     for (var index = 0; index < batches; index++)
                     {
@@ -1006,12 +1006,12 @@ namespace Azure.Messaging.EventHubs.Tests
 
                 var producerOptions = new EventHubProducerClientOptions
                 {
-                    RetryOptions = new RetryOptions { TryTimeout = TimeSpan.FromMinutes(2) },
+                    RetryOptions = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromMinutes(2) },
 
                     ConnectionOptions = new EventHubConnectionOptions
                     {
                         Proxy = new WebProxy("http://1.2.3.4:9999"),
-                        TransportType = TransportType.AmqpWebSockets
+                        TransportType = EventHubsTransportType.AmqpWebSockets
                     }
                 };
 
@@ -1028,9 +1028,9 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [TestCase(TransportType.AmqpTcp)]
-        [TestCase(TransportType.AmqpWebSockets)]
-        public async Task ProducerCanRetrieveEventHubProperties(TransportType transportType)
+        [TestCase(EventHubsTransportType.AmqpTcp)]
+        [TestCase(EventHubsTransportType.AmqpWebSockets)]
+        public async Task ProducerCanRetrieveEventHubProperties(EventHubsTransportType transportType)
         {
             var partitionCount = 4;
 
@@ -1057,9 +1057,9 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [TestCase(TransportType.AmqpTcp)]
-        [TestCase(TransportType.AmqpWebSockets)]
-        public async Task ProducerCanRetrievePartitionProperties(TransportType transportType)
+        [TestCase(EventHubsTransportType.AmqpTcp)]
+        [TestCase(EventHubsTransportType.AmqpWebSockets)]
+        public async Task ProducerCanRetrievePartitionProperties(EventHubsTransportType transportType)
         {
             var partitionCount = 4;
 
@@ -1177,12 +1177,12 @@ namespace Azure.Messaging.EventHubs.Tests
 
                 var invalidProxyOptions = new EventHubProducerClientOptions
                 {
-                    RetryOptions = new RetryOptions { TryTimeout = TimeSpan.FromMinutes(2) },
+                    RetryOptions = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromMinutes(2) },
 
                     ConnectionOptions = new EventHubConnectionOptions
                     {
                         Proxy = new WebProxy("http://1.2.3.4:9999"),
-                        TransportType = TransportType.AmqpWebSockets
+                        TransportType = EventHubsTransportType.AmqpWebSockets
                     }
                 };
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientOptionsTests.cs
@@ -24,8 +24,8 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubProducerClientOptions
             {
-                ConnectionOptions = new EventHubConnectionOptions { TransportType = TransportType.AmqpWebSockets },
-                RetryOptions = new RetryOptions { TryTimeout = TimeSpan.FromMinutes(36) }
+                ConnectionOptions = new EventHubConnectionOptions { TransportType = EventHubsTransportType.AmqpWebSockets },
+                RetryOptions = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromMinutes(36) }
             };
 
             EventHubProducerClientOptions clone = options.Clone();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientTests.cs
@@ -91,7 +91,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ConnectionStringConstructorSetsTheRetryPolicy()
         {
             var expected = Mock.Of<EventHubsRetryPolicy>();
-            var options = new EventHubProducerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = expected } };
+            var options = new EventHubProducerClientOptions { RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = expected } };
             var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
             var producer = new EventHubProducerClient(connectionString, options);
 
@@ -107,7 +107,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var expected = Mock.Of<EventHubsRetryPolicy>();
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var options = new EventHubProducerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = expected } };
+            var options = new EventHubProducerClientOptions { RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = expected } };
             var producer = new EventHubProducerClient("namespace", "eventHub", credential.Object, options);
 
             Assert.That(GetRetryPolicy(producer), Is.SameAs(expected));
@@ -121,7 +121,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ConnectionConstructorSetsTheRetryPolicy()
         {
             var expected = Mock.Of<EventHubsRetryPolicy>();
-            var options = new EventHubProducerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = expected } };
+            var options = new EventHubProducerClientOptions { RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = expected } };
             var mockConnection = new MockConnection();
             var producer = new EventHubProducerClient(mockConnection, options);
 
@@ -223,7 +223,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var mockConnection = new MockConnection();
             var retryPolicy = Mock.Of<EventHubsRetryPolicy>();
-            var options = new EventHubProducerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = retryPolicy } };
+            var options = new EventHubProducerClientOptions { RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = retryPolicy } };
             var producer = new EventHubProducerClient(mockConnection, options);
 
             await producer.GetEventHubPropertiesAsync();
@@ -240,7 +240,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var mockConnection = new MockConnection();
             var retryPolicy = Mock.Of<EventHubsRetryPolicy>();
-            var options = new EventHubProducerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = retryPolicy } };
+            var options = new EventHubProducerClientOptions { RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = retryPolicy } };
             var producer = new EventHubProducerClient(mockConnection, options);
 
             await producer.GetPartitionIdsAsync();
@@ -257,7 +257,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var mockConnection = new MockConnection();
             var retryPolicy = Mock.Of<EventHubsRetryPolicy>();
-            var options = new EventHubProducerClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = retryPolicy } };
+            var options = new EventHubProducerClientOptions { RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = retryPolicy } };
             var producer = new EventHubProducerClient(mockConnection, options);
 
             await producer.GetPartitionPropertiesAsync("1");
@@ -285,7 +285,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SendSingleRequiresAnEvent()
         {
             var producer = new EventHubProducerClient(new MockConnection());
-            Assert.That(async () => await producer.SendAsync(default(EventData), new SendOptions()), Throws.ArgumentNullException);
+            Assert.That(async () => await producer.SendAsync(default(EventData), new SendEventOptions()), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -300,7 +300,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var producer = new Mock<EventHubProducerClient> { CallBase = true };
 
             producer
-                .Setup(instance => instance.SendAsync(It.Is<IEnumerable<EventData>>(value => value.Count() == 1), It.IsAny<SendOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(instance => instance.SendAsync(It.Is<IEnumerable<EventData>>(value => value.Count() == 1), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask)
                 .Verifiable("The single send should delegate to the batch send.");
 
@@ -319,11 +319,11 @@ namespace Azure.Messaging.EventHubs.Tests
             var producer = new Mock<EventHubProducerClient> { CallBase = true };
 
             producer
-                .Setup(instance => instance.SendAsync(It.Is<IEnumerable<EventData>>(value => value.Count() == 1), It.IsAny<SendOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(instance => instance.SendAsync(It.Is<IEnumerable<EventData>>(value => value.Count() == 1), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask)
                 .Verifiable("The single send should delegate to the batch send.");
 
-            await producer.Object.SendAsync(new EventData(new byte[] { 0x22 }), new SendOptions());
+            await producer.Object.SendAsync(new EventData(new byte[] { 0x22 }), new SendEventOptions());
         }
 
         /// <summary>
@@ -351,7 +351,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var transportProducer = new ObservableTransportProducerMock();
             var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
-            Assert.That(async () => await producer.SendAsync(default(IEnumerable<EventData>), new SendOptions()), Throws.ArgumentNullException);
+            Assert.That(async () => await producer.SendAsync(default(IEnumerable<EventData>), new SendEventOptions()), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -376,7 +376,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void SendAllowsAPartitionHashKey()
         {
-            var sendOptions = new SendOptions { PartitionKey = "testKey" };
+            var sendOptions = new SendEventOptions { PartitionKey = "testKey" };
             var events = new[] { new EventData(new byte[] { 0x44, 0x66, 0x88 }) };
             var transportProducer = new ObservableTransportProducerMock();
             var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
@@ -408,7 +408,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void SendForASpecificPartitionDoesNotAllowAPartitionHashKey()
         {
-            var sendOptions = new SendOptions { PartitionKey = "testKey", PartitionId = "1" };
+            var sendOptions = new SendEventOptions { PartitionKey = "testKey", PartitionId = "1" };
             var events = new[] { new EventData(new byte[] { 0x44, 0x66, 0x88 }) };
             var transportProducer = new ObservableTransportProducerMock();
             var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
@@ -446,7 +446,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             await producer.SendAsync(events);
 
-            (IEnumerable<EventData> calledWithEvents, SendOptions calledWithOptions) = transportProducer.SendCalledWith;
+            (IEnumerable<EventData> calledWithEvents, SendEventOptions calledWithOptions) = transportProducer.SendCalledWith;
 
             Assert.That(calledWithEvents, Is.EquivalentTo(events), "The events should contain same elements.");
             Assert.That(calledWithOptions, Is.Not.Null, "A default set of options should be used.");
@@ -461,13 +461,13 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task SendInvokesTheTransportProducer()
         {
             var events = new EventData[0];
-            var options = new SendOptions();
+            var options = new SendEventOptions();
             var transportProducer = new ObservableTransportProducerMock();
             var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
             await producer.SendAsync(events, options);
 
-            (IEnumerable<EventData> calledWithEvents, SendOptions calledWithOptions) = transportProducer.SendCalledWith;
+            (IEnumerable<EventData> calledWithEvents, SendEventOptions calledWithOptions) = transportProducer.SendCalledWith;
 
             Assert.That(calledWithEvents, Is.EquivalentTo(events), "The events should contain same elements.");
             Assert.That(calledWithOptions, Is.SameAs(options), "The options should be the same instance");
@@ -571,8 +571,8 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task CloseAsyncClosesTheTransportProducers()
         {
             var transportProducer = new ObservableTransportProducerMock();
-            var mockFirstBatch = new EventDataBatch(new MockTransportBatch(), new SendOptions { PartitionId = "1" });
-            var mockSecondBatch = new EventDataBatch(new MockTransportBatch(), new SendOptions { PartitionId = "2" });
+            var mockFirstBatch = new EventDataBatch(new MockTransportBatch(), new SendEventOptions { PartitionId = "1" });
+            var mockSecondBatch = new EventDataBatch(new MockTransportBatch(), new SendEventOptions { PartitionId = "2" });
             var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
             try { await producer.SendAsync(mockFirstBatch); } catch {}
@@ -594,7 +594,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var mockTransportProducer = new Mock<TransportProducer>();
             var mockConnection = new MockConnection(() => mockTransportProducer.Object);
-            var mockBatch = new EventDataBatch(new MockTransportBatch(), new SendOptions { PartitionId = "1" });;
+            var mockBatch = new EventDataBatch(new MockTransportBatch(), new SendEventOptions { PartitionId = "1" });;
             var producer = new EventHubProducerClient(mockConnection);
 
             mockTransportProducer
@@ -667,12 +667,12 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             public int CloseCallCount = 0;
             public bool WasCloseCalled = false;
-            public (IEnumerable<EventData>, SendOptions) SendCalledWith;
+            public (IEnumerable<EventData>, SendEventOptions) SendCalledWith;
             public EventDataBatch SendBatchCalledWith;
             public CreateBatchOptions CreateBatchCalledWith;
 
             public override Task SendAsync(IEnumerable<EventData> events,
-                                           SendOptions sendOptions,
+                                           SendEventOptions sendOptions,
                                            CancellationToken cancellationToken)
             {
                 SendCalledWith = (events, sendOptions);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventProcessorClient/EventProcessorClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventProcessorClient/EventProcessorClientLiveTests.cs
@@ -34,7 +34,7 @@ namespace Azure.Messaging.EventHubs.Tests
         private const int ReceiveRetryLimit = 10;
 
         /// <summary>The default retry policy to use for test operations.</summary>
-        private static readonly EventHubsRetryPolicy DefaultRetryPolicy = new RetryOptions().ToRetryPolicy();
+        private static readonly EventHubsRetryPolicy DefaultRetryPolicy = new EventHubsRetryOptions().ToRetryPolicy();
 
         /// <summary>
         ///   Verifies that the <see cref="EventProcessorClient" /> is able to
@@ -226,7 +226,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         await using (var producer = new EventHubProducerClient(connection))
                         {
-                            await producer.SendAsync(expectedEvents[partitionId], new SendOptions { PartitionId = partitionId });
+                            await producer.SendAsync(expectedEvents[partitionId], new SendEventOptions { PartitionId = partitionId });
                         }
                     }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventProcessorClient/EventProcessorClientOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventProcessorClient/EventProcessorClientOptionsTests.cs
@@ -25,9 +25,9 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new EventProcessorClientOptions
             {
                 MaximumReceiveWaitTime = TimeSpan.FromMinutes(65),
-                TrackLastEnqueuedEventInformation = false,
-                RetryOptions = new RetryOptions { TryTimeout = TimeSpan.FromMinutes(1), Delay = TimeSpan.FromMinutes(4) },
-                ConnectionOptions = new EventHubConnectionOptions { TransportType = TransportType.AmqpWebSockets }
+                TrackLastEnqueuedEventProperties = false,
+                RetryOptions = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromMinutes(1), Delay = TimeSpan.FromMinutes(4) },
+                ConnectionOptions = new EventHubConnectionOptions { TransportType = EventHubsTransportType.AmqpWebSockets }
             };
 
             EventProcessorClientOptions clone = options.Clone();
@@ -35,7 +35,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(clone, Is.Not.SameAs(options), "The clone should be a different instance.");
 
             Assert.That(clone.MaximumReceiveWaitTime, Is.EqualTo(options.MaximumReceiveWaitTime), "The maximum receive wait time of the clone should match.");
-            Assert.That(clone.TrackLastEnqueuedEventInformation, Is.EqualTo(options.TrackLastEnqueuedEventInformation), "The tracking of last event information of the clone should match.");
+            Assert.That(clone.TrackLastEnqueuedEventProperties, Is.EqualTo(options.TrackLastEnqueuedEventProperties), "The tracking of last event information of the clone should match.");
             Assert.That(clone.ConnectionOptions.TransportType, Is.EqualTo(options.ConnectionOptions.TransportType), "The connection options of the clone should copy properties.");
             Assert.That(clone.ConnectionOptions, Is.Not.SameAs(options.ConnectionOptions), "The connection options of the clone should be a copy, not the same instance.");
             Assert.That(clone.RetryOptions.IsEquivalentTo(options.RetryOptions), Is.True, "The retry options of the clone should be considered equal.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventProcessorClient/EventProcessorClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventProcessorClient/EventProcessorClientTests.cs
@@ -122,7 +122,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ConnectionStringConstructorSetsTheRetryPolicy()
         {
             var expected = Mock.Of<EventHubsRetryPolicy>();
-            var options = new EventProcessorClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = expected } };
+            var options = new EventProcessorClientOptions { RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = expected } };
             var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
             var processor = new EventProcessorClient(EventHubConsumerClient.DefaultConsumerGroupName, Mock.Of<PartitionManager>(), connectionString, options);
 
@@ -138,7 +138,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var expected = Mock.Of<EventHubsRetryPolicy>();
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
-            var options = new EventProcessorClientOptions { RetryOptions = new RetryOptions { CustomRetryPolicy = expected } };
+            var options = new EventProcessorClientOptions { RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = expected } };
             var processor = new EventProcessorClient(EventHubConsumerClient.DefaultConsumerGroupName, Mock.Of<PartitionManager>(), "namespace", "hubName", credential.Object, options);
 
             Assert.That(GetRetryPolicy(processor), Is.SameAs(expected));
@@ -160,7 +160,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(options, Is.Not.Null, $"The { constructorDescription } constructor should have set default options.");
             Assert.That(options, Is.Not.SameAs(defaultOptions), $"The { constructorDescription } constructor should not have the same options instance.");
             Assert.That(options.MaximumReceiveWaitTime, Is.EqualTo(defaultOptions.MaximumReceiveWaitTime), $"The { constructorDescription } constructor should have the correct maximum receive wait time.");
-            Assert.That(options.TrackLastEnqueuedEventInformation, Is.EqualTo(defaultOptions.TrackLastEnqueuedEventInformation), $"The { constructorDescription } constructor should default tracking of last event information.");
+            Assert.That(options.TrackLastEnqueuedEventProperties, Is.EqualTo(defaultOptions.TrackLastEnqueuedEventProperties), $"The { constructorDescription } constructor should default tracking of last event information.");
             Assert.That(options.ConnectionOptions.TransportType, Is.EqualTo(defaultOptions.ConnectionOptions.TransportType), $"The { constructorDescription } constructor should have a default set of connection options.");
             Assert.That(options.RetryOptions.IsEquivalentTo(defaultOptions.RetryOptions), Is.True, $"The { constructorDescription } constructor should have a default set of retry options.");
         }
@@ -176,8 +176,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new EventProcessorClientOptions
             {
                 MaximumReceiveWaitTime = TimeSpan.FromMinutes(65),
-                RetryOptions = new RetryOptions { TryTimeout = TimeSpan.FromMinutes(1), Delay = TimeSpan.FromMinutes(4) },
-                ConnectionOptions = new EventHubConnectionOptions { TransportType = TransportType.AmqpWebSockets }
+                RetryOptions = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromMinutes(1), Delay = TimeSpan.FromMinutes(4) },
+                ConnectionOptions = new EventHubConnectionOptions { TransportType = EventHubsTransportType.AmqpWebSockets }
             };
 
             var eventProcessor = new ReadableOptionsMock("consumerGroup", Mock.Of<PartitionManager>(), "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub", options);
@@ -186,7 +186,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(clonedOptions, Is.Not.Null, "The constructor should have set the options.");
             Assert.That(clonedOptions, Is.Not.SameAs(options), "The constructor should have cloned the options.");
             Assert.That(clonedOptions.MaximumReceiveWaitTime, Is.EqualTo(options.MaximumReceiveWaitTime), "The constructor should have the correct maximum receive wait time.");
-            Assert.That(clonedOptions.TrackLastEnqueuedEventInformation, Is.EqualTo(options.TrackLastEnqueuedEventInformation), "The tracking of last event information of the clone should match.");
+            Assert.That(clonedOptions.TrackLastEnqueuedEventProperties, Is.EqualTo(options.TrackLastEnqueuedEventProperties), "The tracking of last event information of the clone should match.");
             Assert.That(clonedOptions.ConnectionOptions.TransportType, Is.EqualTo(options.ConnectionOptions.TransportType), "The connection options of the clone should copy properties.");
             Assert.That(clonedOptions.ConnectionOptions, Is.Not.SameAs(options.ConnectionOptions), "The connection options of the clone should be a copy, not the same instance.");
             Assert.That(clonedOptions.RetryOptions.IsEquivalentTo(options.RetryOptions), Is.True, "The retry options of the clone should be considered equal.");
@@ -204,8 +204,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new EventProcessorClientOptions
             {
                 MaximumReceiveWaitTime = TimeSpan.FromMinutes(65),
-                RetryOptions = new RetryOptions { TryTimeout = TimeSpan.FromMinutes(1), Delay = TimeSpan.FromMinutes(4) },
-                ConnectionOptions = new EventHubConnectionOptions { TransportType = TransportType.AmqpWebSockets }
+                RetryOptions = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromMinutes(1), Delay = TimeSpan.FromMinutes(4) },
+                ConnectionOptions = new EventHubConnectionOptions { TransportType = EventHubsTransportType.AmqpWebSockets }
             };
 
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
@@ -215,7 +215,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(clonedOptions, Is.Not.Null, "The constructor should have set the options.");
             Assert.That(clonedOptions, Is.Not.SameAs(options), "The constructor should have cloned the options.");
             Assert.That(clonedOptions.MaximumReceiveWaitTime, Is.EqualTo(options.MaximumReceiveWaitTime), "The constructor should have the correct maximum receive wait time.");
-            Assert.That(clonedOptions.TrackLastEnqueuedEventInformation, Is.EqualTo(options.TrackLastEnqueuedEventInformation), "The tracking of last event information of the clone should match.");
+            Assert.That(clonedOptions.TrackLastEnqueuedEventProperties, Is.EqualTo(options.TrackLastEnqueuedEventProperties), "The tracking of last event information of the clone should match.");
             Assert.That(clonedOptions.ConnectionOptions.TransportType, Is.EqualTo(options.ConnectionOptions.TransportType), "The connection options of the clone should copy properties.");
             Assert.That(clonedOptions.ConnectionOptions, Is.Not.SameAs(options.ConnectionOptions), "The connection options of the clone should be a copy, not the same instance.");
             Assert.That(clonedOptions.RetryOptions.IsEquivalentTo(options.RetryOptions), Is.True, "The retry options of the clone should be considered equal.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventHubsRetryOptionsExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventHubsRetryOptionsExtensions.cs
@@ -6,11 +6,11 @@ using System;
 namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
-    ///   The set of extension methods for the <see cref="RetryOptions" />
+    ///   The set of extension methods for the <see cref="EventHubsRetryOptions" />
     ///   class.
     /// </summary>
     ///
-    internal static class RetryOptionsExtensions
+    internal static class EventHubsRetryOptionsExtensions
     {
         /// <summary>
         ///   Compares retry options between two instances to determine if the
@@ -22,8 +22,8 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         /// <returns><c>true</c>, if the two sets of options are structurally equivalent; otherwise, <c>false</c>.</returns>
         ///
-        public static bool IsEquivalentTo(this RetryOptions instance,
-                                          RetryOptions other)
+        public static bool IsEquivalentTo(this EventHubsRetryOptions instance,
+                                          EventHubsRetryOptions other)
         {
             // If the events are the same instance, they're equal.  This should only happen
             // if both are null or they are the exact same instance.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventHubsRetryOptionsExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventHubsRetryOptionsExtensionsTests.cs
@@ -9,99 +9,99 @@ using NUnit.Framework;
 namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
-    ///   The suite of tests for the <see cref="RetryOptionsExtensions" />
+    ///   The suite of tests for the <see cref="EventHubsRetryOptionsExtensions" />
     ///   class.
     /// </summary>
     ///
     [TestFixture]
-    public class RetryOptionsExtensionsTests
+    public class EventHubsRetryOptionsExtensionsTests
     {
         /// <summary>
-        ///   Verifies functionality of the <see cref="RetryOptionsExtensions.IsEquivalentTo" /> test
+        ///   Verifies functionality of the <see cref="EventHubsRetryOptionsExtensions.IsEquivalentTo" /> test
         ///   helper.
         /// </summary>
         ///
         [Test]
         public void IsEquivalentToDetectsModes()
         {
-            var first = new RetryOptions { Mode = RetryMode.Exponential };
-            var second = new RetryOptions { Mode = RetryMode.Fixed };
+            var first = new EventHubsRetryOptions { Mode = EventHubsRetryMode.Exponential };
+            var second = new EventHubsRetryOptions { Mode = EventHubsRetryMode.Fixed };
 
             Assert.That(first.IsEquivalentTo(second), Is.False);
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="RetryOptionsExtensions.IsEquivalentTo" /> test
+        ///   Verifies functionality of the <see cref="EventHubsRetryOptionsExtensions.IsEquivalentTo" /> test
         ///   helper.
         /// </summary>
         ///
         [Test]
         public void IsEquivalentToDetectsMaximumRetries()
         {
-            var first = new RetryOptions { MaximumRetries = 7 };
-            var second = new RetryOptions { MaximumRetries = 99 };
+            var first = new EventHubsRetryOptions { MaximumRetries = 7 };
+            var second = new EventHubsRetryOptions { MaximumRetries = 99 };
 
             Assert.That(first.IsEquivalentTo(second), Is.False);
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="RetryOptionsExtensions.IsEquivalentTo" /> test
+        ///   Verifies functionality of the <see cref="EventHubsRetryOptionsExtensions.IsEquivalentTo" /> test
         ///   helper.
         /// </summary>
         ///
         [Test]
         public void IsEquivalentToDetectsMaximumDelay()
         {
-            var first = new RetryOptions { MaximumDelay = TimeSpan.FromSeconds(7) };
-            var second = new RetryOptions { MaximumDelay = TimeSpan.FromSeconds(8) };
+            var first = new EventHubsRetryOptions { MaximumDelay = TimeSpan.FromSeconds(7) };
+            var second = new EventHubsRetryOptions { MaximumDelay = TimeSpan.FromSeconds(8) };
 
             Assert.That(first.IsEquivalentTo(second), Is.False);
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="RetryOptionsExtensions.IsEquivalentTo" /> test
+        ///   Verifies functionality of the <see cref="EventHubsRetryOptionsExtensions.IsEquivalentTo" /> test
         ///   helper.
         /// </summary>
         ///
         [Test]
         public void IsEquivalentToDetectsDelay()
         {
-            var first = new RetryOptions { Delay = TimeSpan.FromSeconds(7) };
-            var second = new RetryOptions { Delay = TimeSpan.FromMinutes(1) };
+            var first = new EventHubsRetryOptions { Delay = TimeSpan.FromSeconds(7) };
+            var second = new EventHubsRetryOptions { Delay = TimeSpan.FromMinutes(1) };
 
             Assert.That(first.IsEquivalentTo(second), Is.False);
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="RetryOptionsExtensions.IsEquivalentTo" /> test
+        ///   Verifies functionality of the <see cref="EventHubsRetryOptionsExtensions.IsEquivalentTo" /> test
         ///   helper.
         /// </summary>
         ///
         [Test]
         public void IsEquivalentToDetectsTryTimeout()
         {
-            var first = new RetryOptions { TryTimeout = TimeSpan.FromSeconds(9) };
-            var second = new RetryOptions { TryTimeout = TimeSpan.FromSeconds(8) };
+            var first = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(9) };
+            var second = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromSeconds(8) };
 
             Assert.That(first.IsEquivalentTo(second), Is.False);
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="RetryOptionsExtensions.IsEquivalentTo" /> test
+        ///   Verifies functionality of the <see cref="EventHubsRetryOptionsExtensions.IsEquivalentTo" /> test
         ///   helper.
         /// </summary>
         ///
         [Test]
         public void IsEquivalentToDetectsCustomPolicy()
         {
-            var first = new RetryOptions { CustomRetryPolicy = Mock.Of<EventHubsRetryPolicy>() };
-            var second = new RetryOptions { CustomRetryPolicy = new BasicRetryPolicy(new RetryOptions()) };
+            var first = new EventHubsRetryOptions { CustomRetryPolicy = Mock.Of<EventHubsRetryPolicy>() };
+            var second = new EventHubsRetryOptions { CustomRetryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions()) };
 
             Assert.That(first.IsEquivalentTo(second), Is.False);
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="RetryOptionsExtensions.IsEquivalentTo" /> test
+        ///   Verifies functionality of the <see cref="EventHubsRetryOptionsExtensions.IsEquivalentTo" /> test
         ///   helper.
         /// </summary>
         ///
@@ -109,23 +109,23 @@ namespace Azure.Messaging.EventHubs.Tests
         public void IsEquivalentToDetectsEqualOptionSets()
         {
             var customPolicy = Mock.Of<EventHubsRetryPolicy>();
-            var first = new RetryOptions { CustomRetryPolicy = customPolicy };
-            var second = new RetryOptions { CustomRetryPolicy = customPolicy };
+            var first = new EventHubsRetryOptions { CustomRetryPolicy = customPolicy };
+            var second = new EventHubsRetryOptions { CustomRetryPolicy = customPolicy };
 
             Assert.That(first.IsEquivalentTo(second), Is.True);
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="RetryOptionsExtensions.IsEquivalentTo" /> test
+        ///   Verifies functionality of the <see cref="EventHubsRetryOptionsExtensions.IsEquivalentTo" /> test
         ///   helper.
         /// </summary>
         ///
         [Test]
         public void IsEquivalentToDetectsSameInstance()
         {
-            var first = new RetryOptions
+            var first = new EventHubsRetryOptions
             {
-                Mode = RetryMode.Fixed,
+                Mode = EventHubsRetryMode.Fixed,
                 MaximumRetries = 99,
                 MaximumDelay = TimeSpan.FromMinutes(3),
                 Delay = TimeSpan.FromSeconds(4),
@@ -136,54 +136,54 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="RetryOptionsExtensions.IsEquivalentTo" /> test
+        ///   Verifies functionality of the <see cref="EventHubsRetryOptionsExtensions.IsEquivalentTo" /> test
         ///   helper.
         /// </summary>
         ///
         [Test]
         public void IsEquivalentToDetectsTwoNulls()
         {
-            Assert.That(((RetryOptions)null).IsEquivalentTo(null), Is.True);
+            Assert.That(((EventHubsRetryOptions)null).IsEquivalentTo(null), Is.True);
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="RetryOptionsExtensions.IsEquivalentTo" /> test
+        ///   Verifies functionality of the <see cref="EventHubsRetryOptionsExtensions.IsEquivalentTo" /> test
         ///   helper.
         /// </summary>
         ///
         [Test]
         public void IsEquivalentToDetectsNullInstance()
         {
-            var first = new RetryOptions
+            var first = new EventHubsRetryOptions
             {
-                Mode = RetryMode.Fixed,
+                Mode = EventHubsRetryMode.Fixed,
                 MaximumRetries = 99,
                 MaximumDelay = TimeSpan.FromMinutes(3),
                 Delay = TimeSpan.FromSeconds(4),
                 TryTimeout = TimeSpan.Zero
             };
 
-            Assert.That(((RetryOptions)null).IsEquivalentTo(first), Is.False);
+            Assert.That(((EventHubsRetryOptions)null).IsEquivalentTo(first), Is.False);
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="RetryOptionsExtensions.IsEquivalentTo" /> test
+        ///   Verifies functionality of the <see cref="EventHubsRetryOptionsExtensions.IsEquivalentTo" /> test
         ///   helper.
         /// </summary>
         ///
         [Test]
         public void IsEquivalentToDetectsNullArgument()
         {
-            var first = new RetryOptions
+            var first = new EventHubsRetryOptions
             {
-                Mode = RetryMode.Fixed,
+                Mode = EventHubsRetryMode.Fixed,
                 MaximumRetries = 99,
                 MaximumDelay = TimeSpan.FromMinutes(3),
                 Delay = TimeSpan.FromSeconds(4),
                 TryTimeout = TimeSpan.Zero
             };
 
-            Assert.That(first.IsEquivalentTo((RetryOptions)null), Is.False);
+            Assert.That(first.IsEquivalentTo((EventHubsRetryOptions)null), Is.False);
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/RetryPolicies/BasicRetryPolicyTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/RetryPolicies/BasicRetryPolicyTests.cs
@@ -95,7 +95,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CalulateTryTimeoutRespectsOptions(int attemptCount)
         {
             var timeout = TimeSpan.FromSeconds(5);
-            var options = new RetryOptions { TryTimeout = timeout };
+            var options = new EventHubsRetryOptions { TryTimeout = timeout };
             var policy = new BasicRetryPolicy(options);
 
             Assert.That(policy.CalculateTryTimeout(attemptCount), Is.EqualTo(options.TryTimeout));
@@ -109,12 +109,12 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void CalculateRetryDelayDoesNotRetryWhenThereIsNoMaximumRetries()
         {
-            var policy = new BasicRetryPolicy(new RetryOptions
+            var policy = new BasicRetryPolicy(new EventHubsRetryOptions
             {
                 MaximumRetries = 0,
                 Delay = TimeSpan.FromSeconds(1),
                 MaximumDelay = TimeSpan.FromHours(1),
-                Mode = RetryMode.Fixed
+                Mode = EventHubsRetryMode.Fixed
             });
 
             Assert.That(policy.CalculateRetryDelay(Mock.Of<TimeoutException>(), -1), Is.Null);
@@ -128,12 +128,12 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void CalculateRetryDelayDoesNotRetryWhenThereIsNoMaximumDelay()
         {
-            var policy = new BasicRetryPolicy(new RetryOptions
+            var policy = new BasicRetryPolicy(new EventHubsRetryOptions
             {
                 MaximumRetries = 99,
                 Delay = TimeSpan.FromSeconds(1),
                 MaximumDelay = TimeSpan.Zero,
-                Mode = RetryMode.Fixed
+                Mode = EventHubsRetryMode.Fixed
             });
 
             Assert.That(policy.CalculateRetryDelay(Mock.Of<TimeoutException>(), 88), Is.Null);
@@ -151,12 +151,12 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase(200)]
         public void CalculateRetryDelayDoesNotRetryWhenAttemptsExceedTheMaximum(int retryAttempt)
         {
-            var policy = new BasicRetryPolicy(new RetryOptions
+            var policy = new BasicRetryPolicy(new EventHubsRetryOptions
             {
                 MaximumRetries = 5,
                 Delay = TimeSpan.FromSeconds(1),
                 MaximumDelay = TimeSpan.FromHours(1),
-                Mode = RetryMode.Fixed
+                Mode = EventHubsRetryMode.Fixed
             });
 
             Assert.That(policy.CalculateRetryDelay(Mock.Of<TimeoutException>(), retryAttempt), Is.Null);
@@ -170,12 +170,12 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void CalculateRetryDelayAllowsRetryForTransientExceptions()
         {
-            var policy = new BasicRetryPolicy(new RetryOptions
+            var policy = new BasicRetryPolicy(new EventHubsRetryOptions
             {
                 MaximumRetries = 99,
                 Delay = TimeSpan.FromSeconds(1),
                 MaximumDelay = TimeSpan.FromSeconds(100),
-                Mode = RetryMode.Fixed
+                Mode = EventHubsRetryMode.Fixed
             });
 
             Assert.That(policy.CalculateRetryDelay(new EventHubsException(true, null, null), 88), Is.Not.Null);
@@ -190,12 +190,12 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCaseSource(nameof(RetriableExceptionTestCases))]
         public void CalculateRetryDelayAllowsRetryForKnownRetriableExceptions(Exception exception)
         {
-            var policy = new BasicRetryPolicy(new RetryOptions
+            var policy = new BasicRetryPolicy(new EventHubsRetryOptions
             {
                 MaximumRetries = 99,
                 Delay = TimeSpan.FromSeconds(1),
                 MaximumDelay = TimeSpan.FromSeconds(100),
-                Mode = RetryMode.Fixed
+                Mode = EventHubsRetryMode.Fixed
             });
 
             Assert.That(policy.CalculateRetryDelay(exception, 88), Is.Not.Null);
@@ -210,12 +210,12 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCaseSource(nameof(NonRetriableExceptionTestCases))]
         public void CalculateRetryDelayDoesNotRetryForNotKnownRetriableExceptions(Exception exception)
         {
-            var policy = new BasicRetryPolicy(new RetryOptions
+            var policy = new BasicRetryPolicy(new EventHubsRetryOptions
             {
                 MaximumRetries = 99,
                 Delay = TimeSpan.FromSeconds(1),
                 MaximumDelay = TimeSpan.FromSeconds(100),
-                Mode = RetryMode.Fixed
+                Mode = EventHubsRetryMode.Fixed
             });
 
             Assert.That(policy.CalculateRetryDelay(exception, 88), Is.Null);
@@ -234,12 +234,12 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase(240)]
         public void CalculateRetryDelayRespectsMaximumDuration(int delaySeconds)
         {
-            var policy = new BasicRetryPolicy(new RetryOptions
+            var policy = new BasicRetryPolicy(new EventHubsRetryOptions
             {
                 MaximumRetries = 99,
                 Delay = TimeSpan.FromSeconds(delaySeconds),
                 MaximumDelay = TimeSpan.FromSeconds(1),
-                Mode = RetryMode.Fixed
+                Mode = EventHubsRetryMode.Fixed
             });
 
             Assert.That(policy.CalculateRetryDelay(Mock.Of<TimeoutException>(), 88), Is.EqualTo(policy.Options.MaximumDelay));
@@ -258,12 +258,12 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase(120)]
         public void CalculateRetryDelayUsesFixedMode(int iterations)
         {
-            var policy = new BasicRetryPolicy(new RetryOptions
+            var policy = new BasicRetryPolicy(new EventHubsRetryOptions
             {
                 MaximumRetries = 99,
                 Delay = TimeSpan.FromSeconds(iterations),
                 MaximumDelay = TimeSpan.FromHours(72),
-                Mode = RetryMode.Fixed
+                Mode = EventHubsRetryMode.Fixed
             });
 
             var variance = TimeSpan.FromSeconds(policy.Options.Delay.TotalSeconds * policy.JitterFactor);
@@ -287,12 +287,12 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase(25)]
         public void CalculateRetryDelayUsesExponentialMode(int iterations)
         {
-            var policy = new BasicRetryPolicy(new RetryOptions
+            var policy = new BasicRetryPolicy(new EventHubsRetryOptions
             {
                 MaximumRetries = 99,
                 Delay = TimeSpan.FromMilliseconds(15),
                 MaximumDelay = TimeSpan.FromHours(50000),
-                Mode = RetryMode.Exponential
+                Mode = EventHubsRetryMode.Exponential
             });
 
             TimeSpan previousDelay = TimeSpan.Zero;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/RetryPolicies/EventHubsRetryOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/RetryPolicies/EventHubsRetryOptionsTests.cs
@@ -9,24 +9,24 @@ using NUnit.Framework;
 namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
-    ///   The suite of tests for the <see cref="RetryOptions" />
+    ///   The suite of tests for the <see cref="EventHubsRetryOptions" />
     ///   class.
     /// </summary>
     ///
     [TestFixture]
-    public class RetryOptionsTests
+    public class EventHubsRetryOptionsTests
     {
         /// <summary>
-        ///   Verifies functionality of the <see cref="RetryOptions.Clone" />
+        ///   Verifies functionality of the <see cref="EventHubsRetryOptions.Clone" />
         ///   method.
         /// </summary>
         ///
         [Test]
         public void CloneProducesACopy()
         {
-            var options = new RetryOptions
+            var options = new EventHubsRetryOptions
             {
-                Mode = RetryMode.Fixed,
+                Mode = EventHubsRetryMode.Fixed,
                 MaximumRetries = 65,
                 Delay = TimeSpan.FromSeconds(1),
                 MaximumDelay = TimeSpan.FromSeconds(2),
@@ -34,7 +34,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 CustomRetryPolicy = Mock.Of<EventHubsRetryPolicy>()
             };
 
-            RetryOptions clone = options.Clone();
+            EventHubsRetryOptions clone = options.Clone();
             Assert.That(clone, Is.Not.Null, "The clone should not be null.");
 
             Assert.That(clone.Mode, Is.EqualTo(options.Mode), "The mode of the clone should match.");
@@ -46,7 +46,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///  Verifies that setting the <see cref="RetryOptions.MaximumRetries" /> is
+        ///  Verifies that setting the <see cref="EventHubsRetryOptions.MaximumRetries" /> is
         ///  validated.
         /// </summary>
         ///
@@ -59,12 +59,12 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase(1000)]
         public void MaximumRetriesIsValidated(int invalidValue)
         {
-            var options = new RetryOptions();
+            var options = new EventHubsRetryOptions();
             Assert.That(() => options.MaximumRetries = invalidValue, Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
-        ///  Verifies that setting the <see cref="RetryOptions.Delay" /> is
+        ///  Verifies that setting the <see cref="EventHubsRetryOptions.Delay" /> is
         ///  validated.
         /// </summary>
         ///
@@ -78,13 +78,13 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase(500)]
         public void DelayIsValidated(int seconds)
         {
-            var options = new RetryOptions();
+            var options = new EventHubsRetryOptions();
             var invalidValue = TimeSpan.FromSeconds(seconds);
             Assert.That(() => options.Delay = invalidValue, Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
-        ///  Verifies that setting the <see cref="RetryOptions.MaximumDelay" /> is
+        ///  Verifies that setting the <see cref="EventHubsRetryOptions.MaximumDelay" /> is
         ///  validated.
         /// </summary>
         ///
@@ -94,13 +94,13 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase(-9999)]
         public void MaximumDelayIsValidated(int seconds)
         {
-            var options = new RetryOptions();
+            var options = new EventHubsRetryOptions();
             var invalidValue = TimeSpan.FromSeconds(seconds);
             Assert.That(() => options.MaximumDelay = invalidValue, Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
-        ///  Verifies that setting the <see cref="RetryOptions.TryTimeout" /> is
+        ///  Verifies that setting the <see cref="EventHubsRetryOptions.TryTimeout" /> is
         ///  validated.
         /// </summary>
         ///
@@ -113,22 +113,22 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase(5000)]
         public void TryTimeoutIsValidated(int seconds)
         {
-            var options = new RetryOptions();
+            var options = new EventHubsRetryOptions();
             var invalidValue = TimeSpan.FromSeconds(seconds);
             Assert.That(() => options.TryTimeout = invalidValue, Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="RetryOptions.Clone" />
+        ///   Verifies functionality of the <see cref="EventHubsRetryOptions.Clone" />
         ///   method.
         /// </summary>
         ///
         [Test]
         public void ToRetryPolicyWithoutCustomPolicyCreatesThePolicy()
         {
-            var options = new RetryOptions
+            var options = new EventHubsRetryOptions
             {
-                Mode = RetryMode.Fixed,
+                Mode = EventHubsRetryMode.Fixed,
                 MaximumRetries = 65,
                 Delay = TimeSpan.FromSeconds(1),
                 MaximumDelay = TimeSpan.FromSeconds(2),
@@ -144,16 +144,16 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="RetryOptions.Clone" />
+        ///   Verifies functionality of the <see cref="EventHubsRetryOptions.Clone" />
         ///   method.
         /// </summary>
         ///
         [Test]
         public void ToRetryPolicyWithCustomPolicyUsesTheCustomPolicy()
         {
-            var options = new RetryOptions
+            var options = new EventHubsRetryOptions
             {
-                Mode = RetryMode.Fixed,
+                Mode = EventHubsRetryMode.Fixed,
                 MaximumRetries = 65,
                 Delay = TimeSpan.FromSeconds(1),
                 MaximumDelay = TimeSpan.FromSeconds(2),


### PR DESCRIPTION
# Summary

The focus of these changes is to perform minor cleanup on the Event Hubs types and members in order to to incorporate feedback from the architecture board in the final review. The following items are included:

- `RetryMode` has been renamed to `EventHubsRetryMode`
- `RetryOptions` has been renamed to `EventHubsRetryOptions`
- `TransportType` has been renamed to `EventHubsTransportType`
- `ReadOptions` has been renamed to `ReadEventOptons`
- `SendOptions` has been renamed to `SendEventOptions` _(internal-facing change)_
- Types and members using `LastEnqueuedEventInformation` have been aligned to the terminology `LastEnqueuedEventProperties` to reflect the associated type.
- `EventHubsSharedKeyCredential` has been made internal pending review; it is planned to return to the public scope in a future release.

# Last Upstream Rebase

Thursday, November 21, 1:12pm (EST)

# Related and Follow-Up Issues

- [Release Event Hubs Track 2 Library for .NET](https://github.com/Azure/azure-sdk-for-net/issues/8552) (#8552) 
- [Incorporate architecture board review feedback](https://github.com/Azure/azure-sdk-for-net/issues/8583) (#8583) 