### PR TITLE
Update HttpBearerTokenAuthenticationPolicy to block non-TLS endpoints

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Release History
 
-## 1.1.0-preview1
+## Unreleased
+
+- Block bearer token authentication for non TLS protected endpoints.
 
 ## 1.0.1
 

--- a/sdk/core/Azure.Core/src/Pipeline/BearerTokenAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/BearerTokenAuthenticationPolicy.cs
@@ -59,6 +59,11 @@ namespace Azure.Core.Pipeline
         /// <inheritdoc />
         private async ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline, bool async)
         {
+            if (message.Request.Uri.Scheme != Uri.UriSchemeHttps)
+            {
+                throw new InvalidOperationException("Bearer token authentication is not permitted for non TLS protected (https) endpoints.");
+            }
+
             if (DateTimeOffset.UtcNow >= _refreshOn)
             {
                 AccessToken token = async ?

--- a/sdk/core/Azure.Core/tests/TestFramework/SyncAsyncPolicyTestBase.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/SyncAsyncPolicyTestBase.cs
@@ -43,12 +43,12 @@ namespace Azure.Core.Testing
             return await SendRequestAsync(pipeline, requestAction, bufferResponse, CancellationToken.None);
         }
 
-        protected async Task<Response> SendGetRequest(HttpPipelineTransport transport, HttpPipelinePolicy policy, ResponseClassifier responseClassifier = null, bool bufferResponse = true)
+        protected async Task<Response> SendGetRequest(HttpPipelineTransport transport, HttpPipelinePolicy policy, ResponseClassifier responseClassifier = null, bool bufferResponse = true, Uri uri = null)
         {
             return await SendRequestAsync(transport, request =>
             {
                 request.Method = RequestMethod.Get;
-                request.Uri.Reset(new Uri("http://example.com"));
+                request.Uri.Reset(uri ?? new Uri("http://example.com"));
             }, policy, responseClassifier, bufferResponse);
         }
     }


### PR DESCRIPTION
Updated `HttpBearerTokenAuthenticationPolicy` to throw `InvalidOperationException` when invoked on requests with http protocol rather than https, to prevent sending requests with bearer tokens in clear text.