### PR TITLE
[Event Hubs Client] Track One (Disable Failing Tests)

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ReceiverRuntimeMetricsTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ReceiverRuntimeMetricsTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Consistently failing during nightly runs; tracked by #8892")]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task DefaultBehaviorDisabled()
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Consistently failing during nightly runs; tracked by #8892")]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task DisableWithReceiverOptions()


### PR DESCRIPTION
# Summary

The focus of these changes is to disable a set of tests that have begun consistently failing during nightly runs.   These failures are tracked by issue #8892.

# Last Upstream Rebase

Monday, November 25, 10:03am (EST)

# Related and Follow-Up Issues

- [[Track One] Tests for runtime metrics on the client are consistently failing nightly runs](https://github.com/Azure/azure-sdk-for-net/issues/8892) (#8892) 