### PR TITLE
Pin Azure Storage swaggers to a commit

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/swagger/readme.md
+++ b/sdk/storage/Azure.Storage.Blobs/swagger/readme.md
@@ -4,7 +4,7 @@
 ## Configuration
 ``` yaml
 # Generate blob storage
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/storage-dataplane-preview/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-02-02/blob.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/507724d32aa07f688bb49577cf9bd18c30bb7cc1/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-02-02/blob.json
 output-folder: ../src/Generated
 clear-output-folder: false
 

--- a/sdk/storage/Azure.Storage.Files.DataLake/swagger/readme.md
+++ b/sdk/storage/Azure.Storage.Files.DataLake/swagger/readme.md
@@ -4,7 +4,7 @@
 ## Configuration
 ``` yaml
 # Generate file storage
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/storage-dataplane-preview/specification/storage/data-plane/Microsoft.StorageDataLake/stable/2018-11-09/DataLakeStorage.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/507724d32aa07f688bb49577cf9bd18c30bb7cc1/specification/storage/data-plane/Microsoft.StorageDataLake/stable/2018-11-09/DataLakeStorage.json
 output-folder: ../src/Generated
 clear-output-folder: false
 

--- a/sdk/storage/Azure.Storage.Files.Shares/swagger/readme.md
+++ b/sdk/storage/Azure.Storage.Files.Shares/swagger/readme.md
@@ -4,7 +4,7 @@
 ## Configuration
 ``` yaml
 # Generate file storage
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/storage-dataplane-preview/specification/storage/data-plane/Microsoft.FileStorage/preview/2019-02-02/file.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/507724d32aa07f688bb49577cf9bd18c30bb7cc1/specification/storage/data-plane/Microsoft.FileStorage/preview/2019-02-02/file.json
 output-folder: ../src/Generated
 clear-output-folder: false
 

--- a/sdk/storage/Azure.Storage.Queues/swagger/readme.md
+++ b/sdk/storage/Azure.Storage.Queues/swagger/readme.md
@@ -4,7 +4,7 @@
 ## Configuration
 ``` yaml
 # Generate queue storage
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/storage-dataplane-preview/specification/storage/data-plane/Microsoft.QueueStorage/preview/2018-03-28/queue.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/507724d32aa07f688bb49577cf9bd18c30bb7cc1/specification/storage/data-plane/Microsoft.QueueStorage/preview/2018-03-28/queue.json
 output-folder: ../src/Generated
 clear-output-folder: false
 


### PR DESCRIPTION
The build is broken because the generator uses latest and swagger was updated.

Pins to this commit: https://github.com/Azure/azure-rest-api-specs/commit/507724d32aa07f688bb49577cf9bd18c30bb7cc1