### PR TITLE
[WIP] Adding configuration to allow users to permit bearer token auth over HTTP instead of HTTPS via TokenCredential

### DIFF
--- a/eng/Directory.Build.Data.targets
+++ b/eng/Directory.Build.Data.targets
@@ -80,7 +80,7 @@
   <PropertyGroup>
     <CentralPackagesFile>$(MSBuildThisFileDirectory)Packages.Data.props</CentralPackagesFile>
     <CentralPackageVersionPackagePath>$(MSBuildThisFileDirectory)Microsoft.Build.CentralPackageVersions\2.0.46\Sdk</CentralPackageVersionPackagePath>
-    <UseProjectReferenceToAzureClients Condition="'$(UseProjectReferenceToAzureClients)' == ''">false</UseProjectReferenceToAzureClients>
+    <UseProjectReferenceToAzureClients Condition="'$(UseProjectReferenceToAzureClients)' == ''">true</UseProjectReferenceToAzureClients>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UseProjectReferenceToAzureClients)' == 'true'">

--- a/sdk/core/Azure.Core/src/Pipeline/BearerTokenAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/BearerTokenAuthenticationPolicy.cs
@@ -59,9 +59,9 @@ namespace Azure.Core.Pipeline
         /// <inheritdoc />
         private async ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline, bool async)
         {
-            if (message.Request.Uri.Scheme != Uri.UriSchemeHttps)
+            if ((message.Request.Uri.Scheme != Uri.UriSchemeHttps) && (!_credential.AllowInsecureTransport))
             {
-                throw new InvalidOperationException("Bearer token authentication is not permitted for non TLS protected (https) endpoints.");
+                throw new InvalidOperationException("The specified TokenCredential does not permit authentication on non TLS protected (https) endpoints.");
             }
 
             if (DateTimeOffset.UtcNow >= _refreshOn)

--- a/sdk/core/Azure.Core/src/TokenCredential.cs
+++ b/sdk/core/Azure.Core/src/TokenCredential.cs
@@ -12,6 +12,11 @@ namespace Azure.Core
     public abstract class TokenCredential
     {
         /// <summary>
+        /// Gets a value indicating whether the tokens provided by the <see cref="TokenCredential"/> should be sent over non TLS protected connections. The default is false.
+        /// </summary>
+        public virtual bool AllowInsecureTransport { get { return false; } }
+
+        /// <summary>
         /// Gets an <see cref="AccessToken"/> for the specified set of scopes.
         /// </summary>
         /// <param name="requestContext">The <see cref="TokenRequestContext"/> with authentication information.</param>

--- a/sdk/identity/Azure.Identity/src/AuthorizationCodeCredential.cs
+++ b/sdk/identity/Azure.Identity/src/AuthorizationCodeCredential.cs
@@ -68,7 +68,12 @@ namespace Azure.Identity
             _confidentialClient = ConfidentialClientApplicationBuilder.Create(clientId).WithHttpClientFactory(new HttpPipelineClientFactory(_pipeline)).WithTenantId(tenantId).WithClientSecret(clientSecret).Build();
 
             _clientDiagnostics = new ClientDiagnostics(options);
+
+            AllowInsecureTransport = options != null ? options.AllowInsecureTransport : false;
         }
+
+        /// <inheritdoc/>
+        public override bool AllowInsecureTransport { get; } = false;
 
         /// <summary>
         /// Obtains a token from the Azure Active Directory service, using the specified authorization code authenticate. This method is called by Azure SDK clients. It isn't intended for use in application code.

--- a/sdk/identity/Azure.Identity/src/ClientCertificateCredential.cs
+++ b/sdk/identity/Azure.Identity/src/ClientCertificateCredential.cs
@@ -64,6 +64,7 @@ namespace Azure.Identity
             : this(tenantId, clientId, clientCertificate, CredentialPipeline.GetInstance(options))
 
         {
+            AllowInsecureTransport = options != null ? options.AllowInsecureTransport : false;
         }
 
         internal ClientCertificateCredential(string tenantId, string clientId, X509Certificate2 clientCertificate, CredentialPipeline pipeline)
@@ -83,6 +84,9 @@ namespace Azure.Identity
 
             _client = client;
         }
+
+        /// <inheritdoc/>
+        public override bool AllowInsecureTransport { get; } = false;
 
         /// <summary>
         /// Obtains a token from the Azure Active Directory service, using the specified X509 certificate to authenticate. This method is called by Azure SDK clients. It isn't intended for use in application code.

