### PR TITLE
[Event Hubs Client] Track Two (Samples and Documentation)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/README.md
@@ -189,25 +189,7 @@ For detailed information about these and other exceptions that may occur, please
 
 ## Next steps
 
-Beyond the scenarios discussed, the Azure Event Hubs Event Prcessor library offers support for additional scenarios to help take advantage of the full feature set of the `EventProcessorClient`.  In order to help explore some of these scenarios, the library offers a [project of samples](./samples) to serve as an illustration for common scenarios.
-
-The samples are accompanied by a console application which you can use to execute and debug them interactively.  The simplest way to begin is to launch the project for debugging in Visual Studio or your preferred IDE and provide the Event Hubs connection information in response to the prompts.  
-
-Each of the samples is self-contained and focused on illustrating one specific scenario.  Each is numbered, with the lower numbers concentrating on basic scenarios and building to more complex scenarios as they increase; though each sample is independent, it will assume an understanding of the content discussed in earlier samples.
-
-The available samples are:
-
-- [Hello world](./samples/Sample01_HelloWorld.cs)  
-  An introduction to the Event Processor client, illustrating how to create the client and perform basic operations.
-
-- [Create an Event Processor client with custom options](./samples/Sample02_ProcessorWithCustomOptions.cs)  
-  An introduction to the Event Processor client, exploring additional options for creating the processor.
-
-- [Perform basic event processing](./samples/Sample03_BasicEventProcessing.cs)  
-  An introduction to the Event Processor client, illustrating how to perform basic event processing.
-
-- [Create checkpoints while processing](./samples/Sample04_BasicCheckpointing.cs)  
-  An introduction to the Event Processor client, illustrating how to create simple checkpoints.
+Beyond the scenarios discussed, the Azure Event Hubs Processor library offers support for additional scenarios to help take advantage of the full feature set of the `EventProcessorClient`.  In order to help explore some of these scenarios, the Event Hubs Processor client library offers a project of samples to serve as an illustration for common scenarios.  Please see the samples [README](./samples/README.md) for details.
 
 ## Contributing  
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Azure.Messaging.EventHubs.Processor.Samples.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Azure.Messaging.EventHubs.Processor.Samples.csproj
@@ -12,6 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="README.md" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\src\Azure.Messaging.EventHubs.Processor.csproj" />
   </ItemGroup>
 </Project>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/README.md
@@ -11,9 +11,63 @@ description: Samples for the Azure.Messaging.EventHubs.Processor client library
 
 # Azure.Messaging.EventHubs.Processor Samples
 
-The samples are accompanied by a console application which you can use to execute and debug them interactively.  The simplest way to begin is to launch the project for debugging in Visual Studio or your preferred IDE and provide the Event Hubs connection information in response to the prompts.
+The  Azure Event Hubs Processor samples are intended to serve as an example and introduction to common scenarios in which the Event Hubs Processor client library is used, and to help demonstrate library features.  The samples are accompanied by a [console application](./Program.cs) which you can use to execute and debug them interactively.  The simplest way to begin is to launch the project for debugging in Visual Studio or your preferred IDE and provide the Event Hubs connection information in response to the prompts.
 
 Each of the samples is self-contained and focused on illustrating one specific scenario.  Each is numbered, with the lower numbers concentrating on basic scenarios and building to more complex scenarios as they increase; though each sample is independent, it will assume an understanding of the content discussed in earlier samples.
 
