### PR TITLE
Generate client with new Licensetype enum value "DR"

### DIFF
--- a/eng/mgmt/mgmtmetadata/sqlvirtualmachine_resource-manager.txt
+++ b/eng/mgmt/mgmtmetadata/sqlvirtualmachine_resource-manager.txt
@@ -3,12 +3,12 @@ AutoRest installed successfully.
 Commencing code generation
 Generating CSharp code
 Executing AutoRest command
-cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/sqlvirtualmachine/resource-manager/readme.md --csharp --version=latest --reflect-api-versions --csharp-sdks-folder=C:\Users\t-elroc\Documents\azure-sdk-for-net\sdk
-2019-07-15 21:31:18 UTC
+cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/sqlvirtualmachine/resource-manager/readme.md --csharp --version=latest --reflect-api-versions --csharp-sdks-folder=C:\Users\myvmadmin\azure-sdk-for-net\sdk
+2019-12-10 02:48:59 UTC
 Azure-rest-api-specs repository information
 GitHub fork: Azure
 Branch:      master
-Commit:      9d9ee638387862888a72974c98790a63666d427b
+Commit:      e63401cb21aba92650b877be0b7d8893452cd6fe
 AutoRest information
 Requested version: latest
-Bootstrapper version:    autorest@2.0.4283
+Bootstrapper version:    autorest@2.0.4407

--- a/sdk/sqlvirtualmachine/Microsoft.Azure.Management.SqlVirtualMachine/src/Generated/Models/SqlServerLicenseType.cs
+++ b/sdk/sqlvirtualmachine/Microsoft.Azure.Management.SqlVirtualMachine/src/Generated/Models/SqlServerLicenseType.cs
@@ -18,5 +18,6 @@ namespace Microsoft.Azure.Management.SqlVirtualMachine.Models
     {
         public const string PAYG = "PAYG";
         public const string AHUB = "AHUB";
+        public const string DR = "DR";
     }
 }

--- a/sdk/sqlvirtualmachine/Microsoft.Azure.Management.SqlVirtualMachine/src/Generated/Models/SqlVirtualMachineModel.cs
+++ b/sdk/sqlvirtualmachine/Microsoft.Azure.Management.SqlVirtualMachine/src/Generated/Models/SqlVirtualMachineModel.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Management.SqlVirtualMachine.Models
         /// <param name="sqlImageOffer">SQL image offer. Examples include
         /// SQL2016-WS2016, SQL2017-WS2016.</param>
         /// <param name="sqlServerLicenseType">SQL Server license type.
-        /// Possible values include: 'PAYG', 'AHUB'</param>
+        /// Possible values include: 'PAYG', 'AHUB', 'DR'</param>
         /// <param name="sqlManagement">SQL Server Management type. Possible
         /// values include: 'Full', 'LightWeight', 'NoAgent'</param>
         /// <param name="sqlImageSku">SQL Server edition type. Possible values
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.Management.SqlVirtualMachine.Models
 
         /// <summary>
         /// Gets or sets SQL Server license type. Possible values include:
-        /// 'PAYG', 'AHUB'
+        /// 'PAYG', 'AHUB', 'DR'
         /// </summary>
         [JsonProperty(PropertyName = "properties.sqlServerLicenseType")]
         public string SqlServerLicenseType { get; set; }

--- a/sdk/sqlvirtualmachine/Microsoft.Azure.Management.SqlVirtualMachine/src/Generated/Models/WsfcDomainProfile.cs
+++ b/sdk/sqlvirtualmachine/Microsoft.Azure.Management.SqlVirtualMachine/src/Generated/Models/WsfcDomainProfile.cs
@@ -11,7 +11,6 @@
 namespace Microsoft.Azure.Management.SqlVirtualMachine.Models
 {
     using Newtonsoft.Json;
-    using System;
     using System.Linq;
 
     /// <summary>

--- a/sdk/sqlvirtualmachine/Microsoft.Azure.Management.SqlVirtualMachine/src/Generated/SdkInfo_SqlVirtualMachineManagementClient.cs
+++ b/sdk/sqlvirtualmachine/Microsoft.Azure.Management.SqlVirtualMachine/src/Generated/SdkInfo_SqlVirtualMachineManagementClient.cs
@@ -28,11 +28,11 @@ namespace Microsoft.Azure.Management.SqlVirtualMachine
       }
       // BEGIN: Code Generation Metadata Section
       public static readonly String AutoRestVersion = "latest";
-      public static readonly String AutoRestBootStrapperVersion = "autorest@2.0.4283";
-      public static readonly String AutoRestCmdExecuted = "cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/sqlvirtualmachine/resource-manager/readme.md --csharp --version=latest --reflect-api-versions --csharp-sdks-folder=C:\\Users\\t-elroc\\Documents\\azure-sdk-for-net\\sdk";
+      public static readonly String AutoRestBootStrapperVersion = "autorest@2.0.4407";
+      public static readonly String AutoRestCmdExecuted = "cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/sqlvirtualmachine/resource-manager/readme.md --csharp --version=latest --reflect-api-versions --csharp-sdks-folder=C:\\Users\\myvmadmin\\azure-sdk-for-net\\sdk";
       public static readonly String GithubForkName = "Azure";
       public static readonly String GithubBranchName = "master";
-      public static readonly String GithubCommidId = "9d9ee638387862888a72974c98790a63666d427b";
+      public static readonly String GithubCommidId = "e63401cb21aba92650b877be0b7d8893452cd6fe";
       public static readonly String CodeGenerationErrors = "";
       public static readonly String GithubRepoName = "azure-rest-api-specs";
       // END: Code Generation Metadata Section

--- a/sdk/sqlvirtualmachine/Microsoft.Azure.Management.SqlVirtualMachine/src/generate.ps1
+++ b/sdk/sqlvirtualmachine/Microsoft.Azure.Management.SqlVirtualMachine/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "sqlvirtualmachine/resource-manager" -AutoRestVersion "latest" -SdkRepoRootPath "."
+Start-AutoRestCodeGeneration -ResourceProvider "sqlvirtualmachine/resource-manager" -AutoRestVersion "latest"


### PR DESCRIPTION
Generating the Dot Net Client following the Spec update made in the following PR:
https://github.com/Azure/azure-rest-api-specs/pull/7819

We are adding a new value to the SqlServerLicenseType enum called "DR"