--- a/sdk/identity/Azure.Identity/src/ClientSecretCredential.cs
+++ b/sdk/identity/Azure.Identity/src/ClientSecretCredential.cs
@@ -61,6 +61,7 @@ namespace Azure.Identity
         public ClientSecretCredential(string tenantId, string clientId, string clientSecret, TokenCredentialOptions options)
             : this (tenantId, clientId, clientSecret, CredentialPipeline.GetInstance(options))
         {
+            AllowInsecureTransport = options != null ? options.AllowInsecureTransport : false;
         }
 
         internal ClientSecretCredential(string tenantId, string clientId, string clientSecret, CredentialPipeline pipeline)
@@ -80,6 +81,9 @@ namespace Azure.Identity
 
             _client = client;
         }
+
+        /// <inheritdoc/>
+        public override bool AllowInsecureTransport { get; } = false;
 
         /// <summary>
         /// Obtains a token from the Azure Active Directory service, using the specified client secret to authenticate. This method is called by Azure SDK clients. It isn't intended for use in application code.

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredential.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredential.cs
@@ -58,7 +58,12 @@ namespace Azure.Identity
             _pipeline = factory.Pipeline;
 
             _sources = GetDefaultAzureCredentialChain(factory, options);
+
+            AllowInsecureTransport = options != null ? options.AllowInsecureTransport : false;
         }
+
+        /// <inheritdoc/>
+        public override bool AllowInsecureTransport { get; } = false;
 
         /// <summary>
         /// Sequentially calls <see cref="TokenCredential.GetToken"/> on all the included credentials in the order <see cref="EnvironmentCredential"/>, <see cref="ManagedIdentityCredential"/>, <see cref="SharedTokenCacheCredential"/>,

--- a/sdk/identity/Azure.Identity/src/DeviceCodeCredential.cs
+++ b/sdk/identity/Azure.Identity/src/DeviceCodeCredential.cs
@@ -56,6 +56,7 @@ namespace Azure.Identity
         public DeviceCodeCredential(Func<DeviceCodeInfo, CancellationToken, Task> deviceCodeCallback, string tenantId, string clientId,  TokenCredentialOptions options = default)
             : this(deviceCodeCallback, tenantId, clientId, CredentialPipeline.GetInstance(options))
         {
+            AllowInsecureTransport = options != null ? options.AllowInsecureTransport : false;
         }
 
         internal DeviceCodeCredential(Func<DeviceCodeInfo, CancellationToken, Task> deviceCodeCallback, string tenantId, string clientId, CredentialPipeline pipeline)
@@ -73,6 +74,10 @@ namespace Azure.Identity
 
             _client = client;
         }
+
+        /// <inheritdoc/>
+        public override bool AllowInsecureTransport { get; } = false;
+
         /// <summary>
         /// Obtains a token for a user account, authenticating them through the device code authentication flow. This method is called by Azure SDK clients. It isn't intended for use in application code.
         /// </summary>

--- a/sdk/identity/Azure.Identity/src/EnvironmentCredential.cs
+++ b/sdk/identity/Azure.Identity/src/EnvironmentCredential.cs
@@ -47,7 +47,11 @@ namespace Azure.Identity
         public EnvironmentCredential(TokenCredentialOptions options)
             : this(CredentialPipeline.GetInstance(options))
         {
+            AllowInsecureTransport = options != null ? options.AllowInsecureTransport : false;
         }
+
+        /// <inheritdoc/>
+        public override bool AllowInsecureTransport { get; } = false;
 
         internal EnvironmentCredential(CredentialPipeline pipeline)
         {

--- a/sdk/identity/Azure.Identity/src/InteractiveBrowserCredential.cs
+++ b/sdk/identity/Azure.Identity/src/InteractiveBrowserCredential.cs
@@ -49,6 +49,7 @@ namespace Azure.Identity
         public InteractiveBrowserCredential(string tenantId, string clientId, TokenCredentialOptions options = default)
             : this(tenantId, clientId, CredentialPipeline.GetInstance(options))
         {
+            AllowInsecureTransport = options != null ? options.AllowInsecureTransport : false;
         }
 
         internal InteractiveBrowserCredential(string tenantId, string clientId, CredentialPipeline pipeline)
@@ -66,6 +67,10 @@ namespace Azure.Identity
 
             _client = client;
         }
+
+        /// <inheritdoc/>
+        public override bool AllowInsecureTransport { get; } = false;
+
 
         /// <summary>
         /// Obtains an <see cref="AccessToken"/> token for a user account silently if the user has already authenticated, otherwise the default browser is launched to authenticate the user. This method is called by Azure SDK clients. It isn't intended for use in application code.

