### PR TITLE
[WIP] Adding configuration to allow users to permit bearer token auth over HTTP instead of HTTPS via ClientOptions

### DIFF
--- a/eng/Directory.Build.Data.targets
+++ b/eng/Directory.Build.Data.targets
@@ -80,7 +80,7 @@
   <PropertyGroup>
     <CentralPackagesFile>$(MSBuildThisFileDirectory)Packages.Data.props</CentralPackagesFile>
     <CentralPackageVersionPackagePath>$(MSBuildThisFileDirectory)Microsoft.Build.CentralPackageVersions\2.0.46\Sdk</CentralPackageVersionPackagePath>
-    <UseProjectReferenceToAzureClients Condition="'$(UseProjectReferenceToAzureClients)' == ''">false</UseProjectReferenceToAzureClients>
+    <UseProjectReferenceToAzureClients Condition="'$(UseProjectReferenceToAzureClients)' == ''">true</UseProjectReferenceToAzureClients>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UseProjectReferenceToAzureClients)' == 'true'">

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
@@ -77,7 +77,7 @@ namespace Azure.Data.AppConfiguration
             Argument.AssertNotNull(credential, nameof(credential));
 
             _endpoint = endpoint;
-            _pipeline = CreatePipeline(options, new BearerTokenAuthenticationPolicy(credential, GetDefaultScope(endpoint)));
+            _pipeline = CreatePipeline(options, new BearerTokenAuthenticationPolicy(credential, GetDefaultScope(endpoint), options));
 
             _clientDiagnostics = new ClientDiagnostics(options);
         }

--- a/sdk/core/Azure.Core/src/ClientOptions.cs
+++ b/sdk/core/Azure.Core/src/ClientOptions.cs
@@ -22,6 +22,7 @@ namespace Azure.Core
         {
             Retry = new RetryOptions();
             Diagnostics = new DiagnosticsOptions();
+            Security = new SecurityOptions();
         }
 
         /// <summary>
@@ -42,6 +43,11 @@ namespace Azure.Core
         /// Gets the client retry options.
         /// </summary>
         public RetryOptions Retry { get; }
+
+        /// <summary>
+        /// Gets the client security options.
+        /// </summary>
+        public SecurityOptions Security { get; }
 
         /// <summary>
         /// Adds an <see cref="HttpPipeline"/> policy into the client pipeline. The position of policy in the pipeline is controlled by <paramref name="position"/> parameter.

--- a/sdk/core/Azure.Core/src/SecurityOptions.cs
+++ b/sdk/core/Azure.Core/src/SecurityOptions.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Core
+{
+    /// <summary>
+    ///  The set of options that can be specified to influence how security constraints are enforced by the client.
+    /// </summary>
+    public class SecurityOptions
+    {
+        /// <summary>
+        /// Gets or sets a value determining if the client will allow confidential authentication schemes over non-TLS (non-HTTPS)
+        /// protected connections. WARNING: Setting this value can compromise the security of accounts used by your application.
+        /// </summary>
+        public bool AllowInsecureConfidentialAuthenticationTransport { get; set; } = false;
+    }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateClient.cs
@@ -58,7 +58,7 @@ namespace Azure.Security.KeyVault.Certificates
 
             options ??= new CertificateClientOptions();
 
-            HttpPipeline pipeline = HttpPipelineBuilder.Build(options, new ChallengeBasedAuthenticationPolicy(credential));
+            HttpPipeline pipeline = HttpPipelineBuilder.Build(options, new ChallengeBasedAuthenticationPolicy(credential, options));
 
             _pipeline = new KeyVaultPipeline(vaultUri, options.GetVersionString(), pipeline, new ClientDiagnostics(options));
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/KeyResolver.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/KeyResolver.cs
@@ -57,7 +57,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
             _apiVersion = options.GetVersionString();
 
             _pipeline = HttpPipelineBuilder.Build(options,
-                    new ChallengeBasedAuthenticationPolicy(credential));
+                    new ChallengeBasedAuthenticationPolicy(credential, options));
 
             _clientDiagnostics = new ClientDiagnostics(options);
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/RemoteCryptographyClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Cryptography/RemoteCryptographyClient.cs
@@ -27,7 +27,7 @@ namespace Azure.Security.KeyVault.Keys.Cryptography
             string apiVersion = options.GetVersionString();
 
             HttpPipeline pipeline = HttpPipelineBuilder.Build(options,
-                    new ChallengeBasedAuthenticationPolicy(credential));
+                    new ChallengeBasedAuthenticationPolicy(credential, options));
 
             Pipeline = new KeyVaultPipeline(keyId, apiVersion, pipeline, new ClientDiagnostics(options));
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient.cs
@@ -58,7 +58,7 @@ namespace Azure.Security.KeyVault.Keys
             string apiVersion = options.GetVersionString();
 
             HttpPipeline pipeline = HttpPipelineBuilder.Build(options,
-                    new ChallengeBasedAuthenticationPolicy(credential));
+                    new ChallengeBasedAuthenticationPolicy(credential, options));
 
             _clientDiagnostics = new ClientDiagnostics(options);
             _pipeline = new KeyVaultPipeline(vaultUri, apiVersion, pipeline, _clientDiagnostics);

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClient.cs
@@ -57,7 +57,7 @@ namespace Azure.Security.KeyVault.Secrets
             string apiVersion = options.GetVersionString();
 
             HttpPipeline pipeline = HttpPipelineBuilder.Build(options,
-                    new ChallengeBasedAuthenticationPolicy(credential));
+                    new ChallengeBasedAuthenticationPolicy(credential, options));
 
             _pipeline = new KeyVaultPipeline(vaultUri, apiVersion, pipeline, new ClientDiagnostics(options));
         }

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -248,9 +248,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// every request.
         /// </param>
         public BlobBaseClient(Uri blobUri, TokenCredential credential, BlobClientOptions options = default)
