### PR TITLE
[Event Hubs Client] Track Two (Formatting Pass)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/BlobsCheckpointStore/BlobsCheckpointStoreLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/BlobsCheckpointStore/BlobsCheckpointStoreLiveTests.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Tests;
 using Azure.Storage.Blobs;
-using Moq;
 using NUnit.Framework;
 
 namespace Azure.Messaging.EventHubs.Processor.Tests

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/BlobsCheckpointStore/BlobsCheckpointStoreTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/BlobsCheckpointStore/BlobsCheckpointStoreTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using Azure.Storage.Blobs;
 using Moq;
 using NUnit.Framework;

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/EventProcessorClient/EventProcessorClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/EventProcessorClient/EventProcessorClientLiveTests.cs
@@ -999,11 +999,11 @@ namespace Azure.Messaging.EventHubs.Tests
                         (
                             EventHubConsumerClient.DefaultConsumerGroupName,
                             connectionString
-                            // TODO: fix test. OwnerIdentifier is not accessible anymore.
-                            // onInitialize: eventArgs =>
-                            //     ownedPartitionsCount.AddOrUpdate(eventArgs.Context.OwnerIdentifier, 1, (ownerId, value) => value + 1),
-                            // onStop: eventArgs =>
-                            //     ownedPartitionsCount.AddOrUpdate(eventArgs.Context.OwnerIdentifier, 0, (ownerId, value) => value - 1)
+                        // TODO: fix test. OwnerIdentifier is not accessible anymore.
+                        // onInitialize: eventArgs =>
+                        //     ownedPartitionsCount.AddOrUpdate(eventArgs.Context.OwnerIdentifier, 1, (ownerId, value) => value + 1),
+                        // onStop: eventArgs =>
+                        //     ownedPartitionsCount.AddOrUpdate(eventArgs.Context.OwnerIdentifier, 0, (ownerId, value) => value - 1)
                         );
 
                     eventProcessorManager.AddEventProcessors(1);

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/EventProcessorClient/EventProcessorClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/EventProcessorClient/EventProcessorClientTests.cs
@@ -764,7 +764,8 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             for (var index = 0; index < eventCount; ++index)
             {
-                if (cancellationToken.IsCancellationRequested) { break; }
+                if (cancellationToken.IsCancellationRequested)
+                { break; }
                 await Task.Delay(25).ConfigureAwait(false);
                 yield return new PartitionEvent(new MockPartitionContext("fake"), new EventData(Encoding.UTF8.GetBytes($"Event { index }")));
             }
