### PR TITLE
Publish test results even if build is canceled

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -159,7 +159,7 @@ jobs:
           DOTNET_CLI_TELEMETRY_OPTOUT: 1
           DOTNET_MULTILEVEL_LOOKUP: 0
       - task: PublishTestResults@2
-        condition: succeededOrFailed()
+        condition: always()
         displayName: "Publish Results ($(TestTargetFramework))"
         inputs:
           testResultsFiles: "**/$(TestTargetFramework)*.trx"

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -63,7 +63,7 @@ jobs:
           ${{ insert }}: ${{ parameters.EnvVars }}
 
       - task: PublishTestResults@2
-        condition: succeededOrFailed()
+        condition: always()
         displayName: "Publish Results ($(TestTargetFramework))"
         inputs:
           testResultsFiles: "**/$(TestTargetFramework)*.trx"


### PR DESCRIPTION
- If build is cancelled due to agent timeout, some tests results may have already been generated and should still be published