-- [Hello world](./Sample01_HelloWorld.cs)
-  An introduction to processing events using the Event Processor, illustrating how to configure the processor and connect to the Event Hubs service.
+## Getting started
+
+- **Microsoft Azure Subscription:**  To use Azure services, including Azure Event Hubs, you'll need a subscription.  If you do not have an existing Azure account, you may sign up for a free trial or use your MSDN subscriber benefits when you [create an account](https://account.windowsazure.com/Home/Index).
+
+- **Event Hubs namespace with an Event Hub:** To interact with Azure Event Hubs, you'll also need to have a namespace and Event Hub available.  If you are not familiar with creating Azure resources, you may wish to follow the step-by-step guide for [creating an Event Hub using the Azure portal](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-create).  There, you can also find detailed instructions for using the Azure CLI, Azure PowerShell, or Azure Resource Manager (ARM) templates to create an Event Hub.
+
+- **Azure Storage account with blob storage:** To persist checkpoints as blobs in Azure Storage, you'll need to have an Azure Storage account with blobs available.  If you are not familiar with Azure Storage accounts, you may wish to follow the step-by-step guide for [creating a storage account using the Azure portal](https://docs.microsoft.com/en-us/azure/storage/common/storage-quickstart-create-account?toc=%2Fazure%2Fstorage%2Fblobs%2Ftoc.json&tabs=azure-portal).  There, you can also find detailed instructions for using the Azure CLI, Azure PowerShell, or Azure Resource Manager (ARM) templates to create storage accounts.
+
+- **C# 8.0:** The Azure Event Hubs client library makes use of new features that were introduced in C# 8.0.  You can still use the library with older versions of C#, but some of its functionality won't be available.  In order to enable these features, you need to [target .NET Core 3.0](https://docs.microsoft.com/en-us/dotnet/standard/frameworks#how-to-specify-target-frameworks) or [specify the language version](https://docs.microsoft.com/en-gb/dotnet/csharp/language-reference/configure-language-version#override-a-default) you want to use (8.0 or above).  If you are using Visual Studio, versions prior to Visual Studio 2019 are not compatible with the tools needed to build C# 8.0 projects.  Visual Studio 2019, including the free Community edition, can be downloaded [here](https://visualstudio.microsoft.com/vs/).
+
+  **Important Note:** The use of C# 8.0 is mandatory to run the samples without modification.  You can still run the samples if you decide to tweak them.
+
+To quickly create the needed resources in Azure and to receive connection strings for them, you can deploy our sample template by clicking:  
+
+[![](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-sdk-for-net%2Fmaster%2Fsdk%2Feventhub%2FAzure.Messaging.EventHubs.Processor%2Fassets%2Fsamples-azure-deploy.json)
+
+## Available samples
+
+- [Hello world](./Sample01_HelloWorld.cs)  
+  An introduction to the Event Processor client, illustrating how to create the client and perform basic operations.
+  
+- [Create an Event Processor client with custom options](./Sample02_ProcessorWithCustomOptions.cs)  
+  An introduction to the Event Processor client, exploring additional options for creating the processor.
+
+- [Perform basic event processing](./Sample03_BasicEventProcessing.cs)  
+  An introduction to the Event Processor client, illustrating how to perform basic event processing.
+
+- [Create checkpoints to track processing state](./Sample04_BasicCheckpointing.cs)  
+  An introduction to the Event Processor client, illustrating how to create simple checkpoints.
+  
+- [Initialize an Event Hub partition for processing by a specific Event Processor client](./Sample05_InitializeAPartition.cs)  
+  An introduction to the Event Processor client, illustrating how to participate in initialization for a partition.
+
+- [Track when an Event Hub partition will no longer be processed by a specific Event Processor client](./Sample06_TrackWhenAPartitionIsClosed.cs)  
+  An introduction to the Event Processor client, illustrating how to track when processing stops for a partition.
+  
+- [Manage the Event Processor when an error is encountered](./Sample07_RestartProcessongOnError.cs)  
+  An example of stopping and restarting the Event Processor client when a specific error is encountered.
+
+- [Send a heartbeat for health monitoring while processing events](./Sample08_EventProcessingHeartbeat.cs)  
+  An example of ensuring that the handler for processing events is invoked on a fixed interval when no events are available.
+
+- [Process events in batches](./Sample09_ProcessEventsByBatch.cs)  
+  An example of grouping events into batches for downstream processing.
+  
+## Contributing  
+
+This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+Please see our [contributing guide](./../Azure.Messaging.EventHubs/CONTRIBUTING.md) for more information.
+  
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsdk%2Feventhub%2FAzure.Messaging.EventHubs.Processor/samples/%2FREADME.png)

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample02_ProcessorWithCustomOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample02_ProcessorWithCustomOptions.cs
@@ -66,8 +66,8 @@ namespace Azure.Messaging.EventHubs.Processor.Samples
 
                 RetryOptions = new EventHubsRetryOptions
                 {
-                   MaximumRetries = 5,
-                   TryTimeout = TimeSpan.FromMinutes(1)
+                    MaximumRetries = 5,
+                    TryTimeout = TimeSpan.FromMinutes(1)
                 }
             };
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample05_InitializeAPartition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample05_InitializeAPartition.cs
@@ -63,49 +63,64 @@ namespace Azure.Messaging.EventHubs.Processor.Samples
 
             Task partitionInitializingHandler(PartitionInitializingEventArgs eventArgs)
             {
-               try
-               {
-                  eventArgs.DefaultStartingPosition = EventPosition.Latest;
-                  Console.WriteLine($"Initialized partition: { eventArgs.PartitionId }");
-               }
-               catch (Exception ex)
-               {
-                   // For real-world scenarios, you should take action appropriate to your application.  For our example, we'll just log
-                   // the exception to the console.
+                if (eventArgs.CancellationToken.IsCancellationRequested)
+                {
+                    return Task.CompletedTask;
+                }
 
-                   Console.WriteLine();
-                   Console.WriteLine($"An error was observed while initializing partition: { eventArgs.PartitionId }.  Message: { ex.Message }");
-                   Console.WriteLine();
-               }
+                try
+                {
+                    eventArgs.DefaultStartingPosition = EventPosition.Latest;
+                    Console.WriteLine($"Initialized partition: { eventArgs.PartitionId }");
+                }
+                catch (Exception ex)
+                {
+                    // For real-world scenarios, you should take action appropriate to your application.  For our example, we'll just log
+                    // the exception to the console.
 
-               return Task.CompletedTask;
+                    Console.WriteLine();
+                    Console.WriteLine($"An error was observed while initializing partition: { eventArgs.PartitionId }.  Message: { ex.Message }");
+                    Console.WriteLine();
+                }
+
+                return Task.CompletedTask;
             }
 
             // For this example, events will just be logged to the console.
 
             Task processEventHandler(ProcessEventArgs eventArgs)
             {
-               try
-               {
-                  Console.WriteLine($"Event Received: { Encoding.UTF8.GetString(eventArgs.Data.Body.ToArray()) }");
-               }
-               catch (Exception ex)
-               {
-                   // For real-world scenarios, you should take action appropriate to your application.  For our example, we'll just log
-                   // the exception to the console.
+                if (eventArgs.CancellationToken.IsCancellationRequested)
+                {
+                    return Task.CompletedTask;
+                }
 
-                   Console.WriteLine();
-                   Console.WriteLine($"An error was observed while processing events.  Message: { ex.Message }");
-                   Console.WriteLine();
-               }
+                try
+                {
+                    Console.WriteLine($"Event Received: { Encoding.UTF8.GetString(eventArgs.Data.Body.ToArray()) }");
+                }
+                catch (Exception ex)
+                {
+                    // For real-world scenarios, you should take action appropriate to your application.  For our example, we'll just log
+                    // the exception to the console.
 
-               return Task.CompletedTask;
+                    Console.WriteLine();
+                    Console.WriteLine($"An error was observed while processing events.  Message: { ex.Message }");
+                    Console.WriteLine();
+                }
+
+                return Task.CompletedTask;
             };
 
             // For this example, exceptions will just be logged to the console.
 
             Task processErrorHandler(ProcessErrorEventArgs eventArgs)
             {
+                if (eventArgs.CancellationToken.IsCancellationRequested)
+                {
+                    return Task.CompletedTask;
+                }
+
                 Console.WriteLine("===============================");
                 Console.WriteLine($"The error handler was invoked during the operation: { eventArgs.Operation ?? "Unknown" }, for Exception: { eventArgs.Exception.Message }");
                 Console.WriteLine("===============================");

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample06_TrackWhenAPartitionIsClosed.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample06_TrackWhenAPartitionIsClosed.cs
@@ -76,46 +76,56 @@ namespace Azure.Messaging.EventHubs.Processor.Samples
 
             Task partitionInitializingHandler(PartitionInitializingEventArgs eventArgs)
             {
-               try
-               {
-                  ownedPartitions[eventArgs.PartitionId] = default(ProcessEventArgs);
-                  Console.WriteLine($"Initialized partition: { eventArgs.PartitionId }");
-               }
-               catch (Exception ex)
-               {
-                   // For real-world scenarios, you should take action appropriate to your application.  For our example, we'll just log
-                   // the exception to the console.
+                if (eventArgs.CancellationToken.IsCancellationRequested)
+                {
+                    return Task.CompletedTask;
+                }
 
-                   Console.WriteLine();
-                   Console.WriteLine($"An error was observed while initializing partition: { eventArgs.PartitionId }.  Message: { ex.Message }");
-                   Console.WriteLine();
-               }
+                try
+                {
+                    ownedPartitions[eventArgs.PartitionId] = default(ProcessEventArgs);
+                    Console.WriteLine($"Initialized partition: { eventArgs.PartitionId }");
+                }
+                catch (Exception ex)
+                {
+                    // For real-world scenarios, you should take action appropriate to your application.  For our example, we'll just log
+                    // the exception to the console.
 
-               return Task.CompletedTask;
+                    Console.WriteLine();
+                    Console.WriteLine($"An error was observed while initializing partition: { eventArgs.PartitionId }.  Message: { ex.Message }");
+                    Console.WriteLine();
+                }
+
+                return Task.CompletedTask;
             }
 
             // The handler for partition close will stop tracking the partition and checkpoint if an event was processed for it.
 
             async Task partitionClosingHandler(PartitionClosingEventArgs eventArgs)
             {
-               try
-               {
-                  if (ownedPartitions.TryRemove(eventArgs.PartitionId, out ProcessEventArgs lastProcessEventArgs))
-                  {
-                      await lastProcessEventArgs.UpdateCheckpointAsync();
-                  }
+                if (eventArgs.CancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
 
-                  Console.WriteLine($"Closing partition: { eventArgs.PartitionId }");
-               }
-               catch (Exception ex)
-               {
-                   // For real-world scenarios, you should take action appropriate to your application.  For our example, we'll just log
-                   // the exception to the console.
+                try
+                {
+                    if (ownedPartitions.TryRemove(eventArgs.PartitionId, out ProcessEventArgs lastProcessEventArgs))
+                    {
+                        await lastProcessEventArgs.UpdateCheckpointAsync();
+                    }
 
-                   Console.WriteLine();
-                   Console.WriteLine($"An error was observed while closing partition: { eventArgs.PartitionId }.  Message: { ex.Message }");
-                   Console.WriteLine();
-               }
+                    Console.WriteLine($"Closing partition: { eventArgs.PartitionId }");
+                }
+                catch (Exception ex)
+                {
+                    // For real-world scenarios, you should take action appropriate to your application.  For our example, we'll just log
+                    // the exception to the console.
+
+                    Console.WriteLine();
+                    Console.WriteLine($"An error was observed while closing partition: { eventArgs.PartitionId }.  Message: { ex.Message }");
+                    Console.WriteLine();
+                }
             }
 
             // When an event is received, update the partition if tracked.  In the case that the value changes in the
@@ -123,30 +133,40 @@ namespace Azure.Messaging.EventHubs.Processor.Samples
 
             Task processEventHandler(ProcessEventArgs eventArgs)
             {
-               try
-               {
-                  ownedPartitions[eventArgs.Partition.PartitionId] = eventArgs;
+                if (eventArgs.CancellationToken.IsCancellationRequested)
+                {
+                    return Task.CompletedTask;
+                }
 
-                  ++eventsProcessed;
-                  Console.WriteLine($"Event Received: { Encoding.UTF8.GetString(eventArgs.Data.Body.ToArray()) }");
-               }
-               catch (Exception ex)
-               {
-                   // For real-world scenarios, you should take action appropriate to your application.  For our example, we'll just log
-                   // the exception to the console.
+                try
+                {
+                    ownedPartitions[eventArgs.Partition.PartitionId] = eventArgs;
 
-                   Console.WriteLine();
-                   Console.WriteLine($"An error was observed while processing events.  Message: { ex.Message }");
-                   Console.WriteLine();
-               }
+                    ++eventsProcessed;
+                    Console.WriteLine($"Event Received: { Encoding.UTF8.GetString(eventArgs.Data.Body.ToArray()) }");
+                }
+                catch (Exception ex)
+                {
+                    // For real-world scenarios, you should take action appropriate to your application.  For our example, we'll just log
+                    // the exception to the console.
 
-               return Task.CompletedTask;
+                    Console.WriteLine();
+                    Console.WriteLine($"An error was observed while processing events.  Message: { ex.Message }");
+                    Console.WriteLine();
+                }
+
+                return Task.CompletedTask;
             };
 
             // For this example, exceptions will just be logged to the console.
 
             Task processErrorHandler(ProcessErrorEventArgs eventArgs)
             {
+                if (eventArgs.CancellationToken.IsCancellationRequested)
+                {
+                    return Task.CompletedTask;
+                }
+
                 Console.WriteLine("===============================");
                 Console.WriteLine($"The error handler was invoked during the operation: { eventArgs.Operation ?? "Unknown" }, for Exception: { eventArgs.Exception.Message }");
                 Console.WriteLine("===============================");

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample08_EventProcessingHeartbeat.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample08_EventProcessingHeartbeat.cs
@@ -1,0 +1,224 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Processor.Samples.Infrastructure;
+using Azure.Storage.Blobs;
+
+namespace Azure.Messaging.EventHubs.Processor.Samples
+{
+    /// <summary>
+    ///   An example of ensuring that the handler for processing events is invoked on a fixed interval when no events are available.
+    /// </summary>
+    ///
+    public class Sample08_EventProcessingHeartbeat : IEventHubsBlobCheckpointSample
+    {
+        /// <summary>
+        ///   The name of the sample.
+        /// </summary>
+        ///
+        public string Name => nameof(Sample08_EventProcessingHeartbeat);
+
+        /// <summary>
+        ///   A short description of the sample.
+        /// </summary>
+        ///
+        public string Description => "An example of ensuring that the handler for processing events is invoked on a fixed interval when no events are available.";
+
+        /// <summary>
+        ///   Runs the sample using the specified Event Hubs and Azure storage connection information.
+        /// </summary>
+        ///
+        /// <param name="eventHubsConnectionString">The connection string for the Event Hubs namespace that the sample should target.</param>
+        /// <param name="eventHubName">The name of the Event Hub, sometimes known as its path, that the sample should run against.</param>
+        /// <param name="blobStorageConnectionString">The connection string for the storage account where checkpoints and state should be persisted.</param>
+        /// <param name="blobContainerName">The name of the blob storage container where checkpoints and state should be persisted.</param>
+        ///
+        public async Task RunAsync(string eventHubsConnectionString,
+                                   string eventHubName,
+                                   string blobStorageConnectionString,
+                                   string blobContainerName)
+        {
+            // In this example, our Event Processor client will be configured to use a maximum wait time which is considered when the processor is reading events.
+            // When events are available, the Event Processor client will pass them to the ProcessEvent handler to be processed.  When no events are available in any
+            // partition for longer than the specified maximum wait interval, the processor will invoke the ProcessEvent handler with a set of arguments that do not
+            // include an event.  This allows your handler code to receive control and perform actions such as sending a heartbeat, emitting telemetry, or another
+            // operation specific to your application needs.
+            //
+            // For our processor, we'll specify a small maximum wait time value as part of the options.
+
+            EventProcessorClientOptions clientOptions = new EventProcessorClientOptions
+            {
+                MaximumWaitTime = TimeSpan.FromMilliseconds(150)
+            };
+
+            string consumerGroup = EventHubConsumerClient.DefaultConsumerGroupName;
+            BlobContainerClient storageClient = new BlobContainerClient(blobStorageConnectionString, blobContainerName);
+            EventProcessorClient processor = new EventProcessorClient(storageClient, consumerGroup, eventHubsConnectionString, eventHubName, clientOptions);
+
+            // For this example, we'll create a simple event handler that writes to the
+            // console each time it was invoked.
+
+            int eventIndex = 0;
+
+            async Task processEventHandler(ProcessEventArgs eventArgs)
+            {
+                if (eventArgs.CancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                try
+                {
+                    // The "HasEvent" property of the arguments will be set if an event was available from the
+                    // Event Hubs service.  If so, the argument properties for the event is populated and checkpoints
+                    // may be created.
+                    //
+                    // If the "HasEvent" property is unset, the event will be empty and checkpoints may not be created.
+                    //
+                    // NOTE:  There is a bug in the Event Hubs preview 6 library causing "HasEvents" to return the
+                    //        wrong value.  We'll substitute a check against the "Data" property to work around it.
+                    //
+                    //        if (eventArgs.HasEvents) {} is the preferred snippet.
+
+                    if (eventArgs.Data != null)
+                    {
+                        Console.WriteLine($"Event Received: { Encoding.UTF8.GetString(eventArgs.Data.Body.ToArray()) }");
+                    }
+
+                    // Simulate sending a heartbeat using a simple helper that writes a status to the
+                    // console.
+
+                    await SendHeartbeatAsync();
+                    ++eventIndex;
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine();
+                    Console.WriteLine($"An error was observed while processing events.  Message: { ex.Message }");
+                    Console.WriteLine();
+                }
+            };
+
+            // For this example, exceptions will just be logged to the console.
+
+            Task processErrorHandler(ProcessErrorEventArgs eventArgs)
+            {
+                if (eventArgs.CancellationToken.IsCancellationRequested)
+                {
+                    return Task.CompletedTask;
+                }
+
+                Console.WriteLine();
+                Console.WriteLine("===============================");
+                Console.WriteLine($"The error handler was invoked during the operation: { eventArgs.Operation ?? "Unknown" }, for Exception: { eventArgs.Exception.Message }");
+                Console.WriteLine("===============================");
+                Console.WriteLine();
+
+                return Task.CompletedTask;
+            }
+
+            processor.ProcessEventAsync += processEventHandler;
+            processor.ProcessErrorAsync += processErrorHandler;
+
+            try
+            {
+                Console.WriteLine("Starting the Event Processor client...");
+                Console.WriteLine();
+
+                eventIndex = 0;
+                await processor.StartProcessingAsync();
+
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromSeconds(45));
+
+                // We'll publish a batch of events for our processor to receive. We'll split the events into a couple of batches to
+                // increase the chance they'll be spread around to different partitions and introduce a delay between batches to
+                // allow for the handler to be invoked without an available event interleaved.
+
+                var expectedEvents = new List<EventData>()
+                {
+                   new EventData(Encoding.UTF8.GetBytes("First Event, First Batch")),
+                   new EventData(Encoding.UTF8.GetBytes("Second Event, First Batch")),
+                   new EventData(Encoding.UTF8.GetBytes("Third Event, First Batch")),
+
+                   new EventData(Encoding.UTF8.GetBytes("First Event, Second Batch")),
+                   new EventData(Encoding.UTF8.GetBytes("Second Event, Second Batch")),
+                   new EventData(Encoding.UTF8.GetBytes("Third Event, Second Batch")),
+
+                   new EventData(Encoding.UTF8.GetBytes("First Event, Third Batch")),
+                   new EventData(Encoding.UTF8.GetBytes("Second Event, Third Batch")),
+                   new EventData(Encoding.UTF8.GetBytes("Third Event, Third Batch"))
+                };
+
+                int sentIndex = 0;
+                int numberOfBatches = 3;
+                int eventsPerBatch = (expectedEvents.Count / numberOfBatches);
+
+                await using (var producer = new EventHubProducerClient(eventHubsConnectionString, eventHubName))
+                {
+                    while (sentIndex < expectedEvents.Count)
+                    {
+                        using EventDataBatch eventBatch = await producer.CreateBatchAsync();
+
+                        for (int index = 0; index < eventsPerBatch; ++index)
+                        {
+                            eventBatch.TryAdd(expectedEvents[sentIndex]);
+                            ++sentIndex;
+                        }
+
+                        await producer.SendAsync(eventBatch);
+                        await Task.Delay(250, cancellationSource.Token);
+                    }
+                }
+
+                // We'll allow the Event Processor client to read and dispatch the events that we published, along with
+                // ensuring a few invocations with no event.  Note that, due to non-determinism in the timing, we may or may
+                // not see all of the events from our batches read.
+
+                while ((!cancellationSource.IsCancellationRequested) && (eventIndex <= expectedEvents.Count + 5))
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(250));
+                }
+
+                // Once we arrive at this point, either cancellation was requested or we have processed all of our events.  In
+                // both cases, we'll want to shut down the processor.
+
+                Console.WriteLine();
+                Console.WriteLine("Stopping the processor...");
+
+                await processor.StopProcessingAsync();
+            }
+            finally
+            {
+                // It is encouraged that you unregister your handlers when you have finished
+                // using the Event Processor to ensure proper cleanup.  This is especially
+                // important when using lambda expressions or handlers in any form that may
+                // contain closure scopes or hold other references.
+
+                processor.ProcessEventAsync -= processEventHandler;
+                processor.ProcessErrorAsync -= processErrorHandler;
+            }
+
+            // The Event Processor client has been stopped and is not explicitly disposable; there
+            // is nothing further that we need to do for cleanup.
+
+            Console.WriteLine();
+        }
+
+        /// <summary>
+        ///   A helper method to simulate sending a heartbeat for health monitoring
+        ///   during event processing.
+        /// </summary>
+        ///
+        private async Task SendHeartbeatAsync()
+        {
+            Console.WriteLine("Sending heartbeat (simulated)...");
+            await Task.Delay(50);
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample09_ProcessEventsByBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample09_ProcessEventsByBatch.cs
@@ -1,0 +1,300 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Processor.Samples.Infrastructure;
+using Azure.Storage.Blobs;
+
+namespace Azure.Messaging.EventHubs.Processor.Samples
+{
+    /// <summary>
+    ///   An example of grouping events into batches for downstream processing.
+    /// </summary>
+    ///
+    public class Sample09_ProcessEventsByBatch : IEventHubsBlobCheckpointSample
+    {
+        /// <summary>
+        ///   The name of the sample.
+        /// </summary>
+        ///
+        public string Name => nameof(Sample09_ProcessEventsByBatch);
+
+        /// <summary>
+        ///   A short description of the sample.
+        /// </summary>
+        ///
+        public string Description => "An example of grouping events into batches for downstream processing.";
+
+        /// <summary>
+        ///   Runs the sample using the specified Event Hubs and Azure storage connection information.
+        /// </summary>
+        ///
+        /// <param name="eventHubsConnectionString">The connection string for the Event Hubs namespace that the sample should target.</param>
+        /// <param name="eventHubName">The name of the Event Hub, sometimes known as its path, that the sample should run against.</param>
+        /// <param name="blobStorageConnectionString">The connection string for the storage account where checkpoints and state should be persisted.</param>
+        /// <param name="blobContainerName">The name of the blob storage container where checkpoints and state should be persisted.</param>
+        ///
+        public async Task RunAsync(string eventHubsConnectionString,
+                                   string eventHubName,
+                                   string blobStorageConnectionString,
+                                   string blobContainerName)
+        {
+            // In order to ensure efficient communication with the Event Hubs service and the best throughput possible for dispatching events to be processed,
+            // the Event Processor client is eagerly reading from each partition of the Event Hub and staging events.  The processor will dispatch an event
+            // to the "ProcessEvent" handler immediately when one is available.  Each call to the handler passes a single event and the context of the partition
+            // from which the event was read.  This pattern is intended to allow developers to act on an event as soon as possible, and present a straightforward
+            // and understandable interface.
+            //
+            // This approach is optimized for scenarios where the processing of events can be performed quickly and without heavy resource costs.  For scenarios
+            // where that is not the case, it may be advantageous to collect the events into batches and send them to be processed outside of the context
+            // of the "ProcessEvent" handler.
+            //
+            // In this example, our "ProcessEvent" handler will group events into batches by partition, sending them for downstream processing when the desired
+            // batch size was reached or when no event was available for more than a maximum wait time interval.
+
+            int desiredBatchSize = 3;
+            TimeSpan maximumWaitTime = TimeSpan.FromMilliseconds(150);
+
+            // The Event Processor client will preserve the order that events were enqueued in a partition by waiting for the "ProcessEvent" handler to
+            // complete before it is invoked with a new event for the same partition.  However, partitions are processed concurrently, so the
+            // handler is likely to be executing for multiple partitions at the same time.
+            //
+            // To account for this, we'll use a concurrent dictionary to track batches, grouping them by partition.
+
+            ConcurrentDictionary<string, List<ProcessEventArgs>> eventBatches = new ConcurrentDictionary<string, List<ProcessEventArgs>>();
+
+            // Create our Event Processor client, specifying the maximum wait time as an option to ensure that
+            // our handler is invoked when no event was available.
+
+            EventProcessorClientOptions clientOptions = new EventProcessorClientOptions
+            {
+                MaximumWaitTime = maximumWaitTime
+            };
+
+            string consumerGroup = EventHubConsumerClient.DefaultConsumerGroupName;
+            BlobContainerClient storageClient = new BlobContainerClient(blobStorageConnectionString, blobContainerName);
+            EventProcessorClient processor = new EventProcessorClient(storageClient, consumerGroup, eventHubsConnectionString, eventHubName, clientOptions);
+
+            // For this example, we'll create a simple event handler that writes to the
+            // console each time it was invoked.
+
+            int eventIndex = 0;
+
+            async Task processEventHandler(ProcessEventArgs eventArgs)
+            {
+                if (eventArgs.CancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                try
+                {
+                    // Retrieve or create the active batch for the current partition.
+                    //
+                    // NOTE:  There is a bug in the Event Hubs Processor preview 6 library causing the "Partition"
+                    //        property to be null when no event was available.  This sample will work when run against the
+                    //        referenced project but will require adjustments to work with the preview 6 package.
+
+                    List<ProcessEventArgs> currentBatch = eventBatches.GetOrAdd(eventArgs.Partition.PartitionId, _ => new List<ProcessEventArgs>());
+                    bool sendBatchForProcessing = false;
+
+                    // If there was an event emitted, add the event and check to see if the size of the batch has reached the desired
+                    // size.  If so, it will need to be sent.
+                    //
+                    // NOTE:  There is a bug in the Event Hubs preview 6 library causing "HasEvents" to return the
+                    //        wrong value.  We'll substitute a check against the "Data" property to work around it.
+                    //
+                    //        if (eventArgs.HasEvents) {} is the preferred snippet.
+                    //
+                    if (eventArgs.Data != null)
+                    {
+                        currentBatch.Add(eventArgs);
+                        sendBatchForProcessing = (currentBatch.Count >= desiredBatchSize);
+                    }
+                    else
+                    {
+                        // There was no event available within the interval requested by the maximum
+                        // wait time, send the batch for processing if it contains any events.
+
+                        sendBatchForProcessing = (currentBatch.Count > 0);
+                    }
+
+                    // It is important to be aware that no events for the partition will be processed until the handler returns,
+                    // so you may wish to delegate processing to a downstream service or background task in order to maintain
+                    // throughput.
+                    //
+                    // In this example, if the batch is to be sent, we'll delegate to simple helper method that will write
+                    // to the console.  If sending our batch completed successfully, we'll checkpoint using the last
+                    // event and clear the batch.
+
+                    if (sendBatchForProcessing)
+                    {
+                        await SendEventBatchAsync(currentBatch.Select(item => item.Data));
+                        await currentBatch[currentBatch.Count - 1].UpdateCheckpointAsync();
+                        currentBatch.Clear();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine();
+                    Console.WriteLine($"An error was observed while processing events.  Message: { ex.Message }");
+                    Console.WriteLine();
+                }
+
+                ++eventIndex;
+            };
+
+            // For this example, exceptions will just be logged to the console.
+
+            Task processErrorHandler(ProcessErrorEventArgs eventArgs)
+            {
+                if (eventArgs.CancellationToken.IsCancellationRequested)
+                {
+                    return Task.CompletedTask;
+                }
+
+                Console.WriteLine();
+                Console.WriteLine("===============================");
+                Console.WriteLine($"The error handler was invoked during the operation: { eventArgs.Operation ?? "Unknown" }, for Exception: { eventArgs.Exception.Message }");
+                Console.WriteLine("===============================");
+                Console.WriteLine();
+
+                return Task.CompletedTask;
+            }
+
+            processor.ProcessEventAsync += processEventHandler;
+            processor.ProcessErrorAsync += processErrorHandler;
+
+            try
+            {
+                Console.WriteLine("Starting the Event Processor client...");
+                Console.WriteLine();
+
+                eventIndex = 0;
+                await processor.StartProcessingAsync();
+
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromSeconds(45));
+
+                // We'll publish a batch of events for our processor to receive. We'll split the events into a couple of batches to
+                // increase the chance they'll be spread around to different partitions and introduce a delay between batches to
+                // allow for the handler to be invoked without an available event interleaved.
+
+                var expectedEvents = new List<EventData>()
+                {
+                   new EventData(Encoding.UTF8.GetBytes("First Event, First Batch")),
+                   new EventData(Encoding.UTF8.GetBytes("Second Event, First Batch")),
+                   new EventData(Encoding.UTF8.GetBytes("Third Event, First Batch")),
+
+                   new EventData(Encoding.UTF8.GetBytes("First Event, Second Batch")),
+                   new EventData(Encoding.UTF8.GetBytes("Second Event, Second Batch")),
+                   new EventData(Encoding.UTF8.GetBytes("Third Event, Second Batch")),
+
+                   new EventData(Encoding.UTF8.GetBytes("First Event, Third Batch")),
+                   new EventData(Encoding.UTF8.GetBytes("Second Event, Third Batch")),
+                   new EventData(Encoding.UTF8.GetBytes("Third Event, Third Batch")),
+
+                   new EventData(Encoding.UTF8.GetBytes("First Event, Fourth Batch")),
+                   new EventData(Encoding.UTF8.GetBytes("Second Event, Fourth Batch")),
+                   new EventData(Encoding.UTF8.GetBytes("Third Event, Fourth Batch")),
+
+                   new EventData(Encoding.UTF8.GetBytes("First Event, Fifth Batch")),
+                   new EventData(Encoding.UTF8.GetBytes("Second Event, Fifth Batch")),
+                   new EventData(Encoding.UTF8.GetBytes("Third Event, Fifth Batch")),
+
+                   new EventData(Encoding.UTF8.GetBytes("First Event, Fifth Batch")),
+                   new EventData(Encoding.UTF8.GetBytes("Second Event, Fifth Batch")),
+                   new EventData(Encoding.UTF8.GetBytes("Third Event, Fifth Batch")),
+
+                   new EventData(Encoding.UTF8.GetBytes("First Event, Sixth Batch")),
+                   new EventData(Encoding.UTF8.GetBytes("Second Event, Sixth Batch")),
+                   new EventData(Encoding.UTF8.GetBytes("Third Event, Sixth Batch")),
+
+                   new EventData(Encoding.UTF8.GetBytes("First Event, Seventh Batch")),
+                   new EventData(Encoding.UTF8.GetBytes("Second Event, Seventh Batch")),
+                   new EventData(Encoding.UTF8.GetBytes("Third Event, Seventh Batch"))
+                };
+
+                int sentIndex = 0;
+                int numberOfBatches = 3;
+                int eventsPerBatch = (expectedEvents.Count / numberOfBatches);
+
+                await using (var producer = new EventHubProducerClient(eventHubsConnectionString, eventHubName))
+                {
+                    while (sentIndex < expectedEvents.Count)
+                    {
+                        using EventDataBatch eventBatch = await producer.CreateBatchAsync();
+
+                        for (int index = 0; index < eventsPerBatch; ++index)
+                        {
+                            eventBatch.TryAdd(expectedEvents[sentIndex]);
+                            ++sentIndex;
+                        }
+
+                        await producer.SendAsync(eventBatch);
+                        await Task.Delay(250, cancellationSource.Token);
+                    }
+                }
+
+                // We'll allow the Event Processor client to read and dispatch the events that we published, along with
+                // ensuring a few invocations with no event.  Note that, due to non-determinism in the timing, we may or may
+                // not see all of the events from our batches read.
+
+                while ((!cancellationSource.IsCancellationRequested) && (eventIndex <= expectedEvents.Count + 5))
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(250));
+                }
+
+                // Once we arrive at this point, either cancellation was requested or we have processed all of our events.  In
+                // both cases, we'll want to shut down the processor.
+
+                Console.WriteLine();
+                Console.WriteLine("Stopping the processor...");
+
+                await processor.StopProcessingAsync();
+            }
+            finally
+            {
+                // It is encouraged that you unregister your handlers when you have finished
+                // using the Event Processor to ensure proper cleanup.  This is especially
+                // important when using lambda expressions or handlers in any form that may
+                // contain closure scopes or hold other references.
+
+                processor.ProcessEventAsync -= processEventHandler;
+                processor.ProcessErrorAsync -= processErrorHandler;
+            }
+
+            // The Event Processor client has been stopped and is not explicitly disposable; there
+            // is nothing further that we need to do for cleanup.
+
+            Console.WriteLine();
+        }
+
+        /// <summary>
+        ///   A helper method to simulate sending an event batch for processing.
+        /// </summary>
+        ///
+        /// <param name="eventBatch">The event batch to "send".</param>
+        ///
+        private async Task SendEventBatchAsync(IEnumerable<EventData> eventBatch)
+        {
+            StringBuilder batchMessage = new StringBuilder();
+            int eventCount = 0;
+
+            foreach (EventData data in eventBatch)
+            {
+                batchMessage.AppendLine($"\tEvent: { Encoding.UTF8.GetString(data.Body.ToArray()) }");
+                ++eventCount;
+            }
+
+            Console.WriteLine($"Event Batch with { eventCount } events sent:{ Environment.NewLine }{ batchMessage.ToString() }{ Environment.NewLine }");
+            await Task.Delay(50);
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -15,6 +15,7 @@ using Azure.Core.Pipeline;
 using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Diagnostics;
 using Azure.Messaging.EventHubs.Errors;
+using Azure.Messaging.EventHubs.Metadata;
 using Azure.Messaging.EventHubs.Processor;
 using Azure.Storage.Blobs;
 
@@ -612,52 +613,49 @@ namespace Azure.Messaging.EventHubs
                 {
                     cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
-                    if (ActiveLoadBalancingTask != null)
+                    // Cancel the current running task.
+
+                    RunningTaskTokenSource.Cancel();
+                    RunningTaskTokenSource.Dispose();
+                    RunningTaskTokenSource = null;
+
+                    // Now that a cancellation request has been issued, wait for the running task to finish.  In case something
+                    // unexpected happened and it stopped working midway, this is the moment we expect to catch an exception.
+
+                    Exception loadBalancingException = default;
+
+                    try
                     {
-                        // Cancel the current running task.
+                        await ActiveLoadBalancingTask.ConfigureAwait(false);
+                    }
+                    catch (Exception ex) when (ex is TaskCanceledException || ex is OperationCanceledException)
+                    {
+                        // Nothing to do here.  These exceptions are expected.
+                    }
+                    catch (Exception ex)
+                    {
+                        loadBalancingException = ex;
+                    }
 
-                        RunningTaskTokenSource.Cancel();
-                        RunningTaskTokenSource.Dispose();
-                        RunningTaskTokenSource = null;
+                    // Now that the task has finished, clean up what is left.  Stop and remove every partition processing task that is
+                    // still running and clear our dictionaries.  ActivePartitionProcessors dictionary is already cleared by the
+                    // StopPartitionProcessingIfRunningAsync method.
 
-                        // Now that a cancellation request has been issued, wait for the running task to finish.  In case something
-                        // unexpected happened and it stopped working midway, this is the moment we expect to catch an exception.
+                    await Task.WhenAll(ActivePartitionProcessors.Keys
+                        .Select(partitionId => StopPartitionProcessingIfRunningAsync(partitionId, ProcessingStoppedReason.Shutdown, CancellationToken.None)))
+                        .ConfigureAwait(false);
 
-                        Exception loadBalancingException = default;
+                    InstanceOwnership.Clear();
 
-                        try
-                        {
-                            await ActiveLoadBalancingTask.ConfigureAwait(false);
-                        }
-                        catch (Exception ex) when (ex is TaskCanceledException || ex is OperationCanceledException)
-                        {
-                            // Nothing to do here.  These exceptions are expected.
-                        }
-                        catch (Exception ex)
-                        {
-                            loadBalancingException = ex;
-                        }
+                    // We need to wait until all tasks have stopped before making the load balancing task null.  If we did it sooner, we
+                    // would have a race condition where the user could update the processing handlers while some pumps are still running.
 
-                        // Now that the task has finished, clean up what is left.  Stop and remove every partition processing task that is
-                        // still running and clear our dictionaries.  ActivePartitionProcessors dictionary is already cleared by the
-                        // StopPartitionProcessingIfRunningAsync method.
+                    ActiveLoadBalancingTask.Dispose();
+                    ActiveLoadBalancingTask = null;
 
-                        await Task.WhenAll(ActivePartitionProcessors.Keys
-                            .Select(partitionId => StopPartitionProcessingIfRunningAsync(partitionId, ProcessingStoppedReason.Shutdown, CancellationToken.None)))
-                            .ConfigureAwait(false);
-
-                        InstanceOwnership.Clear();
-
-                        // We need to wait until all tasks have stopped before making the load balancing task null.  If we did it sooner, we
-                        // would have a race condition where the user could update the processing handlers while some pumps are still running.
-
-                        ActiveLoadBalancingTask.Dispose();
-                        ActiveLoadBalancingTask = null;
-
-                        if (loadBalancingException != default)
-                        {
-                            throw loadBalancingException;
-                        }
+                    if (loadBalancingException != default)
+                    {
+                        throw loadBalancingException;
                     }
                 }
             }
@@ -862,7 +860,7 @@ namespace Azure.Messaging.EventHubs
                 await Task.WhenAll(InstanceOwnership
                     .Select(async kvp =>
                     {
-                        if (!ActivePartitionProcessors.TryGetValue(kvp.Key, out var activeTokenSource) || activeTokenSource.Item1.IsCompleted)
+                        if (!ActivePartitionProcessors.TryGetValue(kvp.Key, out var activeTaskAndTokenSource) || activeTaskAndTokenSource.Item1.IsCompleted)
                         {
                             await StopPartitionProcessingIfRunningAsync(kvp.Key, ProcessingStoppedReason.Shutdown, cancellationToken).ConfigureAwait(false);
                             await StartPartitionProcessingAsync(kvp.Key, cancellationToken).ConfigureAwait(false);
@@ -1141,9 +1139,9 @@ namespace Azure.Messaging.EventHubs
         {
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
-            if (ActivePartitionProcessors.TryRemove(partitionId, out var activeTokenSource))
+            if (ActivePartitionProcessors.TryRemove(partitionId, out var activeTaskAndTokenSource))
             {
-                var (processingTask, tokenSource) = activeTokenSource;
+                var (processingTask, tokenSource) = activeTaskAndTokenSource;
 
                 try
                 {
@@ -1292,6 +1290,8 @@ namespace Azure.Messaging.EventHubs
                                                  EventPosition startingPosition,
                                                  CancellationToken cancellationToken) => Task.Run(async () =>
             {
+                var emptyPartitionContext = new EmptyPartitionContext(partitionId);
+
                 await using (var connection = ConnectionFactory())
                 await using (var consumer = CreateConsumer(ConsumerGroup, connection, ProcessingConsumerOptions))
                 {
@@ -1322,7 +1322,8 @@ namespace Azure.Messaging.EventHubs
                                 updateCheckpoint = EmptyEventUpdateCheckpoint;
                             }
 
-                            var eventArgs = new ProcessEventArgs(partitionEvent.Partition, partitionEvent.Data, updateCheckpoint, RunningTaskTokenSource.Token);
+                            var eventArgs = new ProcessEventArgs(partitionEvent.Partition ?? emptyPartitionContext, partitionEvent.Data, updateCheckpoint, RunningTaskTokenSource.Token);
+
                             await OnProcessEventAsync(eventArgs).ConfigureAwait(false);
                         }
                         catch (Exception eventProcessingException)
@@ -1362,6 +1363,38 @@ namespace Azure.Messaging.EventHubs
             {
                 throw new InvalidOperationException(Resources.RunningEventProcessorCannotPerformOperation);
             }
+        }
+
+        /// <summary>
+        ///   Represents a basic partition context for event processing when the
+        ///   full context was not available.
+        /// </summary>
+        ///
+        /// <seealso cref="Azure.Messaging.EventHubs.PartitionContext" />
+        ///
+        private class EmptyPartitionContext : PartitionContext
+        {
+            /// <summary>
+            ///   Initializes a new instance of the <see cref="EmptyPartitionContext" /> class.
+            /// </summary>
+            ///
+            /// <param name="partitionId">The identifier of the partition that the context represents.</param>
+            ///
+            public EmptyPartitionContext(string partitionId) : base(partitionId)
+            {
+            }
+
+            /// <summary>
+            ///   A set of information about the last enqueued event of a partition, not available for the
+            ///   empty context.
+            /// </summary>
+            ///
+            /// <returns>The set of properties for the last event that was enqueued to the partition.</returns>
+            ///
+            /// <exception cref="InvalidOperationException">The method call is not available on the <see cref="EmptyPartitionContext"/>.</exception>
+            ///
+            public override LastEnqueuedEventProperties ReadLastEnqueuedEventProperties() =>
+                throw new InvalidOperationException(Resources.CannotReadLastEnqueuedEventPropertiesWithoutEvent);
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
@@ -506,5 +506,16 @@ namespace Azure.Messaging.EventHubs {
                 return ResourceManager.GetString("OperationReadEvents", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The last enqueued event properties cannot be read when an event is not available..
+        /// </summary>
+        internal static string CannotReadLastEnqueuedEventPropertiesWithoutEvent
+        {
+            get
+            {
+                return ResourceManager.GetString("CannotReadLastEnqueuedEventPropertiesWithoutEvent", resourceCulture);
+            }
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
@@ -261,4 +261,7 @@
   <data name="OperationReadEvents" xml:space="preserve">
     <value>Reading events from the Event Hubs service.</value>
   </data>
+  <data name="CannotReadLastEnqueuedEventPropertiesWithoutEvent" xml:space="preserve">
+    <value>The last enqueued event properties cannot be read when an event is not available.</value>
+  </data>
 </root>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/README.md
@@ -178,46 +178,7 @@ For detailed information about these and other exceptions that may occur, please
 
 ## Next steps
 
-Beyond the introductory scenarios discussed, the Azure Event Hubs client library offers support for many additional scenarios to help take advantage of the full feature set of the Azure Event Hubs service.  In order to help explore some of these scenarios, the Event Hubs client library offers a [project of samples](./samples) to serve as an illustration for common scenarios.
-
-The samples are accompanied by a console application which you can use to execute and debug them interactively.  The simplest way to begin is to launch the project for debugging in Visual Studio or your preferred editor and provide the Event Hubs connection information in response to the prompts.  
-
-Each of the samples is self-contained and focused on illustrating one specific scenario.  Each is numbered, with the lower numbers concentrating on basic scenarios and building to more complex scenarios as they increase; though each sample is independent, it will assume an understanding of the content discussed in earlier samples.
-
-The available samples are:
-
-- [Hello world](./samples/Sample01_HelloWorld.cs)  
-  An introduction to Event Hubs, illustrating how to create a client and explore an Event Hub.
-
-- [Create an Event Hub client with custom options](./samples/Sample02_ClientWithCustomOptions.cs)  
-  An introduction to Event Hubs, exploring additional options for creating the different Event Hub clients.
-
-- [Publish an event batch to an Event Hub](./samples/Sample03_PublishAnEventBatch.cs)  
-  An introduction to publishing events, using a batch with single event.  
-
-- [Read events from an Event Hub](./samples/Sample04_ReadEvents.cs)  
-  An introduction to reading all events available from an Event Hub.
-
-- [Publish an event batch using a partition key](./samples/Sample05_PublishAnEventBatchWithPartitionKey.cs)  
-  An introduction to publishing events using a partition key to group batches together.
-
-- [Publish an event batch to a specific partition](./samples/Sample06_PublishAnEventBatchToASpecificPartition.cs)  
-  An introduction to publishing events, specifying a specific partition for the batch to be published to.
-
-- [Publish events with custom metadata](./samples/Sample07_PublishEventsWithCustomMetadata.cs)  
-  An example of publishing events, extending the event data with custom metadata.
-
-- [Read only new events from an Event Hub](./samples/Sample08_ReadOnlyNewEvents.cs)  
-  An example of reading events, beginning with only those newly available from an Event Hub.
-
-- [Read events from a known position in an Event Hub partition](./samples/Sample09_ReadEventsFromAKnownPosition.cs)  
-  An example of reading events from a single Event Hub partition, starting at a well-known position.
-
-- [Publish an event batch with a custom size limit](./samples/Sample10_PublishAnEventBatchWithCustomSizeLimit.cs)  
-  An example of publishing events using a custom size limitation with the batch.
-
-- [Authorize using a service principal with client secret](./samples/Sample11_AuthenticateWithClientSecretCredential.cs)  
-  An example of interacting with an Event Hub using an Azure Active Directory application with client secret for authorization.
+Beyond the introductory scenarios discussed, the Azure Event Hubs client library offers support for additional scenarios to help take advantage of the full feature set of the Azure Event Hubs service.  In order to help explore some of these scenarios, the Event Hubs client library offers a project of samples to serve as an illustration for common scenarios.  Please see the samples [README](./samples/README.md) for details.
 
 ## Contributing  
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Azure.Messaging.EventHubs.Samples.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Azure.Messaging.EventHubs.Samples.csproj
@@ -12,6 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="README.md" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Azure.Identity" />
     <ProjectReference Include="..\src\Azure.Messaging.EventHubs.csproj" />
   </ItemGroup>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/README.md
@@ -11,39 +11,69 @@ description: Samples for the Azure.Messaging.EventHubs client library
 
 # Azure.Messaging.EventHubs Samples
 
-The  Azure Event Hubs samples are accompanied by a [console application](./Program.cs) which you can use to execute and debug them interactively.  The simplest way to begin is to launch the project for debugging in Visual Studio or your preferred IDE and provide the Event Hubs connection information in response to the prompts.
+The  Azure Event Hubs samples are intended to serve as an example and introduction to common scenarios in which the Event Hubs client library is used, and to help demonstrate library features.  The samples are accompanied by a [console application](./Program.cs) which you can use to execute and debug them interactively.  The simplest way to begin is to launch the project for debugging in Visual Studio or your preferred IDE and provide the Event Hubs connection information in response to the prompts.
 
 Each of the samples is self-contained and focused on illustrating one specific scenario.  Each is numbered, with the lower numbers concentrating on basic scenarios and building to more complex scenarios as they increase; though each sample is independent, it will assume an understanding of the content discussed in earlier samples.
 
-- [Hello world](./Sample01_HelloWorld.cs)
+## Getting started
+
+- **Microsoft Azure Subscription:**  To use Azure services, including Azure Event Hubs, you'll need a subscription.  If you do not have an existing Azure account, you may sign up for a free trial or use your MSDN subscriber benefits when you [create an account](https://account.windowsazure.com/Home/Index).
+
+- **Event Hubs namespace with an Event Hub:** To interact with Azure Event Hubs, you'll also need to have a namespace and Event Hub available.  If you are not familiar with creating Azure resources, you may wish to follow the step-by-step guide for [creating an Event Hub using the Azure portal](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-create).  There, you can also find detailed instructions for using the Azure CLI, Azure PowerShell, or Azure Resource Manager (ARM) templates to create an Event Hub.
+
+- **C# 8.0:** The Azure Event Hubs client library makes use of new features that were introduced in C# 8.0.  You can still use the library with older versions of C#, but some of its functionality won't be available.  In order to enable these features, you need to [target .NET Core 3.0](https://docs.microsoft.com/en-us/dotnet/standard/frameworks#how-to-specify-target-frameworks) or [specify the language version](https://docs.microsoft.com/en-gb/dotnet/csharp/language-reference/configure-language-version#override-a-default) you want to use (8.0 or above).  If you are using Visual Studio, versions prior to Visual Studio 2019 are not compatible with the tools needed to build C# 8.0 projects.  Visual Studio 2019, including the free Community edition, can be downloaded [here](https://visualstudio.microsoft.com/vs/).
+
+  **Important Note:** The use of C# 8.0 is mandatory to run the samples without modification.  You can still run the samples if you decide to tweak them.
+
+To quickly create the needed Event Hubs resources in Azure and to receive a connection string for them, you can deploy our sample template by clicking:
+
+[![](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-sdk-for-net%2Fmaster%2Fsdk%2Feventhub%2FAzure.Messaging.EventHubs%2Fassets%2Fsamples-azure-deploy.json)
+
+If you'd like to run samples that use [Azure.Identity](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/identity/Azure.Identity), you'll also need a service principal with the correct roles. To make configuration for the identity samples easier, a [PowerShell script](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/assets/identity-tests-azure-setup.ps1) script is available. Please see the [Contributing Guide](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/CONTRIBUTING.md#Azure-Identity-Samples) for more details about the script.
+
+## Available samples
+
+- [Hello world](./samples/Sample01_HelloWorld.cs)  
   An introduction to Event Hubs, illustrating how to create a client and explore an Event Hub.
 
-- [Create an Event Hub client with custom options](./Sample02_ClientWithCustomOptions.cs)
+- [Create an Event Hub client with custom options](./samples/Sample02_ClientWithCustomOptions.cs)  
   An introduction to Event Hubs, exploring additional options for creating the different Event Hub clients.
 
-- [Publish an event to an Event Hub](./Sample03_PublishAnEvent.cs)
-  An introduction to publishing events, using a simple Event Hub producer client.
+- [Publish an event batch to an Event Hub](./samples/Sample03_PublishAnEventBatch.cs)  
+  An introduction to publishing events, using a batch with single event.  
 
-- [Publish events using a partition key](./Sample04_PublishEventsWithPartitionKey.cs)
-  An introduction to publishing events, using a partition key to group them together.
+- [Read events from an Event Hub](./samples/Sample04_ReadEvents.cs)  
+  An introduction to reading all events available from an Event Hub.
 
-- [Publish a size-limited batch of events](./Sample05_PublishAnEventBatch.cs)
-  An introduction to publishing events, using a size-aware batch to ensure the size does not exceed the transport size limits.
+- [Publish an event batch using a partition key](./samples/Sample05_PublishAnEventBatchWithPartitionKey.cs)  
+  An introduction to publishing events using a partition key to group batches together.
 
-- [Publish events to a specific Event Hub partition](./Sample06_PublishEventsToSpecificPartitions.cs)
-  An introduction to publishing events, using an Event Hub producer client that is associated with a specific partition.
+- [Publish an event batch to a specific partition](./samples/Sample06_PublishAnEventBatchToASpecificPartition.cs)  
+  An introduction to publishing events, specifying a specific partition for the batch to be published to.
 
-- [Publish events with custom metadata](./Sample07_PublishEventsWithCustomMetadata.cs)
+- [Publish events with custom metadata](./samples/Sample07_PublishEventsWithCustomMetadata.cs)  
   An example of publishing events, extending the event data with custom metadata.
 
-- [Consume events from an Event Hub partition](./Sample08_ConsumeEvents.cs)
-  An introduction to consuming events, using a simple Event Hub consumer client.
+- [Read only new events from an Event Hub](./samples/Sample08_ReadOnlyNewEvents.cs)  
+  An example of reading events, beginning with only those newly available from an Event Hub.
 
-- [Consume events from an Event Hub partition, limiting the period of time to wait for an event](./Sample09_ConsumeEventsWithMaximumWaitTime.cs)
-  An introduction to consuming events, using an Event Hub consumer client with maximum wait time.
+- [Read events from a known position in an Event Hub partition](./samples/Sample09_ReadEventsFromAKnownPosition.cs)  
+  An example of reading events from a single Event Hub partition, starting at a well-known position.
 
-- [Consume events from a known position in the Event Hub partition](./Sample10_ConsumeEventsFromAKnownPosition.cs)
-  An example of consuming events, starting at a well-known position in the Event Hub partition.
+- [Publish an event batch with a custom size limit](./samples/Sample10_PublishAnEventBatchWithCustomSizeLimit.cs)  
+  An example of publishing events using a custom size limitation with the batch.
 
-- [Consume events from all partitions of an Event Hub with the Event Processor](./Sample11_ConsumeEventsWithEventProcessor.cs)
-  An example of consuming events from all Event Hub partitions at once, using the Event Processor client.
+- [Authorize using a service principal with client secret](./samples/Sample11_AuthenticateWithClientSecretCredential.cs)  
+  An example of interacting with an Event Hub using an Azure Active Directory application with client secret for authorization.
+
+## Contributing  
+
+This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+Please see our [contributing guide](./CONTRIBUTING.md) for more information.
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsdk%2Feventhub%2FAzure.Messaging.EventHubs/samples/%2FREADME.png)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/PartitionContext.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/PartitionContext.cs
@@ -34,6 +34,8 @@ namespace Azure.Messaging.EventHubs
         ///   created with <see cref="ReadEventOptions.TrackLastEnqueuedEventProperties" /> set.
         /// </summary>
         ///
+        /// <returns>The set of properties for the last event that was enqueued to the partition.</returns>
+        ///
         /// <remarks>
         ///   When information about the partition's last enqueued event is being tracked, each event received from the Event Hubs
         ///   service will carry metadata about the partition that it otherwise would not. This results in a small amount of

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/ProcessEventArgs.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/ProcessEventArgs.cs
@@ -27,7 +27,7 @@ namespace Azure.Messaging.EventHubs.Processor
         ///
         /// <value><c>true</c> if the arguments contain an event to be processed; otherwise, <c>false</c>.</value>
         ///
-        public bool HasEvent => ((Data == null) || (Partition == null));
+        public bool HasEvent => ((Data != null) && (Partition != null));
 
         /// <summary>
         ///   The context of the Event Hub partition this instance is associated with.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientLiveTests.cs
@@ -2293,6 +2293,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        [Ignore("Consistently failing on Linux and macOS.  To be fixed with the upcoming test stabilization.")]
         public async Task ConsumerCannotRetrieveMetadataWhenProxyIsInvalid()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))


### PR DESCRIPTION
# Summary

The focus of these changes is to revise the samples for the Event Processor client, extend the set of samples with additional scenarios and flesh out the README content for the samples in each package. 

Also included are some small refinements to the Event Processor client that were deferred from feedback for an earlier pull request, a fix for an empty partition context when the maximum wait time elapses, and ignoring a test that requires follow-up analysis.

# Last Upstream Rebase

Thursday, December 5, 3:10pm (EST)

# Related and Follow-Up Issues

- [Release Event Hubs Track 2 Library for .NET](https://github.com/Azure/azure-sdk-for-net/issues/8552) (#8552) 
- [Review and update documentation](https://github.com/Azure/azure-sdk-for-net/issues/8553) (#8553) 
- [Create and revise samples](https://github.com/Azure/azure-sdk-for-net/issues/8554) (#8554) 