### PR TITLE
[Event Hubs Client] Track Two (Preview 6 Documentation)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -1,30 +1,37 @@
 # Release History
 
-## 1.0.0-preview.3 (2019-11-04)
+## 5.0.0-preview.6
 
 ### Acknowledgments 
 
-Thank you to our developer community members who helped to make the Azure SDKs better with their contributions to this release:
+Thank you to our developer community members who helped to make the Event Hubs client libraries better with their contributions to this release:
 
-- Vyacheslav Benedichuk _([GitHub](https://github.com/vbenedichuk))_
+- Christopher Scott _([GitHub](https://github.com/christothes))_
 
 ### Changes
 
 #### Organization and naming
 
-- For consistency with the official nomenclature of the Azure Storage Blobs service, the package has been renamed to `Azure.Messaging.EventHubs.CheckpointStore.Blobs` and the namespaces have also been adjusted to "Blobs."  
-  _(A community contribution, courtesy of [vbenedichuk](https://github.com/vbenedichuk))_
+- This version is a reorganization of the Event Hubs client library packages, moving the `EventProcessorClient` into its own package and evolving this version into an opinionated implementation on top of Azure Storage Blobs.  This is intended to offer a more streamlined developer experience for the majority of scenarios and allow developers to more easily take advantage of the processor.
 
-- Some minor documentation updates to reflect the changes made to the `EventProcessorClient` and its associated namespaces.
+- A large portion of the public API surface, including members and parameters, have had adjustments to their naming in order to improve discoverability, provide better context to developers, and better conform to the [Azure SDK Design Guidelines for .NET](https://azure.github.io/azure-sdk/dotnet_introduction.html).
 
-## 1.0.0-preview.2 (2019-10-09)
+#### Event Processing
 
-### Changes
+- The API for the `EventProcessorClient` has been revised, adopting an event-driven model that aligns to many of the .NET base class library types and reduces complexity when constructing the client.
 
-#### Event Hubs
+- The handlers for event processing will now process events on an individual basis, allowing developers to control whether or not they wish to handle events as they're available or batch events before processing.
 
-- The Azure Event Hubs client library has included the Event Hubs fully qualified namespace as part of the checkpoint information, ensuring that there is no conflict between Event Hubs instances in different regions using the same Event Hub and consumer group names.  As a consequence, this library has been updated to reflect these changes.
+- The mechanism for creating checkpoints has been bundled with the event dispatched for processing; this allows a checkpoint to be created with a clear association with a given event, removing the need for developers to explicitly pass an event to a dedicated checkpoint manager.
 
-## 1.0.0-preview.1 (2019-09-13)
+#### Storage Operations
 
-Version 1.0.0-preview.1 is a preview of our efforts in creating a checkpoint store library that is developer-friendly, idiomatic to the .NET ecosystem, and as consistent across different languages and platforms as possible.  The principles that guide our efforts can be found in the [Azure SDK Design Guidelines for .NET](https://azure.github.io/azure-sdk/dotnet_introduction.html).
+- The concept of a plug-in model for the durable storage used by the processor has been removed; this package has taken a strong dependency on Azure Storage Blobs and no longer requires developers to manipulate an abstraction on top of storage.
+
+- Checkpoints are now ensuring case-insensitivity for metadata to guard against inadvertent creation of multiple checkpoints for the same Event Hub / Consumer Group / Partition combination due to mixed casing.
+
+#### General
+
+- Removed the concept of explicitly closing or disposing the processor; the lifespan of resources is now managed implicitly within the scope of starting and stopping the processor.
+
+- Synchronous members have been added for starting and stopping the event processor.

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/README.md
@@ -1,8 +1,16 @@
-# Azure Event Hubs Checkpoint Store for Azure Storage blobs client library for .NET
+# Azure Event Hubs Event Processor client library for .NET
 
-Intended as a companion to the `Azure.Messaging.EventHubs` client library, the Azure Event Hubs Checkpoint Store for Azure Storage Blobs enables using an Azure Storage account as the durable persistence mechanism for an `EventProcessor`.  The constructs in this library plug into the `EventProcessor` allowing it to preserve its state, in the form of checkpoints, as Azure storage blobs.
+Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers. This lets you process and analyze the massive amounts of data produced by your connected devices and applications. Once Event Hubs has collected the data, you can retrieve, transform and store it by using any real-time analytics provider or with batching/storage adapters.  If you would like to know more about Azure Event Hubs, you may wish to review: [What is Event Hubs](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-about)?
 
-[Source code](.) | [Package (NuGet)](https://www.nuget.org/packages/Azure.Messaging.EventHubs.CheckpointStore.Blob/) | [API reference documentation](https://azure.github.io/azure-sdk-for-net/eventhub.html) | [Product documentation](https://docs.microsoft.com/en-us/azure/event-hubs/)
+The Event Processor client library is a companion to the Azure Event Hubs client library, providing a stand-alone client for consuming events in a robust, durable, and scalable way that is suitable for the majority of production scenarios.  An opinionated implementation built using Azure Storage blobs, the Event Processor is recommended for:
+
+- Reading and processing events across all partitions of an Event Hub at scale with resilience to transient failures and intermittent network issues.
+
+- Procesing events cooperatively, where multiple processors dynamically distribute and share the responsibility in the context of a consumer group, gracefully managing the load as processors are added and removed from the group.
+
+- Managing checkpoints and state for processing in a durable manner using Azure Storage blobs as the underlying data store.
+
+[Source code](.) | [Package (NuGet)](https://www.nuget.org/packages/Azure.Messaging.EventHubs.Processor/) | [API reference documentation](https://azure.github.io/azure-sdk-for-net/eventhub.html) | [Product documentation](https://docs.microsoft.com/en-us/azure/event-hubs/)
 
 ## Getting started
 
@@ -14,41 +22,37 @@ Intended as a companion to the `Azure.Messaging.EventHubs` client library, the A
 
 - **Azure Storage account with blob storage:** To persist checkpoints as blobs in Azure Storage, you'll need to have an Azure Storage account with blobs available.  If you are not familiar with Azure Storage accounts, you may wish to follow the step-by-step guide for [creating a storage account using the Azure portal](https://docs.microsoft.com/en-us/azure/storage/common/storage-quickstart-create-account?toc=%2Fazure%2Fstorage%2Fblobs%2Ftoc.json&tabs=azure-portal).  There, you can also find detailed instructions for using the Azure CLI, Azure PowerShell, or Azure Resource Manager (ARM) templates to create storage accounts.
 
+- **C# 8.0:** The Azure Event Hubs client library makes use of new features that were introduced in C# 8.0.  You can still use the library with older versions of C#, but some of its functionality won't be available.  In order to enable these features, you need to [target .NET Core 3.0](https://docs.microsoft.com/en-us/dotnet/standard/frameworks#how-to-specify-target-frameworks) or [specify the language version](https://docs.microsoft.com/en-gb/dotnet/csharp/language-reference/configure-language-version#override-a-default) you want to use (8.0 or above).  If you are using Visual Studio, versions prior to Visual Studio 2019 are not compatible with the tools needed to build C# 8.0 projects.  Visual Studio 2019, including the free Community edition, can be downloaded [here](https://visualstudio.microsoft.com/vs/).
+
+  **Important Note:** The use of C# 8.0 is mandatory to run the [examples](#examples) and the [samples](#next-steps) without modification.  You can still run the samples if you decide to tweak them.
+
 To quickly create the needed resources in Azure and to receive connection strings for them, you can deploy our sample template by clicking:  
 
-[![](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-sdk-for-net%2Fmaster%2Fsdk%2Feventhub%2FAzure.Messaging.EventHubs.CheckpointStore.Blob%2Fassets%2Fsamples-azure-deploy.json)
+[![](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-sdk-for-net%2Fmaster%2Fsdk%2Feventhub%2FAzure.Messaging.EventHubs.Processor%2Fassets%2Fsamples-azure-deploy.json)
 
 ### Install the package
 
-Install the Azure Event Hubs Checkpoint Store for Azure Storage Blobs client library for .NET using [NuGet](https://www.nuget.org/):
+Install the Azure Event Hubs Event Processor client library for .NET using [NuGet](https://www.nuget.org/):
 
 ```PowerShell
-Install-Package Azure.Messaging.EventHubs.CheckpointStore.Blobs -Version 1.0.0-preview.3
+Install-Package Azure.Messaging.EventHubs.Processor -Version 5.0.0-preview.6
 ```
 
 ### Obtain an Event Hubs connection string
 
-For the event processor to interact with an Event Hub, it will need to understand how to connect and authorize with it.  The easiest means for doing so is to use a connection string, which is created automatically when creating an Event Hubs namespace.  If you aren't familiar with shared access policies in Azure, you may wish to follow the step-by-step guide to [get an Event Hubs connection string](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string).
+For the event processor client to interact with an Event Hub, it will need to understand how to connect and authorize with it.  The easiest means for doing so is to use a connection string, which is created automatically when creating an Event Hubs namespace.  If you aren't familiar with shared access policies in Azure, you may wish to follow the step-by-step guide to [get an Event Hubs connection string](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string).
 
 ### Obtain an Azure Storage connection string
 
-For checkpoint storage to make use of Azure Storage blobs, it will need to understand how to connect to a storage account and authorize with it.  The most straightforward method of doing so is to use a connection string, which is generated at the time that the storage account is created.  If you aren't familiar with storage accounts in Azure, you may wish to follow the step-by-step guide to [configure Azure Storage connection strings](https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string).
-
-### Create an Event Processor that persists checkpoints in Azure Storage Blobs
-
-Once the Azure resources and connection strings are available, they can be used to create an event processor for interacting with Azure Event Hubs which persists its state via checkpoints in Azure Storage blobs.  The simplest way to create an `EventProcessor` that uses the `**TODO: CHECKPOINT BLOB NAME THING HERE**` is:
-
-```csharp
-// CODE GOES HERE
-```
+For the event processor client to make use of Azure Storage blobs, it will need to understand how to connect to a storage account and authorize with it.  The most straightforward method of doing so is to use a connection string, which is generated at the time that the storage account is created.  If you aren't familiar with storage accounts in Azure, you may wish to follow the step-by-step guide to [configure Azure Storage connection strings](https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string).
 
 ## Key concepts
 
 - An **event processor** is a construct intended to manage the responsibilities associated with connecting to a given Event Hub and processing events from each of its partitions, in the context of a specific consumer group.  The act of processing events read from the partition and handling any errors that occur is delegated by the event processor to code that you provide, allowing your logic to concentrate on delivering business value while the processor handles the tasks associated with reading events, managing the partitions, and allowing state to be persisted in the form of checkpoints. 
 
-- **Checkpointing** is a process by which readers mark and persist their position for events that have been processed for a partition. Checkpointing is the responsibility of the consumer and occurs on a per-partition, typically in the context of a specific consumer group.  For the `EventProcessor`, this means that for consumer group and partition combination, the processor must keep track of its current position in the event stream.  
+- **Checkpointing** is a process by which readers mark and persist their position for events that have been processed for a partition. Checkpointing is the responsibility of the consumer and occurs on a per-partition, typically in the context of a specific consumer group.  For the `EventProcessorClient`, this means that, for a consumer group and partition combination, the processor must keep track of its current position in the event stream.  
 
-  When an event processor connects, it will begin reading events at the checkpoint that was previously submitted by the last processor of that partition in that consumer group, if one exists.  As an event processor reads and acts on events in the partition, it should periodically create checkpoints to both mark the events as "complete" by downstream applications and to provide resiliency should an event processor or the environment hosting it fail.  Should it be necessary, it is possible to reprocess events that were previously marked as "complete" by specifying an earlier offset through this checkpointing process.
+  When an event processor connects, it will begin reading events at the checkpoint that was previously persisted by the last processor of that partition in that consumer group, if one exists.  As an event processor reads and acts on events in the partition, it should periodically create checkpoints to both mark the events as "complete" by downstream applications and to provide resiliency should an event processor or the environment hosting it fail.  Should it be necessary, it is possible to reprocess events that were previously marked as "complete" by specifying an earlier offset through this checkpointing process.
 
 - A **partition** is an ordered sequence of events that is held in an Event Hub. Partitions are a means of data organization associated with the parallelism required by event consumers.  Azure Event Hubs provides message streaming through a partitioned consumer pattern in which each consumer only reads a specific subset, or partition, of the message stream. As newer events arrive, they are added to the end of this sequence. The number of partitions is specified at the time an Event Hub is created and cannot be changed.
 
@@ -58,13 +62,115 @@ For more concepts and deeper discussion, see: [Event Hubs Features](https://docs
 
 ## Examples
 
-### Some Example
+### Creating an Event Processor Client
 
-WORDS NEEDED.
+Since the `EventProcessorClient` as a dependency on Azure Storage blobs for persistence of its state, you'll need to provide a `BlobContainerClient` for the processor, which has been configured for the storage account and container that should be used.
 
 ```csharp
-// CODE HERE
+string storageConnectionString = "<< CONNECTION STRING FOR THE STORAGE ACCOUNT >>";
+string blobContainerName = "<< NAME OF THE BLOBS CONTAINER >>";
+
+string eventHubsConnectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
+string eventHubName = "<< NAME OF THE EVENT HUB >>";
+string consumerGroup = "<< NAME OF THE EVENT HUB CONSUMER GROUP >>";
+
+BlobContainerClient storageClient = new BlobContainerClient(storageConnectionString, blobContainerName);
+
+EventProcessorClient processor = new EventProcessorClient
+(
+    storageClient,
+    consumerGroup,
+    eventHubsConnectionString,
+    eventHubName
+);
 ```
+
+### Configure the Event and Error Handlers
+
+In order to use the `EventProcessorClient`, handlers for event processing and errors must be provided.  These handlers are considered self-contained and developers are responsible for ensuring that exceptions within the handler code are accounted for.
+
+```csharp
+var storageConnectionString = "<< CONNECTION STRING FOR THE STORAGE ACCOUNT >>";
+var blobContainerName = "<< NAME OF THE BLOBS CONTAINER >>";
+var eventHubsConnectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
+var eventHubName = "<< NAME OF THE EVENT HUB >>";
+var consumerGroup = "<< NAME OF THE EVENT HUB CONSUMER GROUP >>";
+
+async Task processEventHandler(ProcessEventArgs eventArgs)
+{
+    try
+    {
+        // Perform the application-specific processing for an event
+        await DoSomethingWithTheEvent(eventArgs.Partition, eventArgs.Data);
+    }
+    catch
+    {
+        // Handle the exception from handler code
+    }
+}
+
+async Task processErrorHandler(ProcessErrorEventArgs eventArgs)
+{
+    try
+    {
+        // Perform the application-specific processing for an error
+        await DoSomethingWithTheError(eventArgs.Exception);
+    }
+    catch
+    {
+        // Handle the exception from handler code
+    }   
+}
+
+var storageClient = new BlobContainerClient(storageConnectionString, blobContainerName);
+var processor = new EventProcessorClient(storageClient, consumerGroup, eventHubsConnectionString, eventHubName);
+
+processor.ProcessEventAsync += processEventHandler;
+processor.ProcessErrorAsync += processErrorHandler;
+```
+
+### Start and Stop Procesing
+
+The `EventProcessorClient` will perform its processing in the background once it has been explicitly started and continue doing so until it has been explicitly stopped.  While this allows the application code to perform other tasks, it also places the responsibility of ensuring that the process does not terminate during processing if there are no other tasks being performed.
+
+```csharp
+private async Task ProcessUntilCanceled(CancellationToken cancellationToken)
+{
+    var storageConnectionString = "<< CONNECTION STRING FOR THE STORAGE ACCOUNT >>";
+    var blobContainerName = "<< NAME OF THE BLOBS CONTAINER >>";
+    var eventHubsConnectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
+    var eventHubName = "<< NAME OF THE EVENT HUB >>";
+    var consumerGroup = "<< NAME OF THE EVENT HUB CONSUMER GROUP >>";
+
+    Task processEventHandler(ProcessEventArgs eventArgs) => Task.CompletedTask;
+    Task processErrorHandler(ProcessErrorEventArgs eventArgs) => Task.CompletedTask;
+
+    var storageClient = new BlobContainerClient(storageConnectionString, blobContainerName);
+    var processor = new EventProcessorClient(storageClient, consumerGroup, eventHubsConnectionString, eventHubName);
+
+    processor.ProcessEventAsync += processEventHandler;
+    processor.ProcessErrorAsync += processErrorHandler;
+    
+    await processor.StartProcessingAsync();
+    
+    try
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(1));
+        }
+        
+        await processor.StopProcessingAsync();
+    }
+    finally
+    {
+        // To prevent leaks, the handlers should be removed when processing is complete
+        processor.ProcessEventAsync -= processEventHandler;
+        processor.ProcessErrorAsync -= processErrorHandler;
+    }
+}
+```
+
 ## Troubleshooting
 
 ### Common exceptions
@@ -73,13 +179,17 @@ WORDS NEEDED.
 
 This indicates that the Event Hubs service did not respond to an operation within the expected amount of time.  This may have been caused by a transient network issue or service problem.  The Event Hubs service may or may not have successfully completed the request; the status is not known.  It is recommended to attempt to verify the current state and retry if necessary.
 
+#### Quota Exceeded
+
+This typically indicates that there are too many active event processors for a consumer group.  This limit depends on the tier of the Event Hubs namespace, and moving to a higher tier may be desired.  An alternative would be do create additional consumer groups and ensure that the number of active processors for any group is within the limit.  Please see [Azure Event Hubs quotas and limits](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-quotas) for more information.
+
 ### Other exceptions
 
 For detailed information about these and other exceptions that may occur, please refer to [Event Hubs messaging exceptions](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-messaging-exceptions). 
 
 ## Next steps
 
-Beyond the scenarios discussed, the Azure Event Hubs checkpoint store for Azure Storage blobs offers support for additional scenarios to help take advantage of the full feature set of the `EventProcessor`.  In order to help explore some of these scenarios, the library offers a [project of samples](./samples) to serve as an illustration for common scenarios.
+Beyond the scenarios discussed, the Azure Event Hubs Event Prcessor library offers support for additional scenarios to help take advantage of the full feature set of the `EventProcessorClient`.  In order to help explore some of these scenarios, the library offers a [project of samples](./samples) to serve as an illustration for common scenarios.
 
 The samples are accompanied by a console application which you can use to execute and debug them interactively.  The simplest way to begin is to launch the project for debugging in Visual Studio or your preferred IDE and provide the Event Hubs connection information in response to the prompts.  
 
@@ -88,7 +198,16 @@ Each of the samples is self-contained and focused on illustrating one specific s
 The available samples are:
 
 - [Hello world](./samples/Sample01_HelloWorld.cs)  
-  An introduction to processing events using the Event Processor, illustrating how to configure the processor and connect to the Event Hubs service.
+  An introduction to the Event Processor client, illustrating how to create the client and perform basic operations.
+
+- [Create an Event Processor client with custom options](./samples/Sample02_ProcessorWithCustomOptions.cs)  
+  An introduction to the Event Processor client, exploring additional options for creating the processor.
+
+- [Perform basic event processing](./samples/Sample03_BasicEventProcessing.cs)  
+  An introduction to the Event Processor client, illustrating how to perform basic event processing.
+
+- [Create checkpoints while processing](./samples/Sample04_BasicCheckpointing.cs)  
+  An introduction to the Event Processor client, illustrating how to create simple checkpoints.
 
 ## Contributing  
 
@@ -100,4 +219,4 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 
 Please see our [contributing guide](./../Azure.Messaging.EventHubs/CONTRIBUTING.md) for more information.
   
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsdk%2Feventhub%2FAzure.Messaging.EventHubs.CheckpointStore.Blobs%2FREADME.png)
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsdk%2Feventhub%2FAzure.Messaging.EventHubs.Processor%2FREADME.png)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -1,6 +1,55 @@
 # Release History
 
-## 5.0.0-preview.5 (2019-11-04)
+## 5.0.0-preview.6
+
+### Acknowledgements
+
+Thank you to our developer community members who helped to make the Event Hubs client libraries better with their contributions to this release:
+
+- Alberto De Natale _([GitHub](https://github.com/albertodenatale))_
+
+### Changes
+
+#### Bug fixes and foundation improvements
+
+- A bug with the use of Azure.Identity credential scopes has been fixed; Azure identities should now allow for proper authorization with Event Hubs resources.   
+_(A community contribution, courtesy of [albertodenatale](https://github.com/albertodenatale))_
+
+- A bug with the renewal of connection string-based credentials has been fixed; clients using a connection string will now properly refresh when necessary instead of experiencing an error.
+
+- Some performance tuning has been done, focusing on reducing allocations associated with frequently used types where possible.
+
+#### Consuming events
+
+- The `EventHubsConsumerClient` is no longer bound to a partition, an owner level, or tracking of last enqueued event properties; these attributes may be specified when requesting to read events, allowing more granular control over behavior without the need to create multiple clients.
+
+- Events may now be read across all partitions of an Event Hub using the `ReadEvents` method of the consumer client.  This is intened for exploring Event Hubs and not recommended for production use; for production scenarios, please consider using the `EventProcessorClient` as a more robust alternative.
+
+- Events read using the consumer client are now accompanied by a `PartitionContext` helping to identify the source partition for an event and allowing for partition-specific operations, such as reading the last enqueued event properties for that partition.
+
+#### Publishing events
+
+- The `EventHubsProducerClient` client is no longer bound to a partition for sending events to a specific partition.  It will now accept a partition identifier as part of the options when creating an event batch.  This option may not be used with a partition key in the same batch; only one or the other may be specified.  This allows for more flexibility when publishing events without the need to create multiple clients.
+
+#### Authorization
+
+- Test and sample infrastructure has been updated to work with Azure.Identity credentials in addition to connection strings.  
+_(A community contribution, courtesy of [albertodenatale](https://github.com/albertodenatale))_
+  
+- A sample demonstrating the use of an Azure Active Identity principal with Event Hubs is now available.  
+_(A community contribution, courtesy of [albertodenatale](https://github.com/albertodenatale))_
+
+- The `EventHubsSharedKeyCredential` has been removed from this release for further design and improvements; it is intended to be reintroduced in the future.
+
+#### Organization and naming
+
+- A large portion of the public API surface, including members and parameters, have had adjustments to their naming in order to improve discoverability, provide better context to developers, and better conform to the [Azure SDK Design Guidelines for .NET](https://azure.github.io/azure-sdk/dotnet_introduction.html).
+
+- The `EventProcessorClient` has been moved into its own [package](./../Azure.Messaging.EventHubs.Processor) and evolved into an opinionated implementation on top of Azure Storage Blobs.  This is intended to offer a more streamlined developer experience for the majority of scenarios and allow developers to more easily take advantage of the processor.
+
+- A collection of internal supporting types were moved into a new [shared library](./../Azure.Messaging.EventHubs.Shared) to allow them to be shared as source between the Event Hubs client libraries.  The tests assoociated with these types were also moved to the shared library for locality with the source being tested.
+
+## 5.0.0-preview.5 
 
 ### Acknowledgments 
 
@@ -35,7 +84,7 @@ Thank you to our developer community members who helped to make the Azure SDKs b
 
 - The information about the last event enqueued to an Event Hub partition is now presented on-demand as an immutable object, if the tracking option was enabled.  This ensures that the properties are stable and consistent when being read, rather than being subject to in-place updates each time a new event is received.
 
-## 5.0.0-preview.4 (2019-10-07)
+## 5.0.0-preview.4
 
 ### Changes
 
@@ -53,7 +102,7 @@ Thank you to our developer community members who helped to make the Azure SDKs b
 
 - Improved stability and performance with refactorings around hot paths and areas of technical debt.
 
-## 5.0.0-preview.3 (2019-09-06)
+## 5.0.0-preview.3
 
 ### Changes
 
@@ -79,7 +128,7 @@ Thank you to our developer community members who helped to make the Azure SDKs b
 
 - Some public types were scoped in a way that made them difficult to mock for library consumers.  These have been re-scoped to `protected internal` for better testability.  `EventData` and metadata types were the significant instances.
 
-## 5.0.0-preview.2 (2019-08-06)
+## 5.0.0-preview.2
 
 ### Changes
 
@@ -122,7 +171,7 @@ Thank you to our developer community members who helped to make the Azure SDKs b
 - An option for fixed retry has been added to accompany the exponential retry that was in place previously.
 Operation timeouts have been moved from the associated client options and incorporated into the retry options and retry policies.
 
-## 5.0.0-preview.1 (2019-07-01)
+## 5.0.0-preview.1
 
 Version 5.0.0-preview.1 is a preview of our efforts in creating a client library that is developer-friendly, idiomatic to the .NET ecosystem, and as consistent across different languages and platforms as possible.  The principles that guide our efforts can be found in the [Azure SDK Design Guidelines for .NET](https://azure.github.io/azure-sdk/dotnet_introduction.html).
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/README.md
@@ -24,7 +24,7 @@ The Azure Event Hubs client library allows for publishing and consuming of Azure
 
 - **C# 8.0:** The Azure Event Hubs client library makes use of new features that were introduced in C# 8.0.  You can still use the library with older versions of C#, but some of its functionality won't be available.  In order to enable these features, you need to [target .NET Core 3.0](https://docs.microsoft.com/en-us/dotnet/standard/frameworks#how-to-specify-target-frameworks) or [specify the language version](https://docs.microsoft.com/en-gb/dotnet/csharp/language-reference/configure-language-version#override-a-default) you want to use (8.0 or above).  If you are using Visual Studio, versions prior to Visual Studio 2019 are not compatible with the tools needed to build C# 8.0 projects.  Visual Studio 2019, including the free Community edition, can be downloaded [here](https://visualstudio.microsoft.com/vs/).
 
-  **Important Note:** The use of C# 8.0 is mandatory to run the [examples](#examples) and the [samples](#next-steps) below.  It's necessary to run them without modification.  You can still run the samples if you decide to tweak them.
+  **Important Note:** The use of C# 8.0 is mandatory to run the [examples](#examples) and the [samples](#next-steps) without modification.  You can still run the samples if you decide to tweak them.
 
 To quickly create the needed Event Hubs resources in Azure and to receive a connection string for them, you can deploy our sample template by clicking:
 
@@ -103,16 +103,16 @@ var connectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
 var eventHubName = "<< NAME OF THE EVENT HUB >>";
 
 string consumerGroup = EventHubConsumerClient.DefaultConsumerGroupName;
-    
+
 await using (var consumer = new EventHubConsumerClient(consumerGroup, connectionString, eventHubName))
 {
     using var cancellationSource = new CancellationTokenSource();
     cancellationSource.CancelAfter(TimeSpan.FromSeconds(45));
-    
+
     await foreach (PartitionEvent receivedEvent in consumer.ReadEvents(cancellationSource.Token))
     {
-        // At this point, the loop will wait for events to be available in the Event Hub.  When an event 
-        // is available, the loop will iterate with the event that was received.  Because we did not 
+        // At this point, the loop will wait for events to be available in the Event Hub.  When an event
+        // is available, the loop will iterate with the event that was received.  Because we did not
         // specify a maximum wait time, the loop will wait forever unless cancellation is requested using
         // the cancellation token.
     }
@@ -128,19 +128,19 @@ var connectionString = "<< CONNECTION STRING FOR THE EVENT HUBS NAMESPACE >>";
 var eventHubName = "<< NAME OF THE EVENT HUB >>";
 
 string consumerGroup = EventHubConsumerClient.DefaultConsumerGroupName;
-    
+
 await using (var consumer = new EventHubConsumerClient(consumerGroup, connectionString, eventHubName))
 {
     EventPosition startingPosition = EventPosition.Earliest;
     string partitionId = (await consumer.GetPartitionIdsAsync()).First();
-    
+
     using var cancellationSource = new CancellationTokenSource();
     cancellationSource.CancelAfter(TimeSpan.FromSeconds(45));
-    
+
     await foreach (PartitionEvent receivedEvent in consumer.ReadEventsFromPartitionAsync(partitionId, startingPosition, cancellationSource.Token))
     {
-        // At this point, the loop will wait for events to be available in the partition.  When an event 
-        // is available, the loop will iterate with the event that was received.  Because we did not 
+        // At this point, the loop will wait for events to be available in the partition.  When an event
+        // is available, the loop will iterate with the event that was received.  Because we did not
         // specify a maximum wait time, the loop will wait forever unless cancellation is requested using
         // the cancellation token.
     }
@@ -149,7 +149,7 @@ await using (var consumer = new EventHubConsumerClient(consumerGroup, connection
 
 ### Process events using an Event Processor Client
 
-For the majority of production scenarios, it is recommended that the  [Event Processor Client](./../Azure.Messaging.EventHubs.Processor) be used for reading and processing events.  The processor is intended to provide a robust experience for processing events across all partitions of an Event Hub in a performant and fault tolerant manner while providing a means to persist its state.  Event Processor clients are also capable of working cooperatively within the context of a consumer group for a given Event Hub, where they will automatically manage distribution and balancing of work as instances become available or unavailable for the group.
+For the majority of production scenarios, it is recommended that the [Event Processor Client](./../Azure.Messaging.EventHubs.Processor) be used for reading and processing events.  The processor is intended to provide a robust experience for processing events across all partitions of an Event Hub in a performant and fault tolerant manner while providing a means to persist its state.  Event Processor clients are also capable of working cooperatively within the context of a consumer group for a given Event Hub, where they will automatically manage distribution and balancing of work as instances become available or unavailable for the group.
 
 More details can be found in the Event Processor Client [README](./../Azure.Messaging.EventHubs.Processor/README.md) and the accompanying [samples](./../Azure.Messaging.EventHubs.Processor/samples).
 
@@ -165,12 +165,16 @@ This occurs when an operation has been requested on an Event Hub client that has
 
 This indicates that the Event Hubs service did not respond to an operation within the expected amount of time.  This may have been caused by a transient network issue or service problem.  The Event Hubs service may or may not have successfully completed the request; the status is not known.  It is recommended to attempt to verify the current state and retry if necessary.  
 
+#### Quota Exceeded
+
+This typically indicates that there are too many active read operations for a single consumer group.  This limit depends on the tier of the Event Hubs namespace, and moving to a higher tier may be desired.  An alternative would be do create additional consumer groups and ensure that the number of consumer client reads for any group is within the limit.  Please see [Azure Event Hubs quotas and limits](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-quotas) for more information.
+
 #### Message Size Exceeded
 
 Event data, both individual and in batches, have a maximum size allowed.  This includes the data of the event, as well as any associated metadata and system overhead.  The best approach for resolving this error is to reduce the number of events being sent in a batch or the size of data included in the message.  Because size limits are subject to change, please refer to [Azure Event Hubs quotas and limits](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-quotas) for specifics.  
 ### Other exceptions
 
-For detailed information about these and other exceptions that may occur, please refer to [Event Hubs messaging exceptions](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-messaging-exceptions). 
+For detailed information about these and other exceptions that may occur, please refer to [Event Hubs messaging exceptions](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-messaging-exceptions).
 
 ## Next steps
 
@@ -187,31 +191,31 @@ The available samples are:
 
 - [Create an Event Hub client with custom options](./samples/Sample02_ClientWithCustomOptions.cs)  
   An introduction to Event Hubs, exploring additional options for creating the different Event Hub clients.
-  
+
 - [Publish an event batch to an Event Hub](./samples/Sample03_PublishAnEventBatch.cs)  
   An introduction to publishing events, using a batch with single event.  
 
 - [Read events from an Event Hub](./samples/Sample04_ReadEvents.cs)  
   An introduction to reading all events available from an Event Hub.
-  
+
 - [Publish an event batch using a partition key](./samples/Sample05_PublishAnEventBatchWithPartitionKey.cs)  
   An introduction to publishing events using a partition key to group batches together.
-  
+
 - [Publish an event batch to a specific partition](./samples/Sample06_PublishAnEventBatchToASpecificPartition.cs)  
   An introduction to publishing events, specifying a specific partition for the batch to be published to.
-  
+
 - [Publish events with custom metadata](./samples/Sample07_PublishEventsWithCustomMetadata.cs)  
   An example of publishing events, extending the event data with custom metadata.
-  
+
 - [Read only new events from an Event Hub](./samples/Sample08_ReadOnlyNewEvents.cs)  
   An example of reading events, beginning with only those newly available from an Event Hub.
 
 - [Read events from a known position in an Event Hub partition](./samples/Sample09_ReadEventsFromAKnownPosition.cs)  
   An example of reading events from a single Event Hub partition, starting at a well-known position.
-  
+
 - [Publish an event batch with a custom size limit](./samples/Sample10_PublishAnEventBatchWithCustomSizeLimit.cs)  
   An example of publishing events using a custom size limitation with the batch.
-  
+
 - [Authorize using a service principal with client secret](./samples/Sample11_AuthenticateWithClientSecretCredential.cs)  
   An example of interacting with an Event Hub using an Azure Active Directory application with client secret for authorization.
 
@@ -224,5 +228,5 @@ When you submit a pull request, a CLA-bot will automatically determine whether y
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 Please see our [contributing guide](./CONTRIBUTING.md) for more information.
-  
+
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsdk%2Feventhub%2FAzure.Messaging.EventHubs%2FREADME.png)


### PR DESCRIPTION
# Summary

The focus of these changes is to build on the documentation for the preview 6 release, adding in the change logs for both client libraries, fleshing out the event processor README, and making minor tweaks to the main library README.

# Last Upstream Rebase

Monday, December 2, 2:04pm (EST)

# Related and Follow-Up Issues

- [Release Event Hubs Track 2 Library for .NET](https://github.com/Azure/azure-sdk-for-net/issues/8552) (#8552) 
- [Review and update documentation](https://github.com/Azure/azure-sdk-for-net/issues/8553) (#8553) 