### PR TITLE
[EventHubs] Event Processor Client delegates internal errors to its error handler

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -657,8 +657,7 @@ namespace Azure.Messaging.EventHubs
 
                         if (loadBalancingException != default)
                         {
-                            // TODO: investigate exceptions being thrown in tests.
-                            // throw loadBalancingException;
+                            throw loadBalancingException;
                         }
                     }
                 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -871,7 +871,7 @@ namespace Azure.Messaging.EventHubs
                     }))
                     .ConfigureAwait(false);
 
-                // From the storage service provided by the user, obtain a complete list of ownership, including expired ones.  We may still need
+                // From the storage service, obtain a complete list of ownership, including expired ones.  We may still need
                 // their eTags to claim orphan partitions.
 
                 var completeOwnershipList = default(IEnumerable<PartitionOwnership>);
@@ -889,7 +889,7 @@ namespace Azure.Messaging.EventHubs
                     // If ownership list retrieval fails, give up on the current cycle.  There's nothing more we can do
                     // without an updated ownership list.
 
-                    var errorEventArgs = new ProcessErrorEventArgs(null, Resources.ListOwnershipOperation, ex, cancellationToken);
+                    var errorEventArgs = new ProcessErrorEventArgs(null, Resources.OperationListOwnership, ex, cancellationToken);
                     await OnProcessErrorAsync(errorEventArgs).ConfigureAwait(false);
                 }
 
@@ -921,7 +921,7 @@ namespace Azure.Messaging.EventHubs
                     {
                         cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
-                        var eventArgs = new ProcessErrorEventArgs(null, Resources.GetPartitionIdsOperation, ex, cancellationToken);
+                        var eventArgs = new ProcessErrorEventArgs(null, Resources.OperationGetPartitionIds, ex, cancellationToken);
                         await OnProcessErrorAsync(eventArgs).ConfigureAwait(false);
                     }
 
@@ -1103,7 +1103,7 @@ namespace Azure.Messaging.EventHubs
                 // This should happen on the next load balancing loop as long as this instance still owns the
                 // partition.
 
-                var errorEventArgs = new ProcessErrorEventArgs(null, Resources.ListCheckpointsOperation, ex, cancellationToken);
+                var errorEventArgs = new ProcessErrorEventArgs(null, Resources.OperationListCheckpoints, ex, cancellationToken);
                 await OnProcessErrorAsync(errorEventArgs).ConfigureAwait(false);
 
                 return;
@@ -1163,7 +1163,7 @@ namespace Azure.Messaging.EventHubs
                     // TODO: should the handler be notified in the processing task instead?  User will be notified
                     // earlier.
 
-                    var errorEventArgs = new ProcessErrorEventArgs(partitionId, Resources.ReadEventsOperation, ex, cancellationToken);
+                    var errorEventArgs = new ProcessErrorEventArgs(partitionId, Resources.OperationReadEvents, ex, cancellationToken);
                     await OnProcessErrorAsync(errorEventArgs).ConfigureAwait(false);
                 }
                 finally
@@ -1225,7 +1225,7 @@ namespace Azure.Messaging.EventHubs
 
                 // If ownership claim fails, just treat it as a usual ownership claim failure.
 
-                var errorEventArgs = new ProcessErrorEventArgs(null, Resources.ClaimOwnershipOperation, ex, cancellationToken);
+                var errorEventArgs = new ProcessErrorEventArgs(null, Resources.OperationClaimOwnership, ex, cancellationToken);
                 await OnProcessErrorAsync(errorEventArgs).ConfigureAwait(false);
 
                 return default;
@@ -1273,7 +1273,7 @@ namespace Azure.Messaging.EventHubs
                 // If ownership renewal fails just give up and try again in the next cycle.  The processor may
                 // end up losing some of its ownership.
 
-                var errorEventArgs = new ProcessErrorEventArgs(null, Resources.RenewOwnershipOperation, ex, cancellationToken);
+                var errorEventArgs = new ProcessErrorEventArgs(null, Resources.OperationRenewOwnership, ex, cancellationToken);
                 await OnProcessErrorAsync(errorEventArgs).ConfigureAwait(false);
 
                 return;

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -69,7 +69,7 @@ namespace Azure.Messaging.EventHubs
 
                 if (_partitionInitializingAsync != default)
                 {
-                    throw new NotSupportedException("TODO: A handler has already been assigned to this event.");
+                    throw new NotSupportedException(Resources.HandlerHasAlreadyBeenAssigned);
                 }
 
                 EnsureNotRunningAndInvoke(() => _partitionInitializingAsync = value);
@@ -81,7 +81,7 @@ namespace Azure.Messaging.EventHubs
 
                 if (_partitionInitializingAsync != value)
                 {
-                    throw new ArgumentException("TODO: Handler has not been previously assigned to this event.");
+                    throw new ArgumentException(Resources.HandlerHasNotBeenAssigned);
                 }
 
                 EnsureNotRunningAndInvoke(() => _partitionInitializingAsync = default);
@@ -100,7 +100,7 @@ namespace Azure.Messaging.EventHubs
 
                 if (_partitionClosingAsync != default)
                 {
-                    throw new NotSupportedException("TODO: A handler has already been assigned to this event.");
+                    throw new NotSupportedException(Resources.HandlerHasAlreadyBeenAssigned);
                 }
 
                 EnsureNotRunningAndInvoke(() => _partitionClosingAsync = value);
@@ -112,7 +112,7 @@ namespace Azure.Messaging.EventHubs
 
                 if (_partitionClosingAsync != value)
                 {
-                    throw new ArgumentException("TODO: Handler has not been previously assigned to this event.");
+                    throw new ArgumentException(Resources.HandlerHasNotBeenAssigned);
                 }
 
                 EnsureNotRunningAndInvoke(() => _partitionClosingAsync = default);
@@ -132,7 +132,7 @@ namespace Azure.Messaging.EventHubs
 
                 if (_processEventAsync != default)
                 {
-                    throw new NotSupportedException("TODO: A handler has already been assigned to this event.");
+                    throw new NotSupportedException(Resources.HandlerHasAlreadyBeenAssigned);
                 }
 
                 EnsureNotRunningAndInvoke(() => _processEventAsync = value);
@@ -144,7 +144,7 @@ namespace Azure.Messaging.EventHubs
 
                 if (_processEventAsync != value)
                 {
-                    throw new ArgumentException("TODO: Handler has not been previously assigned to this event.");
+                    throw new ArgumentException(Resources.HandlerHasNotBeenAssigned);
                 }
 
                 EnsureNotRunningAndInvoke(() => _processEventAsync = default);
@@ -164,7 +164,7 @@ namespace Azure.Messaging.EventHubs
 
                 if (_processErrorAsync != default)
                 {
-                    throw new NotSupportedException("TODO: A handler has already been assigned to this event.");
+                    throw new NotSupportedException(Resources.HandlerHasAlreadyBeenAssigned);
                 }
 
                 EnsureNotRunningAndInvoke(() => _processErrorAsync = value);
@@ -176,7 +176,7 @@ namespace Azure.Messaging.EventHubs
 
                 if (_processErrorAsync != value)
                 {
-                    throw new ArgumentException("TODO: Handler has not been previously assigned to this event.");
+                    throw new ArgumentException(Resources.HandlerHasNotBeenAssigned);
                 }
 
                 EnsureNotRunningAndInvoke(() => _processErrorAsync = default);
@@ -889,7 +889,7 @@ namespace Azure.Messaging.EventHubs
                     // If ownership list retrieval fails, give up on the current cycle.  There's nothing more we can do
                     // without an updated ownership list.
 
-                    var errorEventArgs = new ProcessErrorEventArgs(null, "TODO: Retrieving list of ownership from the storage service.", ex, cancellationToken);
+                    var errorEventArgs = new ProcessErrorEventArgs(null, Resources.ListOwnershipOperation, ex, cancellationToken);
                     await OnProcessErrorAsync(errorEventArgs).ConfigureAwait(false);
                 }
 
@@ -921,7 +921,7 @@ namespace Azure.Messaging.EventHubs
                     {
                         cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
-                        var eventArgs = new ProcessErrorEventArgs(null, "TODO: Retrieving list of partition identifiers from a Consumer Client.", ex, cancellationToken);
+                        var eventArgs = new ProcessErrorEventArgs(null, Resources.GetPartitionIdsOperation, ex, cancellationToken);
                         await OnProcessErrorAsync(eventArgs).ConfigureAwait(false);
                     }
 
@@ -1103,7 +1103,7 @@ namespace Azure.Messaging.EventHubs
                 // This should happen on the next load balancing loop as long as this instance still owns the
                 // partition.
 
-                var errorEventArgs = new ProcessErrorEventArgs(null, "TODO: Retrieving list of checkpoints from the storage service.", ex, cancellationToken);
+                var errorEventArgs = new ProcessErrorEventArgs(null, Resources.ListCheckpointsOperation, ex, cancellationToken);
                 await OnProcessErrorAsync(errorEventArgs).ConfigureAwait(false);
 
                 return;
@@ -1163,7 +1163,7 @@ namespace Azure.Messaging.EventHubs
                     // TODO: should the handler be notified in the processing task instead?  User will be notified
                     // earlier.
 
-                    var errorEventArgs = new ProcessErrorEventArgs(partitionId, "TODO: Receiving events from the Event Hubs service.", ex, cancellationToken);
+                    var errorEventArgs = new ProcessErrorEventArgs(partitionId, Resources.ReadEventsOperation, ex, cancellationToken);
                     await OnProcessErrorAsync(errorEventArgs).ConfigureAwait(false);
                 }
                 finally
