### PR TITLE
ToString for request content

### DIFF
--- a/sdk/core/Azure.Core/src/RequestContent.cs
+++ b/sdk/core/Azure.Core/src/RequestContent.cs
@@ -7,6 +7,7 @@ using Azure.Core.Buffers;
 using System.Threading.Tasks;
 using System.Threading;
 using System.Buffers;
+using System.Text;
 
 namespace Azure.Core
 {
@@ -172,6 +173,8 @@ namespace Azure.Core
             {
                 await stream.WriteAsync(_bytes, _contentStart, _contentLength, cancellation).ConfigureAwait(false);
             }
+
+            public override string ToString() => Encoding.UTF8.GetString(_bytes, 0, _bytes.Length);
         }
 
         private sealed class MemoryContent : RequestContent
@@ -199,6 +202,8 @@ namespace Azure.Core
             {
                 await stream.WriteAsync(_bytes, cancellation).ConfigureAwait(false);
             }
+
+            public override string ToString() => Encoding.UTF8.GetString(_bytes.ToArray(), 0, _bytes.Length);
         }
 
         private sealed class ReadOnlySequenceContent : RequestContent
@@ -226,6 +231,8 @@ namespace Azure.Core
             {
                 await stream.WriteAsync(_bytes, cancellation).ConfigureAwait(false);
             }
+
+            public override string ToString() => Encoding.UTF8.GetString(_bytes.ToArray(), 0, (int)_bytes.Length);
         }
     }
 }


### PR DESCRIPTION
Adds ToString overrides for the non-stream content types. This allows you to debug/view the actual content easier.

To write the equivalent in the Watch window in VisualStudio looks like this:
```csharp
System.Text.Encoding.UTF8.GetString(((Azure.Core.RequestContent.MemoryContent)request.Content)._bytes.ToArray(), 0, ((Azure.Core.RequestContent.MemoryContent)request.Content)._bytes.Length)
```