--- a/sdk/identity/Azure.Identity/src/ManagedIdentityCredential.cs
+++ b/sdk/identity/Azure.Identity/src/ManagedIdentityCredential.cs
@@ -44,6 +44,7 @@ namespace Azure.Identity
         public ManagedIdentityCredential(string clientId = null, TokenCredentialOptions options = null)
             : this(clientId, CredentialPipeline.GetInstance(options))
         {
+            AllowInsecureTransport = options != null ? options.AllowInsecureTransport : false;
         }
 
         internal ManagedIdentityCredential(string clientId, CredentialPipeline pipeline)
@@ -59,6 +60,9 @@ namespace Azure.Identity
 
             _client = client;
         }
+
+        /// <inheritdoc/>
+        public override bool AllowInsecureTransport { get; } = false;
 
         /// <summary>
         /// Obtains an <see cref="AccessToken"/> from the Managed Identity service if available. This method is called by Azure SDK clients. It isn't intended for use in application code.

--- a/sdk/identity/Azure.Identity/src/SharedTokenCacheCredential.cs
+++ b/sdk/identity/Azure.Identity/src/SharedTokenCacheCredential.cs
@@ -56,6 +56,7 @@ namespace Azure.Identity
         public SharedTokenCacheCredential(string username, TokenCredentialOptions options = default)
             : this(tenantId: null, username: username, pipeline: CredentialPipeline.GetInstance(options))
         {
+            AllowInsecureTransport = options != null ? options.AllowInsecureTransport : false;
         }
 
         internal SharedTokenCacheCredential(string tenantId, string username, CredentialPipeline pipeline)
@@ -75,6 +76,9 @@ namespace Azure.Identity
 
             _account = new Lazy<Task<(IAccount, Exception)>>(GetAccountAsync);
         }
+
+        /// <inheritdoc/>
+        public override bool AllowInsecureTransport { get; } = false;
 
         /// <summary>
         /// Obtains an <see cref="AccessToken"/> token for a user account silently if the user has already authenticated to another Microsoft application participating in SSO through a shared MSAL cache. This method is called by Azure SDK clients. It isn't intended for use in application code.

--- a/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
@@ -19,6 +19,11 @@ namespace Azure.Identity
         public Uri AuthorityHost { get; set; }
 
         /// <summary>
+        /// Gets a value indicating whether the tokens provided by the <see cref="TokenCredential"/> should be sent over non TLS protected connections. The default is false.
+        /// </summary>
+        public bool AllowInsecureTransport { get; set; } = false;
+
+        /// <summary>
         /// Creates an instance of <see cref="TokenCredentialOptions"/> with default settings.
         /// </summary>
         public TokenCredentialOptions()

--- a/sdk/identity/Azure.Identity/src/UsernamePasswordCredential.cs
+++ b/sdk/identity/Azure.Identity/src/UsernamePasswordCredential.cs
@@ -57,6 +57,7 @@ namespace Azure.Identity
         public UsernamePasswordCredential(string username, string password, string tenantId, string clientId, TokenCredentialOptions options)
             : this(username, password, tenantId, clientId, CredentialPipeline.GetInstance(options))
         {
+            AllowInsecureTransport = options != null ? options.AllowInsecureTransport : false;
         }
 
         internal UsernamePasswordCredential(string username, string password, string tenantId, string clientId, CredentialPipeline pipeline)
@@ -74,6 +75,9 @@ namespace Azure.Identity
 
             _client = client;
         }
+
+        /// <inheritdoc/>
+        public override bool AllowInsecureTransport { get; } = false;
 
         /// <summary>
         /// Obtains a token for a user account, authenticating them using the given username and password.  Note: This will fail with


### PR DESCRIPTION
Previously we added validation to `BearerTokenAuthenticationPolicy` to disallow sending bearer tokens over non TLS protected connections. However, currently there is no convenient way for a user to allow this for scenarios where HTTP is required. Some possible scenarios which might require this would be proxied connections and Azure Stack on premise or hybrid solutions.

The changes in this PR provide a way to prevent `BearerTokenAuthenticationPolicy` from throwing when used with HTTP endpoints. The first commit contains the changes in Azure.Core and the second contains changes in Azure.Identity. If we decide to take these changes I'll add tests to these and stage them over two PRs as Azure.Core would need to be published before we could add the changes to Azure.Identity.