-            : this(blobUri, credential.AsPolicy(), options)
+            : this(blobUri, credential.AsPolicy(options), options)
         {
-            Errors.VerifyHttpsTokenAuth(blobUri);
+            Errors.VerifyHttpsTokenAuth(blobUri, options);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -232,9 +232,9 @@ namespace Azure.Storage.Blobs
         /// every request.
         /// </param>
         public BlobContainerClient(Uri blobContainerUri, TokenCredential credential, BlobClientOptions options = default)
-            : this(blobContainerUri, credential.AsPolicy(), options)
+            : this(blobContainerUri, credential.AsPolicy(options), options)
         {
-            Errors.VerifyHttpsTokenAuth(blobContainerUri);
+            Errors.VerifyHttpsTokenAuth(blobContainerUri, options);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
@@ -144,7 +144,7 @@ namespace Azure.Storage.Blobs
             var conn = StorageConnectionString.Parse(connectionString);
             _uri = conn.BlobEndpoint;
             options ??= new BlobClientOptions();
-            _authenticationPolicy = StorageClientOptions.GetAuthenticationPolicy(conn.Credentials);
+            _authenticationPolicy = StorageClientOptions.GetAuthenticationPolicy(conn.Credentials, options);
             _pipeline = options.Build(_authenticationPolicy);
             _clientDiagnostics = new ClientDiagnostics(options);
             _customerProvidedKey = options.CustomerProvidedKey;
@@ -206,9 +206,9 @@ namespace Azure.Storage.Blobs
         /// every request.
         /// </param>
         public BlobServiceClient(Uri serviceUri, TokenCredential credential, BlobClientOptions options = default)
-            : this(serviceUri, credential.AsPolicy(), options ?? new BlobClientOptions())
+            : this(serviceUri, credential.AsPolicy(options), options ?? new BlobClientOptions())
         {
-            Errors.VerifyHttpsTokenAuth(serviceUri);
+            Errors.VerifyHttpsTokenAuth(serviceUri, options);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Common/src/Errors.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Errors.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Globalization;
 using System.Security.Authentication;
+using Azure.Core;
 
 namespace Azure.Storage
 {
@@ -109,9 +110,9 @@ namespace Azure.Storage
         public static ArgumentException SeekOutsideBufferRange(long index, long inclusiveRangeStart, long exclusiveRangeEnd)
             => new ArgumentException($"Tried to seek ouside buffer range. Gave index {index}, range is [{inclusiveRangeStart},{exclusiveRangeEnd}).");
 
-        public static void VerifyHttpsTokenAuth(Uri uri)
+        public static void VerifyHttpsTokenAuth(Uri uri, ClientOptions options)
         {
-            if (uri.Scheme != Constants.Https)
+            if (uri.Scheme != Constants.Https && (options?.Security.AllowInsecureConfidentialAuthenticationTransport ?? false))
             {
                 throw new ArgumentException("Cannot use TokenCredential without HTTPS.");
             }

--- a/sdk/storage/Azure.Storage.Common/src/StorageClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/StorageClientOptions.cs
@@ -45,18 +45,20 @@ namespace Azure.Storage
         /// Get an authentication policy to sign Storage requests.
         /// </summary>
         /// <param name="credential">Credential to use.</param>
+        /// <param name="options"><see cref="ClientOptions"/> that allow to configure the authentication policy.</param>
         /// <returns>An authentication policy.</returns>
-        public static HttpPipelinePolicy AsPolicy(this TokenCredential credential) =>
+        public static HttpPipelinePolicy AsPolicy(this TokenCredential credential, ClientOptions options) =>
             new BearerTokenAuthenticationPolicy(
                 credential ?? throw Errors.ArgumentNull(nameof(credential)),
-                StorageScope);
+                StorageScope, options);
 
         /// <summary>
         /// Get an optional authentication policy to sign Storage requests.
         /// </summary>
         /// <param name="credentials">Optional credentials to use.</param>
+        /// <param name="options"><see cref="ClientOptions"/> that allow to configure the authentication policy.</param>
         /// <returns>An optional authentication policy.</returns>
-        public static HttpPipelinePolicy GetAuthenticationPolicy(object credentials = null)
+        public static HttpPipelinePolicy GetAuthenticationPolicy(object credentials = null, ClientOptions options = null)
         {
             // Use the credentials to decide on the authentication policy
             switch (credentials)
@@ -67,7 +69,7 @@ namespace Azure.Storage
                 case StorageSharedKeyCredential sharedKey:
                     return sharedKey.AsPolicy();
                 case TokenCredential token:
-                    return token.AsPolicy();
+                    return token.AsPolicy(options);
                 default:
                     throw Errors.InvalidCredentials(credentials.GetType().FullName);
             }
@@ -108,6 +110,6 @@ namespace Azure.Storage
         /// <param name="geoRedundantSecondaryStorageUri">The secondary URI to be used for retries on failed read requests</param>
         /// <returns>An HttpPipeline to use for Storage requests.</returns>
         public static HttpPipeline Build(this ClientOptions options, object credentials, Uri geoRedundantSecondaryStorageUri = null) =>
-            Build(options, GetAuthenticationPolicy(credentials), geoRedundantSecondaryStorageUri);
+            Build(options, GetAuthenticationPolicy(credentials, options), geoRedundantSecondaryStorageUri);
     }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeDirectoryClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeDirectoryClient.cs
@@ -111,9 +111,9 @@ namespace Azure.Storage.Files.DataLake
         /// The token credential used to sign requests.
         /// </param>
         public DataLakeDirectoryClient(Uri directoryUri, TokenCredential credential)
-            : this(directoryUri, credential.AsPolicy(), null)
+            : this(directoryUri, credential.AsPolicy(null), null)
         {
-            Errors.VerifyHttpsTokenAuth(directoryUri);
+            Errors.VerifyHttpsTokenAuth(directoryUri, null);
         }
 
         /// <summary>
@@ -134,9 +134,9 @@ namespace Azure.Storage.Files.DataLake
         /// every request.
         /// </param>
         public DataLakeDirectoryClient(Uri directoryUri, TokenCredential credential, DataLakeClientOptions options)
-            : this(directoryUri, credential.AsPolicy(), options)
+            : this(directoryUri, credential.AsPolicy(options), options)
         {
-            Errors.VerifyHttpsTokenAuth(directoryUri);
+            Errors.VerifyHttpsTokenAuth(directoryUri, options);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
@@ -107,9 +107,9 @@ namespace Azure.Storage.Files.DataLake
         /// The token credential used to sign requests.
         /// </param>
         public DataLakeFileClient(Uri fileUri, TokenCredential credential)
-            : this(fileUri, credential.AsPolicy(), null)
+            : this(fileUri, credential.AsPolicy(null), null)
         {
-            Errors.VerifyHttpsTokenAuth(fileUri);
+            Errors.VerifyHttpsTokenAuth(fileUri, null);
         }
 
         /// <summary>
@@ -129,9 +129,9 @@ namespace Azure.Storage.Files.DataLake
         /// applied to every request.
         /// </param>
         public DataLakeFileClient(Uri fileUri, TokenCredential credential, DataLakeClientOptions options)
-            : this(fileUri, credential.AsPolicy(), options)
+            : this(fileUri, credential.AsPolicy(options), options)
         {
-            Errors.VerifyHttpsTokenAuth(fileUri);
+            Errors.VerifyHttpsTokenAuth(fileUri, options);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileSystemClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileSystemClient.cs
@@ -199,9 +199,9 @@ namespace Azure.Storage.Files.DataLake
         /// The token credential used to sign requests.
         /// </param>
         public DataLakeFileSystemClient(Uri fileSystemUri, TokenCredential credential)
-            : this(fileSystemUri, credential.AsPolicy(), null)
+            : this(fileSystemUri, credential.AsPolicy(null), null)
         {
-            Errors.VerifyHttpsTokenAuth(fileSystemUri);
+            Errors.VerifyHttpsTokenAuth(fileSystemUri, null);
         }
 
         /// <summary>
@@ -221,9 +221,9 @@ namespace Azure.Storage.Files.DataLake
         /// every request.
         /// </param>
         public DataLakeFileSystemClient(Uri fileSystemUri, TokenCredential credential, DataLakeClientOptions options)
-            : this(fileSystemUri, credential.AsPolicy(), options)
+            : this(fileSystemUri, credential.AsPolicy(options), options)
         {
-            Errors.VerifyHttpsTokenAuth(fileSystemUri);
+            Errors.VerifyHttpsTokenAuth(fileSystemUri, options);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakePathClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakePathClient.cs
@@ -240,9 +240,9 @@ namespace Azure.Storage.Files.DataLake
         /// The token credential used to sign requests.
         /// </param>
         public DataLakePathClient(Uri pathUri, TokenCredential credential)
-            : this(pathUri, credential.AsPolicy(), null)
+            : this(pathUri, credential.AsPolicy(null), null)
         {
-            Errors.VerifyHttpsTokenAuth(pathUri);
+            Errors.VerifyHttpsTokenAuth(pathUri, null);
         }
 
         /// <summary>
@@ -263,9 +263,9 @@ namespace Azure.Storage.Files.DataLake
         /// every request.
         /// </param>
         public DataLakePathClient(Uri pathUri, TokenCredential credential, DataLakeClientOptions options)
-            : this(pathUri, credential.AsPolicy(), options)
+            : this(pathUri, credential.AsPolicy(options), options)
         {
-            Errors.VerifyHttpsTokenAuth(pathUri);
+            Errors.VerifyHttpsTokenAuth(pathUri, options);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeServiceClient.cs
@@ -169,9 +169,9 @@ namespace Azure.Storage.Files.DataLake
         /// The token credential used to sign requests.
         /// </param>
         public DataLakeServiceClient(Uri serviceUri, TokenCredential credential)
-            : this(serviceUri, credential.AsPolicy(), null)
+            : this(serviceUri, credential.AsPolicy(null), null)
         {
-            Errors.VerifyHttpsTokenAuth(serviceUri);
+            Errors.VerifyHttpsTokenAuth(serviceUri, null);
         }
 
         /// <summary>
@@ -190,9 +190,9 @@ namespace Azure.Storage.Files.DataLake
         /// every request.
         /// </param>
         public DataLakeServiceClient(Uri serviceUri, TokenCredential credential, DataLakeClientOptions options)
-            : this(serviceUri, credential.AsPolicy(), options)
+            : this(serviceUri, credential.AsPolicy(options), options)
         {
-            Errors.VerifyHttpsTokenAuth(serviceUri);
+            Errors.VerifyHttpsTokenAuth(serviceUri, options);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
@@ -227,9 +227,9 @@ namespace Azure.Storage.Queues
         /// every request.
         /// </param>
         public QueueClient(Uri queueUri, TokenCredential credential, QueueClientOptions options = default)
-            : this(queueUri, credential.AsPolicy(), options)
+            : this(queueUri, credential.AsPolicy(options), options)
         {
-            Errors.VerifyHttpsTokenAuth(queueUri);
+            Errors.VerifyHttpsTokenAuth(queueUri, options);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Queues/src/QueueServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueServiceClient.cs
@@ -174,9 +174,9 @@ namespace Azure.Storage.Queues
         /// every request.
         /// </param>
         public QueueServiceClient(Uri serviceUri, TokenCredential credential, QueueClientOptions options = default)
-            : this(serviceUri, credential.AsPolicy(), options)
+            : this(serviceUri, credential.AsPolicy(options), options)
         {
-            Errors.VerifyHttpsTokenAuth(serviceUri);
+            Errors.VerifyHttpsTokenAuth(serviceUri, options);
         }
 
         /// <summary>


### PR DESCRIPTION
This is an alternative implementation for the changes proposed in #8882, adding configuration to override the default behavior and allow bearer tokens to be sent over HTTP. In this implementation the configuration properties are added to `ClientOptions` rather than `TokenCredential`. This PR adds a new class `SecurityOptions` to `ClientOptions`. The `SecurityOptions` class introduces a property to allow bearer tokens to be sent over HTTP, namely `AllowInsecureConfidentialAuthenticationTransport`

I like the API surface of this implementation better then the implementation adding the configuration to `TokenCredential` as I feel this is a more natural place for this configuration to live. You are in essence configuring the client communication with the service, not the credential communication with the authority. This also lets me use the same credential with clients which are configured differently in this regard.

One drawback to this implementation is that it requires each client library to plumb the `ClientOptions` to the `BearerTokenAuthenticationPolicy` in order for the client to properly respect this configuration, so this change touches all client libraries vs. the `TokenCredential` implementation which only impacts Azure.Core and Azure.Identity.

Finally, I know the property `AllowInsecureConfidentialAuthenticationTransport` is quite a mouthful. I purposefully tried to create a daunting property name which was somewhat impenetrable to scare people off unless they specifically know they want to set this property. That being said I'd welcome any other suggestions for this.