@@ -1225,7 +1225,7 @@ namespace Azure.Messaging.EventHubs
 
                 // If ownership claim fails, just treat it as a usual ownership claim failure.
 
-                var errorEventArgs = new ProcessErrorEventArgs(null, "TODO: Attempting to claim a new ownership in the storage service.", ex, cancellationToken);
+                var errorEventArgs = new ProcessErrorEventArgs(null, Resources.ClaimOwnershipOperation, ex, cancellationToken);
                 await OnProcessErrorAsync(errorEventArgs).ConfigureAwait(false);
 
                 return default;
@@ -1273,7 +1273,7 @@ namespace Azure.Messaging.EventHubs
                 // If ownership renewal fails just give up and try again in the next cycle.  The processor may
                 // end up losing some of its ownership.
 
-                var errorEventArgs = new ProcessErrorEventArgs(null, "TODO: Attempting to renew all of the processor's ownership in the storage service.", ex, cancellationToken);
+                var errorEventArgs = new ProcessErrorEventArgs(null, Resources.RenewOwnershipOperation, ex, cancellationToken);
                 await OnProcessErrorAsync(errorEventArgs).ConfigureAwait(false);
 
                 return;

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -417,8 +417,8 @@ namespace Azure.Messaging.EventHubs
             FullyQualifiedNamespace = connectionStringProperties.Endpoint.Host;
             EventHubName = string.IsNullOrEmpty(eventHubName) ? connectionStringProperties.EventHubName : eventHubName;
             ConsumerGroup = consumerGroup;
-            StorageManager = CreateStorageManager(checkpointStore);
             RetryPolicy = clientOptions.RetryOptions.ToRetryPolicy();
+            StorageManager = CreateStorageManager(checkpointStore);
             Identifier = string.IsNullOrEmpty(clientOptions.Identifier) ? Guid.NewGuid().ToString() : clientOptions.Identifier;
         }
 
@@ -463,8 +463,8 @@ namespace Azure.Messaging.EventHubs
             FullyQualifiedNamespace = fullyQualifiedNamespace;
             EventHubName = eventHubName;
             ConsumerGroup = consumerGroup;
-            StorageManager = CreateStorageManager(checkpointStore);
             RetryPolicy = clientOptions.RetryOptions.ToRetryPolicy();
+            StorageManager = CreateStorageManager(checkpointStore);
             Identifier = string.IsNullOrEmpty(clientOptions.Identifier) ? Guid.NewGuid().ToString() : clientOptions.Identifier;
         }
 
@@ -519,8 +519,8 @@ namespace Azure.Messaging.EventHubs
             FullyQualifiedNamespace = fullyQualifiedNamespace;
             EventHubName = eventHubName;
             ConsumerGroup = consumerGroup;
-            StorageManager = storageManager;
             RetryPolicy = clientOptions.RetryOptions.ToRetryPolicy();
+            StorageManager = storageManager;
             Identifier = string.IsNullOrEmpty(clientOptions.Identifier) ? Guid.NewGuid().ToString() : clientOptions.Identifier;
         }
 
@@ -775,7 +775,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <returns>A <see cref="PartitionManager" /> with the requested configuration.</returns>
         ///
-        internal virtual PartitionManager CreateStorageManager(BlobContainerClient checkpointStore) => new BlobsCheckpointStore(checkpointStore);
+        internal virtual PartitionManager CreateStorageManager(BlobContainerClient checkpointStore) => new BlobsCheckpointStore(checkpointStore, RetryPolicy);
 
         /// <summary>
         ///   Called when a 'partition initializing' event is triggered.

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -704,7 +704,7 @@ namespace Azure.Messaging.EventHubs
         /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
         ///
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override string ToString() => base.ToString();
+        public override string ToString() => $"Event Processor: { Identifier }";
 
         /// <summary>
         ///   Updates the checkpoint using the given information for the associated partition and consumer group in the chosen storage service.

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -742,9 +742,9 @@ namespace Azure.Messaging.EventHubs
             try
             {
                 // TODO: apply retry policy here.  Do not call error handler in case of failure and notify
-                // the user directly.
+                // the user directly.  Pass the cancellation token.
 
-                await StorageManager.UpdateCheckpointAsync(checkpoint).ConfigureAwait(false);
+                await StorageManager.UpdateCheckpointAsync(checkpoint, default).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -853,7 +853,7 @@ namespace Azure.Messaging.EventHubs
 
                 // TODO: apply retry policy here.
 
-                var completeOwnershipList = (await StorageManager.ListOwnershipAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup)
+                var completeOwnershipList = (await StorageManager.ListOwnershipAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, cancellationToken)
                     .ConfigureAwait(false))
                     .ToList();
 
@@ -1090,7 +1090,7 @@ namespace Azure.Messaging.EventHubs
             // TODO: make partition manager take a cancellation token.
 
             Func<CancellationToken, Task<IEnumerable<Checkpoint>>> functionToRetry = cancellationToken =>
-                StorageManager.ListCheckpointsAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup);
+                StorageManager.ListCheckpointsAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, cancellationToken);
 
             var availableCheckpoints = default(IEnumerable<Checkpoint>);
 
@@ -1220,7 +1220,7 @@ namespace Azure.Messaging.EventHubs
 
                 // TODO: make partition manager take a cancellation token.
 
-                return StorageManager.ClaimOwnershipAsync(new List<PartitionOwnership> { newOwnership });
+                return StorageManager.ClaimOwnershipAsync(new List<PartitionOwnership> { newOwnership }, cancellationToken);
             };
 
             var claimedOwnership = default(IEnumerable<PartitionOwnership>);
@@ -1275,7 +1275,7 @@ namespace Azure.Messaging.EventHubs
 
                 // TODO: make partition manager take a cancellation token.
 
-                return StorageManager.ClaimOwnershipAsync(ownershipToRenew);
+                return StorageManager.ClaimOwnershipAsync(ownershipToRenew, cancellationToken);
             };
 
             try

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -858,7 +858,9 @@ namespace Azure.Messaging.EventHubs
                 var utcNow = DateTimeOffset.UtcNow;
 
                 IEnumerable<PartitionOwnership> activeOwnership = completeOwnershipList
-                    .Where(ownership => utcNow.Subtract(ownership.LastModifiedTime.Value) < OwnershipExpiration);
+                    .Where(ownership =>
+                        utcNow.Subtract(ownership.LastModifiedTime.Value) < OwnershipExpiration
+                        && !string.IsNullOrEmpty(ownership.OwnerIdentifier));
 
                 // Dispose of all previous partition ownership instances and get a whole new dictionary.
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -69,7 +69,7 @@ namespace Azure.Messaging.EventHubs
 
                 if (_partitionInitializingAsync != default)
                 {
-                    throw new NotSupportedException("TODO: A handler has already be assigned to this event.");
+                    throw new NotSupportedException("TODO: A handler has already been assigned to this event.");
                 }
 
                 EnsureNotRunningAndInvoke(() => _partitionInitializingAsync = value);
@@ -100,7 +100,7 @@ namespace Azure.Messaging.EventHubs
 
                 if (_partitionClosingAsync != default)
                 {
-                    throw new NotSupportedException("TODO: A handler has already be assigned to this event.");
+                    throw new NotSupportedException("TODO: A handler has already been assigned to this event.");
                 }
 
                 EnsureNotRunningAndInvoke(() => _partitionClosingAsync = value);
@@ -132,7 +132,7 @@ namespace Azure.Messaging.EventHubs
 
                 if (_processEventAsync != default)
                 {
-                    throw new NotSupportedException("TODO: A handler has already be assigned to this event.");
+                    throw new NotSupportedException("TODO: A handler has already been assigned to this event.");
                 }
 
                 EnsureNotRunningAndInvoke(() => _processEventAsync = value);
@@ -164,7 +164,7 @@ namespace Azure.Messaging.EventHubs
 
                 if (_processErrorAsync != default)
                 {
-                    throw new NotSupportedException("TODO: A handler has already be assigned to this event.");
+                    throw new NotSupportedException("TODO: A handler has already been assigned to this event.");
                 }
 
                 EnsureNotRunningAndInvoke(() => _processErrorAsync = value);

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/PartitionManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/PartitionManager.cs
@@ -11,11 +11,6 @@ namespace Azure.Messaging.EventHubs.Processor
     ///   list/claim ownership.
     /// </summary>
     ///
-    /// <remarks>
-    ///   An instance of a concrete subclass is provided by the user in the <see cref="EventProcessorClient" />
-    ///   constructor.
-    /// </remarks>
-    ///
     internal abstract class PartitionManager
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/PartitionManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/PartitionManager.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Azure.Messaging.EventHubs.Processor
@@ -20,22 +21,26 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
         /// <param name="eventHubName">The name of the specific Event Hub the ownership are associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the ownership are associated with.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>An enumerable containing all the existing ownership for the associated Event Hub and consumer group.</returns>
         ///
         public abstract Task<IEnumerable<PartitionOwnership>> ListOwnershipAsync(string fullyQualifiedNamespace,
                                                                                  string eventHubName,
-                                                                                 string consumerGroup);
+                                                                                 string consumerGroup,
+                                                                                 CancellationToken cancellationToken);
 
         /// <summary>
         ///   Attempts to claim ownership of partitions for processing.
         /// </summary>
         ///
         /// <param name="partitionOwnership">An enumerable containing all the ownership to claim.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>An enumerable containing the successfully claimed ownership instances.</returns>
         ///
