### PR TITLE
[EventHubs] Event Processor Tests (error handler should be able to stop the event processor)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Infrastructure/EventProcessorManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Infrastructure/EventProcessorManager.cs
@@ -7,8 +7,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Core;
-using Azure.Storage.Blobs;
-using Moq;
 
 namespace Azure.Messaging.EventHubs.Processor.Tests
 {


### PR DESCRIPTION
Including one test that wasn't added to an older PR by accident.