### PR TITLE
remove reflection from smoke tests

### DIFF
--- a/common/SmokeTests/SmokeTest/Program.cs
+++ b/common/SmokeTests/SmokeTest/Program.cs
@@ -3,9 +3,7 @@
 // Licensed under the MIT License.
 // ------------------------------------
 // ------------------------------------
-using Azure.Messaging.EventHubs;
 using System;
-using System.Reflection.Metadata;
 using System.Threading.Tasks;
 
 namespace SmokeTest

--- a/common/SmokeTests/SmokeTest/SmokeTest.csproj
+++ b/common/SmokeTests/SmokeTest/SmokeTest.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Azure.Security.Keyvault.Secrets" Version="4.0.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.0.0" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" />
-    <PackageReference Include="System.Reflection.Metadata" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`System.Reflection.Metadata` is no longer required for smoke tests