-        public abstract Task<IEnumerable<PartitionOwnership>> ClaimOwnershipAsync(IEnumerable<PartitionOwnership> partitionOwnership);
+        public abstract Task<IEnumerable<PartitionOwnership>> ClaimOwnershipAsync(IEnumerable<PartitionOwnership> partitionOwnership,
+                                                                                  CancellationToken cancellationToken);
 
 
         /// <summary>
@@ -45,19 +50,23 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
         /// <param name="eventHubName">The name of the specific Event Hub the ownership are associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the ownership are associated with.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>An enumerable containing all the existing checkpoints for the associated Event Hub and consumer group.</returns>
         ///
         public abstract Task<IEnumerable<Checkpoint>> ListCheckpointsAsync(string fullyQualifiedNamespace,
                                                                            string eventHubName,
-                                                                           string consumerGroup);
+                                                                           string consumerGroup,
+                                                                           CancellationToken cancellationToken);
 
         /// <summary>
         ///   Updates the checkpoint using the given information for the associated partition and consumer group in the chosen storage service.
         /// </summary>
         ///
         /// <param name="checkpoint">The checkpoint containing the information to be stored.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
-        public abstract Task UpdateCheckpointAsync(Checkpoint checkpoint);
+        public abstract Task UpdateCheckpointAsync(Checkpoint checkpoint,
+                                                   CancellationToken cancellationToken);
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Storage/BlobsCheckpointStore.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Storage/BlobsCheckpointStore.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Storage.Blobs;
@@ -69,12 +70,14 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
         /// <param name="eventHubName">The name of the specific Event Hub the ownership are associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the ownership are associated with.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>An enumerable containing all the existing ownership for the associated Event Hub and consumer group.</returns>
         ///
         public override async Task<IEnumerable<PartitionOwnership>> ListOwnershipAsync(string fullyQualifiedNamespace,
                                                                                        string eventHubName,
-                                                                                       string consumerGroup)
+                                                                                       string consumerGroup,
+                                                                                       CancellationToken cancellationToken)
         {
             List<PartitionOwnership> ownershipList = new List<PartitionOwnership>();
             try
@@ -111,10 +114,12 @@ namespace Azure.Messaging.EventHubs.Processor
         /// </summary>
         ///
         /// <param name="partitionOwnership">An enumerable containing all the ownership to claim.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>An enumerable containing the successfully claimed ownership.</returns>
         ///
-        public override async Task<IEnumerable<PartitionOwnership>> ClaimOwnershipAsync(IEnumerable<PartitionOwnership> partitionOwnership)
+        public override async Task<IEnumerable<PartitionOwnership>> ClaimOwnershipAsync(IEnumerable<PartitionOwnership> partitionOwnership,
+                                                                                        CancellationToken cancellationToken)
         {
             var claimedOwnership = new List<PartitionOwnership>();
             var metadata = new Dictionary<string, string>();
@@ -209,12 +214,14 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
         /// <param name="eventHubName">The name of the specific Event Hub the ownership are associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the ownership are associated with.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>An enumerable containing all the existing checkpoints for the associated Event Hub and consumer group.</returns>
         ///
         public override async Task<IEnumerable<Checkpoint>> ListCheckpointsAsync(string fullyQualifiedNamespace,
                                                                                  string eventHubName,
-                                                                                 string consumerGroup)
+                                                                                 string consumerGroup,
+                                                                                 CancellationToken cancellationToken)
         {
             List<Checkpoint> checkpoints = new List<Checkpoint>();
             try
@@ -258,10 +265,12 @@ namespace Azure.Messaging.EventHubs.Processor
         /// </summary>
         ///
         /// <param name="checkpoint">The checkpoint containing the information to be stored.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///
-        public override async Task UpdateCheckpointAsync(Checkpoint checkpoint)
+        public override async Task UpdateCheckpointAsync(Checkpoint checkpoint,
+                                                         CancellationToken cancellationToken)
         {
             var blobName = string.Format(CheckpointPrefix + checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace.ToLower(), checkpoint.EventHubName.ToLower(), checkpoint.ConsumerGroup.ToLower());
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Storage/BlobsCheckpointStore.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Storage/BlobsCheckpointStore.cs
@@ -39,16 +39,27 @@ namespace Azure.Messaging.EventHubs.Processor
         private BlobContainerClient ContainerClient { get; }
 
         /// <summary>
+        ///   The active policy which governs retry attempts for the
+        ///   <see cref="BlobsCheckpointStore" />.
+        /// </summary>
+        ///
+        private EventHubsRetryPolicy RetryPolicy { get; }
+
+        /// <summary>
         ///   Initializes a new instance of the <see cref="BlobsCheckpointStore"/> class.
         /// </summary>
         ///
         /// <param name="blobContainerClient">The client used to interact with the Azure Blob Storage service.</param>
+        /// <param name="retryPolicy">The retry policy to use as the basis for interacting with the Storage Blobs service.</param>
         ///
-        public BlobsCheckpointStore(BlobContainerClient blobContainerClient)
+        public BlobsCheckpointStore(BlobContainerClient blobContainerClient,
+                                    EventHubsRetryPolicy retryPolicy)
         {
             Argument.AssertNotNull(blobContainerClient, nameof(blobContainerClient));
+            Argument.AssertNotNull(retryPolicy, nameof(retryPolicy));
 
             ContainerClient = blobContainerClient;
+            RetryPolicy = retryPolicy;
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/BlobsCheckpointStore/BlobsCheckpointStoreLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/BlobsCheckpointStore/BlobsCheckpointStoreLiveTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Tests;
 using Azure.Storage.Blobs;
 using Moq;
@@ -28,6 +29,9 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
     [Category(TestCategory.DisallowVisualStudioLiveUnitTesting)]
     public class BlobsCheckpointStoreLiveTests
     {
+        /// <summary>The default retry policy to use for the test cases in this class.</summary>
+        private EventHubsRetryPolicy DefaultRetryPolicy { get; } = new BasicRetryPolicy(new EventHubsRetryOptions());
+
         /// <summary>
         ///   Verifies that the <see cref="BlobsCheckpointStore" /> is able to
         ///   connect to the Storage service.
@@ -41,7 +45,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
+                var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
 
                 Assert.That(async () => await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default), Throws.Nothing);
             }
@@ -60,7 +64,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
+                var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
 
                 Assert.That(async () => await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup", default), Throws.Nothing);
             }
@@ -81,7 +85,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
+                var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
                 var ownershipList = new List<PartitionOwnership>
                 {
 
@@ -116,7 +120,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
+                var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
                 var ownershipList = new List<PartitionOwnership>
                 {
 
@@ -153,7 +157,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
+                var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
                 IEnumerable<PartitionOwnership> ownership = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default);
 
                 Assert.That(ownership, Is.Not.Null.And.Empty);
@@ -173,7 +177,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
+                var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
                 IEnumerable<Checkpoint> checkpoints = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup", default);
 
                 Assert.That(checkpoints, Is.Not.Null.And.Empty);
@@ -193,7 +197,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
+                var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
                 var ownershipList = new List<PartitionOwnership>();
                 var ownership =
                     new PartitionOwnership
@@ -232,7 +236,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
+                var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
                 var ownershipList = new List<PartitionOwnership>();
                 var ownership =
                     new PartitionOwnership
@@ -271,7 +275,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
+                var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
                 var ownershipList = new List<PartitionOwnership>();
                 var ownership =
                     new PartitionOwnership
@@ -309,7 +313,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
+                var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
                 var ownershipList = new List<PartitionOwnership>();
                 var firstOwnership =
                     new PartitionOwnership
@@ -363,7 +367,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
+                var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
                 var ownershipList = new List<PartitionOwnership>();
 
                 var eTaggyOwnership =
@@ -400,7 +404,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
+                var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
                 var ownershipList = new List<PartitionOwnership>();
                 var firstOwnership =
                     new PartitionOwnership
@@ -458,7 +462,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
+                var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
                 var ownershipList = new List<PartitionOwnership>();
                 var ownershipCount = 5;
 
@@ -505,7 +509,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
+                var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
                 var ownershipList = new List<PartitionOwnership>();
                 var ownershipCount = 5;
 
@@ -578,7 +582,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
+                var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
                 var ownershipList = new List<PartitionOwnership>();
                 var firstOwnership =
                     new PartitionOwnership
@@ -613,7 +617,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
                 ownershipList.Add(secondOwnership);
 
-                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
+                Assert.That(async () => await checkpointStore.ClaimOwnershipAsync(ownershipList, default), Throws.InstanceOf<RequestFailedException>());
 
                 IEnumerable<PartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup1", default);
 
@@ -636,7 +640,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
+                var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
                 var ownershipList = new List<PartitionOwnership>();
                 var firstOwnership =
                     new PartitionOwnership
@@ -671,7 +675,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
                 ownershipList.Add(secondOwnership);
 
-                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
+                Assert.That(async () => await checkpointStore.ClaimOwnershipAsync(ownershipList, default), Throws.InstanceOf<RequestFailedException>());
 
                 IEnumerable<PartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName1", "consumerGroup", default);
 
@@ -694,7 +698,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
+                var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
                 var ownershipList = new List<PartitionOwnership>();
                 var firstOwnership =
                     new PartitionOwnership
@@ -729,7 +733,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
                 ownershipList.Add(secondOwnership);
 
-                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
+                Assert.That(async () => await checkpointStore.ClaimOwnershipAsync(ownershipList, default), Throws.InstanceOf<RequestFailedException>());
 
                 var storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace1", "eventHubName", "consumerGroup", default);
 
@@ -752,7 +756,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, $"test-container-{Guid.NewGuid()}");
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
+                var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
 
                 Assert.That(async () => await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default), Throws.InstanceOf<RequestFailedException>());
             }
@@ -771,7 +775,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, $"test-container-{Guid.NewGuid()}");
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
+                var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
 
                 Assert.That(async () => await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup", default), Throws.InstanceOf<RequestFailedException>());
             }