@@ -781,7 +782,8 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             for (var index = 0; index < eventCount; ++index)
             {
-                if (cancellationToken.IsCancellationRequested) { break; }
+                if (cancellationToken.IsCancellationRequested)
+                { break; }
                 await Task.Delay(25).ConfigureAwait(false);
                 yield return new PartitionEvent();
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Authorization/SharedAccessSignature.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Authorization/SharedAccessSignature.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.ComponentModel;
 using System.Globalization;
 using System.Net;
 using System.Security.Cryptography;

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
@@ -8,9 +8,8 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Azure.Messaging.EventHubs {
-    using System;
-
+namespace Azure.Messaging.EventHubs
+{
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -21,23 +20,28 @@ namespace Azure.Messaging.EventHubs {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources {
+    internal class Resources
+    {
 
         private static global::System.Resources.ResourceManager resourceMan;
 
         private static global::System.Globalization.CultureInfo resourceCulture;
 
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Resources() {
+        internal Resources()
+        {
         }
 
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
-            get {
-                if (object.ReferenceEquals(resourceMan, null)) {
+        internal static global::System.Resources.ResourceManager ResourceManager
+        {
+            get
+            {
+                if (object.ReferenceEquals(resourceMan, null))
+                {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager(ResourcesNamespace.Current, typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
@@ -50,11 +54,14 @@ namespace Azure.Messaging.EventHubs {
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
-            get {
+        internal static global::System.Globalization.CultureInfo Culture
+        {
+            get
+            {
                 return resourceCulture;
             }
-            set {
+            set
+            {
                 resourceCulture = value;
             }
         }
@@ -62,8 +69,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to The {0} value is expected to be a {1} bit signed integer. Actual value: &apos;{2}&apos;..
         /// </summary>
-        internal static string CannotParseIntegerType {
-            get {
+        internal static string CannotParseIntegerType
+        {
+            get
+            {
                 return ResourceManager.GetString("CannotParseIntegerType", resourceCulture);
             }
         }
@@ -71,8 +80,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to A producer created for a specific partition cannot send events using a partition key. This producer is associated with partition &apos;{0}&apos;..
         /// </summary>
-        internal static string CannotSendWithPartitionIdAndPartitionKey {
-            get {
+        internal static string CannotSendWithPartitionIdAndPartitionKey
+        {
+            get
+            {
                 return ResourceManager.GetString("CannotSendWithPartitionIdAndPartitionKey", resourceCulture);
             }
         }
@@ -80,8 +91,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to Cannot begin processing without {0} handler set..
         /// </summary>
-        internal static string CannotStartEventProcessorWithoutHandler {
-            get {
+        internal static string CannotStartEventProcessorWithoutHandler
+        {
+            get
+            {
                 return ResourceManager.GetString("CannotStartEventProcessorWithoutHandler", resourceCulture);
             }
         }
@@ -89,8 +102,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to The Event Hub client responsible for this information.
         /// </summary>
-        internal static string ClientNeededForThisInformation {
-            get {
+        internal static string ClientNeededForThisInformation
+        {
+            get
+            {
                 return ResourceManager.GetString("ClientNeededForThisInformation", resourceCulture);
             }
         }
@@ -98,8 +113,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to {0} has already been closed and cannot perform the requested operation..
         /// </summary>
-        internal static string ClosedConnectionCannotPerformOperation {
-            get {
+        internal static string ClosedConnectionCannotPerformOperation
+        {
+            get
+            {
                 return ResourceManager.GetString("ClosedConnectionCannotPerformOperation", resourceCulture);
             }
         }
@@ -107,8 +124,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to {0} has already been closed and cannot perform the requested operation..
         /// </summary>
-        internal static string ClosedInstanceCannotPerformOperation {
-            get {
+        internal static string ClosedInstanceCannotPerformOperation
+        {
+            get
+            {
                 return ResourceManager.GetString("ClosedInstanceCannotPerformOperation", resourceCulture);
             }
         }
@@ -116,8 +135,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to The &apos;identifier&apos; parameter exceeds the maximum allowed size of {0} characters..
         /// </summary>
-        internal static string ConsumerIdentifierOverMaxValue {
-            get {
+        internal static string ConsumerIdentifierOverMaxValue
+        {
+            get
+            {
                 return ResourceManager.GetString("ConsumerIdentifierOverMaxValue", resourceCulture);
             }
         }
@@ -125,8 +146,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to Unable to acquire an access token using the provided credential..
         /// </summary>
-        internal static string CouldNotAcquireAccessToken {
-            get {
+        internal static string CouldNotAcquireAccessToken
+        {
+            get
+            {
                 return ResourceManager.GetString("CouldNotAcquireAccessToken", resourceCulture);
             }
         }
@@ -134,8 +157,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to Unable to create the items needed to communicate with the Event Hubs service..
         /// </summary>
-        internal static string CouldNotCreateLink {
-            get {
+        internal static string CouldNotCreateLink
+        {
+            get
+            {
                 return ResourceManager.GetString("CouldNotCreateLink", resourceCulture);
             }
         }
@@ -143,8 +168,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to Could not create a reader of events for Event Hub: &apos;{0}&apos;, partition: &apos;{1}&apos;, consumer group: &apos;{2}&apos;..
         /// </summary>
-        internal static string FailedToCreateReader {
-            get {
+        internal static string FailedToCreateReader
+        {
+            get
+            {
                 return ResourceManager.GetString("FailedToCreateReader", resourceCulture);
             }
         }
@@ -152,8 +179,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to Serialization failed due to an unsupported type, {0}..
         /// </summary>
-        internal static string FailedToSerializeUnsupportedType {
-            get {
+        internal static string FailedToSerializeUnsupportedType
+        {
+            get
+            {
                 return ResourceManager.GetString("FailedToSerializeUnsupportedType", resourceCulture);
             }
         }
@@ -161,8 +190,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to The connection string could not be parsed; either it was malformed or contains no well-known tokens..
         /// </summary>
-        internal static string InvalidConnectionString {
-            get {
+        internal static string InvalidConnectionString
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidConnectionString", resourceCulture);
             }
         }
@@ -170,8 +201,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to The string has an invalid encoding format..
         /// </summary>
-        internal static string InvalidEncoding {
-            get {
+        internal static string InvalidEncoding
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidEncoding", resourceCulture);
             }
         }
@@ -179,8 +212,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to The event position is not valid for filtering.  It must have an offset, sequence number, or enqueued time available to filter against..
         /// </summary>
-        internal static string InvalidEventPositionForFilter {
-            get {
+        internal static string InvalidEventPositionForFilter
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidEventPositionForFilter", resourceCulture);
             }
         }
@@ -188,8 +223,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to An invalid message body was encountered.  Either the body was null or an incorrect type. Expected: {0}.
         /// </summary>
-        internal static string InvalidMessageBody {
-            get {
+        internal static string InvalidMessageBody
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidMessageBody", resourceCulture);
             }
         }
@@ -197,8 +234,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to The shared access signature could not be parsed; it was either malformed or incorrectly encoded..
         /// </summary>
-        internal static string InvalidSharedAccessSignature {
-            get {
+        internal static string InvalidSharedAccessSignature
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidSharedAccessSignature", resourceCulture);
             }
         }
@@ -206,8 +245,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to The time period may not be Zero or Infinite..
         /// </summary>
-        internal static string InvalidTimePeriod {
-            get {
+        internal static string InvalidTimePeriod
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidTimePeriod", resourceCulture);
             }
         }
@@ -215,8 +256,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to The requested transport type, &apos;{0}&apos; is not supported..
         /// </summary>
-        internal static string InvalidTransportType {
-            get {
+        internal static string InvalidTransportType
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidTransportType", resourceCulture);
             }
         }
@@ -224,8 +267,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to The message (id:{0}, size:{1} bytes) is larger than is currently allowed ({2} bytes)..
         /// </summary>
-        internal static string MessageSizeExceeded {
-            get {
+        internal static string MessageSizeExceeded
+        {
+            get
+            {
                 return ResourceManager.GetString("MessageSizeExceeded", resourceCulture);
             }
         }
@@ -233,8 +278,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to The connection string used for an Event Hub client must specify the Event Hubs namespace host, and a Shared Access Signature (both the name and value) to be valid. The path to an Event Hub must be included in the connection string or specified separately..
         /// </summary>
-        internal static string MissingConnectionInformation {
-            get {
+        internal static string MissingConnectionInformation
+        {
+            get
+            {
                 return ResourceManager.GetString("MissingConnectionInformation", resourceCulture);
             }
         }
@@ -242,8 +289,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to The path to an Event Hub may be specified as part of the connection string or as a separate value, but not both..
         /// </summary>
-        internal static string OnlyOneEventHubNameMayBeSpecified {
-            get {
+        internal static string OnlyOneEventHubNameMayBeSpecified
+        {
+            get
+            {
                 return ResourceManager.GetString("OnlyOneEventHubNameMayBeSpecified", resourceCulture);
             }
         }
@@ -251,8 +300,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to A proxy may only be used for a web sockets connection..
         /// </summary>
-        internal static string ProxyMustUseWebSockets {
-            get {
+        internal static string ProxyMustUseWebSockets
+        {
+            get
+            {
                 return ResourceManager.GetString("ProxyMustUseWebSockets", resourceCulture);
             }
         }
@@ -260,8 +311,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to The requested resource, &apos;{0}&apos;, does not match the resource of the shared access signature, &apos;{1}&apos;. A token cannot be issued..
         /// </summary>
-        internal static string ResourceMustMatchSharedAccessSignature {
-            get {
+        internal static string ResourceMustMatchSharedAccessSignature
+        {
+            get
+            {
                 return ResourceManager.GetString("ResourceMustMatchSharedAccessSignature", resourceCulture);
             }
         }
@@ -269,8 +322,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to Retry options must be specified; if no retry is desired, please set the maximum number of retries to 0. To provide a custom retry policy, please assign it on the client directly..
         /// </summary>
-        internal static string RetryOptionsMustBeSet {
-            get {
+        internal static string RetryOptionsMustBeSet
+        {
+            get
+            {
                 return ResourceManager.GetString("RetryOptionsMustBeSet", resourceCulture);
             }
         }
@@ -278,8 +333,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to The event processor is already running and needs to be stopped in order to perform this operation..
         /// </summary>
-        internal static string RunningEventProcessorCannotPerformOperation {
-            get {
+        internal static string RunningEventProcessorCannotPerformOperation
+        {
+            get
+            {
                 return ResourceManager.GetString("RunningEventProcessorCannotPerformOperation", resourceCulture);
             }
         }
@@ -287,8 +344,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to In order to update the signature, a shared access key must have been provided when the shared access signature was created..
         /// </summary>
-        internal static string SharedAccessKeyIsRequired {
-            get {
+        internal static string SharedAccessKeyIsRequired
+        {
+            get
+            {
                 return ResourceManager.GetString("SharedAccessKeyIsRequired", resourceCulture);
             }
         }
@@ -296,8 +355,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to A shared key credential is unable to generate a token directly. Please use this credential when creating an Event Hub Client, for proper generation of shared key tokens..
         /// </summary>
-        internal static string SharedKeyCredentialCannotGenerateTokens {
-            get {
+        internal static string SharedKeyCredentialCannotGenerateTokens
+        {
+            get
+            {
                 return ResourceManager.GetString("SharedKeyCredentialCannotGenerateTokens", resourceCulture);
             }
         }
@@ -305,8 +366,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to A timeout value must be positive. To request using the default timeout, please use TimeSpan.Zero or null..
         /// </summary>
-        internal static string TimeoutMustBePositive {
-            get {
+        internal static string TimeoutMustBePositive
+        {
+            get
+            {
                 return ResourceManager.GetString("TimeoutMustBePositive", resourceCulture);
             }
         }
@@ -314,8 +377,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to Argument {0} must be a non-negative timespan value. The provided value was {1}..
         /// </summary>
-        internal static string TimeSpanMustBeNonNegative {
-            get {
+        internal static string TimeSpanMustBeNonNegative
+        {
+            get
+            {
                 return ResourceManager.GetString("TimeSpanMustBeNonNegative", resourceCulture);
             }
         }
@@ -323,8 +388,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to This information is only available when TrackLastEnqueuedEventProperties is set on the Event Hub consumer options..
         /// </summary>
-        internal static string TrackLastEnqueuedEventPropertiesNotSet {
-            get {
+        internal static string TrackLastEnqueuedEventPropertiesNotSet
+        {
+            get
+            {
                 return ResourceManager.GetString("TrackLastEnqueuedEventPropertiesNotSet", resourceCulture);
             }
         }
@@ -332,8 +399,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to An unknown error was encountered while communicating with the Event Hubs service..
         /// </summary>
-        internal static string UnknownCommunicationException {
-            get {
+        internal static string UnknownCommunicationException
+        {
+            get
+            {
                 return ResourceManager.GetString("UnknownCommunicationException", resourceCulture);
             }
         }
@@ -341,8 +410,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to The specified connection type, &quot;{0}&quot;, is not recognized as valid in this context..
         /// </summary>
-        internal static string UnknownConnectionType {
-            get {
+        internal static string UnknownConnectionType
+        {
+            get
+            {
                 return ResourceManager.GetString("UnknownConnectionType", resourceCulture);
             }
         }
@@ -350,8 +421,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to The requested retry mode, &apos;{0}&apos;, is not known; a retry delay canot be determined..
         /// </summary>
-        internal static string UnknownRetryMode {
-            get {
+        internal static string UnknownRetryMode
+        {
+            get
+            {
                 return ResourceManager.GetString("UnknownRetryMode", resourceCulture);
             }
         }
@@ -359,8 +432,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to An unrecoverable exception was encountered that left the environment in a bad state..
         /// </summary>
-        internal static string UnrecoverableException {
-            get {
+        internal static string UnrecoverableException
+        {
+            get
+            {
                 return ResourceManager.GetString("UnrecoverableException", resourceCulture);
             }
         }
@@ -368,8 +443,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to The credential is not a known and supported credential type. Please use a JWT credential or shared key credential..
         /// </summary>
-        internal static string UnsupportedCredential {
-            get {
+        internal static string UnsupportedCredential
+        {
+            get
+            {
                 return ResourceManager.GetString("UnsupportedCredential", resourceCulture);
             }
         }
@@ -377,8 +454,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to The requested transport event type, &apos;{0}&apos;, is not supported by the active transport client..
         /// </summary>
-        internal static string UnsupportedTransportEventType {
-            get {
+        internal static string UnsupportedTransportEventType
+        {
+            get
+            {
                 return ResourceManager.GetString("UnsupportedTransportEventType", resourceCulture);
             }
         }
@@ -386,8 +465,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to The value supplied must be greater than or equal to {0}..
         /// </summary>
-        internal static string ValueMustBeAtLeast {
-            get {
+        internal static string ValueMustBeAtLeast
+        {
+            get
+            {
                 return ResourceManager.GetString("ValueMustBeAtLeast", resourceCulture);
             }
         }
@@ -395,8 +476,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to The value supplied must be between {0} and {1}..
         /// </summary>
-        internal static string ValueOutOfRange {
-            get {
+        internal static string ValueOutOfRange
+        {
+            get
+            {
                 return ResourceManager.GetString("ValueOutOfRange", resourceCulture);
             }
         }
@@ -404,8 +487,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to The Azure Storage Blobs container or blob used by the Event Processor Client does not exist..
         /// </summary>
-        internal static string BlobsResourceDoesNotExist {
-            get {
+        internal static string BlobsResourceDoesNotExist
+        {
+            get
+            {
                 return ResourceManager.GetString("BlobsResourceDoesNotExist", resourceCulture);
             }
         }
@@ -413,8 +498,10 @@ namespace Azure.Messaging.EventHubs {
         /// <summary>
         ///   Looks up a localized string similar to A checkpoint cannot be created or updated using an empty event..
         /// </summary>
-        internal static string CannotCreateCheckpointForEmptyEvent {
-            get {
+        internal static string CannotCreateCheckpointForEmptyEvent
+        {
+            get
+            {
                 return ResourceManager.GetString("CannotCreateCheckpointForEmptyEvent", resourceCulture);
             }
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Core/ConnectionStringParserTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Core/ConnectionStringParserTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using Azure.Messaging.EventHubs.Core;
-using Azure.Messaging.EventHubs.Metadata;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Properties/AssemblyInfo.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Properties/AssemblyInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Runtime.CompilerServices;
 using NUnit.Framework;
 
 [assembly: Parallelizable(ParallelScope.All)]

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Infrastructure/IEventHubsIdentitySample.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Infrastructure/IEventHubsIdentitySample.cs
@@ -11,7 +11,7 @@ namespace Azure.Messaging.EventHubs.Samples.Infrastructure
     ///
     /// <seealso href="https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/identity/Azure.Identity" />
     ///
-    public interface IEventHubsIdentitySample: ISample
+    public interface IEventHubsIdentitySample : ISample
     {
         /// <summary>
         ///   Allows for executing the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Infrastructure/IEventHubsSample.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Infrastructure/IEventHubsSample.cs
@@ -9,7 +9,7 @@ namespace Azure.Messaging.EventHubs.Samples.Infrastructure
     ///   Provides a well-known means of executing a sample.
     /// </summary>
     ///
-    public interface IEventHubsSample: ISample
+    public interface IEventHubsSample : ISample
     {
         /// <summary>
         ///   Allows for executing the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample02_ClientWithCustomOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample02_ClientWithCustomOptions.cs
@@ -55,7 +55,7 @@ namespace Azure.Messaging.EventHubs.Samples
 
             var producerOptions = new EventHubProducerClientOptions
             {
-               ConnectionOptions = new EventHubConnectionOptions
+                ConnectionOptions = new EventHubConnectionOptions
                 {
                     TransportType = EventHubsTransportType.AmqpWebSockets,
                     Proxy = (IWebProxy)null
@@ -63,8 +63,8 @@ namespace Azure.Messaging.EventHubs.Samples
 
                 RetryOptions = new EventHubsRetryOptions
                 {
-                   MaximumRetries = 5,
-                   TryTimeout = TimeSpan.FromMinutes(1)
+                    MaximumRetries = 5,
+                    TryTimeout = TimeSpan.FromMinutes(1)
                 }
             };
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsRetryOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsRetryOptions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Azure.Core;
-using Azure.Messaging.EventHubs.Core;
 
 namespace Azure.Messaging.EventHubs
 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventPosition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventPosition.cs
@@ -167,7 +167,7 @@ namespace Azure.Messaging.EventHubs
         {
             if (ReferenceEquals(this, other))
             {
-               return true;
+                return true;
             }
 
             return (Offset == other.Offset)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/ProcessEventArgs.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/ProcessEventArgs.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
-using Azure.Messaging.EventHubs.Errors;
 
 namespace Azure.Messaging.EventHubs.Processor
 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventPositionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventPositionTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.IO;
 using NUnit.Framework;
 
 namespace Azure.Messaging.EventHubs.Tests

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientTests.cs
@@ -615,7 +615,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     if (++receivedEvents >= expectedEvents)
                     {
-                       break;
+                        break;
                     }
                 }
             }, Throws.Nothing, "The iterator should not have been canceled.");
@@ -1427,7 +1427,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     if (++receivedEvents >= expectedEvents)
                     {
-                       break;
+                        break;
                     }
                 }
             }, Throws.Nothing, "The iterator should not have been canceled.");
@@ -1795,7 +1795,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Select(index => new EventData(Encoding.UTF8.GetBytes($"Event: { index }")))
                 .ToList();
 
-            var mockConnection = new MockConnection(() =>  new PublishingTransportConsumerMock(events));
+            var mockConnection = new MockConnection(() => new PublishingTransportConsumerMock(events));
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
             var receivedEvents = new Dictionary<string, int>();
             var partitions = await mockConnection.GetPartitionIdsAsync(Mock.Of<EventHubsRetryPolicy>());

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientTests.cs
@@ -575,8 +575,12 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockSecondBatch = new EventDataBatch(new MockTransportBatch(), new SendEventOptions { PartitionId = "2" });
             var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
-            try { await producer.SendAsync(mockFirstBatch); } catch {}
-            try { await producer.SendAsync(mockSecondBatch); } catch {}
+            try
+            { await producer.SendAsync(mockFirstBatch); }
+            catch { }
+            try
+            { await producer.SendAsync(mockSecondBatch); }
+            catch { }
 
             await producer.CloseAsync();
 
@@ -594,14 +598,16 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var mockTransportProducer = new Mock<TransportProducer>();
             var mockConnection = new MockConnection(() => mockTransportProducer.Object);
-            var mockBatch = new EventDataBatch(new MockTransportBatch(), new SendEventOptions { PartitionId = "1" });;
+            var mockBatch = new EventDataBatch(new MockTransportBatch(), new SendEventOptions { PartitionId = "1" });
             var producer = new EventHubProducerClient(mockConnection);
 
             mockTransportProducer
                 .Setup(producer => producer.CloseAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException(new InvalidCastException()));
 
-            try { await producer.SendAsync(mockBatch); } catch {}
+            try
+            { await producer.SendAsync(mockBatch); }
+            catch { }
 
             Assert.That(async () => await producer.CloseAsync(), Throws.InstanceOf<InvalidCastException>());
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Samples/SamplesLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Samples/SamplesLiveTests.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Azure.Messaging.EventHubs.Core;
-using Azure.Messaging.EventHubs.Metadata;
 using Azure.Messaging.EventHubs.Samples.Infrastructure;
 using NUnit.Framework;
 


### PR DESCRIPTION
# Summary

The focus of these changes is to run an automated formatting pass over each of the three Event Hubs solutions.   No functional or orthogonal changes were intended.

# Last Upstream Rebase

Monday, December 9, 9:33am (EST)