### PR TITLE
Update logic that verifies project references

### DIFF
--- a/eng/Directory.Build.Data.targets
+++ b/eng/Directory.Build.Data.targets
@@ -106,11 +106,11 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(UseProjectReferenceToAzureClients)' == 'true'">
-      <ShouldBeProjectReference Include="@(AzureReferences)" Condition="!Exists('%(MSBuildSourceProjectFile)')" />
+      <ShouldBeProjectReference Include="@(AzureReferences)" Exclude="@(AzureReferences->HasMetadata('MSBuildSourceProjectFile'))" />
     </ItemGroup>
 
     <Error Condition="'$(UseProjectReferenceToAzureClients)' == 'true' and '@(ShouldBeProjectReference)' != ''"
-           Text="Expected to have all Azure references to be Project References, but found [@(ShouldBeProjectReference)] are not." />
+           Text="When UseProjectReferenceToAzureClients=true all Azure.* references should be Project References, but the following are not [@(ShouldBeProjectReference)]" />
   </Target>
 
   <Import Project="$(CentralPackageVersionPackagePath)\Sdk.targets" />


### PR DESCRIPTION
PTAL @pakrym @jsquire 

Based on some recent confusion I've updated the checking logic so that it will actually reach the error message instead of failing in a strange msbuild error. Also updated the error text to make it clear that all Azure.* references should be project references in this mode. 

This helps with https://github.com/Azure/azure-sdk-for-net/issues/8856. 