### PR TITLE
[Event Hubs Client] Track Two (Project Configuration)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/Directory.Build.props
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/Directory.Build.props
@@ -1,30 +1,16 @@
 ﻿<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--
-    Identify samples as a test support project to keep the target framework synchronized, since both are
-    based on a version of netcoreapp.
+    Extend the criteria for identifying a samples project, to allow for the pattern:
+    Azure.Messaging.EventHubs.Samples.[[ SCENARIO ]].  This is intended to support breaking
+    the samples into self-contained executables.
 
     Because the common SDK build properties need this value in order to recognize the desired
     target frameworks and related, this needs to be set before the common properties import.
   -->
   <PropertyGroup Condition="$(MSBuildProjectName.Contains('.Samples'))">
-    <IsTestProject>true</IsTestProject>
-    <IsTestSupportProject>true</IsTestSupportProject>
+    <IsSamplesProject>true</IsSamplesProject>
   </PropertyGroup>
 
   <!-- Import the common SDK build properties. -->
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
-
-  <!-- Set any needed overrides to the decisions made within the common SDK build properties. -->
-  <PropertyGroup>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-
-    <!-- Do not inherit implicit dependencies from the engineering system during build or packaging -->
-    <ImportDefaultReferences>false</ImportDefaultReferences>
-
-    <!-- Disable the custom analyzer; it is currently in development and based against draft standards. -->
-    <EnableClientSdkAnalyzers>false</EnableClientSdkAnalyzers>
-  </PropertyGroup>
 </Project>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -62,6 +63,8 @@ namespace Azure.Messaging.EventHubs
         ///   The event to be raised just before event processing starts for a given partition.
         /// </summary>
         ///