@@ -790,7 +794,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, $"test-container-{Guid.NewGuid()}");
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
+                var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
 
                 Assert.That(async () => await checkpointStore.UpdateCheckpointAsync(new Checkpoint
                     ("namespace", "eventHubName", "consumerGroup", "partitionId", offset: 10, sequenceNumber: 20), default), Throws.InstanceOf<RequestFailedException>());
@@ -810,7 +814,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
+                var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
 
                 await checkpointStore.UpdateCheckpointAsync(new Checkpoint
                     ("namespace", "eventHubName", "consumerGroup1", "partitionId", 10, 20), default);
@@ -842,7 +846,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
+                var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
 
                 await checkpointStore.UpdateCheckpointAsync(new Checkpoint
                     ("namespace", "eventHubName1", "consumerGroup", "partitionId", 10, 20), default);
@@ -874,7 +878,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
+                var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
 
                 await checkpointStore.UpdateCheckpointAsync(new Checkpoint
                     ("namespace1", "eventHubName", "consumerGroup", "partitionId", 10, 20), default);
@@ -906,7 +910,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
+                var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
 
                 await checkpointStore.UpdateCheckpointAsync(new Checkpoint
                     ("namespace", "eventHubName", "consumerGroup", "partitionId1", 10, 20), default);

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/BlobsCheckpointStore/BlobsCheckpointStoreLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/BlobsCheckpointStore/BlobsCheckpointStoreLiveTests.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Tests;
 using Azure.Storage.Blobs;
+using Moq;
 using NUnit.Framework;
 
 namespace Azure.Messaging.EventHubs.Processor.Tests
@@ -40,7 +41,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient);
+                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
 
                 Assert.That(async () => await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup"), Throws.Nothing);
             }
@@ -59,7 +60,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient);
+                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
 
                 Assert.That(async () => await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup"), Throws.Nothing);
             }
@@ -80,7 +81,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient);
+                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
                 var ownershipList = new List<PartitionOwnership>
                 {
 
@@ -115,7 +116,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient);
+                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
                 var ownershipList = new List<PartitionOwnership>
                 {
 
@@ -152,7 +153,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient);
+                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
                 IEnumerable<PartitionOwnership> ownership = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup");
 
                 Assert.That(ownership, Is.Not.Null.And.Empty);
@@ -172,7 +173,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient);
+                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
                 IEnumerable<Checkpoint> checkpoints = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup");
 
                 Assert.That(checkpoints, Is.Not.Null.And.Empty);
@@ -192,7 +193,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient);
+                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
                 var ownershipList = new List<PartitionOwnership>();
                 var ownership =
                     new PartitionOwnership
@@ -231,7 +232,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient);
+                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
                 var ownershipList = new List<PartitionOwnership>();
                 var ownership =
                     new PartitionOwnership
@@ -249,8 +250,8 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
                 IEnumerable<PartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup");
 
-                Match claimedOwnershipMatch = s_doubleQuotesExpression.Match(claimedOwnership.First().ETag);
-                Match storedOwnershipListMatch = s_doubleQuotesExpression.Match(storedOwnershipList.First().ETag);
+                var claimedOwnershipMatch = s_doubleQuotesExpression.Match(claimedOwnership.First().ETag);
+                var storedOwnershipListMatch = s_doubleQuotesExpression.Match(storedOwnershipList.First().ETag);
 
                 Assert.That(claimedOwnershipMatch.Success, Is.False);
                 Assert.That(storedOwnershipListMatch.Success, Is.False);
@@ -270,7 +271,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient);
+                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
                 var ownershipList = new List<PartitionOwnership>();
                 var ownership =
                     new PartitionOwnership
@@ -308,7 +309,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient);
+                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
                 var ownershipList = new List<PartitionOwnership>();
                 var firstOwnership =
                     new PartitionOwnership
@@ -362,7 +363,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient);
+                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
                 var ownershipList = new List<PartitionOwnership>();
 
                 var eTaggyOwnership =
@@ -399,7 +400,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient);
+                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
                 var ownershipList = new List<PartitionOwnership>();
                 var firstOwnership =
                     new PartitionOwnership
@@ -457,7 +458,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient);
+                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
                 var ownershipList = new List<PartitionOwnership>();
                 var ownershipCount = 5;
 
@@ -504,7 +505,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient);
+                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
                 var ownershipList = new List<PartitionOwnership>();
                 var ownershipCount = 5;
 
@@ -577,7 +578,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient);
+                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
                 var ownershipList = new List<PartitionOwnership>();
                 var firstOwnership =
                     new PartitionOwnership
@@ -635,7 +636,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient);
+                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
                 var ownershipList = new List<PartitionOwnership>();
                 var firstOwnership =
                     new PartitionOwnership
@@ -693,7 +694,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient);
+                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
                 var ownershipList = new List<PartitionOwnership>();
                 var firstOwnership =
                     new PartitionOwnership
@@ -751,7 +752,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, $"test-container-{Guid.NewGuid()}");
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient);
+                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
 
                 Assert.That(async () => await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup"), Throws.InstanceOf<RequestFailedException>());
             }
@@ -770,7 +771,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, $"test-container-{Guid.NewGuid()}");
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient);
+                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
 
                 Assert.That(async () => await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup"), Throws.InstanceOf<RequestFailedException>());
             }
@@ -789,7 +790,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, $"test-container-{Guid.NewGuid()}");
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient);
+                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
 
                 Assert.That(async () => await checkpointStore.UpdateCheckpointAsync(new Checkpoint
                     ("namespace", "eventHubName", "consumerGroup", "partitionId", offset: 10, sequenceNumber: 20)), Throws.InstanceOf<RequestFailedException>());
@@ -809,7 +810,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient);
+                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
 
                 await checkpointStore.UpdateCheckpointAsync(new Checkpoint
                     ("namespace", "eventHubName", "consumerGroup1", "partitionId", 10, 20));
@@ -841,7 +842,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient);
+                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
 
                 await checkpointStore.UpdateCheckpointAsync(new Checkpoint
                     ("namespace", "eventHubName1", "consumerGroup", "partitionId", 10, 20));
@@ -873,7 +874,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient);
+                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
 
                 await checkpointStore.UpdateCheckpointAsync(new Checkpoint
                     ("namespace1", "eventHubName", "consumerGroup", "partitionId", 10, 20));
@@ -905,7 +906,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
-                var checkpointStore = new BlobsCheckpointStore(containerClient);
+                var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
 
                 await checkpointStore.UpdateCheckpointAsync(new Checkpoint
                     ("namespace", "eventHubName", "consumerGroup", "partitionId1", 10, 20));

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/BlobsCheckpointStore/BlobsCheckpointStoreLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/BlobsCheckpointStore/BlobsCheckpointStoreLiveTests.cs
@@ -43,7 +43,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
                 var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
 
-                Assert.That(async () => await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup"), Throws.Nothing);
+                Assert.That(async () => await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default), Throws.Nothing);
             }
         }
 
@@ -62,7 +62,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
                 var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
 
-                Assert.That(async () => await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup"), Throws.Nothing);
+                Assert.That(async () => await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup", default), Throws.Nothing);
             }
         }
 
@@ -99,7 +99,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                     )
                 };
 
-                Assert.That(async () => await checkpointStore.ClaimOwnershipAsync(ownershipList), Throws.Nothing);
+                Assert.That(async () => await checkpointStore.ClaimOwnershipAsync(ownershipList, default), Throws.Nothing);
             }
         }
 
@@ -132,11 +132,11 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                     )
                 };
 
-                await checkpointStore.ClaimOwnershipAsync(ownershipList);
+                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
 
                 var checkpoint = new Checkpoint("namespace", "eventHubName", "consumerGroup", "partitionId", 10, 20);
 
-                Assert.That(async () => await checkpointStore.UpdateCheckpointAsync(checkpoint), Throws.Nothing);
+                Assert.That(async () => await checkpointStore.UpdateCheckpointAsync(checkpoint, default), Throws.Nothing);
             }
         }
 
@@ -154,7 +154,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
                 var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
-                IEnumerable<PartitionOwnership> ownership = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup");
+                IEnumerable<PartitionOwnership> ownership = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default);
 
                 Assert.That(ownership, Is.Not.Null.And.Empty);
             }
@@ -174,7 +174,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
 
                 var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
-                IEnumerable<Checkpoint> checkpoints = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup");
+                IEnumerable<Checkpoint> checkpoints = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup", default);
 
                 Assert.That(checkpoints, Is.Not.Null.And.Empty);
             }
@@ -207,9 +207,9 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
                 ownershipList.Add(ownership);
 
-                await checkpointStore.ClaimOwnershipAsync(ownershipList);
+                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
 
-                IEnumerable<PartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup");
+                IEnumerable<PartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default);
 
                 Assert.That(storedOwnershipList, Is.Not.Null);
                 Assert.That(storedOwnershipList.Count, Is.EqualTo(1));
@@ -246,9 +246,9 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
                 ownershipList.Add(ownership);
 
-                IEnumerable<PartitionOwnership> claimedOwnership = await checkpointStore.ClaimOwnershipAsync(ownershipList);
+                IEnumerable<PartitionOwnership> claimedOwnership = await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
 
