### PR TITLE
[Event Hubs Client] Track Two (Event Processor Release Preparation)

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -12,7 +12,7 @@
     <PackageReference Update="Azure.Core" Version="1.0.1" />
     <PackageReference Update="Azure.Identity" Version="1.1.0" />
     <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.0.0" />
-    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.0.0-preview.5" />
+    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.0.0-preview.6" />
     <PackageReference Update="Azure.Storage.Blobs" Version="12.0.0" />
     <PackageReference Update="BenchmarkDotNet" Version="0.11.5" />
     <PackageReference Update="FsCheck.Xunit" Version="2.14.0" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj" /><!-- TEMP:  THIS SHOULD BE UPDATED POST RELEASE OF PREVIEW 6 -->
+    <PackageReference Include="Azure.Messaging.EventHubs" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare the Event Processor package for release, bumping the central Event Hubs client library package version to preview 6 and restoring the package refrerence for the Processor package.

# Last Upstream Rebase

Tuesday, December 3, 5:27pm (EST)

# Related and Follow-Up Issues

- [Release Event Hubs Track 2 Library for .NET](https://github.com/Azure/azure-sdk-for-net/issues/8552) (#8552) 