### PR TITLE
[Event Hubs Client] Track Two (AmqpMessageConverter Fix)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpMessageConverter.cs
@@ -669,7 +669,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                     break;
 
                 default:
-                    var exception = new SerializationException(string.Format(CultureInfo.CurrentCulture, Resources.FailedToSerializeUnsupportedType, eventPropertyValue.GetType().FullName));
+                    var exception = new SerializationException(string.Format(CultureInfo.CurrentCulture, Resources.FailedToSerializeUnsupportedType, amqpPropertyValue.GetType().FullName));
                     EventHubsEventSource.Log.UnexpectedException(exception.Message);
                     throw exception;
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/PartitionEvent.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/PartitionEvent.cs
@@ -28,6 +28,12 @@ namespace Azure.Messaging.EventHubs
         ///   time period, <c>null</c>.
         /// </value>
         ///
+        /// <remarks>
+        ///   Ownership of this data, including the memory that holds its <see cref="EventData.Body" />,
+        ///   is assumed to transfer to consumers of the <see cref="PartitionEvent" />.  It may be considered
+        ///   immutable and is safe to access so long as the reference is held.
+        /// </remarks>
+        ///
         public EventData Data { get; }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/ProcessEventArgs.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/ProcessEventArgs.cs
@@ -38,6 +38,12 @@ namespace Azure.Messaging.EventHubs.Processor
         ///   The received event to be processed.  Expected to be <c>null</c> if the receive call has timed out.
         /// </summary>
         ///
+        /// <remarks>
+        ///   Ownership of this data, including the memory that holds its <see cref="EventData.Body" />,
+        ///   is assumed to transfer to consumers of the <see cref="ProcessEventArgs" />.  It may be considered
+        ///   immutable and is safe to access so long as the reference is held.
+        /// </remarks>
+        ///
         public EventData Data { get; }
 
         /// <summary>


### PR DESCRIPTION
# Summary

The focus of these changes is to fix a misused variable which, in a specific exception case, could trigger a null reference error that would mask the actual exception.  Also included is an enhancement for doc comments to make the ownership and semantics of the ReadOnlyMemory<T> in EventData clear to those consuming it.

# Last Upstream Rebase

Thursday,  December 12, 2:53pm (EST)

# Related and Follow-Up Issues

- [Event Hubs Client Library for .NET - January Milestone](https://github.com/Azure/azure-sdk-for-net/issues/9040) (#9040)  
- [Fix potential null dereference in the AmqpMessageConverter](https://github.com/Azure/azure-sdk-for-net/issues/9052) (#9052)