-                IEnumerable<PartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup");
+                IEnumerable<PartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default);
 
                 var claimedOwnershipMatch = s_doubleQuotesExpression.Match(claimedOwnership.First().ETag);
                 var storedOwnershipListMatch = s_doubleQuotesExpression.Match(storedOwnershipList.First().ETag);
@@ -285,7 +285,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
                 ownershipList.Add(ownership);
 
-                await checkpointStore.ClaimOwnershipAsync(ownershipList);
+                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
 
                 Assert.That(ownership.LastModifiedTime, Is.Not.Null);
                 Assert.That(ownership.LastModifiedTime.Value, Is.GreaterThan(DateTimeOffset.UtcNow.Subtract(TimeSpan.FromSeconds(5))));
@@ -323,7 +323,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
                 ownershipList.Add(firstOwnership);
 
-                await checkpointStore.ClaimOwnershipAsync(ownershipList);
+                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
 
                 ownershipList.Clear();
 
@@ -340,9 +340,9 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
                 ownershipList.Add(secondOwnership);
 
-                await checkpointStore.ClaimOwnershipAsync(ownershipList);
+                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
 
-                IEnumerable<PartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup");
+                IEnumerable<PartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default);
 
                 Assert.That(storedOwnershipList, Is.Not.Null);
                 Assert.That(storedOwnershipList.Count, Is.EqualTo(1));
@@ -379,9 +379,9 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
                 ownershipList.Add(eTaggyOwnership);
 
-                await checkpointStore.ClaimOwnershipAsync(ownershipList);
+                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
 
-                IEnumerable<PartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup");
+                IEnumerable<PartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default);
 
                 Assert.That(storedOwnershipList, Is.Not.Null.And.Empty);
             }
@@ -414,7 +414,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
                 ownershipList.Add(firstOwnership);
 
-                await checkpointStore.ClaimOwnershipAsync(ownershipList);
+                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
 
                 // ETag must have been set by the checkpoint store.
 
@@ -435,9 +435,9 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
                 ownershipList.Add(secondOwnership);
 
-                await checkpointStore.ClaimOwnershipAsync(ownershipList);
+                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
 
-                IEnumerable<PartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup");
+                IEnumerable<PartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default);
 
                 Assert.That(storedOwnershipList, Is.Not.Null);
                 Assert.That(storedOwnershipList.Count, Is.EqualTo(1));
@@ -475,9 +475,9 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                         ));
                 }
 
-                await checkpointStore.ClaimOwnershipAsync(ownershipList);
+                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
 
-                IEnumerable<PartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup");
+                IEnumerable<PartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default);
 
                 Assert.That(storedOwnershipList, Is.Not.Null);
                 Assert.That(storedOwnershipList.Count, Is.EqualTo(ownershipCount));
@@ -522,7 +522,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                         ));
                 }
 
-                await checkpointStore.ClaimOwnershipAsync(ownershipList);
+                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
 
                 // The ETags must have been set by the checkpoint store.
 
@@ -549,7 +549,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                         ));
                 }
 
-                IEnumerable<PartitionOwnership> claimedOwnershipList = await checkpointStore.ClaimOwnershipAsync(ownershipList);
+                IEnumerable<PartitionOwnership> claimedOwnershipList = await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
                 IEnumerable<PartitionOwnership> expectedOwnership = ownershipList.Where(ownership => int.Parse(ownership.PartitionId) % 2 == 1);
 
                 Assert.That(claimedOwnershipList, Is.Not.Null);
@@ -592,7 +592,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
                 ownershipList.Add(firstOwnership);
 
-                await checkpointStore.ClaimOwnershipAsync(ownershipList);
+                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
 
                 // ETag must have been set by the checkpoint store.
 
@@ -613,9 +613,9 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
                 ownershipList.Add(secondOwnership);
 
-                await checkpointStore.ClaimOwnershipAsync(ownershipList);
+                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
 
-                IEnumerable<PartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup1");
+                IEnumerable<PartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup1", default);
 
                 Assert.That(storedOwnershipList, Is.Not.Null);
                 Assert.That(storedOwnershipList.Count, Is.EqualTo(1));
@@ -650,7 +650,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
                 ownershipList.Add(firstOwnership);
 
-                await checkpointStore.ClaimOwnershipAsync(ownershipList);
+                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
 
                 // ETag must have been set by the checkpoint store.
 
@@ -671,9 +671,9 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
                 ownershipList.Add(secondOwnership);
 
-                await checkpointStore.ClaimOwnershipAsync(ownershipList);
+                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
 
-                IEnumerable<PartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName1", "consumerGroup");
+                IEnumerable<PartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName1", "consumerGroup", default);
 
                 Assert.That(storedOwnershipList, Is.Not.Null);
                 Assert.That(storedOwnershipList.Count, Is.EqualTo(1));
@@ -708,7 +708,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
                 ownershipList.Add(firstOwnership);
 
-                await checkpointStore.ClaimOwnershipAsync(ownershipList);
+                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
 
                 // ETag must have been set by the checkpoint store.
 
@@ -729,9 +729,9 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
                 ownershipList.Add(secondOwnership);
 
-                await checkpointStore.ClaimOwnershipAsync(ownershipList);
+                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
 
-                var storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace1", "eventHubName", "consumerGroup");
+                var storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace1", "eventHubName", "consumerGroup", default);
 
                 Assert.That(storedOwnershipList, Is.Not.Null);
                 Assert.That(storedOwnershipList.Count, Is.EqualTo(1));
@@ -754,7 +754,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
                 var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
 
-                Assert.That(async () => await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup"), Throws.InstanceOf<RequestFailedException>());
+                Assert.That(async () => await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default), Throws.InstanceOf<RequestFailedException>());
             }
         }
 
@@ -773,7 +773,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
                 var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
 
-                Assert.That(async () => await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup"), Throws.InstanceOf<RequestFailedException>());
+                Assert.That(async () => await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup", default), Throws.InstanceOf<RequestFailedException>());
             }
         }
 
@@ -793,7 +793,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
 
                 Assert.That(async () => await checkpointStore.UpdateCheckpointAsync(new Checkpoint
-                    ("namespace", "eventHubName", "consumerGroup", "partitionId", offset: 10, sequenceNumber: 20)), Throws.InstanceOf<RequestFailedException>());
+                    ("namespace", "eventHubName", "consumerGroup", "partitionId", offset: 10, sequenceNumber: 20), default), Throws.InstanceOf<RequestFailedException>());
             }
         }
 
@@ -813,13 +813,13 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
 
                 await checkpointStore.UpdateCheckpointAsync(new Checkpoint
-                    ("namespace", "eventHubName", "consumerGroup1", "partitionId", 10, 20));
+                    ("namespace", "eventHubName", "consumerGroup1", "partitionId", 10, 20), default);
 
                 await checkpointStore.UpdateCheckpointAsync(new Checkpoint
-                    ("namespace", "eventHubName", "consumerGroup2", "partitionId", 10, 20));
+                    ("namespace", "eventHubName", "consumerGroup2", "partitionId", 10, 20), default);
 
-                IEnumerable<Checkpoint> storedCheckpointsList1 = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup1");
-                IEnumerable<Checkpoint> storedCheckpointsList2 = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup2");
+                IEnumerable<Checkpoint> storedCheckpointsList1 = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup1", default);
+                IEnumerable<Checkpoint> storedCheckpointsList2 = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup2", default);
 
                 Assert.That(storedCheckpointsList1, Is.Not.Null);
                 Assert.That(storedCheckpointsList1.Count, Is.EqualTo(1));
@@ -845,13 +845,13 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
 
                 await checkpointStore.UpdateCheckpointAsync(new Checkpoint
-                    ("namespace", "eventHubName1", "consumerGroup", "partitionId", 10, 20));
+                    ("namespace", "eventHubName1", "consumerGroup", "partitionId", 10, 20), default);
 
                 await checkpointStore.UpdateCheckpointAsync(new Checkpoint
-                    ("namespace", "eventHubName2", "consumerGroup", "partitionId", 10, 20));
+                    ("namespace", "eventHubName2", "consumerGroup", "partitionId", 10, 20), default);
 
-                IEnumerable<Checkpoint> storedCheckpointsList1 = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName1", "consumerGroup");
-                IEnumerable<Checkpoint> storedCheckpointsList2 = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName2", "consumerGroup");
+                IEnumerable<Checkpoint> storedCheckpointsList1 = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName1", "consumerGroup", default);
+                IEnumerable<Checkpoint> storedCheckpointsList2 = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName2", "consumerGroup", default);
 
                 Assert.That(storedCheckpointsList1, Is.Not.Null);
                 Assert.That(storedCheckpointsList1.Count, Is.EqualTo(1));
@@ -877,13 +877,13 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
 
                 await checkpointStore.UpdateCheckpointAsync(new Checkpoint
-                    ("namespace1", "eventHubName", "consumerGroup", "partitionId", 10, 20));
+                    ("namespace1", "eventHubName", "consumerGroup", "partitionId", 10, 20), default);
 
                 await checkpointStore.UpdateCheckpointAsync(new Checkpoint
-                    ("namespace2", "eventHubName", "consumerGroup", "partitionId", 10, 20));
+                    ("namespace2", "eventHubName", "consumerGroup", "partitionId", 10, 20), default);
 
