### PR TITLE
Convert ReceiverRuntimeMetricsTests to unit tests and speed up some existing long sleep tests

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/PartitionReceiver.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/PartitionReceiver.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.EventHubs
         /// <param name="eventPosition"></param>
         /// <param name="epoch"></param>
         /// <param name="receiverOptions"></param>
-        protected internal PartitionReceiver(
+        protected PartitionReceiver(
             EventHubClient eventHubClient,
             string consumerGroupName,
             string partitionId,

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/MockEventDataSender.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/MockEventDataSender.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.EventHubs.Tests.Client
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    internal class MockEventDataSender : EventDataSender
+    {
+        private readonly MockEventHubClient eventHubClient;
+
+        internal MockEventDataSender(MockEventHubClient eventHubClient, string partitionId)
+            : base(eventHubClient, partitionId)
+        {
+            this.RetryPolicy = eventHubClient.RetryPolicy.Clone();
+            this.eventHubClient = eventHubClient;
+        }
+
+        public override Task CloseAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        protected override Task OnSendAsync(IEnumerable<EventData> eventDatas, string partitionKey)
+        {
+            if (eventHubClient.EventManager.TryGetValue(PartitionId, out var eventQueue))
+            {
+                var utcNow = DateTime.UtcNow;
+                foreach (var eventData in eventDatas)
+                {
+                    eventData.LastEnqueuedTime = utcNow;
+                    eventData.SystemProperties = new EventData.SystemPropertiesCollection(1, eventData.LastEnqueuedTime, eventData.LastEnqueuedOffset, partitionKey);
+
+                    eventHubClient.PartitionRuntimeInformations.TryAdd(partitionKey, new EventHubPartitionRuntimeInformation());
+                    eventHubClient.PartitionRuntimeInformations[partitionKey].LastEnqueuedOffset = eventData.LastEnqueuedOffset;
+                    eventHubClient.PartitionRuntimeInformations[partitionKey].LastEnqueuedTimeUtc = eventData.LastEnqueuedTime;
+                    eventHubClient.PartitionRuntimeInformations[partitionKey].LastEnqueuedSequenceNumber = eventData.LastSequenceNumber;
+                    eventQueue.Enqueue(eventData);
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/MockEventHubClient.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/MockEventHubClient.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.EventHubs.Tests.Client
+{
+    using System.Collections.Concurrent;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.EventHubs;
+
+    /// <summary>
+    /// Anchor class - all EventHub client operations start here.
+    /// See <see cref="EventHubClient.CreateFromConnectionString(string)"/>
+    /// </summary>
+    public class MockEventHubClient : EventHubClient
+    {
+        internal MockEventHubClient(EventHubsConnectionStringBuilder csb)
+            : base(csb)
+        {
+            EventManager = new ConcurrentDictionary<string, ConcurrentQueue<EventData>>();
+            PartitionRuntimeInformations = new ConcurrentDictionary<string, EventHubPartitionRuntimeInformation>();
+        }
+
+        internal ConcurrentDictionary<string, ConcurrentQueue<EventData>> EventManager;
+
+        internal ConcurrentDictionary<string, EventHubPartitionRuntimeInformation> PartitionRuntimeInformations;
+
+        protected override Task OnCloseAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        protected override PartitionReceiver OnCreateReceiver(string consumerGroupName, string partitionId, EventPosition eventPosition, long? epoch, ReceiverOptions receiverOptions)
+        {
+            EventManager.TryAdd(partitionId, new ConcurrentQueue<EventData>());
+            return new MockPartitionReceiver(this, consumerGroupName, partitionId, eventPosition, epoch, receiverOptions);
+        }
+
+        protected override Task<EventHubPartitionRuntimeInformation> OnGetPartitionRuntimeInformationAsync(string partitionId)
+        {
+            return Task.FromResult(PartitionRuntimeInformations[partitionId]);
+        }
+
+        protected override Task<EventHubRuntimeInformation> OnGetRuntimeInformationAsync()
+        {
+            return Task.FromResult(new EventHubRuntimeInformation());
+        }
+
+        internal override EventDataSender OnCreateEventSender(string partitionId)
+        {
+            EventManager.TryAdd(partitionId, new ConcurrentQueue<EventData>());
+            return new MockEventDataSender(this, partitionId);
+        }
+    }
+}

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/MockPartitionReceiver.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/MockPartitionReceiver.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.EventHubs.Tests.Client
+{
+    public class MockPartitionReceiver : PartitionReceiver
+    {
+        private readonly MockEventHubClient eventHubClient;
+
+        public MockPartitionReceiver(
+            MockEventHubClient eventHubClient,
+            string consumerGroupName = "consumerGroup",
+            string partitionId = "1",
+            EventPosition eventPosition = default,
+            long? epoch = default,
+            ReceiverOptions receiverOptions = default)
+            : base(eventHubClient, consumerGroupName, partitionId, eventPosition ?? EventPosition.FromStart(), epoch, receiverOptions)
+        {
+            this.eventHubClient = eventHubClient;
+        }
+
+        protected override Task OnCloseAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        protected override Task<IList<EventData>> OnReceiveAsync(int maxMessageCount, TimeSpan waitTime)
+        {
+            IList<EventData> events = new List<EventData>();
+            if (eventHubClient.EventManager.TryGetValue(PartitionId, out var eventQueue))
+            {
+                var count = 0;
+                while (count < maxMessageCount && eventQueue.TryDequeue(out var eventData))
+                {
+                    eventData.RetrievalTime = DateTime.UtcNow;
+                    events.Add(eventData);
+                    count++;
+                }
+            }
+
+            return Task.FromResult(events);
+        }
+
+        protected override void OnSetReceiveHandler(IPartitionReceiveHandler receiveHandler, bool invokeWhenNoEvents)
+        {
+            //TODO: Implement
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ReceiverRuntimeMetricsTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ReceiverRuntimeMetricsTests.cs
@@ -5,159 +5,82 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
 {
     using System;
     using System.Linq;
+    using System.Text;
     using System.Threading.Tasks;
+    using Microsoft.Azure.EventHubs;
     using Xunit;
 
     public class ReceiverRuntimeMetricsTests : ClientTestBase
     {
-        string targetPartitionId = "1";
+        readonly string targetPartitionId = "1";
+        readonly string connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
 
         [Fact]
-        [LiveTest]
         [DisplayTestMethodName]
         public async Task BasicValidation()
         {
-            await using (var scope = await EventHubScope.CreateAsync(2))
-            {
-                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
-                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
-                var partitionReceiver = default(PartitionReceiver);
+            var mockClient = new MockEventHubClient(new EventHubsConnectionStringBuilder(connectionString));
+            var partitionReceiver = mockClient.CreateReceiver("consumerGroup", targetPartitionId, EventPosition.FromStart(), new ReceiverOptions { EnableReceiverRuntimeMetric = true });
+            var partitionSender = mockClient.CreateEventSender(targetPartitionId);
 
-                try
-                {
-                    // Send some number of messages to target partition.
-                    await TestUtility.SendToPartitionAsync(ehClient, targetPartitionId, "this is the message body", 10);
+            await partitionSender.SendAsync(new EventData[] { new EventData(Encoding.UTF8.GetBytes("foo")) }, targetPartitionId);
 
-                    // Get partition runtime info so we can compare with runtime metrics.
-                    var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(targetPartitionId);
+            // Get the partition runtime info so we can compare with runtime metrics.
+            var pInfo = await mockClient.GetPartitionRuntimeInformationAsync(targetPartitionId);
 
-                    // Create a new receiver with ReceiverOptions setting to enable runtime metrics.
-                    partitionReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName,
-                        targetPartitionId,
-                        EventPosition.FromStart(),
-                        new ReceiverOptions()
-                        {
-                            EnableReceiverRuntimeMetric = true
-                        });
-
-                    await ValidateEnabledBehavior(partitionReceiver, pInfo);
-                }
-                finally
-                {
-                    await Task.WhenAll(
-                        partitionReceiver?.CloseAsync(),
-                        ehClient.CloseAsync());
-                }
-            }
+            await ValidateEnabledBehavior(partitionReceiver, pInfo);
         }
 
         [Fact]
-        [LiveTest]
         [DisplayTestMethodName]
         public async Task DefaultBehaviorDisabled()
         {
-            await using (var scope = await EventHubScope.CreateAsync(2))
-            {
-                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
-                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
-                var partitionReceiver = default(PartitionReceiver);
+            var mockClient = new MockEventHubClient(new EventHubsConnectionStringBuilder(connectionString));
+            var partitionReceiver = mockClient.CreateReceiver("consumerGroup", targetPartitionId, EventPosition.FromStart());
+            var partitionSender = mockClient.CreateEventSender(targetPartitionId);
 
-                try
-                {
-                    // Send single event
-                    await TestUtility.SendToPartitionAsync(ehClient, targetPartitionId, "this is the message body");
+            await partitionSender.SendAsync(new EventData[] { new EventData(Encoding.UTF8.GetBytes("foo")) }, targetPartitionId);
 
-                    // Create a new receiver and validate ReceiverRuntimeMetricEnabled.
-                    partitionReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, targetPartitionId, EventPosition.FromStart());
-                    await ValidateDisabledBehavior(partitionReceiver);
-                }
-                finally
-                {
-                    await Task.WhenAll(
-                        partitionReceiver?.CloseAsync(),
-                        ehClient.CloseAsync());
-                }
-            }
+            await ValidateDisabledBehavior(partitionReceiver);
         }
 
         [Fact]
-        [LiveTest]
         [DisplayTestMethodName]
         public async Task DisableWithReceiverOptions()
         {
-            await using (var scope = await EventHubScope.CreateAsync(2))
-            {
-                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
-                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
-                var partitionReceiver = default(PartitionReceiver);
+            var mockClient = new MockEventHubClient(new EventHubsConnectionStringBuilder(connectionString));
+            var partitionReceiver = mockClient.CreateReceiver("consumerGroup", targetPartitionId, EventPosition.FromStart(), new ReceiverOptions { EnableReceiverRuntimeMetric = false });
+            var partitionSender = mockClient.CreateEventSender(targetPartitionId);
 
-                try
-                {
-                    // Send single event
-                    await TestUtility.SendToPartitionAsync(ehClient, targetPartitionId, "this is the message body");
+            await partitionSender.SendAsync(new EventData[] { new EventData(Encoding.UTF8.GetBytes("foo")) }, targetPartitionId);
 
-                    // Enable runtime metrics on the client.
-                    ehClient.EnableReceiverRuntimeMetric = true;
-
-                    // Create a new receiver and disable runtime metrics via ReceiverOptions.
-                    partitionReceiver =
-                        ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, targetPartitionId, EventPosition.FromStart(),
-                        new ReceiverOptions()
-                        {
-                            EnableReceiverRuntimeMetric = false
-                        });
-
-                    await ValidateDisabledBehavior(partitionReceiver);
-                }
-                finally
-                {
-                    await Task.WhenAll(
-                        partitionReceiver?.CloseAsync(),
-                        ehClient.CloseAsync());
-                }
-            }
+            await ValidateDisabledBehavior(partitionReceiver);
         }
 
         [Fact]
-        [LiveTest]
         [DisplayTestMethodName]
         public async Task ClientSettingInherited()
         {
-            await using (var scope = await EventHubScope.CreateAsync(2))
-            {
-                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
-                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
-                var partitionReceiver1 = default(PartitionReceiver);
-                var partitionReceiver2 = default(PartitionReceiver);
+            var mockClient = new MockEventHubClient(new EventHubsConnectionStringBuilder(connectionString));
 
-                try
-                {
-                    // Send some number of messages to target partition.
-                    await TestUtility.SendToPartitionAsync(ehClient, targetPartitionId, "this is the message body", 10);
+            // Enable runtime metrics on the client.
+            mockClient.EnableReceiverRuntimeMetric = true;
 
-                    // Get partition runtime info so we can compare with runtime metrics.
-                    var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(targetPartitionId);
+            var partitionReceiver1 = mockClient.CreateReceiver("consumerGroup", targetPartitionId, EventPosition.FromStart());
+            var partitionReceiver2 = mockClient.CreateReceiver("consumerGroup", targetPartitionId, EventPosition.FromStart());
+            var partitionSender = mockClient.CreateEventSender(targetPartitionId);
 
-                    // Enable runtime metrics on the client.
-                    ehClient.EnableReceiverRuntimeMetric = true;
+            await partitionSender.SendAsync(
+                Enumerable.Range(1, 10)
+                    .Select(number => new EventData(Encoding.UTF8.GetBytes(number.ToString()))
+                ), targetPartitionId);
 
-                    // Create 2 new receivers. These receivers are expected to show runtime metrics since their parent client is enabled.
-                    partitionReceiver1 =
-                        ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, targetPartitionId, EventPosition.FromStart());
-                    partitionReceiver2 =
-                        ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, targetPartitionId, EventPosition.FromStart());
+            // Get the partition runtime info so we can compare with runtime metrics.
+            var pInfo = await mockClient.GetPartitionRuntimeInformationAsync(targetPartitionId);
 
-                    await ValidateEnabledBehavior(partitionReceiver1, pInfo);
-                    await ValidateEnabledBehavior(partitionReceiver2, pInfo);
-                }
-                finally
-                {
-                    await Task.WhenAll(
-                        partitionReceiver1?.CloseAsync(),
-                        partitionReceiver2?.CloseAsync(),
-                        ehClient.CloseAsync());
-                }
-            }
+            await ValidateEnabledBehavior(partitionReceiver1, pInfo);
+            await ValidateEnabledBehavior(partitionReceiver2, pInfo);
+
         }
 
         private async Task ValidateEnabledBehavior(PartitionReceiver partitionReceiver, EventHubPartitionRuntimeInformation pInfo)

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Microsoft.Azure.EventHubs.Tests.csproj
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Microsoft.Azure.EventHubs.Tests.csproj
@@ -20,10 +20,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Management.EventHub"  />
+    <PackageReference Include="Microsoft.Azure.Management.EventHub" />
     <PackageReference Include="Microsoft.Azure.Management.Storage" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="Moq" />
     <PackageReference Include="Polly" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.ServiceFabric.Data" />

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/TestState.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/TestState.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             return this.Processor.TotalBatches;
         }
 
-        public void VerifyNormalStartup(int maxRetries, int retryDelayInMs = 100)
+        public void VerifyNormalStartup(int maxRetries, int retryDelayInMs = 500)
         {
             int retries = 0;
             while (!this.Processor.IsOpened && !this.HasShutDown && (retries < maxRetries))

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/TestState.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/TestState.cs
@@ -88,25 +88,25 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             int retries = 0;
             while ((this.Processor.TotalBatches < atLeastBatches) && !this.HasShutDown && (retries < maxRetries))
             {
-                Thread.Sleep(200);
+                Thread.Sleep(1000);
                 retries++;
             }
             Assert.False(this.HasShutDown, "Uncommanded shut down while processing");
             Assert.True(this.Processor.TotalBatches >= atLeastBatches,
-                $"Unexpected loop exit at {this.Processor.TotalBatches} batches and {retries} retries");
+                $"Unexpected loop exit at {this.Processor.TotalBatches} batches and {retries} seconds");
             return this.Processor.TotalBatches;
         }
 
-        public void VerifyNormalStartup(int maxRetries, int retryDelayInMs = 500)
+        public void VerifyNormalStartup(int maxRetries)
         {
             int retries = 0;
             while (!this.Processor.IsOpened && !this.HasShutDown && (retries < maxRetries))
             {
-                Thread.Sleep(retryDelayInMs);
+                Thread.Sleep(1000);
                 retries++;
             }
             Assert.False(this.HasShutDown, "Shut down before open");
-            Assert.True(this.Processor.IsOpened, $"Open did not succeed after {retries} retries");
+            Assert.True(this.Processor.IsOpened, $"Open did not succeed after {retries} seconds");
         }
 
         public void DoNormalShutdown(int maxRetries)

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/TestState.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/TestState.cs
@@ -97,12 +97,12 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             return this.Processor.TotalBatches;
         }
 
-        public void VerifyNormalStartup(int maxRetries)
+        public void VerifyNormalStartup(int maxRetries, int retryDelayInMs = 5000)
         {
             int retries = 0;
             while (!this.Processor.IsOpened && !this.HasShutDown && (retries < maxRetries))
             {
-                Thread.Sleep(5000);
+                Thread.Sleep(retryDelayInMs);
                 retries++;
             }
             Assert.False(this.HasShutDown, "Shut down before open");

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/TestState.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/TestState.cs
@@ -88,16 +88,16 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             int retries = 0;
             while ((this.Processor.TotalBatches < atLeastBatches) && !this.HasShutDown && (retries < maxRetries))
             {
-                Thread.Sleep(1000);
+                Thread.Sleep(200);
                 retries++;
             }
             Assert.False(this.HasShutDown, "Uncommanded shut down while processing");
             Assert.True(this.Processor.TotalBatches >= atLeastBatches,
-                $"Unexpected loop exit at {this.Processor.TotalBatches} batches and {retries} seconds");
+                $"Unexpected loop exit at {this.Processor.TotalBatches} batches and {retries} retries");
             return this.Processor.TotalBatches;
         }
 
-        public void VerifyNormalStartup(int maxRetries, int retryDelayInMs = 5000)
+        public void VerifyNormalStartup(int maxRetries, int retryDelayInMs = 100)
         {
             int retries = 0;
             while (!this.Processor.IsOpened && !this.HasShutDown && (retries < maxRetries))
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
                 retries++;
             }
             Assert.False(this.HasShutDown, "Shut down before open");
-            Assert.True(this.Processor.IsOpened, $"Open did not succeed after {retries} seconds");
+            Assert.True(this.Processor.IsOpened, $"Open did not succeed after {retries} retries");
         }
 
         public void DoNormalShutdown(int maxRetries)

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/TimeoutTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/TimeoutTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
         {
             TestState state = new TestState();
             state.Initialize("timeoutsuppress", 1, 0);
-            state.Options.ReceiveTimeout = TimeSpan.FromSeconds(5.0);
+            state.Options.ReceiveTimeout = TimeSpan.FromMilliseconds(100);
 
             ServiceFabricProcessor sfp = new ServiceFabricProcessor(
                     state.ServiceUri,
@@ -28,17 +28,18 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
                     state.Processor,
                     state.ConnectionString,
                     "$Default",
-                    state.Options);
-            sfp.MockMode = state.PartitionLister;
-            sfp.EventHubClientFactory = new TimeoutEventHubClientFactoryMock(1);
+                    state.Options)
+            {
+                MockMode = state.PartitionLister,
+                EventHubClientFactory = new TimeoutEventHubClientFactoryMock(1)
+            };
 
             state.PrepareToRun();
             state.StartRun(sfp);
 
-            state.VerifyNormalStartup(10);
+            state.VerifyNormalStartup(10, 100);
 
-            Thread.Sleep(20000); // timeout is 5s, sleep 20s to allow some timeouts
-
+            Thread.Sleep((int)state.Options.ReceiveTimeout.TotalMilliseconds * 2); // sleep to allow some timeouts
             state.DoNormalShutdown(10);
             state.WaitRun();
 
@@ -54,7 +55,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
         {
             TestState state = new TestState();
             state.Initialize("timeoutinvoke", 1, 0);
-            state.Options.ReceiveTimeout = TimeSpan.FromSeconds(5.0);
+            state.Options.ReceiveTimeout = TimeSpan.FromMilliseconds(100);
             state.Options.InvokeProcessorAfterReceiveTimeout = true;
 
             ServiceFabricProcessor sfp = new ServiceFabricProcessor(
@@ -65,16 +66,18 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
                     state.Processor,
                     state.ConnectionString,
                     "$Default",
-                    state.Options);
-            sfp.MockMode = state.PartitionLister;
-            sfp.EventHubClientFactory = new TimeoutEventHubClientFactoryMock(1);
+                    state.Options)
+            {
+                MockMode = state.PartitionLister,
+                EventHubClientFactory = new TimeoutEventHubClientFactoryMock(1)
+            };
 
             state.PrepareToRun();
             state.StartRun(sfp);
 
-            state.VerifyNormalStartup(10);
+            state.VerifyNormalStartup(10, 100);
 
-            Thread.Sleep(20000); // timeout is 5s, sleep 20s to allow some timeouts
+            Thread.Sleep((int)state.Options.ReceiveTimeout.TotalMilliseconds * 2); // sleep to allow some timeouts
 
             state.DoNormalShutdown(10);
             state.WaitRun();

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/TimeoutTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/TimeoutTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
         {
             TestState state = new TestState();
             state.Initialize("timeoutsuppress", 1, 0);
-            state.Options.ReceiveTimeout = TimeSpan.FromMilliseconds(100);
+            state.Options.ReceiveTimeout = TimeSpan.FromMilliseconds(10);
 
             ServiceFabricProcessor sfp = new ServiceFabricProcessor(
                     state.ServiceUri,
@@ -40,6 +40,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             state.VerifyNormalStartup(10);
 
             Thread.Sleep((int)state.Options.ReceiveTimeout.TotalMilliseconds * 10); // sleep to allow some timeouts
+            
             state.DoNormalShutdown(10);
             state.WaitRun();
 
@@ -55,7 +56,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
         {
             TestState state = new TestState();
             state.Initialize("timeoutinvoke", 1, 0);
-            state.Options.ReceiveTimeout = TimeSpan.FromMilliseconds(100);
+            state.Options.ReceiveTimeout = TimeSpan.FromMilliseconds(10);
             state.Options.InvokeProcessorAfterReceiveTimeout = true;
 
             ServiceFabricProcessor sfp = new ServiceFabricProcessor(
@@ -76,8 +77,8 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             state.StartRun(sfp);
 
             state.VerifyNormalStartup(10);
-
-            Thread.Sleep((int)state.Options.ReceiveTimeout.TotalMilliseconds * 10); // sleep to allow some timeouts
+            
+            state.CountNBatches(1, 10);
 
             state.DoNormalShutdown(10);
             state.WaitRun();

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/TimeoutTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/TimeoutTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
 
             state.VerifyNormalStartup(10);
 
-            Thread.Sleep((int)state.Options.ReceiveTimeout.TotalMilliseconds * 2); // sleep to allow some timeouts
+            Thread.Sleep((int)state.Options.ReceiveTimeout.TotalMilliseconds * 10); // sleep to allow some timeouts
             state.DoNormalShutdown(10);
             state.WaitRun();
 
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
 
             state.VerifyNormalStartup(10);
 
-            Thread.Sleep((int)state.Options.ReceiveTimeout.TotalMilliseconds * 2); // sleep to allow some timeouts
+            Thread.Sleep((int)state.Options.ReceiveTimeout.TotalMilliseconds * 10); // sleep to allow some timeouts
 
             state.DoNormalShutdown(10);
             state.WaitRun();

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/TimeoutTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/TimeoutTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             state.PrepareToRun();
             state.StartRun(sfp);
 
-            state.VerifyNormalStartup(10, 100);
+            state.VerifyNormalStartup(10);
 
             Thread.Sleep((int)state.Options.ReceiveTimeout.TotalMilliseconds * 2); // sleep to allow some timeouts
             state.DoNormalShutdown(10);
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             state.PrepareToRun();
             state.StartRun(sfp);
 
-            state.VerifyNormalStartup(10, 100);
+            state.VerifyNormalStartup(10);
 
             Thread.Sleep((int)state.Options.ReceiveTimeout.TotalMilliseconds * 2); // sleep to allow some timeouts
 

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/TimeoutTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/TimeoutTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             state.VerifyNormalStartup(10);
 
             Thread.Sleep((int)state.Options.ReceiveTimeout.TotalMilliseconds * 10); // sleep to allow some timeouts
-            
+
             state.DoNormalShutdown(10);
             state.WaitRun();
 
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             state.StartRun(sfp);
 
             state.VerifyNormalStartup(10);
-            
+
             state.CountNBatches(1, 10);
 
             state.DoNormalShutdown(10);


### PR DESCRIPTION
Just out of curiosity, I investigated the tests mentioned in #8892. Although the tests passed locally for me, it seemed that the mechanism being tested does not require a Live test. 

Scope of Work:
- Mocked out `EventHubClient`, `EventDataSender`, and `PartitionReceiver`
- Converted ReceiverRuntimeMetricsTests to unit tests
- Reduced some long sleeps in `ServiceFabricProcessor` tests

Before and after test run length (excludes Live tests):

Test run for C:\src\azure-sdk-for-net\artifacts\bin\Microsoft.Azure.EventHubs.Tests\Debug\netcoreapp2.1\Microsoft.Azure.EventHubs.Tests.dll(.NETCoreApp,Version=v2.1)
```
Test Run Successful.
Total tests: 71
     Passed: 41
    Skipped: 30
 Total time: 53.7411 Seconds
```
After:
```
Test Run Successful.
Total tests: 75
     Passed: 45
    Skipped: 30
 Total time: 8.7574 Seconds
```