+        [SuppressMessage("Usage", "AZC0002:Ensure all service methods take an optional CancellationToken parameter.", Justification = "Guidance does not apply; this is an event.")]
+        [SuppressMessage("Usage", "AZC0003:DO make service methods virtual.", Justification = "This member follows the standard .NET event pattern; override via the associated On<<EVENT>> method.")]
         public event Func<PartitionInitializingEventArgs, Task> PartitionInitializingAsync
         {
             add
@@ -93,6 +96,8 @@ namespace Azure.Messaging.EventHubs
         ///   The event to be raised once event processing stops for a given partition.
         /// </summary>
         ///
+        [SuppressMessage("Usage", "AZC0002:Ensure all service methods take an optional CancellationToken parameter.", Justification = "Guidance does not apply; this is an event.")]
+        [SuppressMessage("Usage", "AZC0003:DO make service methods virtual.", Justification = "This member follows the standard .NET event pattern; override via the associated On<<EVENT>> method.")]
         public event Func<PartitionClosingEventArgs, Task> PartitionClosingAsync
         {
             add
@@ -125,6 +130,8 @@ namespace Azure.Messaging.EventHubs
         ///   is mandatory.
         /// </summary>
         ///
+        [SuppressMessage("Usage", "AZC0002:Ensure all service methods take an optional CancellationToken parameter.", Justification = "Guidance does not apply; this is an event.")]
+        [SuppressMessage("Usage", "AZC0003:DO make service methods virtual.", Justification = "This member follows the standard .NET event pattern; override via the associated On<<EVENT>> method.")]
         public event Func<ProcessEventArgs, Task> ProcessEventAsync
         {
             add
@@ -157,6 +164,8 @@ namespace Azure.Messaging.EventHubs
         ///   Implementation is mandatory.
         /// </summary>
         ///
+        [SuppressMessage("Usage", "AZC0002:Ensure all service methods take an optional CancellationToken parameter.", Justification = "Guidance does not apply; this is an event.")]
+        [SuppressMessage("Usage", "AZC0003:DO make service methods virtual.", Justification = "This member follows the standard .NET event pattern; override via the associated On<<EVENT>> method.")]
         public event Func<ProcessErrorEventArgs, Task> ProcessErrorAsync
         {
             add

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Properties/AssemblyInfo.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Azure.Messaging.EventHubs.Processor.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100d15ddcb29688295338af4b7686603fe614abd555e09efba8fb88ee09e1f7b1ccaeed2e8f823fa9eef3fdd60217fc012ea67d2479751a0b8c087a4185541b851bd8b16f8d91b840e51b1cb0ba6fe647997e57429265e85ef62d565db50a69ae1647d54d7bd855e4db3d8a91510e5bcbd0edfbbecaa20a7bd9ae74593daa7b11b4")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+
+[assembly: SuppressMessage("Usage", "AZC0004:DO provide both asynchronous and synchronous variants for all service methods.", Justification = "As an AMQP-based offering, Event Hubs has been exempted from providing a synchronous surface.")]
+[assembly: SuppressMessage("Usage", "AZC0008:ClientOptions should have a nested enum called ServiceVersion", Justification = "The Event Hubs interface does not support the concept of versions.")]
+[assembly: SuppressMessage("Usage", "AZC0006:DO provide constructor overloads that allow specifying additional options.", Justification = "Analysis is flagging incorrectly. The Event Hubs constructor patterns adhere to guidance and have obtained board approval.")]

--- a/sdk/eventhub/Azure.Messaging.EventHubs/Directory.Build.props
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/Directory.Build.props
@@ -1,30 +1,16 @@
 ﻿<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--
-    Identify samples as a test support project to keep the target framework synchronized, since both are
-    based on a version of netcoreapp.
+    Extend the criteria for identifying a samples project, to allow for the pattern:
+    Azure.Messaging.EventHubs.Samples.[[ SCENARIO ]].  This is intended to support breaking
+    the samples into self-contained executables.
 
     Because the common SDK build properties need this value in order to recognize the desired
     target frameworks and related, this needs to be set before the common properties import.
   -->
   <PropertyGroup Condition="$(MSBuildProjectName.Contains('.Samples'))">
-    <IsTestProject>true</IsTestProject>
-    <IsTestSupportProject>true</IsTestSupportProject>
+    <IsSamplesProject>true</IsSamplesProject>
   </PropertyGroup>
 
   <!-- Import the common SDK build properties. -->
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
-
-  <!-- Set any needed overrides to the decisions made within the common SDK build properties. -->
-  <PropertyGroup>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-
-    <!-- Do not inherit implicit dependencies from the engineering system during build or packaging -->
-    <ImportDefaultReferences>false</ImportDefaultReferences>
-
-    <!-- Disable the custom analyzer; it is currently in development and based against draft standards. -->
-    <EnableClientSdkAnalyzers>false</EnableClientSdkAnalyzers>
-  </PropertyGroup>
 </Project>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Azure.Messaging.EventHubs.Samples.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Azure.Messaging.EventHubs.Samples.csproj
@@ -19,5 +19,4 @@
     <PackageReference Include="Azure.Identity" />
     <ProjectReference Include="..\src\Azure.Messaging.EventHubs.csproj" />
   </ItemGroup>
-
 </Project>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -45,7 +45,7 @@
 
   <!--Embed the shared resources -->
   <ItemGroup>
-     <Compile Update="Resources.Local.cs">
+    <Compile Update="Resources.Local.cs">
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerClient.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -650,6 +651,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///
+        [SuppressMessage("Usage", "AZC0002:Ensure all service methods take an optional CancellationToken parameter.", Justification = "This signature must match the IAsyncDisposable interface.")]
         public virtual async ValueTask DisposeAsync() => await CloseAsync().ConfigureAwait(false);
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducerClient.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -612,6 +613,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///
+        [SuppressMessage("Usage", "AZC0002:Ensure all service methods take an optional CancellationToken parameter.", Justification = "This signature must match the IAsyncDisposable interface.")]
         public virtual async ValueTask DisposeAsync() => await CloseAsync().ConfigureAwait(false);
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Properties/AssemblyInfo.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Azure.Messaging.EventHubs.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100d15ddcb29688295338af4b7686603fe614abd555e09efba8fb88ee09e1f7b1ccaeed2e8f823fa9eef3fdd60217fc012ea67d2479751a0b8c087a4185541b851bd8b16f8d91b840e51b1cb0ba6fe647997e57429265e85ef62d565db50a69ae1647d54d7bd855e4db3d8a91510e5bcbd0edfbbecaa20a7bd9ae74593daa7b11b4")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+
+[assembly: SuppressMessage("Usage", "AZC0004:DO provide both asynchronous and synchronous variants for all service methods.", Justification = "As an AMQP-based offering, Event Hubs has been exempted from providing a synchronous surface.")]
+[assembly: SuppressMessage("Usage", "AZC0008:ClientOptions should have a nested enum called ServiceVersion", Justification = "The Event Hubs interface does not support the concept of versions.")]
+[assembly: SuppressMessage("Usage", "AZC0006:DO provide constructor overloads that allow specifying additional options.", Justification = "Analysis is flagging incorrectly. The Event Hubs constructor patterns adhere to guidance and have obtained board approval.")]


### PR DESCRIPTION
# Summary

The focus of these changes is to revisit the configuration for the Event Hubs projects and remove overrides that are no longer necessary or relevant, adhering more closely to the central engineering system.

As part of these changes, the override to disable our custom code analysis has been removed, enabling analysis.  The results were analyzed, and I've created suppression rules where they were not applicable to Event Hubs or were producing false positives.

# Last Upstream Rebase

Wednesday, December 11, 11:38am (EST)

# Related and Follow-Up Issues

- [Review project file configuration and overrides](https://github.com/Azure/azure-sdk-for-net/issues/9050) (#9050)
- [Event Hubs Client Library for .NET - January Milestone](https://github.com/Azure/azure-sdk-for-net/issues/9040) (#9040)  