### PR TITLE
Delay key creation to avoid throttling

### DIFF
--- a/sdk/core/Azure.Core/tests/TestFramework/ClientTestBase.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/ClientTestBase.cs
@@ -35,7 +35,9 @@ namespace Azure.Core.Testing
             return InstrumentClient((TClient)Activator.CreateInstance(typeof(TClient), args));
         }
 
-        public virtual TClient InstrumentClient<TClient>(TClient client) where TClient : class
+        public virtual TClient InstrumentClient<TClient>(TClient client) where TClient : class => InstrumentClient(client, null);
+
+        public virtual TClient InstrumentClient<TClient>(TClient client, IEnumerable<IInterceptor> preInterceptors) where TClient : class
         {
             Debug.Assert(!client.GetType().Name.EndsWith("Proxy"), $"{nameof(client)} was already instrumented");
 
@@ -60,6 +62,10 @@ namespace Azure.Core.Testing
             }
 
             List<IInterceptor> interceptors = new List<IInterceptor>();
+            if (preInterceptors != null)
+            {
+                interceptors.AddRange(preInterceptors);
+            }
 
             if (TestDiagnostics)
             {

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/DelayCreateKeyInterceptor.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/DelayCreateKeyInterceptor.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using Azure.Core.Testing;
+using Castle.DynamicProxy;
+using NUnit.Framework;
+
+namespace Azure.Security.KeyVault.Keys.Tests
+{
+    // TODO: Remove this implementation when https://github.com/Azure/azure-sdk-for-net/issues/8575 is fixed.
+    internal class DelayCreateKeyInterceptor : IInterceptor
+    {
+        private const string DelayEnvironmentVariableName = "AZURE_KEYVAULT_TEST_DELAY";
+        private const int DefaultDelay = 1000;
+
+        private readonly int _delay = DefaultDelay;
+        private readonly RecordedTestMode _mode;
+
+        internal DelayCreateKeyInterceptor(RecordedTestMode mode)
+        {
+            _mode = mode;
+
+            if (int.TryParse(Environment.GetEnvironmentVariable(DelayEnvironmentVariableName), out int delay))
+            {
+                if (delay >= 0)
+                {
+                    _delay = delay;
+                }
+            }
+        }
+
+        public void Intercept(IInvocation invocation)
+        {
+            if (_mode != RecordedTestMode.Playback && _delay > 0)
+            {
+                string name = invocation.Method.Name;
+                switch (name)
+                {
+                    case nameof(KeyClient.CreateEcKeyAsync):
+                    case nameof(KeyClient.CreateKeyAsync):
+                    case nameof(KeyClient.CreateRsaKeyAsync):
+                        TestContext.WriteLine("Delaying {0} by {1}ms", name, _delay);
+                        Thread.Sleep(_delay);
+                        break;
+                }
+            }
+
+            invocation.Proceed();
+        }
+    }
+}


### PR DESCRIPTION
Key creation limits are much lower than key use limits.