-                IEnumerable<Checkpoint> storedCheckpointsList1 = await checkpointStore.ListCheckpointsAsync("namespace1", "eventHubName", "consumerGroup");
-                IEnumerable<Checkpoint> storedCheckpointsList2 = await checkpointStore.ListCheckpointsAsync("namespace2", "eventHubName", "consumerGroup");
+                IEnumerable<Checkpoint> storedCheckpointsList1 = await checkpointStore.ListCheckpointsAsync("namespace1", "eventHubName", "consumerGroup", default);
+                IEnumerable<Checkpoint> storedCheckpointsList2 = await checkpointStore.ListCheckpointsAsync("namespace2", "eventHubName", "consumerGroup", default);
 
                 Assert.That(storedCheckpointsList1, Is.Not.Null);
                 Assert.That(storedCheckpointsList1.Count, Is.EqualTo(1));
@@ -909,12 +909,12 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 var checkpointStore = new BlobsCheckpointStore(containerClient, Mock.Of<EventHubsRetryPolicy>());
 
                 await checkpointStore.UpdateCheckpointAsync(new Checkpoint
-                    ("namespace", "eventHubName", "consumerGroup", "partitionId1", 10, 20));
+                    ("namespace", "eventHubName", "consumerGroup", "partitionId1", 10, 20), default);
 
                 await checkpointStore.UpdateCheckpointAsync(new Checkpoint
-                    ("namespace", "eventHubName", "consumerGroup", "partitionId2", 10, 20));
+                    ("namespace", "eventHubName", "consumerGroup", "partitionId2", 10, 20), default);
 
-                IEnumerable<Checkpoint> storedCheckpointsList = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup");
+                IEnumerable<Checkpoint> storedCheckpointsList = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup", default);
 
                 Assert.That(storedCheckpointsList, Is.Not.Null);
                 Assert.That(storedCheckpointsList.Count, Is.EqualTo(2));

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/BlobsCheckpointStore/BlobsCheckpointStoreTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/BlobsCheckpointStore/BlobsCheckpointStoreTests.cs
@@ -23,7 +23,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         [Test]
         public void ConstructorRequiresBlobContainerClient()
         {
-            Assert.That(() => new BlobsCheckpointStore(null, Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentNullException>());
+            Assert.That(() => new BlobsCheckpointStore(null, Mock.Of<EventHubsRetryPolicy>()), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         [Test]
         public void ConstructorRequiresRetryPolicy()
         {
-            Assert.That(() => new BlobsCheckpointStore(Mock.Of<BlobContainerClient>(), null), Throws.InstanceOf<ArgumentNullException>());
+            Assert.That(() => new BlobsCheckpointStore(Mock.Of<BlobContainerClient>(), null), Throws.ArgumentNullException);
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/BlobsCheckpointStore/BlobsCheckpointStoreTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/BlobsCheckpointStore/BlobsCheckpointStoreTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
+using Azure.Storage.Blobs;
+using Moq;
 using NUnit.Framework;
 
 namespace Azure.Messaging.EventHubs.Processor.Tests
@@ -21,7 +23,18 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         [Test]
         public void ConstructorRequiresBlobContainerClient()
         {
-            Assert.That(() => new BlobsCheckpointStore(null), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new BlobsCheckpointStore(null, Mock.Of<EventHubsRetryPolicy>()), Throws.InstanceOf<ArgumentNullException>());
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="BlobsCheckpointStore" />
+        ///    constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorRequiresRetryPolicy()
+        {
+            Assert.That(() => new BlobsCheckpointStore(Mock.Of<BlobContainerClient>(), null), Throws.InstanceOf<ArgumentNullException>());
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
@@ -49,7 +49,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             var data = new MockEventData(new byte[0], sequenceNumber: 0, offset: 0);
 
             var storageManager = new Mock<PartitionManager>();
-            var eventProcessor = new Mock<EventProcessorClient>(Mock.Of<BlobContainerClient>(), "cg", endpoint.Host, eventHubName, fakeFactory, null);
+            var eventProcessor = new Mock<EventProcessorClient>(Mock.Of<PartitionManager>(), "cg", endpoint.Host, eventHubName, fakeFactory, null);
 
             storageManager
                 .Setup(manager => manager.UpdateCheckpointAsync(It.IsAny<Checkpoint>()))

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
@@ -60,7 +60,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 .Setup(processor => processor.CreateStorageManager(It.IsAny<BlobContainerClient>()))
                 .Returns(storageManager.Object);
 
-            await eventProcessor.Object.UpdateCheckpointAsync(data, context);
+            await eventProcessor.Object.UpdateCheckpointAsync(data, context, default);
 
             ClientDiagnosticListener.ProducedDiagnosticScope scope = listener.Scopes.Single();
             Assert.That(scope.Name, Is.EqualTo(DiagnosticProperty.EventProcessorCheckpointActivityName));

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Tests;
 using Azure.Messaging.EventHubs.Diagnostics;
@@ -52,7 +53,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             var eventProcessor = new Mock<EventProcessorClient>(Mock.Of<PartitionManager>(), "cg", endpoint.Host, eventHubName, fakeFactory, null);
 
             storageManager
-                .Setup(manager => manager.UpdateCheckpointAsync(It.IsAny<Checkpoint>()))
+                .Setup(manager => manager.UpdateCheckpointAsync(It.IsAny<Checkpoint>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
             eventProcessor

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/EventProcessorClient/EventProcessorClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/EventProcessorClient/EventProcessorClientLiveTests.cs
@@ -8,10 +8,11 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Messaging.EventHubs.Tests;
+using Azure.Messaging.EventHubs.Processor;
+using Azure.Messaging.EventHubs.Processor.Tests;
 using NUnit.Framework;
 
-namespace Azure.Messaging.EventHubs.Processor.Tests
+namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
     ///   The suite of live tests for the <see cref="EventProcessorClient" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/EventProcessorClient/EventProcessorClientOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/EventProcessorClient/EventProcessorClientOptionsTests.cs
@@ -5,7 +5,7 @@ using System;
 using Azure.Messaging.EventHubs.Core;
 using NUnit.Framework;
 
-namespace Azure.Messaging.EventHubs.Processor.Tests
+namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
     ///   The suite of tests for the <see cref="EventProcessorClientOptions" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/EventProcessorClient/EventProcessorClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/EventProcessorClient/EventProcessorClientTests.cs
@@ -9,11 +9,12 @@ using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Messaging.EventHubs.Authorization;
 using Azure.Messaging.EventHubs.Core;
+using Azure.Messaging.EventHubs.Processor;
 using Azure.Storage.Blobs;
 using Moq;
 using NUnit.Framework;
 
-namespace Azure.Messaging.EventHubs.Processor.Tests
+namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
     ///   The suite of tests for the <see cref="EventProcessorClient" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/EventProcessorClient/EventProcessorClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/EventProcessorClient/EventProcessorClientTests.cs
@@ -438,7 +438,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         [Test]
         public void StartAsyncValidatesProcessEventsAsync()
         {
-            var processor = new EventProcessorClient(Mock.Of<BlobContainerClient>(), "consumerGroup", "namespace", "eventHub", () => new MockConnection(), default);
+            var processor = new EventProcessorClient(Mock.Of<PartitionManager>(), "consumerGroup", "namespace", "eventHub", () => new MockConnection(), default);
             processor.ProcessErrorAsync += eventArgs => Task.CompletedTask;
 
             Assert.That(async () => await processor.StartProcessingAsync(), Throws.InstanceOf<InvalidOperationException>().And.Message.Contains(nameof(EventProcessorClient.ProcessEventAsync)));
@@ -452,7 +452,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         [Test]
         public void StartAsyncValidatesProcessExceptionAsync()
         {
-            var processor = new EventProcessorClient(Mock.Of<BlobContainerClient>(), "consumerGroup", "namespace", "eventHub", () => new MockConnection(), default);
+            var processor = new EventProcessorClient(Mock.Of<PartitionManager>(), "consumerGroup", "namespace", "eventHub", () => new MockConnection(), default);
             processor.ProcessEventAsync += eventArgs => Task.CompletedTask;
 
             Assert.That(async () => await processor.StartProcessingAsync(), Throws.InstanceOf<InvalidOperationException>().And.Message.Contains(nameof(EventProcessorClient.ProcessErrorAsync)));
@@ -466,7 +466,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         [Test]
         public async Task StartAsyncStartsTheEventProcessorWhenProcessingHandlerPropertiesAreSet()
         {
-            var processor = new EventProcessorClient(Mock.Of<BlobContainerClient>(), "consumerGroup", "namespace", "eventHub", () => new MockConnection(), default);
+            var processor = new EventProcessorClient(Mock.Of<PartitionManager>(), "consumerGroup", "namespace", "eventHub", () => new MockConnection(), default);
 
             processor.ProcessEventAsync += eventArgs => Task.CompletedTask;
             processor.ProcessErrorAsync += eventArgs => Task.CompletedTask;
@@ -484,7 +484,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         [Ignore("Update to match new event behavior.")]
         public async Task HandlerPropertiesCannotBeSetWhenEventProcessorIsRunning()
         {
-            var processor = new EventProcessorClient(Mock.Of<BlobContainerClient>(), "consumerGroup", "namespace", "eventHub", () => new MockConnection(), default);
+            var processor = new EventProcessorClient(Mock.Of<PartitionManager>(), "consumerGroup", "namespace", "eventHub", () => new MockConnection(), default);
 
             processor.ProcessEventAsync += eventArgs => Task.CompletedTask;
             processor.ProcessErrorAsync += eventArgs => Task.CompletedTask;
@@ -507,7 +507,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         [Ignore("Update to match new event behavior.")]
         public async Task HandlerPropertiesCanBeSetAfterEventProcessorHasStopped()
         {
-            var processor = new EventProcessorClient(Mock.Of<BlobContainerClient>(), "consumerGroup", "namespace", "eventHub", () => new MockConnection(), default);
+            var processor = new EventProcessorClient(Mock.Of<PartitionManager>(), "consumerGroup", "namespace", "eventHub", () => new MockConnection(), default);
 
             processor.ProcessEventAsync += eventArgs => Task.CompletedTask;
             processor.ProcessErrorAsync += eventArgs => Task.CompletedTask;

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Infrastructure/EventProcessorManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Infrastructure/EventProcessorManager.cs
@@ -336,19 +336,14 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             internal override TimeSpan LoadBalanceUpdate => ShortLoadBalanceUpdate;
             internal override TimeSpan OwnershipExpiration => ShortOwnershipExpiration;
 
-            private PartitionManager _partitionManager;
-
             public ShortWaitTimeMock(PartitionManager partitionManager,
                                      string consumerGroup,
                                      string fullyQualifiedNamespace,
                                      string eventHubName,
                                      Func<EventHubConnection> connectionFactory,
-                                     EventProcessorClientOptions clientOptions) : base(Mock.Of<BlobContainerClient>(), consumerGroup, fullyQualifiedNamespace, eventHubName, connectionFactory, clientOptions)
+                                     EventProcessorClientOptions clientOptions) : base(partitionManager, consumerGroup, fullyQualifiedNamespace, eventHubName, connectionFactory, clientOptions)
             {
-                _partitionManager = partitionManager;
             }
-
-            internal override PartitionManager CreateStorageManager(BlobContainerClient checkpointStore) => _partitionManager;
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Infrastructure/EventProcessorManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Infrastructure/EventProcessorManager.cs
@@ -227,7 +227,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 // Remember to filter expired ownership.
 
                 var activeOwnership = (await InnerPartitionManager
-                    .ListOwnershipAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup)
+                    .ListOwnershipAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, timeoutToken)
                     .ConfigureAwait(false))
                     .Where(ownership => DateTimeOffset.UtcNow.Subtract(ownership.LastModifiedTime.Value) < ShortWaitTimeMock.ShortOwnershipExpiration)
                     .ToList();

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Infrastructure/MockCheckPointStorage.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Infrastructure/MockCheckPointStorage.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Azure.Messaging.EventHubs.Processor.Tests
@@ -56,12 +57,14 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
         /// <param name="eventHubName">The name of the specific Event Hub the ownership are associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the ownership are associated with.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.  Not supported.</param>
         ///
         /// <returns>An enumerable containing all the existing ownership for the associated Event Hub and consumer group.</returns>
         ///
         public override Task<IEnumerable<PartitionOwnership>> ListOwnershipAsync(string fullyQualifiedNamespace,
                                                                                  string eventHubName,
-                                                                                 string consumerGroup)
+                                                                                 string consumerGroup,
+                                                                                 CancellationToken cancellationToken = default)
         {
             List<PartitionOwnership> ownershipList;
 
@@ -82,10 +85,12 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         /// </summary>
         ///
         /// <param name="partitionOwnership">An enumerable containing all the ownership to claim.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.  Not supported.</param>
         ///
         /// <returns>An enumerable containing the successfully claimed ownership.</returns>
         ///
-        public override Task<IEnumerable<PartitionOwnership>> ClaimOwnershipAsync(IEnumerable<PartitionOwnership> partitionOwnership)
+        public override Task<IEnumerable<PartitionOwnership>> ClaimOwnershipAsync(IEnumerable<PartitionOwnership> partitionOwnership,
+                                                                                  CancellationToken cancellationToken = default)
         {
             var claimedOwnership = new List<PartitionOwnership>();
 
@@ -132,12 +137,14 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
         /// <param name="eventHubName">The name of the specific Event Hub the ownership are associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the ownership are associated with.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.  Not supported.</param>
         ///
         /// <returns>An enumerable containing all the existing ownership for the associated Event Hub and consumer group.</returns>
         ///
         public override Task<IEnumerable<Checkpoint>> ListCheckpointsAsync(string fullyQualifiedNamespace,
                                                                            string eventHubName,
-                                                                           string consumerGroup)
+                                                                           string consumerGroup,
+                                                                           CancellationToken cancellationToken = default)
         {
             List<Checkpoint> checkpointList;
 
@@ -158,8 +165,10 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         /// </summary>
         ///
         /// <param name="checkpoint">The checkpoint containing the information to be stored.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.  Not supported.</param>
         ///
-        public override Task UpdateCheckpointAsync(Checkpoint checkpoint)
+        public override Task UpdateCheckpointAsync(Checkpoint checkpoint,
+                                                   CancellationToken cancellationToken = default)
         {
             lock (_checkpointLock)
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Processor/PartitionOwnership.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Processor/PartitionOwnership.cs
@@ -88,7 +88,7 @@ namespace Azure.Messaging.EventHubs.Processor
             Argument.AssertNotNullOrEmpty(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace));
             Argument.AssertNotNullOrEmpty(eventHubName, nameof(eventHubName));
             Argument.AssertNotNullOrEmpty(consumerGroup, nameof(consumerGroup));
-            Argument.AssertNotNullOrEmpty(ownerIdentifier, nameof(ownerIdentifier));
+            Argument.AssertNotNull(ownerIdentifier, nameof(ownerIdentifier));
             Argument.AssertNotNullOrEmpty(partitionId, nameof(partitionId));
 
             FullyQualifiedNamespace = fullyQualifiedNamespace;

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
@@ -420,7 +420,7 @@ namespace Azure.Messaging.EventHubs {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Another handler has already been assigned to this event..
+        ///   Looks up a localized string similar to Another handler has already been assigned to this event and there can be only one..
         /// </summary>
         internal static string HandlerHasAlreadyBeenAssigned
         {
@@ -431,7 +431,7 @@ namespace Azure.Messaging.EventHubs {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Handler has not been previously assigned to this event..
+        ///   Looks up a localized string similar to This handler has not been previously assigned to this event..
         /// </summary>
         internal static string HandlerHasNotBeenAssigned
         {
@@ -444,66 +444,66 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to Retrieving list of ownership from the storage service..
         /// </summary>
-        internal static string ListOwnershipOperation
+        internal static string OperationListOwnership
         {
             get
             {
-                return ResourceManager.GetString("ListOwnershipOperation", resourceCulture);
+                return ResourceManager.GetString("OperationListOwnership", resourceCulture);
             }
         }
 
         /// <summary>
         ///   Looks up a localized string similar to Retrieving list of partition identifiers from a Consumer Client..
         /// </summary>
-        internal static string GetPartitionIdsOperation
+        internal static string OperationGetPartitionIds
         {
             get
             {
-                return ResourceManager.GetString("GetPartitionIdsOperation", resourceCulture);
+                return ResourceManager.GetString("OperationGetPartitionIds", resourceCulture);
             }
         }
 
         /// <summary>
         ///   Looks up a localized string similar to Retrieving list of checkpoints from the storage service..
         /// </summary>
-        internal static string ListCheckpointsOperation
+        internal static string OperationListCheckpoints
         {
             get
             {
-                return ResourceManager.GetString("ListCheckpointsOperation", resourceCulture);
+                return ResourceManager.GetString("OperationListCheckpoints", resourceCulture);
             }
         }
 
         /// <summary>
         ///   Looks up a localized string similar to Attempting to claim a new ownership in the storage service..
         /// </summary>
-        internal static string ClaimOwnershipOperation
+        internal static string OperationClaimOwnership
         {
             get
             {
-                return ResourceManager.GetString("ClaimOwnershipOperation", resourceCulture);
+                return ResourceManager.GetString("OperationClaimOwnership", resourceCulture);
             }
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Attempting to renew all of the processor's ownership in the storage service..
+        ///   Looks up a localized string similar to Attempting to renew all of the processor's partition ownership in the storage service..
         /// </summary>
-        internal static string RenewOwnershipOperation
+        internal static string OperationRenewOwnership
         {
             get
             {
-                return ResourceManager.GetString("RenewOwnershipOperation", resourceCulture);
+                return ResourceManager.GetString("OperationRenewOwnership", resourceCulture);
             }
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Receiving events from the Event Hubs service..
+        ///   Looks up a localized string similar to Reading events from the Event Hubs service..
         /// </summary>
-        internal static string ReadEventsOperation
+        internal static string OperationReadEvents
         {
             get
             {
-                return ResourceManager.GetString("ReadEventsOperation", resourceCulture);
+                return ResourceManager.GetString("OperationReadEvents", resourceCulture);
             }
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
@@ -418,5 +418,93 @@ namespace Azure.Messaging.EventHubs {
                 return ResourceManager.GetString("CannotCreateCheckpointForEmptyEvent", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Another handler has already been assigned to this event..
+        /// </summary>
+        internal static string HandlerHasAlreadyBeenAssigned
+        {
+            get
+            {
+                return ResourceManager.GetString("HandlerHasAlreadyBeenAssigned", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Handler has not been previously assigned to this event..
+        /// </summary>
+        internal static string HandlerHasNotBeenAssigned
+        {
+            get
+            {
+                return ResourceManager.GetString("HandlerHasNotBeenAssigned", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Retrieving list of ownership from the storage service..
+        /// </summary>
+        internal static string ListOwnershipOperation
+        {
+            get
+            {
+                return ResourceManager.GetString("ListOwnershipOperation", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Retrieving list of partition identifiers from a Consumer Client..
+        /// </summary>
+        internal static string GetPartitionIdsOperation
+        {
+            get
+            {
+                return ResourceManager.GetString("GetPartitionIdsOperation", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Retrieving list of checkpoints from the storage service..
+        /// </summary>
+        internal static string ListCheckpointsOperation
+        {
+            get
+            {
+                return ResourceManager.GetString("ListCheckpointsOperation", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Attempting to claim a new ownership in the storage service..
+        /// </summary>
+        internal static string ClaimOwnershipOperation
+        {
+            get
+            {
+                return ResourceManager.GetString("ClaimOwnershipOperation", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Attempting to renew all of the processor's ownership in the storage service..
+        /// </summary>
+        internal static string RenewOwnershipOperation
+        {
+            get
+            {
+                return ResourceManager.GetString("RenewOwnershipOperation", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Receiving events from the Event Hubs service..
+        /// </summary>
+        internal static string ReadEventsOperation
+        {
+            get
+            {
+                return ResourceManager.GetString("ReadEventsOperation", resourceCulture);
+            }
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
@@ -238,27 +238,27 @@
     <value>A checkpoint cannot be created or updated using an empty event.</value>
   </data>
   <data name="HandlerHasAlreadyBeenAssigned" xml:space="preserve">
-    <value>Another handler has already been assigned to this event.</value>
+    <value>Another handler has already been assigned to this event and there can be only one.</value>
   </data>
   <data name="HandlerHasNotBeenAssigned" xml:space="preserve">
-    <value>Handler has not been previously assigned to this event.</value>
+    <value>This handler has not been previously assigned to this event.</value>
   </data>
-  <data name="ListOwnershipOperation" xml:space="preserve">
+  <data name="OperationListOwnership" xml:space="preserve">
     <value>Retrieving list of ownership from the storage service.</value>
   </data>
-  <data name="GetPartitionIdsOperation" xml:space="preserve">
+  <data name="OperationGetPartitionIds" xml:space="preserve">
     <value>Retrieving list of partition identifiers from a Consumer Client.</value>
   </data>
-  <data name="ListCheckpointsOperation" xml:space="preserve">
+  <data name="OperationListCheckpoints" xml:space="preserve">
     <value>Retrieving list of checkpoints from the storage service.</value>
   </data>
-  <data name="ClaimOwnershipOperation" xml:space="preserve">
+  <data name="OperationClaimOwnership" xml:space="preserve">
     <value>Attempting to claim a new ownership in the storage service.</value>
   </data>
-  <data name="RenewOwnershipOperation" xml:space="preserve">
-    <value>Attempting to renew all of the processor's ownership in the storage service.</value>
+  <data name="OperationRenewOwnership" xml:space="preserve">
+    <value>Attempting to renew all of the processor's partition ownership in the storage service.</value>
   </data>
-  <data name="ReadEventsOperation" xml:space="preserve">
-    <value>Receiving events from the Event Hubs service.</value>
+  <data name="OperationReadEvents" xml:space="preserve">
+    <value>Reading events from the Event Hubs service.</value>
   </data>
 </root>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
@@ -237,4 +237,28 @@
   <data name="CannotCreateCheckpointForEmptyEvent" xml:space="preserve">
     <value>A checkpoint cannot be created or updated using an empty event.</value>
   </data>
+  <data name="HandlerHasAlreadyBeenAssigned" xml:space="preserve">
+    <value>Another handler has already been assigned to this event.</value>
+  </data>
+  <data name="HandlerHasNotBeenAssigned" xml:space="preserve">
+    <value>Handler has not been previously assigned to this event.</value>
+  </data>
+  <data name="ListOwnershipOperation" xml:space="preserve">
+    <value>Retrieving list of ownership from the storage service.</value>
+  </data>
+  <data name="GetPartitionIdsOperation" xml:space="preserve">
+    <value>Retrieving list of partition identifiers from a Consumer Client.</value>
+  </data>
+  <data name="ListCheckpointsOperation" xml:space="preserve">
+    <value>Retrieving list of checkpoints from the storage service.</value>
+  </data>
+  <data name="ClaimOwnershipOperation" xml:space="preserve">
+    <value>Attempting to claim a new ownership in the storage service.</value>
+  </data>
+  <data name="RenewOwnershipOperation" xml:space="preserve">
+    <value>Attempting to renew all of the processor's ownership in the storage service.</value>
+  </data>
+  <data name="ReadEventsOperation" xml:space="preserve">
+    <value>Receiving events from the Event Hubs service.</value>
+  </data>
 </root>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Testing/EventDataExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Testing/EventDataExtensionsTests.cs
@@ -38,10 +38,10 @@ namespace Azure.Messaging.EventHubs.Tests
         public void IsEquivalentToDetectsDifferentDifferentOffset()
         {
             var firstEvent = new MockEventData(
-                 eventBody: new byte[] { 0x22, 0x44 },
-                 offset: 1,
-                 partitionKey: "hello",
-                 systemProperties: new Dictionary<string, object> { { "test", new object() } });
+                eventBody: new byte[] { 0x22, 0x44 },
+                offset: 1,
+                partitionKey: "hello",
+                systemProperties: new Dictionary<string, object> { { "test", new object() } });
 
             var secondEvent = new MockEventData(
                 eventBody: new byte[] { 0x22, 0x44 },
@@ -61,10 +61,10 @@ namespace Azure.Messaging.EventHubs.Tests
         public void IsEquivalentToDetectsDifferentDifferentSequenceNumbers()
         {
             var firstEvent = new MockEventData(
-                 eventBody: new byte[] { 0x22, 0x44 },
-                 offset: 1,
-                 partitionKey: "hello",
-                 systemProperties: new Dictionary<string, object> { { "test", new object() } });
+                eventBody: new byte[] { 0x22, 0x44 },
+                offset: 1,
+                partitionKey: "hello",
+                systemProperties: new Dictionary<string, object> { { "test", new object() } });
 
             var secondEvent = new MockEventData(
                 eventBody: new byte[] { 0x22, 0x44 },
@@ -84,10 +84,10 @@ namespace Azure.Messaging.EventHubs.Tests
         public void IsEquivalentToDetectsDifferentDifferentPartitionKey()
         {
             var firstEvent = new MockEventData(
-                 eventBody: new byte[] { 0x22, 0x44 },
-                 offset: 1,
-                 partitionKey: "hello",
-                 systemProperties: new Dictionary<string, object> { { "test", new object() } });
+                eventBody: new byte[] { 0x22, 0x44 },
+                offset: 1,
+                partitionKey: "hello",
+                systemProperties: new Dictionary<string, object> { { "test", new object() } });
 
             var secondEvent = new MockEventData(
                 eventBody: new byte[] { 0x22, 0x44 },

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/ProcessEventArgs.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/ProcessEventArgs.cs
@@ -42,7 +42,7 @@ namespace Azure.Messaging.EventHubs.Processor
         public EventData Data { get; }
 
         /// <summary>
-        ///   A <see cref="CancellationToken"/> instance to signal the request to cancel the operation.
+        ///   A <see cref="System.Threading.CancellationToken"/> instance to signal the request to cancel the operation.
         /// </summary>
         ///
         public CancellationToken CancellationToken { get; }
@@ -51,7 +51,7 @@ namespace Azure.Messaging.EventHubs.Processor
         ///   The callback to be called upon <see cref="UpdateCheckpointAsync" /> call.
         /// </summary>
         ///
-        private Func<Task> UpdateCheckpointAsyncImplementation { get; }
+        private Func<CancellationToken, Task> UpdateCheckpointAsyncImplementation { get; }
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="ProcessEventArgs"/> structure.
@@ -60,11 +60,11 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="partition">The context of the Event Hub partition this instance is associated with.</param>
         /// <param name="data">The received event to be processed.  Expected to be <c>null</c> if the receive call has timed out.</param>
         /// <param name="updateCheckpointImplementation">The callback to be called upon <see cref="UpdateCheckpointAsync" /> call.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         public ProcessEventArgs(PartitionContext partition,
                                 EventData data,
-                                Func<Task> updateCheckpointImplementation,
+                                Func<CancellationToken, Task> updateCheckpointImplementation,
                                 CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(updateCheckpointImplementation, nameof(updateCheckpointImplementation));
@@ -80,9 +80,10 @@ namespace Azure.Messaging.EventHubs.Processor
         ///   this event.
         /// </summary>
         ///
-        /// <exception cref="ArgumentNullException">Occurs when <see cref="Data" /> is <c>null</c>.</exception>
-        /// <exception cref="EventHubsClientClosedException">Occurs when the <c>EventProcessorClient</c> needed to perform this operation is no longer available.</exception>
+        /// <param name="cancellationToken">An optional <see cref="System.Threading.CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
-        public Task UpdateCheckpointAsync() => UpdateCheckpointAsyncImplementation();
+        /// <exception cref="InvalidOperationException">Occurs when <see cref="Partition" /> and <see cref="Data" /> are <c>null</c>.</exception>
+        ///
+        public Task UpdateCheckpointAsync(CancellationToken cancellationToken = default) => UpdateCheckpointAsyncImplementation(cancellationToken);
     }
 }


### PR DESCRIPTION
### Summary

The intent of these changes is to include error handling support in the `EventProcessorClient` implementation, as well as some other minor features.

### Changes

- Errors are handled properly in `EventProcessorClient` and `BlobsCheckpointStore` types. Errors that cannot be surfaced are passed to the `OnProcessError` handler.
- `CancellationToken`s are supported and honored in the two aforementioned types.
- The specified `RetryPolicy` is being applied to every blocking operation internally before throwing an error.
- `PartitionOwnership` instances with an empty `OwnerId` are considered ownerless.

### Related issues

[Refactor the Event Processor Client and associated types](https://github.com/Azure/azure-sdk-for-net/issues/8580)
[Event Processor Client should lose ownership when gracefully shutting down](https://github.com/Azure/azure-sdk-for-net/issues/8844) (partially solved)