### PR TITLE
don't throw if table info included in conn string

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
@@ -35,7 +35,7 @@ namespace Azure.Storage.Blobs.Test
             var blobEndpoint = new Uri("http://127.0.0.1/" + accountName);
             var blobSecondaryEndpoint = new Uri("http://127.0.0.1/" + accountName + "-secondary");
 
-            var connectionString = new StorageConnectionString(credentials, (blobEndpoint, blobSecondaryEndpoint), (default, default), (default, default));
+            var connectionString = new StorageConnectionString(credentials, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
 
             var containerName = GetNewContainerName();
             var blobName = GetNewBlobName();

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -40,7 +40,7 @@ namespace Azure.Storage.Blobs.Test
             var blobEndpoint = new Uri("http://127.0.0.1/" + accountName);
             var blobSecondaryEndpoint = new Uri("http://127.0.0.1/" + accountName + "-secondary");
 
-            var connectionString = new StorageConnectionString(credentials, (blobEndpoint, blobSecondaryEndpoint), (default, default), (default, default));
+            var connectionString = new StorageConnectionString(credentials, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
 
             var containerName = GetNewContainerName();
             var blobName = GetNewBlobName();

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
@@ -33,7 +33,7 @@ namespace Azure.Storage.Blobs.Test
             var blobEndpoint = new Uri("http://127.0.0.1/" + accountName);
             var blobSecondaryEndpoint = new Uri("http://127.0.0.1/" + accountName + "-secondary");
 
-            var connectionString = new StorageConnectionString(credentials, (blobEndpoint, blobSecondaryEndpoint), (default, default), (default, default));
+            var connectionString = new StorageConnectionString(credentials, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
 
             var containerName = GetNewContainerName();
             var blobName = GetNewBlobName();

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -431,7 +431,8 @@ namespace Azure.Storage.Test.Shared
 
         internal StorageConnectionString GetConnectionString(
             SharedAccessSignatureCredentials credentials = default,
-            bool includeEndpoint = true)
+            bool includeEndpoint = true,
+            bool includeTable = false)
         {
             credentials ??= GetAccountSasCredentials();
             if (!includeEndpoint)
@@ -447,11 +448,20 @@ namespace Azure.Storage.Test.Shared
                 default,
                 default);
 
+            (Uri, Uri) tableUri = default;
+            if (includeTable)
+            {
+                tableUri = StorageConnectionString.ConstructTableEndpoint(
+                    Constants.Https,
+                    TestConfigDefault.AccountName,
+                    default,
+                    default);
+            }
+
             return new StorageConnectionString(
                     credentials,
-                    blobUri,
-                    (default, default),
-                    (default, default));
+                    blobStorageUri: blobUri,
+                    tableStorageUri: tableUri);
         }
 
         public async Task EnableSoftDelete()

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
@@ -38,7 +38,7 @@ namespace Azure.Storage.Blobs.Test
             var blobEndpoint = new Uri("http://127.0.0.1/" + accountName);
             var blobSecondaryEndpoint = new Uri("http://127.0.0.1/" + accountName + "-secondary");
 
-            var connectionString = new StorageConnectionString(credentials, (blobEndpoint, blobSecondaryEndpoint), (default, default), (default, default));
+            var connectionString = new StorageConnectionString(credentials, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
 
             var containerName = GetNewContainerName();
             var blobName = GetNewBlobName();

--- a/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
@@ -51,18 +51,9 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [Test]
-        public async Task Ctor_ConnectionString_Sas()
-        {
-            await Perform_Ctor_ConnectionString_Sas();
-        }
-
-        [Test]
-        public async Task Ctor_ConnectionString_Sas_Include_Table()
-        {
-            await Perform_Ctor_ConnectionString_Sas(includeTable: true);
-        }
-
-        private async Task Perform_Ctor_ConnectionString_Sas(bool includeTable = false)
+        [TestCase(true)] // https://github.com/Azure/azure-sdk-for-net/issues/9110
+        [TestCase(false)]
+        public async Task Perform_Ctor_ConnectionString_Sas(bool includeTable)
         {
             // Arrange
             SharedAccessSignatureCredentials sasCred = GetAccountSasCredentials(

--- a/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
@@ -37,7 +37,7 @@ namespace Azure.Storage.Blobs.Test
             var blobEndpoint = new Uri("http://127.0.0.1/" + accountName);
             var blobSecondaryEndpoint = new Uri("http://127.0.0.1/" + accountName + "-secondary");
 
-            var connectionString = new StorageConnectionString(credentials, (blobEndpoint, blobSecondaryEndpoint), (default, default), (default, default));
+            var connectionString = new StorageConnectionString(credentials, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
 
             var containerName = "containername";
 
@@ -53,6 +53,17 @@ namespace Azure.Storage.Blobs.Test
         [Test]
         public async Task Ctor_ConnectionString_Sas()
         {
+            await Perform_Ctor_ConnectionString_Sas();
+        }
+
+        [Test]
+        public async Task Ctor_ConnectionString_Sas_Include_Table()
+        {
+            await Perform_Ctor_ConnectionString_Sas(includeTable: true);
+        }
+
+        private async Task Perform_Ctor_ConnectionString_Sas(bool includeTable = false)
+        {
             // Arrange
             SharedAccessSignatureCredentials sasCred = GetAccountSasCredentials(
                 AccountSasServices.All,
@@ -61,7 +72,8 @@ namespace Azure.Storage.Blobs.Test
 
             StorageConnectionString conn1 = GetConnectionString(
                 credentials: sasCred,
-                includeEndpoint: true);
+                includeEndpoint: true,
+                includeTable: includeTable);
 
             BlobContainerClient containerClient1 = GetBlobContainerClient(conn1.ToString(exportSecrets: true));
 
@@ -222,8 +234,6 @@ namespace Azure.Storage.Blobs.Test
                     connectionString,
                     GetNewContainerName(),
                     GetOptions()));
-
-
 
         [Test]
         public void Ctor_Uri()

--- a/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
@@ -42,7 +42,7 @@ namespace Azure.Storage.Blobs.Test
             var blobEndpoint = new Uri("http://127.0.0.1/" + accountName);
             var blobSecondaryEndpoint = new Uri("http://127.0.0.1/" + accountName + "-secondary");
 
-            var connectionString = new StorageConnectionString(credentials, (blobEndpoint, blobSecondaryEndpoint), (default, default), (default, default));
+            var connectionString = new StorageConnectionString(credentials, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
 
             var containerName = GetNewContainerName();
             var blobName = GetNewBlobName();

--- a/sdk/storage/Azure.Storage.Blobs/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ServiceClientTests.cs
@@ -30,7 +30,7 @@ namespace Azure.Storage.Blobs.Test
             var blobEndpoint = new Uri("http://127.0.0.1/" + accountName);
             var blobSecondaryEndpoint = new Uri("http://127.0.0.1/" + accountName + "-secondary");
 
-            var connectionString = new StorageConnectionString(credentials, (blobEndpoint, blobSecondaryEndpoint), (default, default), (default, default));
+            var connectionString = new StorageConnectionString(credentials, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
 
             BlobServiceClient service1 = InstrumentClient(new BlobServiceClient(connectionString.ToString(true)));
             BlobServiceClient service2 = InstrumentClient(new BlobServiceClient(connectionString.ToString(true), GetOptions()));

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Ctor_ConnectionString_Sas_Include_Table.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Ctor_ConnectionString_Sas_Include_Table.json
@@ -1,0 +1,195 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-48aae24a-bc4c-5e82-08d1-766fa9bd6c3c?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-12T20%3A49%3A27Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "traceparent": "00-08abdb99fe94f34a9d05e4ce348c1494-3bea1988cabdf64c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002Bfd9b32014835574bd547864e606bc3fe5832c88f",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "273d7c39-b513-acb5-afa3-26fb39113d1d",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 12 Dec 2019 19:49:26 GMT",
+        "ETag": "\u00220x8D77F3C65ADE227\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 19:49:27 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "273d7c39-b513-acb5-afa3-26fb39113d1d",
+        "x-ms-request-id": "8188092c-c01e-0094-1125-b110bf000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-6d8e5b75-9ec9-0733-2150-837020eb59b3?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-12T20%3A49%3A27Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "traceparent": "00-70e7ae7b8e108046a20ff387c999a9a1-a169df7bc46ebd48-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002Bfd9b32014835574bd547864e606bc3fe5832c88f",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "558443ec-336f-5f46-5f5c-0ab23e156e78",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 12 Dec 2019 19:49:27 GMT",
+        "ETag": "\u00220x8D77F3C65C87574\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 19:49:27 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "558443ec-336f-5f46-5f5c-0ab23e156e78",
+        "x-ms-request-id": "818809c2-c01e-0094-1f25-b110bf000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-48aae24a-bc4c-5e82-08d1-766fa9bd6c3c/test-blob-1c73c377-d9fe-e01d-1d60-779f3d37ee3e?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-12T20%3A49%3A27Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Content-Length": "1024",
+        "traceparent": "00-4e757e2f3396fb4799a7974a5038fd39-b92f7fd8f9e60b45-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002Bfd9b32014835574bd547864e606bc3fe5832c88f",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a9248e77-0ea3-5333-672a-39f3a23780fe",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "a5Ky\u002BbKZzsz310RRJ\u002B4IwaNsx4ZH\u002BQpT1D8yQu1aa73rL0arYnXFGhovBAJUHR00JIRIiNnrk3GIXyRzZovenGyHZvinXF4tpq1rF/UH/rci/h1oEeLk/5vUIwJRUrSOUGeWzbckjcgmGuIsf3t8gGBtUGhtdouJomZc0jhb3FP53ceOcDH//XBVQvYAuH8gWKOh5AFLIdrcDSpQyLuPyj6OMqKz7Q8vbVP3GDOUiOrnPHmVufhRrbztsmIHrjS1xXe4coXcbGqTcnatUwimR4U/aYxB\u002BRBGPITmxjusKL8fQlK72xVlCs8OAkeCo1qzRmrdx0WodMxmcjUA9qUu5kq3jhG262tv2l68MvfJw5kqM3/Rz2F6ds6GVGngZBQp3xv9yhRJ/Fv\u002Bbezm7EHUna6c1sImXRboPRhCMJYCj3VKklLbzPmE4Tck0mJ0k4mMsbe7Q45RA4IFFI38BsvE/N13m1rv\u002BNC1GPWLAoq0dKmOtn7fR0zm\u002BY7Q1rhrh9prX9aE/fgvnbnmBSuZxgH3UJ/kbVBM5bWRkKLLHiEXSpAaH6O0MHewXhjF\u002BEEgTTON2IUYhhqJHnkh8m1VZH6Xz7uafqZeQiAoMw43h\u002B1zcUJvPUWb/8N2kAApkz0JW/qZLimGhs6ML5Vl71ILUZeLrYEq5iY4\u002B8/3JO2lNK/jH9gUnlnE7ep04g6vNg9xaj9pneW833TTYTJZj2Hg5/rmgtB597M\u002Bx8CWtQQYiMTAhbquPJbJJj9kQD0mal6JlPoTybQ\u002B93KLKtYlJSlwuthtmQmnMatkHFuRFbZ2F1xiDSAJBL8PgY5HIxHApAEV9IZkudFU4WNPr6xZreK7FRJ5whgIZrUYXRd6Xw6ao3hZeyEwEV6LDSu9ulUTttOsiw3\u002BRuLpDI3QTFu52oJUtAszADHAiwOz7rTsS6xgBadEztMAm12WcG\u002BUX8UD0TOpaQVJ37ah6wAJSlct/MHgb0azdQuuVBmunY/CLCs\u002BsB2BQ\u002BGnFybxouPT9lAFaXOts\u002B9\u002BT1sn\u002BhXrm0Em377Uy5o6q7nfOVggwtMo213JqDQcFXg8wGDBWUjMu3vkysMk/iu1y725zXqWXoyI/x\u002B3IvINCslFmAo5eVFxEn3dO/gQA9wxE912Ykf9pWHUOFkpFJmJ1sD532YgfFJrR7r9uSKUePxChg8Vl6eCR/OoZUD3SP7kVGQ4FyR1EJeLChqMAOs/P8Bd5o6Kcz8Yd5dzeBYRc/\u002B8GWW9XGDYzHV3io2M9UcHaSV/mmFvWuAlH5\u002BNApiAeZYbz\u002BeGgeNfhBkYEumyi4FPaw7wktmdTb\u002BFlzzBS8rd9xH2cSVfgedCHxVIVkf2c5MdPZaJj\u002Ba8fYIoAOmmng==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "/aDdAYgsNymrWRJNbxKYJg==",
+        "Date": "Thu, 12 Dec 2019 19:49:27 GMT",
+        "ETag": "\u00220x8D77F3C65CE09A9\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 19:49:27 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a9248e77-0ea3-5333-672a-39f3a23780fe",
+        "x-ms-content-crc64": "9/ORd5iIh94=",
+        "x-ms-request-id": "818809e0-c01e-0094-3925-b110bf000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-6d8e5b75-9ec9-0733-2150-837020eb59b3/test-blob-fbfbe8b4-99da-456f-222d-46ecf4a171da?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-12T20%3A49%3A27Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Content-Length": "1024",
+        "traceparent": "00-2df8f8feaeb51941993a9c151fdc5961-c2a6145248cd0e44-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002Bfd9b32014835574bd547864e606bc3fe5832c88f",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "72b18c28-fdc5-2bfb-1be8-b2ae8126b9b9",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "a5Ky\u002BbKZzsz310RRJ\u002B4IwaNsx4ZH\u002BQpT1D8yQu1aa73rL0arYnXFGhovBAJUHR00JIRIiNnrk3GIXyRzZovenGyHZvinXF4tpq1rF/UH/rci/h1oEeLk/5vUIwJRUrSOUGeWzbckjcgmGuIsf3t8gGBtUGhtdouJomZc0jhb3FP53ceOcDH//XBVQvYAuH8gWKOh5AFLIdrcDSpQyLuPyj6OMqKz7Q8vbVP3GDOUiOrnPHmVufhRrbztsmIHrjS1xXe4coXcbGqTcnatUwimR4U/aYxB\u002BRBGPITmxjusKL8fQlK72xVlCs8OAkeCo1qzRmrdx0WodMxmcjUA9qUu5kq3jhG262tv2l68MvfJw5kqM3/Rz2F6ds6GVGngZBQp3xv9yhRJ/Fv\u002Bbezm7EHUna6c1sImXRboPRhCMJYCj3VKklLbzPmE4Tck0mJ0k4mMsbe7Q45RA4IFFI38BsvE/N13m1rv\u002BNC1GPWLAoq0dKmOtn7fR0zm\u002BY7Q1rhrh9prX9aE/fgvnbnmBSuZxgH3UJ/kbVBM5bWRkKLLHiEXSpAaH6O0MHewXhjF\u002BEEgTTON2IUYhhqJHnkh8m1VZH6Xz7uafqZeQiAoMw43h\u002B1zcUJvPUWb/8N2kAApkz0JW/qZLimGhs6ML5Vl71ILUZeLrYEq5iY4\u002B8/3JO2lNK/jH9gUnlnE7ep04g6vNg9xaj9pneW833TTYTJZj2Hg5/rmgtB597M\u002Bx8CWtQQYiMTAhbquPJbJJj9kQD0mal6JlPoTybQ\u002B93KLKtYlJSlwuthtmQmnMatkHFuRFbZ2F1xiDSAJBL8PgY5HIxHApAEV9IZkudFU4WNPr6xZreK7FRJ5whgIZrUYXRd6Xw6ao3hZeyEwEV6LDSu9ulUTttOsiw3\u002BRuLpDI3QTFu52oJUtAszADHAiwOz7rTsS6xgBadEztMAm12WcG\u002BUX8UD0TOpaQVJ37ah6wAJSlct/MHgb0azdQuuVBmunY/CLCs\u002BsB2BQ\u002BGnFybxouPT9lAFaXOts\u002B9\u002BT1sn\u002BhXrm0Em377Uy5o6q7nfOVggwtMo213JqDQcFXg8wGDBWUjMu3vkysMk/iu1y725zXqWXoyI/x\u002B3IvINCslFmAo5eVFxEn3dO/gQA9wxE912Ykf9pWHUOFkpFJmJ1sD532YgfFJrR7r9uSKUePxChg8Vl6eCR/OoZUD3SP7kVGQ4FyR1EJeLChqMAOs/P8Bd5o6Kcz8Yd5dzeBYRc/\u002B8GWW9XGDYzHV3io2M9UcHaSV/mmFvWuAlH5\u002BNApiAeZYbz\u002BeGgeNfhBkYEumyi4FPaw7wktmdTb\u002BFlzzBS8rd9xH2cSVfgedCHxVIVkf2c5MdPZaJj\u002Ba8fYIoAOmmng==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "/aDdAYgsNymrWRJNbxKYJg==",
+        "Date": "Thu, 12 Dec 2019 19:49:27 GMT",
+        "ETag": "\u00220x8D77F3C65D0A253\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 19:49:27 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "72b18c28-fdc5-2bfb-1be8-b2ae8126b9b9",
+        "x-ms-content-crc64": "9/ORd5iIh94=",
+        "x-ms-request-id": "818809f1-c01e-0094-4825-b110bf000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-48aae24a-bc4c-5e82-08d1-766fa9bd6c3c?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-12T20%3A49%3A27Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "traceparent": "00-6206cbc75d7151409f4da1eaee2087d1-29da190ef46d154b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002Bfd9b32014835574bd547864e606bc3fe5832c88f",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "16cb40b6-0e85-9e38-85b1-de327a703652",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 12 Dec 2019 19:49:27 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "16cb40b6-0e85-9e38-85b1-de327a703652",
+        "x-ms-request-id": "81880a0e-c01e-0094-6425-b110bf000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-6d8e5b75-9ec9-0733-2150-837020eb59b3?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-12T20%3A49%3A27Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "traceparent": "00-ce4ba59faf98d6498462d531756af8cb-eba1fa334698b84f-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002Bfd9b32014835574bd547864e606bc3fe5832c88f",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "40f72cf8-a35b-5b33-f073-6c367da9cf00",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 12 Dec 2019 19:49:27 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "40f72cf8-a35b-5b33-f073-6c367da9cf00",
+        "x-ms-request-id": "81880a48-c01e-0094-1725-b110bf000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2019-12-12T11:49:27.0974517-08:00",
+    "RandomSeed": "992836301",
+    "Storage_TestConfigDefault": "ProductionTenant\nstoragedotnettesting\nU2FuaXRpemVk\nhttps://storagedotnettesting.blob.core.windows.net\nhttps://storagedotnettesting.file.core.windows.net\nhttps://storagedotnettesting.queue.core.windows.net\nhttps://storagedotnettesting.table.core.windows.net\n\n\n\n\nhttps://storagedotnettesting-secondary.blob.core.windows.net\nhttps://storagedotnettesting-secondary.file.core.windows.net\nhttps://storagedotnettesting-secondary.queue.core.windows.net\nhttps://storagedotnettesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://storagedotnettesting.blob.core.windows.net/;QueueEndpoint=https://storagedotnettesting.queue.core.windows.net/;FileEndpoint=https://storagedotnettesting.file.core.windows.net/;BlobSecondaryEndpoint=https://storagedotnettesting-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://storagedotnettesting-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://storagedotnettesting-secondary.file.core.windows.net/;AccountName=storagedotnettesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Ctor_ConnectionString_Sas_Include_TableAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Ctor_ConnectionString_Sas_Include_TableAsync.json
@@ -1,0 +1,195 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-f53d0977-106b-b98e-0791-77e7198d6978?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-12T20%3A50%3A04Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "traceparent": "00-651bc0c34f2aa04dac163a48117a4a8f-af8cfe602f401949-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002Bfd9b32014835574bd547864e606bc3fe5832c88f",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "93c9fe0a-0750-bcc3-137e-bd3f18210c78",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 12 Dec 2019 19:50:04 GMT",
+        "ETag": "\u00220x8D77F3C7C0283F9\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 19:50:05 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "93c9fe0a-0750-bcc3-137e-bd3f18210c78",
+        "x-ms-request-id": "85cfb769-201e-000a-3225-b10361000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-5cf39d5e-ba17-bff5-382c-f76dac8e20f9?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-12T20%3A50%3A04Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "traceparent": "00-a8e26442f98db14aa83588a29c5f9a36-78ee384a688ed943-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002Bfd9b32014835574bd547864e606bc3fe5832c88f",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "e1470e2c-9ebd-5e7b-6184-ee3d21e487d6",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 12 Dec 2019 19:50:05 GMT",
+        "ETag": "\u00220x8D77F3C7C1B1B01\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 19:50:05 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e1470e2c-9ebd-5e7b-6184-ee3d21e487d6",
+        "x-ms-request-id": "85cfb7ed-201e-000a-3125-b10361000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-f53d0977-106b-b98e-0791-77e7198d6978/test-blob-7d527e71-ab10-449c-a512-e6de343d5f28?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-12T20%3A50%3A04Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Content-Length": "1024",
+        "traceparent": "00-0fb15841c39d6e49b681ef0e8e9b9452-9f9d7c4cca2eb744-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002Bfd9b32014835574bd547864e606bc3fe5832c88f",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "04fb2640-c431-22f2-ca95-62b558e4e67d",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "SpGxJvV9anHwBE1Anmtr8zjTPseJG5bPW2MN9/krXSKdAPKQM2HhoSq9u7oQcUVoWrEWLQAfYy/64cuScHN3xKYro51527/X8pydy1/cv\u002BkdpJxIFTAhfZzClVGWTjG2RvcT5c6n73/xPztjgpjQHiLhdczWLq92CSUAtkVuQKNr5oVnyNobdbQdVtb0vfsE8nYvtdll3xdHnduopzk5g/6X\u002BJsSaFZIxv8XudjZgUwq\u002B8PPPovKBQduHyr\u002Bc8575NPXXcRg8okg5u7ZTiY/bhyPfqt1aURzzPKUpEgrSVMxnNQFASOHyQk6r1ic8LfgL7EOb/UjBXqOZJHSzE5A9JybqLFSOWz4CLShOrrs1ts6s3WXHNpdDpZadp2Stf27\u002Bbq7AEgGjvVEFmdAgcq/oY61lxjZqdjCPZkb98POZlO25kEAMNWSNCV/UgZyHYzLmtUP3B3k4lDi\u002BMKv6pYydbAUipuJv3C4ImLyWVbRTyAMT13uv4k10QPwHjcS40mPTdxWXpLxQdpkVrm68Yn6EKmiops4RLYm3riXmaE4pj8ZYwt5e/COGw2CiWjQe9969g2OcECuVgkmL3/aWag5K7B5oY5\u002BgJS4E4eNtbpNVmPYHaOTqjX/agwBUkxws8FlSV63VtlR/HV41Vy4IaBP2NkcATwFpYF7ejaBfC1IR2DGJ2xblgCJhyAtG9TZRklssXpzVLKEYKPdPNujz39HL4788vkz80LYknob14qsojTsFcqz1fKuQcfJflkk5reh5utG3FRQOL43msI4aIkZMJqnt7q0lFmbTrAxanXos6zCevGeZsXfm9wMfDswddk\u002BsE2/fS787VGRq46kHs1JTuYVde6Xe8rUxxvdpxceatjX87onKDZ9xYyfDLs2O30Pwy1UGgDqpjSD67UTHkU6c0C2zSsTIiavmK9i\u002BG4PnYyezuTqyU/X7U2FpD2BaadHZZh6gG1R\u002B6EGpIJQh63Gc00odVBhT6nw3uDdjX3oLi4IGpPVlR0eTNJD4yTNhmWfvzDvWPRX5hXviaGNdG4jHXZTSG0Z8N4wCSl9HmuEIld7Pc5N\u002BdY6sTR95gt7kddkH8Wuej73hc5Sv0/L2ciqamZJEjaf1iSgGZc5nAnStXhRGP6l1qgZg7f/\u002BjqHb9dr03ukMX\u002BhxEmhDmGmvunEfwnWesDJBJS\u002BMI5\u002BoNvqGaq/zciOLoP5r1S1BMdHcsXOOnswsPUWoc7n5gHwIiRut/W35/AgNlCF3cpsFADNdr3JsGVfuWi0qCv6pkeCCIwwR03RkIvUrQMqqtIqqozOGm9DJnK\u002BDv2MAj7FJpAJA9Q9PM2y\u002B\u002BYy9QNiNA\u002BWiv6fK4zYP\u002BIacThQRY1ND4ZzIQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "9oRB4QclYVmc1K2jmDjG0Q==",
+        "Date": "Thu, 12 Dec 2019 19:50:05 GMT",
+        "ETag": "\u00220x8D77F3C7C222ABA\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 19:50:05 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "04fb2640-c431-22f2-ca95-62b558e4e67d",
+        "x-ms-content-crc64": "3ocIzvv1Kvc=",
+        "x-ms-request-id": "85cfb811-201e-000a-5225-b10361000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-5cf39d5e-ba17-bff5-382c-f76dac8e20f9/test-blob-ac2f951f-5dbe-e4b2-d4c5-a44f013fe7ed?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-12T20%3A50%3A04Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Content-Length": "1024",
+        "traceparent": "00-2e5fe1a5e7008944ae7534455d4f4be5-e1786c4b62f3a942-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002Bfd9b32014835574bd547864e606bc3fe5832c88f",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "e90d154e-6f8a-e3f0-0bca-a429b869302c",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "SpGxJvV9anHwBE1Anmtr8zjTPseJG5bPW2MN9/krXSKdAPKQM2HhoSq9u7oQcUVoWrEWLQAfYy/64cuScHN3xKYro51527/X8pydy1/cv\u002BkdpJxIFTAhfZzClVGWTjG2RvcT5c6n73/xPztjgpjQHiLhdczWLq92CSUAtkVuQKNr5oVnyNobdbQdVtb0vfsE8nYvtdll3xdHnduopzk5g/6X\u002BJsSaFZIxv8XudjZgUwq\u002B8PPPovKBQduHyr\u002Bc8575NPXXcRg8okg5u7ZTiY/bhyPfqt1aURzzPKUpEgrSVMxnNQFASOHyQk6r1ic8LfgL7EOb/UjBXqOZJHSzE5A9JybqLFSOWz4CLShOrrs1ts6s3WXHNpdDpZadp2Stf27\u002Bbq7AEgGjvVEFmdAgcq/oY61lxjZqdjCPZkb98POZlO25kEAMNWSNCV/UgZyHYzLmtUP3B3k4lDi\u002BMKv6pYydbAUipuJv3C4ImLyWVbRTyAMT13uv4k10QPwHjcS40mPTdxWXpLxQdpkVrm68Yn6EKmiops4RLYm3riXmaE4pj8ZYwt5e/COGw2CiWjQe9969g2OcECuVgkmL3/aWag5K7B5oY5\u002BgJS4E4eNtbpNVmPYHaOTqjX/agwBUkxws8FlSV63VtlR/HV41Vy4IaBP2NkcATwFpYF7ejaBfC1IR2DGJ2xblgCJhyAtG9TZRklssXpzVLKEYKPdPNujz39HL4788vkz80LYknob14qsojTsFcqz1fKuQcfJflkk5reh5utG3FRQOL43msI4aIkZMJqnt7q0lFmbTrAxanXos6zCevGeZsXfm9wMfDswddk\u002BsE2/fS787VGRq46kHs1JTuYVde6Xe8rUxxvdpxceatjX87onKDZ9xYyfDLs2O30Pwy1UGgDqpjSD67UTHkU6c0C2zSsTIiavmK9i\u002BG4PnYyezuTqyU/X7U2FpD2BaadHZZh6gG1R\u002B6EGpIJQh63Gc00odVBhT6nw3uDdjX3oLi4IGpPVlR0eTNJD4yTNhmWfvzDvWPRX5hXviaGNdG4jHXZTSG0Z8N4wCSl9HmuEIld7Pc5N\u002BdY6sTR95gt7kddkH8Wuej73hc5Sv0/L2ciqamZJEjaf1iSgGZc5nAnStXhRGP6l1qgZg7f/\u002BjqHb9dr03ukMX\u002BhxEmhDmGmvunEfwnWesDJBJS\u002BMI5\u002BoNvqGaq/zciOLoP5r1S1BMdHcsXOOnswsPUWoc7n5gHwIiRut/W35/AgNlCF3cpsFADNdr3JsGVfuWi0qCv6pkeCCIwwR03RkIvUrQMqqtIqqozOGm9DJnK\u002BDv2MAj7FJpAJA9Q9PM2y\u002B\u002BYy9QNiNA\u002BWiv6fK4zYP\u002BIacThQRY1ND4ZzIQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "9oRB4QclYVmc1K2jmDjG0Q==",
+        "Date": "Thu, 12 Dec 2019 19:50:05 GMT",
+        "ETag": "\u00220x8D77F3C7C24C368\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 19:50:05 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e90d154e-6f8a-e3f0-0bca-a429b869302c",
+        "x-ms-content-crc64": "3ocIzvv1Kvc=",
+        "x-ms-request-id": "85cfb81f-201e-000a-6025-b10361000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-f53d0977-106b-b98e-0791-77e7198d6978?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-12T20%3A50%3A04Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "traceparent": "00-376c167a31d694429ee03003d936b9a5-2ad00e3d7b02f347-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002Bfd9b32014835574bd547864e606bc3fe5832c88f",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "42670136-fdd7-7ff2-2284-8cd2ebb65603",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 12 Dec 2019 19:50:05 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "42670136-fdd7-7ff2-2284-8cd2ebb65603",
+        "x-ms-request-id": "85cfb835-201e-000a-7625-b10361000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-5cf39d5e-ba17-bff5-382c-f76dac8e20f9?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-12T20%3A50%3A04Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "traceparent": "00-67ba7f89d56f554983b8ab092b7f38f0-0c8efbba1dc9414b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002Bfd9b32014835574bd547864e606bc3fe5832c88f",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "b7f2ef53-ee02-4d54-feed-a402d108c48f",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 12 Dec 2019 19:50:05 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b7f2ef53-ee02-4d54-feed-a402d108c48f",
+        "x-ms-request-id": "85cfb860-201e-000a-2125-b10361000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2019-12-12T11:50:04.4414470-08:00",
+    "RandomSeed": "399553312",
+    "Storage_TestConfigDefault": "ProductionTenant\nstoragedotnettesting\nU2FuaXRpemVk\nhttps://storagedotnettesting.blob.core.windows.net\nhttps://storagedotnettesting.file.core.windows.net\nhttps://storagedotnettesting.queue.core.windows.net\nhttps://storagedotnettesting.table.core.windows.net\n\n\n\n\nhttps://storagedotnettesting-secondary.blob.core.windows.net\nhttps://storagedotnettesting-secondary.file.core.windows.net\nhttps://storagedotnettesting-secondary.queue.core.windows.net\nhttps://storagedotnettesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://storagedotnettesting.blob.core.windows.net/;QueueEndpoint=https://storagedotnettesting.queue.core.windows.net/;FileEndpoint=https://storagedotnettesting.file.core.windows.net/;BlobSecondaryEndpoint=https://storagedotnettesting-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://storagedotnettesting-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://storagedotnettesting-secondary.file.core.windows.net/;AccountName=storagedotnettesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Ctor_ConnectionString_Sas_Permissions_ReadOnly.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Ctor_ConnectionString_Sas_Permissions_ReadOnly.json
@@ -1,12 +1,12 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jolovstorage.blob.core.windows.net/test-container-89cacc57-581a-b296-8e3a-012e04e9e859?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A57%3A38Z\u0026sp=r\u0026sig=Sanitized\u0026restype=container",
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-89cacc57-581a-b296-8e3a-012e04e9e859?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A23%3A09Z\u0026sp=r\u0026sig=Sanitized\u0026restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-9b28587114b00b41ad8cbb0ec1e7939d-4eb1c502d27cc54c-00",
+        "traceparent": "00-0191714d045d56488668068b222b21e0-cbe55507a5e0c944-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "7308670b-af3f-319e-1d6d-ab8165960bef",
@@ -18,26 +18,26 @@
       "ResponseHeaders": {
         "Content-Length": "279",
         "Content-Type": "application/xml",
-        "Date": "Mon, 02 Dec 2019 21:57:38 GMT",
+        "Date": "Thu, 12 Dec 2019 23:23:11 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "7308670b-af3f-319e-1d6d-ab8165960bef",
         "x-ms-error-code": "AuthorizationPermissionMismatch",
-        "x-ms-request-id": "dd2242ef-d01e-0025-015b-a9691c000000",
+        "x-ms-request-id": "908b83fc-b01e-0018-3e43-b178b1000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EAuthorizationPermissionMismatch\u003C/Code\u003E\u003CMessage\u003EThis request is not authorized to perform this operation using this permission.\n",
-        "RequestId:dd2242ef-d01e-0025-015b-a9691c000000\n",
-        "Time:2019-12-02T21:57:38.9969170Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:908b83fc-b01e-0018-3e43-b178b1000000\n",
+        "Time:2019-12-12T23:23:12.5254877Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2019-12-02T13:57:38.9954718-08:00",
+    "DateTimeOffsetNow": "2019-12-12T15:23:09.1893358-08:00",
     "RandomSeed": "1848048512",
-    "Storage_TestConfigDefault": "ProductionTenant\njolovstorage\nU2FuaXRpemVk\nhttps://jolovstorage.blob.core.windows.net\nhttps://jolovstorage.file.core.windows.net\nhttps://jolovstorage.queue.core.windows.net\nhttps://jolovstorage.table.core.windows.net\n\n\n\n\nhttps://jolovstorage-secondary.blob.core.windows.net\nhttps://jolovstorage-secondary.file.core.windows.net\nhttps://jolovstorage-secondary.queue.core.windows.net\nhttps://jolovstorage-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://jolovstorage.blob.core.windows.net/;QueueEndpoint=https://jolovstorage.queue.core.windows.net/;FileEndpoint=https://jolovstorage.file.core.windows.net/;BlobSecondaryEndpoint=https://jolovstorage-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://jolovstorage-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://jolovstorage-secondary.file.core.windows.net/;AccountName=jolovstorage;AccountKey=Sanitized"
+    "Storage_TestConfigDefault": "ProductionTenant\nstoragedotnettesting\nU2FuaXRpemVk\nhttps://storagedotnettesting.blob.core.windows.net\nhttps://storagedotnettesting.file.core.windows.net\nhttps://storagedotnettesting.queue.core.windows.net\nhttps://storagedotnettesting.table.core.windows.net\n\n\n\n\nhttps://storagedotnettesting-secondary.blob.core.windows.net\nhttps://storagedotnettesting-secondary.file.core.windows.net\nhttps://storagedotnettesting-secondary.queue.core.windows.net\nhttps://storagedotnettesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://storagedotnettesting.blob.core.windows.net/;QueueEndpoint=https://storagedotnettesting.queue.core.windows.net/;FileEndpoint=https://storagedotnettesting.file.core.windows.net/;BlobSecondaryEndpoint=https://storagedotnettesting-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://storagedotnettesting-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://storagedotnettesting-secondary.file.core.windows.net/;AccountName=storagedotnettesting;AccountKey=Sanitized"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Ctor_ConnectionString_Sas_Permissions_ReadOnlyAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Ctor_ConnectionString_Sas_Permissions_ReadOnlyAsync.json
@@ -1,12 +1,12 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jolovstorage.blob.core.windows.net/test-container-3fe23fb6-16ce-7ce8-c079-a9338a2abb84?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A57%3A55Z\u0026sp=r\u0026sig=Sanitized\u0026restype=container",
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-3fe23fb6-16ce-7ce8-c079-a9338a2abb84?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A23%3A14Z\u0026sp=r\u0026sig=Sanitized\u0026restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-d40d23718c781840a15d9653e3ab6d1a-754b5d61ce4bcf4f-00",
+        "traceparent": "00-e7d1aa156cafbc4e8e1f7b2692600975-22ff88f580b71549-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "d1fbea36-104a-b0cf-2d9e-02cabb02f118",
@@ -18,26 +18,26 @@
       "ResponseHeaders": {
         "Content-Length": "279",
         "Content-Type": "application/xml",
-        "Date": "Mon, 02 Dec 2019 21:57:54 GMT",
+        "Date": "Thu, 12 Dec 2019 23:23:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "d1fbea36-104a-b0cf-2d9e-02cabb02f118",
         "x-ms-error-code": "AuthorizationPermissionMismatch",
-        "x-ms-request-id": "dd225893-d01e-0025-475b-a9691c000000",
+        "x-ms-request-id": "908b867a-b01e-0018-5643-b178b1000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EAuthorizationPermissionMismatch\u003C/Code\u003E\u003CMessage\u003EThis request is not authorized to perform this operation using this permission.\n",
-        "RequestId:dd225893-d01e-0025-475b-a9691c000000\n",
-        "Time:2019-12-02T21:57:55.1283800Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:908b867a-b01e-0018-5643-b178b1000000\n",
+        "Time:2019-12-12T23:23:14.2511261Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2019-12-02T13:57:55.1277600-08:00",
+    "DateTimeOffsetNow": "2019-12-12T15:23:14.2519139-08:00",
     "RandomSeed": "1716869207",
-    "Storage_TestConfigDefault": "ProductionTenant\njolovstorage\nU2FuaXRpemVk\nhttps://jolovstorage.blob.core.windows.net\nhttps://jolovstorage.file.core.windows.net\nhttps://jolovstorage.queue.core.windows.net\nhttps://jolovstorage.table.core.windows.net\n\n\n\n\nhttps://jolovstorage-secondary.blob.core.windows.net\nhttps://jolovstorage-secondary.file.core.windows.net\nhttps://jolovstorage-secondary.queue.core.windows.net\nhttps://jolovstorage-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://jolovstorage.blob.core.windows.net/;QueueEndpoint=https://jolovstorage.queue.core.windows.net/;FileEndpoint=https://jolovstorage.file.core.windows.net/;BlobSecondaryEndpoint=https://jolovstorage-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://jolovstorage-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://jolovstorage-secondary.file.core.windows.net/;AccountName=jolovstorage;AccountKey=Sanitized"
+    "Storage_TestConfigDefault": "ProductionTenant\nstoragedotnettesting\nU2FuaXRpemVk\nhttps://storagedotnettesting.blob.core.windows.net\nhttps://storagedotnettesting.file.core.windows.net\nhttps://storagedotnettesting.queue.core.windows.net\nhttps://storagedotnettesting.table.core.windows.net\n\n\n\n\nhttps://storagedotnettesting-secondary.blob.core.windows.net\nhttps://storagedotnettesting-secondary.file.core.windows.net\nhttps://storagedotnettesting-secondary.queue.core.windows.net\nhttps://storagedotnettesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://storagedotnettesting.blob.core.windows.net/;QueueEndpoint=https://storagedotnettesting.queue.core.windows.net/;FileEndpoint=https://storagedotnettesting.file.core.windows.net/;BlobSecondaryEndpoint=https://storagedotnettesting-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://storagedotnettesting-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://storagedotnettesting-secondary.file.core.windows.net/;AccountName=storagedotnettesting;AccountKey=Sanitized"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Ctor_ConnectionString_Sas_Permissions_WriteOnly.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Ctor_ConnectionString_Sas_Permissions_WriteOnly.json
@@ -1,12 +1,12 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jolovstorage.blob.core.windows.net/test-container-31d873e6-5cdd-fe00-111f-a4eb167d557c?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A57%3A39Z\u0026sp=wd\u0026sig=Sanitized\u0026restype=container",
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-31d873e6-5cdd-fe00-111f-a4eb167d557c?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A23%3A13Z\u0026sp=wd\u0026sig=Sanitized\u0026restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-8e9a7d14afcd23458d49d361373ffdd2-a8a6449ac4896645-00",
+        "traceparent": "00-9192f4eb5d1369488c8326518c5161a4-498822412d5f6b4f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "ca2f03f9-62bb-0328-0a3e-515a5613627f",
@@ -17,26 +17,26 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 21:57:38 GMT",
-        "ETag": "\u00220x8D77772A5F21D0E\u0022",
-        "Last-Modified": "Mon, 02 Dec 2019 21:57:39 GMT",
+        "Date": "Thu, 12 Dec 2019 23:23:12 GMT",
+        "ETag": "\u00220x8D77F5A42596074\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:23:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "ca2f03f9-62bb-0328-0a3e-515a5613627f",
-        "x-ms-request-id": "dd2242f5-d01e-0025-075b-a9691c000000",
+        "x-ms-request-id": "908b8533-b01e-0018-4343-b178b1000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.blob.core.windows.net/test-container-31d873e6-5cdd-fe00-111f-a4eb167d557c/test-blob-96cb9ab1-6009-b45c-5f28-c78cf971cde9?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A57%3A39Z\u0026sp=wd\u0026sig=Sanitized",
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-31d873e6-5cdd-fe00-111f-a4eb167d557c/test-blob-96cb9ab1-6009-b45c-5f28-c78cf971cde9?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A23%3A13Z\u0026sp=wd\u0026sig=Sanitized",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
-        "traceparent": "00-c9e5829316f8e744a2eec6cc3e0d181a-95809aea48379a40-00",
+        "traceparent": "00-0eb7e653c2244f4e8a54a9c03f4e1175-b62c44a0152f484c-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "a4dbcf8f-3ab4-3dc8-409a-9c4160c475fe",
@@ -46,26 +46,27 @@
       "RequestBody": null,
       "StatusCode": 403,
       "ResponseHeaders": {
-        "Date": "Mon, 02 Dec 2019 21:57:38 GMT",
+        "Date": "Thu, 12 Dec 2019 23:23:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
+        "Vary": "Origin",
         "x-ms-client-request-id": "a4dbcf8f-3ab4-3dc8-409a-9c4160c475fe",
         "x-ms-error-code": "AuthorizationPermissionMismatch",
-        "x-ms-request-id": "dd2242ff-d01e-0025-0f5b-a9691c000000",
+        "x-ms-request-id": "908b85d9-b01e-0018-5543-b178b1000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.blob.core.windows.net/test-container-31d873e6-5cdd-fe00-111f-a4eb167d557c?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A57%3A39Z\u0026sp=wd\u0026sig=Sanitized\u0026restype=container",
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-31d873e6-5cdd-fe00-111f-a4eb167d557c?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A23%3A13Z\u0026sp=wd\u0026sig=Sanitized\u0026restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
-        "traceparent": "00-393e9307521a174eb38cf131f6b6e4cf-5e5d01e66e81aa4b-00",
+        "traceparent": "00-3c101d72bba63a46ab7fba527669f583-abd085e0c665e148-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "6c21e8be-9a0c-bdb0-5a30-15ee95e7de57",
@@ -76,21 +77,21 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 21:57:38 GMT",
+        "Date": "Thu, 12 Dec 2019 23:23:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "6c21e8be-9a0c-bdb0-5a30-15ee95e7de57",
-        "x-ms-request-id": "dd224309-d01e-0025-185b-a9691c000000",
+        "x-ms-request-id": "908b85f5-b01e-0018-6c43-b178b1000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2019-12-02T13:57:39.0278404-08:00",
+    "DateTimeOffsetNow": "2019-12-12T15:23:13.3125502-08:00",
     "RandomSeed": "2029410020",
-    "Storage_TestConfigDefault": "ProductionTenant\njolovstorage\nU2FuaXRpemVk\nhttps://jolovstorage.blob.core.windows.net\nhttps://jolovstorage.file.core.windows.net\nhttps://jolovstorage.queue.core.windows.net\nhttps://jolovstorage.table.core.windows.net\n\n\n\n\nhttps://jolovstorage-secondary.blob.core.windows.net\nhttps://jolovstorage-secondary.file.core.windows.net\nhttps://jolovstorage-secondary.queue.core.windows.net\nhttps://jolovstorage-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://jolovstorage.blob.core.windows.net/;QueueEndpoint=https://jolovstorage.queue.core.windows.net/;FileEndpoint=https://jolovstorage.file.core.windows.net/;BlobSecondaryEndpoint=https://jolovstorage-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://jolovstorage-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://jolovstorage-secondary.file.core.windows.net/;AccountName=jolovstorage;AccountKey=Sanitized"
+    "Storage_TestConfigDefault": "ProductionTenant\nstoragedotnettesting\nU2FuaXRpemVk\nhttps://storagedotnettesting.blob.core.windows.net\nhttps://storagedotnettesting.file.core.windows.net\nhttps://storagedotnettesting.queue.core.windows.net\nhttps://storagedotnettesting.table.core.windows.net\n\n\n\n\nhttps://storagedotnettesting-secondary.blob.core.windows.net\nhttps://storagedotnettesting-secondary.file.core.windows.net\nhttps://storagedotnettesting-secondary.queue.core.windows.net\nhttps://storagedotnettesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://storagedotnettesting.blob.core.windows.net/;QueueEndpoint=https://storagedotnettesting.queue.core.windows.net/;FileEndpoint=https://storagedotnettesting.file.core.windows.net/;BlobSecondaryEndpoint=https://storagedotnettesting-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://storagedotnettesting-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://storagedotnettesting-secondary.file.core.windows.net/;AccountName=storagedotnettesting;AccountKey=Sanitized"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Ctor_ConnectionString_Sas_Permissions_WriteOnlyAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Ctor_ConnectionString_Sas_Permissions_WriteOnlyAsync.json
@@ -1,12 +1,12 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jolovstorage.blob.core.windows.net/test-container-8b961c37-9c5f-b475-d41b-5660709f38b4?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A57%3A55Z\u0026sp=wd\u0026sig=Sanitized\u0026restype=container",
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-8b961c37-9c5f-b475-d41b-5660709f38b4?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A23%3A14Z\u0026sp=wd\u0026sig=Sanitized\u0026restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-d740550b60e0e54ca5cb5fde79b914c7-92dc3fe25768094b-00",
+        "traceparent": "00-a90100ecd701464da4d7b678c7639f73-4f6fc47a92b3f145-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "65aa4a13-b393-7fca-99ee-5550c78bbdf4",
@@ -17,26 +17,26 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 21:57:54 GMT",
-        "ETag": "\u00220x8D77772AF8F6D35\u0022",
-        "Last-Modified": "Mon, 02 Dec 2019 21:57:55 GMT",
+        "Date": "Thu, 12 Dec 2019 23:23:13 GMT",
+        "ETag": "\u00220x8D77F5A42F1F4FF\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:23:14 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "65aa4a13-b393-7fca-99ee-5550c78bbdf4",
-        "x-ms-request-id": "dd2258a1-d01e-0025-545b-a9691c000000",
+        "x-ms-request-id": "908b8697-b01e-0018-7143-b178b1000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.blob.core.windows.net/test-container-8b961c37-9c5f-b475-d41b-5660709f38b4/test-blob-37dc2c58-aa99-b2d4-09e8-66ed669d4398?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A57%3A55Z\u0026sp=wd\u0026sig=Sanitized",
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-8b961c37-9c5f-b475-d41b-5660709f38b4/test-blob-37dc2c58-aa99-b2d4-09e8-66ed669d4398?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A23%3A14Z\u0026sp=wd\u0026sig=Sanitized",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
-        "traceparent": "00-5909386c85afce468ee79b5e4613455d-0de2270eb5f1a04d-00",
+        "traceparent": "00-897e85dcd1f06d40a608bc930d8d0165-148cc8ee02ad1d4f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "1529acbc-9ba1-3d34-f349-8d553575948c",
@@ -46,26 +46,27 @@
       "RequestBody": null,
       "StatusCode": 403,
       "ResponseHeaders": {
-        "Date": "Mon, 02 Dec 2019 21:57:54 GMT",
+        "Date": "Thu, 12 Dec 2019 23:23:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
+        "Vary": "Origin",
         "x-ms-client-request-id": "1529acbc-9ba1-3d34-f349-8d553575948c",
         "x-ms-error-code": "AuthorizationPermissionMismatch",
-        "x-ms-request-id": "dd2258ab-d01e-0025-5d5b-a9691c000000",
+        "x-ms-request-id": "908b86a7-b01e-0018-8043-b178b1000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.blob.core.windows.net/test-container-8b961c37-9c5f-b475-d41b-5660709f38b4?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A57%3A55Z\u0026sp=wd\u0026sig=Sanitized\u0026restype=container",
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-8b961c37-9c5f-b475-d41b-5660709f38b4?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A23%3A14Z\u0026sp=wd\u0026sig=Sanitized\u0026restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
-        "traceparent": "00-7a6723ab0f76bf4b93f2c759ea832d6c-7b5c5c9683043644-00",
+        "traceparent": "00-1f39ed6d73c10b4cbc2c83fa0f2ddca8-7788b816ea19db4e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "e38f0ca2-570a-45cb-c6c0-ca3df3ef2b9d",
@@ -76,21 +77,21 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 21:57:54 GMT",
+        "Date": "Thu, 12 Dec 2019 23:23:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "e38f0ca2-570a-45cb-c6c0-ca3df3ef2b9d",
-        "x-ms-request-id": "dd2258b7-d01e-0025-675b-a9691c000000",
+        "x-ms-request-id": "908b86af-b01e-0018-0843-b178b1000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2019-12-02T13:57:55.1573133-08:00",
+    "DateTimeOffsetNow": "2019-12-12T15:23:14.3356580-08:00",
     "RandomSeed": "873592540",
-    "Storage_TestConfigDefault": "ProductionTenant\njolovstorage\nU2FuaXRpemVk\nhttps://jolovstorage.blob.core.windows.net\nhttps://jolovstorage.file.core.windows.net\nhttps://jolovstorage.queue.core.windows.net\nhttps://jolovstorage.table.core.windows.net\n\n\n\n\nhttps://jolovstorage-secondary.blob.core.windows.net\nhttps://jolovstorage-secondary.file.core.windows.net\nhttps://jolovstorage-secondary.queue.core.windows.net\nhttps://jolovstorage-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://jolovstorage.blob.core.windows.net/;QueueEndpoint=https://jolovstorage.queue.core.windows.net/;FileEndpoint=https://jolovstorage.file.core.windows.net/;BlobSecondaryEndpoint=https://jolovstorage-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://jolovstorage-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://jolovstorage-secondary.file.core.windows.net/;AccountName=jolovstorage;AccountKey=Sanitized"
+    "Storage_TestConfigDefault": "ProductionTenant\nstoragedotnettesting\nU2FuaXRpemVk\nhttps://storagedotnettesting.blob.core.windows.net\nhttps://storagedotnettesting.file.core.windows.net\nhttps://storagedotnettesting.queue.core.windows.net\nhttps://storagedotnettesting.table.core.windows.net\n\n\n\n\nhttps://storagedotnettesting-secondary.blob.core.windows.net\nhttps://storagedotnettesting-secondary.file.core.windows.net\nhttps://storagedotnettesting-secondary.queue.core.windows.net\nhttps://storagedotnettesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://storagedotnettesting.blob.core.windows.net/;QueueEndpoint=https://storagedotnettesting.queue.core.windows.net/;FileEndpoint=https://storagedotnettesting.file.core.windows.net/;BlobSecondaryEndpoint=https://storagedotnettesting-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://storagedotnettesting-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://storagedotnettesting-secondary.file.core.windows.net/;AccountName=storagedotnettesting;AccountKey=Sanitized"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Ctor_ConnectionString_Sas_Resource_Types_Container.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Ctor_ConnectionString_Sas_Resource_Types_Container.json
@@ -1,12 +1,12 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jolovstorage.blob.core.windows.net/test-container-7adf3256-e3fc-2e0f-0395-1accc7b332fc?sv=2019-02-02\u0026ss=bfq\u0026srt=c\u0026spr=https\u0026se=2019-12-02T22%3A57%3A39Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-7adf3256-e3fc-2e0f-0395-1accc7b332fc?sv=2019-02-02\u0026ss=bfqt\u0026srt=c\u0026spr=https\u0026se=2019-12-13T00%3A23%3A14Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-ff75e75a8fecef4dbcf52fd23ac6eb7b-18cd988d16506041-00",
+        "traceparent": "00-2fa69c2cf9990441afde1b4c3c4ad1dd-e1786115d876724a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "9eba7f27-22bd-7e72-b2b3-90f9940f5a73",
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 21:57:38 GMT",
-        "ETag": "\u00220x8D77772A600C5B8\u0022",
-        "Last-Modified": "Mon, 02 Dec 2019 21:57:39 GMT",
+        "Date": "Thu, 12 Dec 2019 23:23:13 GMT",
+        "ETag": "\u00220x8D77F5A42C226DC\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:23:14 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "9eba7f27-22bd-7e72-b2b3-90f9940f5a73",
-        "x-ms-request-id": "dd224316-d01e-0025-245b-a9691c000000",
+        "x-ms-request-id": "908b85ff-b01e-0018-7543-b178b1000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.blob.core.windows.net/test-container-7adf3256-e3fc-2e0f-0395-1accc7b332fc/test-blob-6f8bccfd-82b1-1d49-f6d0-f8c8bacd1474?sv=2019-02-02\u0026ss=bfq\u0026srt=c\u0026spr=https\u0026se=2019-12-02T22%3A57%3A39Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-7adf3256-e3fc-2e0f-0395-1accc7b332fc/test-blob-6f8bccfd-82b1-1d49-f6d0-f8c8bacd1474?sv=2019-02-02\u0026ss=bfqt\u0026srt=c\u0026spr=https\u0026se=2019-12-13T00%3A23%3A14Z\u0026sp=rwdlacup\u0026sig=Sanitized",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Content-Length": "1024",
         "If-None-Match": "*",
-        "traceparent": "00-7276334db557c04bbca2de733c023da3-17687d29e36ef74f-00",
+        "traceparent": "00-a0ba27baf3b4874fb0fef5f69132e4e0-0afaa5ae92f3fc4c-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
@@ -51,29 +51,29 @@
       "ResponseHeaders": {
         "Content-Length": "284",
         "Content-Type": "application/xml",
-        "Date": "Mon, 02 Dec 2019 21:57:38 GMT",
+        "Date": "Thu, 12 Dec 2019 23:23:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "6cf64786-2026-bd31-6308-49c5e543a96f",
         "x-ms-error-code": "AuthorizationResourceTypeMismatch",
-        "x-ms-request-id": "dd224322-d01e-0025-2d5b-a9691c000000",
+        "x-ms-request-id": "908b8633-b01e-0018-1f43-b178b1000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EAuthorizationResourceTypeMismatch\u003C/Code\u003E\u003CMessage\u003EThis request is not authorized to perform this operation using this resource type.\n",
-        "RequestId:dd224322-d01e-0025-2d5b-a9691c000000\n",
-        "Time:2019-12-02T21:57:39.1540282Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:908b8633-b01e-0018-1f43-b178b1000000\n",
+        "Time:2019-12-12T23:23:14.0909746Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
-      "RequestUri": "https://jolovstorage.blob.core.windows.net/test-container-7adf3256-e3fc-2e0f-0395-1accc7b332fc?sv=2019-02-02\u0026ss=bfq\u0026srt=c\u0026spr=https\u0026se=2019-12-02T22%3A57%3A39Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-7adf3256-e3fc-2e0f-0395-1accc7b332fc?sv=2019-02-02\u0026ss=bfqt\u0026srt=c\u0026spr=https\u0026se=2019-12-13T00%3A23%3A14Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
-        "traceparent": "00-7f9a41f5e5e09b44959eaff1b201c2d5-425b231d48eb544c-00",
+        "traceparent": "00-c5b5d2fc47d80441b62aa9f0593e461f-b450c78d09decd42-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "63a751fe-4b12-a17d-df75-83d788ef2cee",
@@ -84,21 +84,21 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 21:57:38 GMT",
+        "Date": "Thu, 12 Dec 2019 23:23:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "63a751fe-4b12-a17d-df75-83d788ef2cee",
-        "x-ms-request-id": "dd224327-d01e-0025-325b-a9691c000000",
+        "x-ms-request-id": "908b863e-b01e-0018-2743-b178b1000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2019-12-02T13:57:39.1229307-08:00",
+    "DateTimeOffsetNow": "2019-12-12T15:23:14.0225839-08:00",
     "RandomSeed": "1315048386",
-    "Storage_TestConfigDefault": "ProductionTenant\njolovstorage\nU2FuaXRpemVk\nhttps://jolovstorage.blob.core.windows.net\nhttps://jolovstorage.file.core.windows.net\nhttps://jolovstorage.queue.core.windows.net\nhttps://jolovstorage.table.core.windows.net\n\n\n\n\nhttps://jolovstorage-secondary.blob.core.windows.net\nhttps://jolovstorage-secondary.file.core.windows.net\nhttps://jolovstorage-secondary.queue.core.windows.net\nhttps://jolovstorage-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://jolovstorage.blob.core.windows.net/;QueueEndpoint=https://jolovstorage.queue.core.windows.net/;FileEndpoint=https://jolovstorage.file.core.windows.net/;BlobSecondaryEndpoint=https://jolovstorage-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://jolovstorage-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://jolovstorage-secondary.file.core.windows.net/;AccountName=jolovstorage;AccountKey=Sanitized"
+    "Storage_TestConfigDefault": "ProductionTenant\nstoragedotnettesting\nU2FuaXRpemVk\nhttps://storagedotnettesting.blob.core.windows.net\nhttps://storagedotnettesting.file.core.windows.net\nhttps://storagedotnettesting.queue.core.windows.net\nhttps://storagedotnettesting.table.core.windows.net\n\n\n\n\nhttps://storagedotnettesting-secondary.blob.core.windows.net\nhttps://storagedotnettesting-secondary.file.core.windows.net\nhttps://storagedotnettesting-secondary.queue.core.windows.net\nhttps://storagedotnettesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://storagedotnettesting.blob.core.windows.net/;QueueEndpoint=https://storagedotnettesting.queue.core.windows.net/;FileEndpoint=https://storagedotnettesting.file.core.windows.net/;BlobSecondaryEndpoint=https://storagedotnettesting-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://storagedotnettesting-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://storagedotnettesting-secondary.file.core.windows.net/;AccountName=storagedotnettesting;AccountKey=Sanitized"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Ctor_ConnectionString_Sas_Resource_Types_ContainerAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Ctor_ConnectionString_Sas_Resource_Types_ContainerAsync.json
@@ -1,12 +1,12 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jolovstorage.blob.core.windows.net/test-container-b1899efe-e5bd-725c-761c-64851974d457?sv=2019-02-02\u0026ss=bfq\u0026srt=c\u0026spr=https\u0026se=2019-12-02T22%3A57%3A55Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-b1899efe-e5bd-725c-761c-64851974d457?sv=2019-02-02\u0026ss=bfqt\u0026srt=c\u0026spr=https\u0026se=2019-12-13T00%3A23%3A14Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-e6d392b564309943a21b2e79f1be0a7d-13b47584b3a2074b-00",
+        "traceparent": "00-4b6b955efac19c44ad48771521a3ab97-6eb6e6b676587a4c-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "b07fecee-2733-e532-4a2e-c6167082c705",
@@ -17,28 +17,28 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 21:57:54 GMT",
-        "ETag": "\u00220x8D77772AF9D0449\u0022",
-        "Last-Modified": "Mon, 02 Dec 2019 21:57:55 GMT",
+        "Date": "Thu, 12 Dec 2019 23:23:13 GMT",
+        "ETag": "\u00220x8D77F5A42FCCD0C\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:23:14 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "b07fecee-2733-e532-4a2e-c6167082c705",
-        "x-ms-request-id": "dd2258bf-d01e-0025-6f5b-a9691c000000",
+        "x-ms-request-id": "908b86b5-b01e-0018-0e43-b178b1000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.blob.core.windows.net/test-container-b1899efe-e5bd-725c-761c-64851974d457/test-blob-a9af93a0-af18-1332-8a58-0e3017fd28f9?sv=2019-02-02\u0026ss=bfq\u0026srt=c\u0026spr=https\u0026se=2019-12-02T22%3A57%3A55Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-b1899efe-e5bd-725c-761c-64851974d457/test-blob-a9af93a0-af18-1332-8a58-0e3017fd28f9?sv=2019-02-02\u0026ss=bfqt\u0026srt=c\u0026spr=https\u0026se=2019-12-13T00%3A23%3A14Z\u0026sp=rwdlacup\u0026sig=Sanitized",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Content-Length": "1024",
         "If-None-Match": "*",
-        "traceparent": "00-5ab20627e04d1f409d27e3c2638cf77a-1db502c615994c42-00",
+        "traceparent": "00-15ce2de3f2749a4cacf4e8256b039850-a7972768500f7248-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-blob-type": "BlockBlob",
@@ -51,29 +51,29 @@
       "ResponseHeaders": {
         "Content-Length": "284",
         "Content-Type": "application/xml",
-        "Date": "Mon, 02 Dec 2019 21:57:54 GMT",
+        "Date": "Thu, 12 Dec 2019 23:23:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "0ff36a2e-bc10-8d36-8419-b88334f6bd49",
         "x-ms-error-code": "AuthorizationResourceTypeMismatch",
-        "x-ms-request-id": "dd2258d0-d01e-0025-7d5b-a9691c000000",
+        "x-ms-request-id": "908b86c3-b01e-0018-1943-b178b1000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EAuthorizationResourceTypeMismatch\u003C/Code\u003E\u003CMessage\u003EThis request is not authorized to perform this operation using this resource type.\n",
-        "RequestId:dd2258d0-d01e-0025-7d5b-a9691c000000\n",
-        "Time:2019-12-02T21:57:55.2784871Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:908b86c3-b01e-0018-1943-b178b1000000\n",
+        "Time:2019-12-12T23:23:14.4152818Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     },
     {
-      "RequestUri": "https://jolovstorage.blob.core.windows.net/test-container-b1899efe-e5bd-725c-761c-64851974d457?sv=2019-02-02\u0026ss=bfq\u0026srt=c\u0026spr=https\u0026se=2019-12-02T22%3A57%3A55Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-b1899efe-e5bd-725c-761c-64851974d457?sv=2019-02-02\u0026ss=bfqt\u0026srt=c\u0026spr=https\u0026se=2019-12-13T00%3A23%3A14Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
-        "traceparent": "00-654d99feff479b4bb8531c615c293997-9d45f541c7b6fe4b-00",
+        "traceparent": "00-1e7192f2473d0c4d96c7a01a1e8976c5-878a25b829cffe48-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "8894703b-dc84-7aae-6b7b-db1b8f992300",
@@ -84,21 +84,21 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 21:57:54 GMT",
+        "Date": "Thu, 12 Dec 2019 23:23:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "8894703b-dc84-7aae-6b7b-db1b8f992300",
-        "x-ms-request-id": "dd2258d8-d01e-0025-055b-a9691c000000",
+        "x-ms-request-id": "908b86c9-b01e-0018-1e43-b178b1000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2019-12-02T13:57:55.2469063-08:00",
+    "DateTimeOffsetNow": "2019-12-12T15:23:14.4070634-08:00",
     "RandomSeed": "31189073",
-    "Storage_TestConfigDefault": "ProductionTenant\njolovstorage\nU2FuaXRpemVk\nhttps://jolovstorage.blob.core.windows.net\nhttps://jolovstorage.file.core.windows.net\nhttps://jolovstorage.queue.core.windows.net\nhttps://jolovstorage.table.core.windows.net\n\n\n\n\nhttps://jolovstorage-secondary.blob.core.windows.net\nhttps://jolovstorage-secondary.file.core.windows.net\nhttps://jolovstorage-secondary.queue.core.windows.net\nhttps://jolovstorage-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://jolovstorage.blob.core.windows.net/;QueueEndpoint=https://jolovstorage.queue.core.windows.net/;FileEndpoint=https://jolovstorage.file.core.windows.net/;BlobSecondaryEndpoint=https://jolovstorage-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://jolovstorage-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://jolovstorage-secondary.file.core.windows.net/;AccountName=jolovstorage;AccountKey=Sanitized"
+    "Storage_TestConfigDefault": "ProductionTenant\nstoragedotnettesting\nU2FuaXRpemVk\nhttps://storagedotnettesting.blob.core.windows.net\nhttps://storagedotnettesting.file.core.windows.net\nhttps://storagedotnettesting.queue.core.windows.net\nhttps://storagedotnettesting.table.core.windows.net\n\n\n\n\nhttps://storagedotnettesting-secondary.blob.core.windows.net\nhttps://storagedotnettesting-secondary.file.core.windows.net\nhttps://storagedotnettesting-secondary.queue.core.windows.net\nhttps://storagedotnettesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://storagedotnettesting.blob.core.windows.net/;QueueEndpoint=https://storagedotnettesting.queue.core.windows.net/;FileEndpoint=https://storagedotnettesting.file.core.windows.net/;BlobSecondaryEndpoint=https://storagedotnettesting-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://storagedotnettesting-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://storagedotnettesting-secondary.file.core.windows.net/;AccountName=storagedotnettesting;AccountKey=Sanitized"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Ctor_ConnectionString_Sas_Resource_Types_Service.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Ctor_ConnectionString_Sas_Resource_Types_Service.json
@@ -1,12 +1,12 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jolovstorage.blob.core.windows.net/test-container-24dc47d0-baae-2498-bc8a-91bf6c931c09?sv=2019-02-02\u0026ss=bfq\u0026srt=s\u0026spr=https\u0026se=2019-12-02T22%3A57%3A39Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-24dc47d0-baae-2498-bc8a-91bf6c931c09?sv=2019-02-02\u0026ss=bfqt\u0026srt=s\u0026spr=https\u0026se=2019-12-13T00%3A23%3A14Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-3206b989f1cc3146b8362aa5fc40014e-fb7ba04e4db01041-00",
+        "traceparent": "00-82a237c82591eb4091881500a1c2d35d-2a6b1dadc4994b49-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "5568a942-cb6e-bf50-66f3-09acc023995a",
@@ -18,26 +18,26 @@
       "ResponseHeaders": {
         "Content-Length": "284",
         "Content-Type": "application/xml",
-        "Date": "Mon, 02 Dec 2019 21:57:38 GMT",
+        "Date": "Thu, 12 Dec 2019 23:23:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "5568a942-cb6e-bf50-66f3-09acc023995a",
         "x-ms-error-code": "AuthorizationResourceTypeMismatch",
-        "x-ms-request-id": "dd224333-d01e-0025-3e5b-a9691c000000",
+        "x-ms-request-id": "908b8659-b01e-0018-3d43-b178b1000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EAuthorizationResourceTypeMismatch\u003C/Code\u003E\u003CMessage\u003EThis request is not authorized to perform this operation using this resource type.\n",
-        "RequestId:dd224333-d01e-0025-3e5b-a9691c000000\n",
-        "Time:2019-12-02T21:57:39.2150718Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:908b8659-b01e-0018-3d43-b178b1000000\n",
+        "Time:2019-12-12T23:23:14.1710517Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2019-12-02T13:57:39.2149545-08:00",
+    "DateTimeOffsetNow": "2019-12-12T15:23:14.1932620-08:00",
     "RandomSeed": "661680159",
-    "Storage_TestConfigDefault": "ProductionTenant\njolovstorage\nU2FuaXRpemVk\nhttps://jolovstorage.blob.core.windows.net\nhttps://jolovstorage.file.core.windows.net\nhttps://jolovstorage.queue.core.windows.net\nhttps://jolovstorage.table.core.windows.net\n\n\n\n\nhttps://jolovstorage-secondary.blob.core.windows.net\nhttps://jolovstorage-secondary.file.core.windows.net\nhttps://jolovstorage-secondary.queue.core.windows.net\nhttps://jolovstorage-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://jolovstorage.blob.core.windows.net/;QueueEndpoint=https://jolovstorage.queue.core.windows.net/;FileEndpoint=https://jolovstorage.file.core.windows.net/;BlobSecondaryEndpoint=https://jolovstorage-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://jolovstorage-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://jolovstorage-secondary.file.core.windows.net/;AccountName=jolovstorage;AccountKey=Sanitized"
+    "Storage_TestConfigDefault": "ProductionTenant\nstoragedotnettesting\nU2FuaXRpemVk\nhttps://storagedotnettesting.blob.core.windows.net\nhttps://storagedotnettesting.file.core.windows.net\nhttps://storagedotnettesting.queue.core.windows.net\nhttps://storagedotnettesting.table.core.windows.net\n\n\n\n\nhttps://storagedotnettesting-secondary.blob.core.windows.net\nhttps://storagedotnettesting-secondary.file.core.windows.net\nhttps://storagedotnettesting-secondary.queue.core.windows.net\nhttps://storagedotnettesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://storagedotnettesting.blob.core.windows.net/;QueueEndpoint=https://storagedotnettesting.queue.core.windows.net/;FileEndpoint=https://storagedotnettesting.file.core.windows.net/;BlobSecondaryEndpoint=https://storagedotnettesting-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://storagedotnettesting-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://storagedotnettesting-secondary.file.core.windows.net/;AccountName=storagedotnettesting;AccountKey=Sanitized"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Ctor_ConnectionString_Sas_Resource_Types_ServiceAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Ctor_ConnectionString_Sas_Resource_Types_ServiceAsync.json
@@ -1,12 +1,12 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jolovstorage.blob.core.windows.net/test-container-88c0b082-4c4e-1274-7c1e-0996e7286bdb?sv=2019-02-02\u0026ss=bfq\u0026srt=s\u0026spr=https\u0026se=2019-12-02T22%3A57%3A55Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-88c0b082-4c4e-1274-7c1e-0996e7286bdb?sv=2019-02-02\u0026ss=bfqt\u0026srt=s\u0026spr=https\u0026se=2019-12-13T00%3A23%3A14Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-9af9907fe819d247b43c95c4cf49b850-a00da5fc3547f648-00",
+        "traceparent": "00-7e9888d718255b43acdaf63a1fd95d38-1523e6cd3f712044-00",
         "User-Agent": [
-          "azsdk-net-Storage.Blobs/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "fd03cc14-02ff-e383-bc23-bc0aa5353479",
@@ -18,26 +18,26 @@
       "ResponseHeaders": {
         "Content-Length": "284",
         "Content-Type": "application/xml",
-        "Date": "Mon, 02 Dec 2019 21:57:54 GMT",
+        "Date": "Thu, 12 Dec 2019 23:23:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "fd03cc14-02ff-e383-bc23-bc0aa5353479",
         "x-ms-error-code": "AuthorizationResourceTypeMismatch",
-        "x-ms-request-id": "dd2258e6-d01e-0025-125b-a9691c000000",
+        "x-ms-request-id": "908b86df-b01e-0018-3343-b178b1000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": [
         "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EAuthorizationResourceTypeMismatch\u003C/Code\u003E\u003CMessage\u003EThis request is not authorized to perform this operation using this resource type.\n",
-        "RequestId:dd2258e6-d01e-0025-125b-a9691c000000\n",
-        "Time:2019-12-02T21:57:55.3395306Z\u003C/Message\u003E\u003C/Error\u003E"
+        "RequestId:908b86df-b01e-0018-3343-b178b1000000\n",
+        "Time:2019-12-12T23:23:14.5053673Z\u003C/Message\u003E\u003C/Error\u003E"
       ]
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2019-12-02T13:57:55.3378398-08:00",
+    "DateTimeOffsetNow": "2019-12-12T15:23:14.5271736-08:00",
     "RandomSeed": "1241350200",
-    "Storage_TestConfigDefault": "ProductionTenant\njolovstorage\nU2FuaXRpemVk\nhttps://jolovstorage.blob.core.windows.net\nhttps://jolovstorage.file.core.windows.net\nhttps://jolovstorage.queue.core.windows.net\nhttps://jolovstorage.table.core.windows.net\n\n\n\n\nhttps://jolovstorage-secondary.blob.core.windows.net\nhttps://jolovstorage-secondary.file.core.windows.net\nhttps://jolovstorage-secondary.queue.core.windows.net\nhttps://jolovstorage-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://jolovstorage.blob.core.windows.net/;QueueEndpoint=https://jolovstorage.queue.core.windows.net/;FileEndpoint=https://jolovstorage.file.core.windows.net/;BlobSecondaryEndpoint=https://jolovstorage-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://jolovstorage-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://jolovstorage-secondary.file.core.windows.net/;AccountName=jolovstorage;AccountKey=Sanitized"
+    "Storage_TestConfigDefault": "ProductionTenant\nstoragedotnettesting\nU2FuaXRpemVk\nhttps://storagedotnettesting.blob.core.windows.net\nhttps://storagedotnettesting.file.core.windows.net\nhttps://storagedotnettesting.queue.core.windows.net\nhttps://storagedotnettesting.table.core.windows.net\n\n\n\n\nhttps://storagedotnettesting-secondary.blob.core.windows.net\nhttps://storagedotnettesting-secondary.file.core.windows.net\nhttps://storagedotnettesting-secondary.queue.core.windows.net\nhttps://storagedotnettesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://storagedotnettesting.blob.core.windows.net/;QueueEndpoint=https://storagedotnettesting.queue.core.windows.net/;FileEndpoint=https://storagedotnettesting.file.core.windows.net/;BlobSecondaryEndpoint=https://storagedotnettesting-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://storagedotnettesting-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://storagedotnettesting-secondary.file.core.windows.net/;AccountName=storagedotnettesting;AccountKey=Sanitized"
   }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Perform_Ctor_ConnectionString_Sas(False).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Perform_Ctor_ConnectionString_Sas(False).json
@@ -1,0 +1,195 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-9de05bc0-4877-a233-31b2-6eb96834f8b1?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A15%3A26Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "traceparent": "00-23eb314337f0bd48824be01e42a0eed5-934ef8b43348fd47-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "d398789f-3b58-0cc7-6255-fb133f7285e9",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 12 Dec 2019 23:15:26 GMT",
+        "ETag": "\u00220x8D77F592C5724F8\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:15:26 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d398789f-3b58-0cc7-6255-fb133f7285e9",
+        "x-ms-request-id": "1b40f11e-f01e-0054-1c42-b1e881000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-9d9c23a5-b4fc-8af9-a263-08c11c48ab49?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A15%3A26Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "traceparent": "00-f54b60aac9ebe84d91bbf24dd6056a60-1200f8715f63b542-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "abcd53ce-f3f7-1763-9c22-a7ebd71f943d",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 12 Dec 2019 23:15:26 GMT",
+        "ETag": "\u00220x8D77F592C596F7B\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:15:26 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "abcd53ce-f3f7-1763-9c22-a7ebd71f943d",
+        "x-ms-request-id": "1b40f12a-f01e-0054-2642-b1e881000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-9de05bc0-4877-a233-31b2-6eb96834f8b1/test-blob-1ac12407-871e-76dc-2b6c-63a87725b9e9?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A15%3A26Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Content-Length": "1024",
+        "traceparent": "00-3ea61664443ff149874c5c65f26532d2-fed7587464d42443-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "0dee40f8-e5f3-c091-77b2-cef4a4c4e9f3",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "fJvaJFgO8WEjCQiNLwXlZnXR5CIlNnbsGZ14815OnkDgYG48RXDljSBclkbZrP8tHy\u002Bfp3YfIUYk7Qq6lf0D1GrHrc\u002BWqSAE7FcByZ8wE22eStQvrvfJwD4oF1dlK/ciWcHcEf4vl3YOm7sfHVim9NmdG0sp1CZz/eyRbpHInsBf32/eUwJubrNeIBM7qqLlgSJ\u002ByA\u002Bs\u002BYWbaBMSnijkRfz6wD7oyKDXLqyXyrMTOFNKq\u002B1vStaxsubqQuvuXNCKetsWQOpj/biBppljFC7RiDDAyPM7dPslSQ1Y/Ya16dLcDVDY/Pdp5q007qM8Tp63Gbq7LZTcTwXg8PfcC/8yy73Ghgfd\u002BYw4V\u002BFFBoVX6fpuoeTM\u002Brs\u002B/71K\u002BAsAjNuuAiLmdceW2R8tgtayl0mAiAf8bWkaZtEBiIdJkwGAOMoGlgRicXMz18fFnnfkjGh0ym8EAx5xk5xR5O1ATUYerUoMrABEHReUyZWiVcdZHfwf1ciRfDSrlQNnEYyF8oqApvAt2N9nL61YbzqIzj7U98fwIXh9jDEVYBf93AyKDtYLIa7XLEQct6UbOQz5I8bEkxnFlNESAhq/GHjIalKgzWFkfayP/cuC1GrSYlMkHD1QOEnzxXkE\u002BB\u002BUFxTMU0xSemyrlKUZNZZNQsBnP6DGmvs7eDIJrQjnYIWN\u002BuW3toAdgOfneYeXNwOypYK5nbh\u002BzXwYkdsZSM1jwzQgizqwlYw/Sb\u002B43yB0o0EvVgiFLsLMDy1pnyWlAzcag7ZSdqvIAQ/1eVP4xe5bo\u002B2a6vHE3ZVyVHwNR/VnmUWInlxqIS2VZlT4kLRu00k/Dfs3CxlFVaUg4CEuu7oajuAOcCeR8IG/BISdzE3hA4Azzjn6L44sQki3SUELZqqa3gLUYGMirR16eAeUqIhXP92h\u002B\u002B2BH15R4S3e2adAs53ZAu5LDaMdECAcgLeHl5rAXwpkamq8GL6jgn41Q9N1OcRpu6WZCzI5g\u002BrNZZ\u002BmykqTHnmd3EkyHOowp4ol6M1MpkbzHdz0JlPXKueA77Me/bczoSVa2Fx7N567aWSnFJodgL9Zs61tnvclxbJhsi03EqrS8Uao8s3peOY\u002BObzvLxVMYm7zxEkKxgMtNBOqGYRxg1a51SNUdY7xbzvHL2Q6NpacFU\u002B\u002BQ01hyCpDer66P15hzLVmNlry\u002BO3gAVUOQ5af8v19DgM0skAJWAz4EfrQNzDcZmKu1P87qh1i3kH4UoWUpIjAPDFbLBp1XN5N\u002BebyD8klMt0z8B3\u002BQWPm0tT/EQWHZG1yD/v\u002BgTlIOXgh7rE2cM530iCnYLNqwvvNdFpGdkvYxZV5fwDOJrCj67al3FOyr2EFhz7k4AO5B03/MQzfAsMsSQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "pSl\u002BdZx76HprFPL3a\u002B5oEg==",
+        "Date": "Thu, 12 Dec 2019 23:15:26 GMT",
+        "ETag": "\u00220x8D77F592C5BD0F5\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:15:26 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0dee40f8-e5f3-c091-77b2-cef4a4c4e9f3",
+        "x-ms-content-crc64": "4sdc/pUEZIs=",
+        "x-ms-request-id": "1b40f131-f01e-0054-2c42-b1e881000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-9d9c23a5-b4fc-8af9-a263-08c11c48ab49/test-blob-b9be119b-e150-2f39-3304-9514785b4247?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A15%3A26Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Content-Length": "1024",
+        "traceparent": "00-f9ece94c0cbdce47848bc79722ec90ad-83145a5bf0422846-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "c1e64716-1fd4-4256-8afc-791cd9b7cb40",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "fJvaJFgO8WEjCQiNLwXlZnXR5CIlNnbsGZ14815OnkDgYG48RXDljSBclkbZrP8tHy\u002Bfp3YfIUYk7Qq6lf0D1GrHrc\u002BWqSAE7FcByZ8wE22eStQvrvfJwD4oF1dlK/ciWcHcEf4vl3YOm7sfHVim9NmdG0sp1CZz/eyRbpHInsBf32/eUwJubrNeIBM7qqLlgSJ\u002ByA\u002Bs\u002BYWbaBMSnijkRfz6wD7oyKDXLqyXyrMTOFNKq\u002B1vStaxsubqQuvuXNCKetsWQOpj/biBppljFC7RiDDAyPM7dPslSQ1Y/Ya16dLcDVDY/Pdp5q007qM8Tp63Gbq7LZTcTwXg8PfcC/8yy73Ghgfd\u002BYw4V\u002BFFBoVX6fpuoeTM\u002Brs\u002B/71K\u002BAsAjNuuAiLmdceW2R8tgtayl0mAiAf8bWkaZtEBiIdJkwGAOMoGlgRicXMz18fFnnfkjGh0ym8EAx5xk5xR5O1ATUYerUoMrABEHReUyZWiVcdZHfwf1ciRfDSrlQNnEYyF8oqApvAt2N9nL61YbzqIzj7U98fwIXh9jDEVYBf93AyKDtYLIa7XLEQct6UbOQz5I8bEkxnFlNESAhq/GHjIalKgzWFkfayP/cuC1GrSYlMkHD1QOEnzxXkE\u002BB\u002BUFxTMU0xSemyrlKUZNZZNQsBnP6DGmvs7eDIJrQjnYIWN\u002BuW3toAdgOfneYeXNwOypYK5nbh\u002BzXwYkdsZSM1jwzQgizqwlYw/Sb\u002B43yB0o0EvVgiFLsLMDy1pnyWlAzcag7ZSdqvIAQ/1eVP4xe5bo\u002B2a6vHE3ZVyVHwNR/VnmUWInlxqIS2VZlT4kLRu00k/Dfs3CxlFVaUg4CEuu7oajuAOcCeR8IG/BISdzE3hA4Azzjn6L44sQki3SUELZqqa3gLUYGMirR16eAeUqIhXP92h\u002B\u002B2BH15R4S3e2adAs53ZAu5LDaMdECAcgLeHl5rAXwpkamq8GL6jgn41Q9N1OcRpu6WZCzI5g\u002BrNZZ\u002BmykqTHnmd3EkyHOowp4ol6M1MpkbzHdz0JlPXKueA77Me/bczoSVa2Fx7N567aWSnFJodgL9Zs61tnvclxbJhsi03EqrS8Uao8s3peOY\u002BObzvLxVMYm7zxEkKxgMtNBOqGYRxg1a51SNUdY7xbzvHL2Q6NpacFU\u002B\u002BQ01hyCpDer66P15hzLVmNlry\u002BO3gAVUOQ5af8v19DgM0skAJWAz4EfrQNzDcZmKu1P87qh1i3kH4UoWUpIjAPDFbLBp1XN5N\u002BebyD8klMt0z8B3\u002BQWPm0tT/EQWHZG1yD/v\u002BgTlIOXgh7rE2cM530iCnYLNqwvvNdFpGdkvYxZV5fwDOJrCj67al3FOyr2EFhz7k4AO5B03/MQzfAsMsSQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "pSl\u002BdZx76HprFPL3a\u002B5oEg==",
+        "Date": "Thu, 12 Dec 2019 23:15:26 GMT",
+        "ETag": "\u00220x8D77F592C61C5D5\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:15:26 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c1e64716-1fd4-4256-8afc-791cd9b7cb40",
+        "x-ms-content-crc64": "4sdc/pUEZIs=",
+        "x-ms-request-id": "1b40f14a-f01e-0054-4142-b1e881000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-9de05bc0-4877-a233-31b2-6eb96834f8b1?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A15%3A26Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "traceparent": "00-b671db7398176b41991a180bd78d21fb-54a06c485d493e4a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "5dde764a-27dd-581e-3ce7-0cf6f71b04d9",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 12 Dec 2019 23:15:26 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5dde764a-27dd-581e-3ce7-0cf6f71b04d9",
+        "x-ms-request-id": "1b40f14f-f01e-0054-4642-b1e881000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-9d9c23a5-b4fc-8af9-a263-08c11c48ab49?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A15%3A26Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "traceparent": "00-97d68fc521ede04bb58e338d77f7b92c-5b9ec55340ba564d-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "62d143f8-6ed9-6462-eaf4-159577dc91ed",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 12 Dec 2019 23:15:26 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "62d143f8-6ed9-6462-eaf4-159577dc91ed",
+        "x-ms-request-id": "1b40f158-f01e-0054-4e42-b1e881000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2019-12-12T15:15:26.9145279-08:00",
+    "RandomSeed": "228007509",
+    "Storage_TestConfigDefault": "ProductionTenant\nstoragedotnettesting\nU2FuaXRpemVk\nhttps://storagedotnettesting.blob.core.windows.net\nhttps://storagedotnettesting.file.core.windows.net\nhttps://storagedotnettesting.queue.core.windows.net\nhttps://storagedotnettesting.table.core.windows.net\n\n\n\n\nhttps://storagedotnettesting-secondary.blob.core.windows.net\nhttps://storagedotnettesting-secondary.file.core.windows.net\nhttps://storagedotnettesting-secondary.queue.core.windows.net\nhttps://storagedotnettesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://storagedotnettesting.blob.core.windows.net/;QueueEndpoint=https://storagedotnettesting.queue.core.windows.net/;FileEndpoint=https://storagedotnettesting.file.core.windows.net/;BlobSecondaryEndpoint=https://storagedotnettesting-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://storagedotnettesting-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://storagedotnettesting-secondary.file.core.windows.net/;AccountName=storagedotnettesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Perform_Ctor_ConnectionString_Sas(False)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Perform_Ctor_ConnectionString_Sas(False)Async.json
@@ -1,0 +1,195 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-1145b819-1074-52ef-e0fb-ce80be127e19?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A14%3A13Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "traceparent": "00-b071021204a8854a86837af1f24c5462-eb8e1aa7955be346-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "bbebad5f-65a7-147b-b57d-a230315b528f",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 12 Dec 2019 23:14:13 GMT",
+        "ETag": "\u00220x8D77F59006612BD\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:14:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bbebad5f-65a7-147b-b57d-a230315b528f",
+        "x-ms-request-id": "8a93881d-601e-009d-6741-b1556c000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-1ad76d32-04db-c702-6e43-de940050fbe0?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A14%3A13Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "traceparent": "00-6824b7d1772b1740b439f4ec8650b848-2ffebcbaec5f9242-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "76247271-207d-6fc9-dd97-e3c5276412d7",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 12 Dec 2019 23:14:13 GMT",
+        "ETag": "\u00220x8D77F590068AB6D\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:14:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "76247271-207d-6fc9-dd97-e3c5276412d7",
+        "x-ms-request-id": "8a938824-601e-009d-6d41-b1556c000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-1145b819-1074-52ef-e0fb-ce80be127e19/test-blob-c171ed00-f064-54cf-d7e1-3e1702dd637f?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A14%3A13Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Content-Length": "1024",
+        "traceparent": "00-8b96b6a022f34c46a917dd73ac937c8e-7e05db3e1607a14b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "36e73d42-f51d-f58b-71e4-9fe7442cb556",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "Hb2lkLntAULmxnXNXXSBHYcAsReWQlpyR2TCtN/\u002BV9p\u002BcKdpv4EeLSKMm1\u002BKXWI\u002BSCNDFlEB3NtiM0lVKkxi526aTuzNF10F4oT0Caf75\u002BkBg2y8u0GIfJTMBos4yAPWKrPw7w52cTDFPTPNDdI0Z0tfU6bgpSwsEtJXARDSzRmBHt/zCvjaixI7930Num/CmJ9A2HVc9YSGw9w8HnAg83AaTO/zQFxShMiUpa6vH1hjlWlxkfWkJChabUYbnmyiGgQN822AzldC7lOsx1DW16SE2YkGr2F6dSjGmNIWN\u002BZb8oqpoivr48YRLqOh\u002BF3Xg5Wil8Xjm2uikn5FuTWELLZtUNXGLDR5mfbC9YC\u002B2X3K7hU8dJ8heFceBxCtpSmQjAHsNKeIEVdhKP3PIabq47kBessgSLgXTNh9qCQkzPPMMWh/0qTVQt2920uhUVawMyRWqyteb0RJ1ejPCmgyPFwKAu89axEUKzfuYmxtdfqBzXQAziDHbsEjNv28Bjh0i5/ul09ncscSQoD0cA3Y21/tTTzzMW48QpQuGTUUVyT\u002BedfMft2rGlqt7Yuf0/20S1qdzrj7gFoxslS6OViR/upb9fY1C12BQjPiRkPinG6Wec7bdohrAvl8m8uJ8OEBG\u002B\u002BgRN4Hfj/9G4yFGTkWThbmI7\u002BKtodi7/P8uXCR\u002BFFS4CtUQleQj/qO3lv85ui/Zky1oswhd2VnPlTqCsXPayI6MjgOwgy\u002BVZTE/NgsZggKPVMj3FWEMWnG7QMCpYQ1vnI4wbOwsKNA9k03XHuMOthL4M1yrI/MtgHPSNUIvLAQjz1l86RVWoyv4uUITNTuObIrt8S3whLibAuy4WjONzqdJ809J0cz9oZAwsmqw2ks4A8j3QTrWcwqgoeZongk4aurayUHsBFq98A9dgBJOKiihQBYqlo1sc4AE6TAmVQNHOEe/lhDJS/9uOVEreLM4Ure9x14yzZQdbpXB51sql1sMFoeKzlQXmDRW/J18ATrMzJa4qI2lVGqzYid7B6SkA6H2H2IrbYQjZi9p3BE24W1a9NrEsi7NZoIdF2xsnJBPsrk7RiGY4Z7SlQJee7hZfID6IBLJn5FzKLjfzlYX9sme2ilYO1sLwhN78d0srurJw5qrcrx9hdLniF1o\u002BNMIut54v6GOwUEl7h4/je30RrmN1cr7bEQNYVQWsLM9oskAMzc\u002Bs\u002B9JewJZhYRePjglMwHjmyMITQ6aKx4NeFDOKAtU/1q29ZKKRFrIoeb/ryMcMX1xGcemN\u002BYoZEiRPAKxS515CX6drn1vWVbIP6tnmrw68UcTXM4Droe0jlFJ\u002BQgYFxZJRqXkvoL/wcCw3jg6gMnMlgr7ne6PdVq3KOAsA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "fgZZD5fQLxLWfjOFNoGH3Q==",
+        "Date": "Thu, 12 Dec 2019 23:14:13 GMT",
+        "ETag": "\u00220x8D77F59006BE7A0\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:14:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "36e73d42-f51d-f58b-71e4-9fe7442cb556",
+        "x-ms-content-crc64": "Nr18mEm9VTU=",
+        "x-ms-request-id": "8a93882e-601e-009d-7541-b1556c000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-1ad76d32-04db-c702-6e43-de940050fbe0/test-blob-81ce231a-ff25-bf2a-b3c9-40cb17031972?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A14%3A13Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Content-Length": "1024",
+        "traceparent": "00-5b1bdca621597940aeb8a2f12f41910d-f0275f546913b24b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "9f278b06-4abb-9f92-f544-4ebdb4920b2c",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "Hb2lkLntAULmxnXNXXSBHYcAsReWQlpyR2TCtN/\u002BV9p\u002BcKdpv4EeLSKMm1\u002BKXWI\u002BSCNDFlEB3NtiM0lVKkxi526aTuzNF10F4oT0Caf75\u002BkBg2y8u0GIfJTMBos4yAPWKrPw7w52cTDFPTPNDdI0Z0tfU6bgpSwsEtJXARDSzRmBHt/zCvjaixI7930Num/CmJ9A2HVc9YSGw9w8HnAg83AaTO/zQFxShMiUpa6vH1hjlWlxkfWkJChabUYbnmyiGgQN822AzldC7lOsx1DW16SE2YkGr2F6dSjGmNIWN\u002BZb8oqpoivr48YRLqOh\u002BF3Xg5Wil8Xjm2uikn5FuTWELLZtUNXGLDR5mfbC9YC\u002B2X3K7hU8dJ8heFceBxCtpSmQjAHsNKeIEVdhKP3PIabq47kBessgSLgXTNh9qCQkzPPMMWh/0qTVQt2920uhUVawMyRWqyteb0RJ1ejPCmgyPFwKAu89axEUKzfuYmxtdfqBzXQAziDHbsEjNv28Bjh0i5/ul09ncscSQoD0cA3Y21/tTTzzMW48QpQuGTUUVyT\u002BedfMft2rGlqt7Yuf0/20S1qdzrj7gFoxslS6OViR/upb9fY1C12BQjPiRkPinG6Wec7bdohrAvl8m8uJ8OEBG\u002B\u002BgRN4Hfj/9G4yFGTkWThbmI7\u002BKtodi7/P8uXCR\u002BFFS4CtUQleQj/qO3lv85ui/Zky1oswhd2VnPlTqCsXPayI6MjgOwgy\u002BVZTE/NgsZggKPVMj3FWEMWnG7QMCpYQ1vnI4wbOwsKNA9k03XHuMOthL4M1yrI/MtgHPSNUIvLAQjz1l86RVWoyv4uUITNTuObIrt8S3whLibAuy4WjONzqdJ809J0cz9oZAwsmqw2ks4A8j3QTrWcwqgoeZongk4aurayUHsBFq98A9dgBJOKiihQBYqlo1sc4AE6TAmVQNHOEe/lhDJS/9uOVEreLM4Ure9x14yzZQdbpXB51sql1sMFoeKzlQXmDRW/J18ATrMzJa4qI2lVGqzYid7B6SkA6H2H2IrbYQjZi9p3BE24W1a9NrEsi7NZoIdF2xsnJBPsrk7RiGY4Z7SlQJee7hZfID6IBLJn5FzKLjfzlYX9sme2ilYO1sLwhN78d0srurJw5qrcrx9hdLniF1o\u002BNMIut54v6GOwUEl7h4/je30RrmN1cr7bEQNYVQWsLM9oskAMzc\u002Bs\u002B9JewJZhYRePjglMwHjmyMITQ6aKx4NeFDOKAtU/1q29ZKKRFrIoeb/ryMcMX1xGcemN\u002BYoZEiRPAKxS515CX6drn1vWVbIP6tnmrw68UcTXM4Droe0jlFJ\u002BQgYFxZJRqXkvoL/wcCw3jg6gMnMlgr7ne6PdVq3KOAsA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "fgZZD5fQLxLWfjOFNoGH3Q==",
+        "Date": "Thu, 12 Dec 2019 23:14:13 GMT",
+        "ETag": "\u00220x8D77F59006E804B\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:14:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9f278b06-4abb-9f92-f544-4ebdb4920b2c",
+        "x-ms-content-crc64": "Nr18mEm9VTU=",
+        "x-ms-request-id": "8a938839-601e-009d-8041-b1556c000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-1145b819-1074-52ef-e0fb-ce80be127e19?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A14%3A13Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "traceparent": "00-289a164f99ab824e8cd0dcbe54a798c4-8a42c34a33595349-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "b9e151bb-1604-419a-bcd3-8b456980e2f7",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 12 Dec 2019 23:14:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b9e151bb-1604-419a-bcd3-8b456980e2f7",
+        "x-ms-request-id": "8a938844-601e-009d-0941-b1556c000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-1ad76d32-04db-c702-6e43-de940050fbe0?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A14%3A13Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "traceparent": "00-9a15b49e682cb3489cbc98d932948067-b5e7ace6fa24e54f-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "6302bbaf-51b0-8c28-d943-43262a7b217e",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 12 Dec 2019 23:14:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6302bbaf-51b0-8c28-d943-43262a7b217e",
+        "x-ms-request-id": "8a93884d-601e-009d-1041-b1556c000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2019-12-12T15:14:13.1918092-08:00",
+    "RandomSeed": "1099728937",
+    "Storage_TestConfigDefault": "ProductionTenant\nstoragedotnettesting\nU2FuaXRpemVk\nhttps://storagedotnettesting.blob.core.windows.net\nhttps://storagedotnettesting.file.core.windows.net\nhttps://storagedotnettesting.queue.core.windows.net\nhttps://storagedotnettesting.table.core.windows.net\n\n\n\n\nhttps://storagedotnettesting-secondary.blob.core.windows.net\nhttps://storagedotnettesting-secondary.file.core.windows.net\nhttps://storagedotnettesting-secondary.queue.core.windows.net\nhttps://storagedotnettesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://storagedotnettesting.blob.core.windows.net/;QueueEndpoint=https://storagedotnettesting.queue.core.windows.net/;FileEndpoint=https://storagedotnettesting.file.core.windows.net/;BlobSecondaryEndpoint=https://storagedotnettesting-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://storagedotnettesting-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://storagedotnettesting-secondary.file.core.windows.net/;AccountName=storagedotnettesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Perform_Ctor_ConnectionString_Sas(True).json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Perform_Ctor_ConnectionString_Sas(True).json
@@ -1,0 +1,196 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-3789d9cd-23c4-dfed-20f0-eb6b24f2e405?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A15%3A25Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "traceparent": "00-912ae7eb3ceb8842a4396422666756fd-301b0fc3cbfeab47-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "60891a48-76c7-695a-922e-3b90caad059e",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 12 Dec 2019 23:15:26 GMT",
+        "ETag": "\u00220x8D77F592C12C12F\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:15:26 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "60891a48-76c7-695a-922e-3b90caad059e",
+        "x-ms-request-id": "d8bca490-b01e-0037-6c42-b1757a000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-ec962067-640e-5b47-fc33-583fda8104c9?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A15%3A25Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "traceparent": "00-741438658a03a3458f0c25837a3367f5-e3311555052e234b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "e6531322-86c1-998d-f09c-f5eeca74b78a",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 12 Dec 2019 23:15:26 GMT",
+        "ETag": "\u00220x8D77F592C2318D7\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:15:26 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e6531322-86c1-998d-f09c-f5eeca74b78a",
+        "x-ms-request-id": "d8bca4b7-b01e-0037-0842-b1757a000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-3789d9cd-23c4-dfed-20f0-eb6b24f2e405/test-blob-2f3021eb-af91-ed29-6bd8-ace6b208530a?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A15%3A25Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Content-Length": "1024",
+        "traceparent": "00-be8183bdddfa72458c6087bf0fabd186-d5edc8bff2907f4d-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "d84096b0-0386-5efc-0aa5-c129a542a13d",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "5BjEnrRsSfisXc9crhP6JkAY0g0TY9zcbQvHVfHzjXTsrwqxsBjVbeYZ5Fl2SpgMcG5Z86mhMoA75zCppfMGuM9bb/8ISHYnQmQm\u002Bn\u002BDZiNzu\u002BSDmprKS3yJdcjoLMjzEiyJGtqZAyf4MbBFejgBuIENNeoOgx01kSOCf9OtPxacM\u002BdT\u002BktI2re8imnphdFEiL1H2/bd5I4OVIm3FoRUSvGaqEZRrr01xFsyUfi0TAtRPfcVZmQfv09YRKbCkcMzaEB3TtyL89n/ERabqpKVWgd9ZdiNPuSNe\u002Bn2\u002BGkXcjKY/\u002Bm4PP0vxkodFlRNgxS9wuqeRSvqpilc6tLzlPtw55/kA6uo3R0JTp\u002BObyiPP/fUOTZ/eS0HrVi/XFErOzFPrS61aYBpFOTMlPeMXDYBzKvbHlvE8G5x3FZS6IHL3hJtP8L62dV2ayRRsuQ2e1Ahvo\u002BmTx3Wiry/RIwqFitjALXkHh10BvPVZLI2cz6JO2EFMCryJY/0l7QFOpVJTFX57bEuUV0zrbeb0OtqnxZ9NQgrJeUBcdsm8IZobsxdjBhdPYaNW\u002BkE0oNyVlSjifieiASMHSZw93zWCGHWyj/rPkTSDWGQ8NofJlNhjxqGgmaNyubH0G7x7EYKtlKILQdEhhcQ0XuXDpcqbffTDmhhT4X6SQBYI23V4SEbhTqHlvhLHQgDdrHq9rtPnWJ3Hd7dqGfNjeQG62OpOvBae4hdotf\u002Bh/FgXtnUEFNECYYLXsNCPd3TuggURDGlWTvBj3oz8fqLeJXtfUqN\u002BX2QwuHcntwsFz6riujO6UK/ugSeEoDYERiMf\u002BUtVb\u002BSRcGLg4JQybpelHg8iGcSvI5SLcJF7ub8uLHJTx72/8F\u002BGEQnQ2bAb/FJP34InIiwesNW2ij8TFfajsvRhnmcaJW2vXAj6nkokr7R/K5o9BsoGdVbnySZgsvtTLSa7uh4rdfoUt8YjY9JLUdpK1CocZqvqW2jQMhwHDqkNp7EjqTWWE7Wf6E8EIxGEXHdMFZ6RNoa6kV71W0PeDakc1bwhZ\u002Bjk9IC0fL4c5nhXS9WkuvjKfHDqqNeWoPhxwdrl5w1VYzSOZ2EeHPoIXasmXc\u002BueVKwEplLdv8RDhPIArqjdz8rAeig1lOX7B\u002B2oksssALow0hIdZRzyex1vVkNFdo/pOar\u002B1wmzWM\u002B2GZ5lJRz5F3Q339yGsGq9zf8a1j6ipZFdz1kgPTmwjXlSZ1uOjUXwZj7PDZazUolAQRkKmHKBA2QNB2XDyOpKh1JTNFkfLzC5KnAP05f6qnzP7/wgteT2wVPngXXgLK1EhIZEUB4gIRHYUW4CgT/MAmz48\u002Bj\u002BKdFtXHL1J63KyQ3Cu08Rpkper77qWFRw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "ENpmFB2c3mXfo\u002BFo3rJGjg==",
+        "Date": "Thu, 12 Dec 2019 23:15:26 GMT",
+        "ETag": "\u00220x8D77F592C287F9F\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:15:26 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d84096b0-0386-5efc-0aa5-c129a542a13d",
+        "x-ms-content-crc64": "LUVkQyK9C98=",
+        "x-ms-request-id": "d8bca4be-b01e-0037-0b42-b1757a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-ec962067-640e-5b47-fc33-583fda8104c9/test-blob-901130da-45b6-47a6-1f6b-94990c7caf45?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A15%3A25Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Content-Length": "1024",
+        "traceparent": "00-ef84151dfca1044e92af09dc1430f026-984c43e1b7345e4e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "574b366b-ad64-6ac1-47a4-37113066cd49",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "5BjEnrRsSfisXc9crhP6JkAY0g0TY9zcbQvHVfHzjXTsrwqxsBjVbeYZ5Fl2SpgMcG5Z86mhMoA75zCppfMGuM9bb/8ISHYnQmQm\u002Bn\u002BDZiNzu\u002BSDmprKS3yJdcjoLMjzEiyJGtqZAyf4MbBFejgBuIENNeoOgx01kSOCf9OtPxacM\u002BdT\u002BktI2re8imnphdFEiL1H2/bd5I4OVIm3FoRUSvGaqEZRrr01xFsyUfi0TAtRPfcVZmQfv09YRKbCkcMzaEB3TtyL89n/ERabqpKVWgd9ZdiNPuSNe\u002Bn2\u002BGkXcjKY/\u002Bm4PP0vxkodFlRNgxS9wuqeRSvqpilc6tLzlPtw55/kA6uo3R0JTp\u002BObyiPP/fUOTZ/eS0HrVi/XFErOzFPrS61aYBpFOTMlPeMXDYBzKvbHlvE8G5x3FZS6IHL3hJtP8L62dV2ayRRsuQ2e1Ahvo\u002BmTx3Wiry/RIwqFitjALXkHh10BvPVZLI2cz6JO2EFMCryJY/0l7QFOpVJTFX57bEuUV0zrbeb0OtqnxZ9NQgrJeUBcdsm8IZobsxdjBhdPYaNW\u002BkE0oNyVlSjifieiASMHSZw93zWCGHWyj/rPkTSDWGQ8NofJlNhjxqGgmaNyubH0G7x7EYKtlKILQdEhhcQ0XuXDpcqbffTDmhhT4X6SQBYI23V4SEbhTqHlvhLHQgDdrHq9rtPnWJ3Hd7dqGfNjeQG62OpOvBae4hdotf\u002Bh/FgXtnUEFNECYYLXsNCPd3TuggURDGlWTvBj3oz8fqLeJXtfUqN\u002BX2QwuHcntwsFz6riujO6UK/ugSeEoDYERiMf\u002BUtVb\u002BSRcGLg4JQybpelHg8iGcSvI5SLcJF7ub8uLHJTx72/8F\u002BGEQnQ2bAb/FJP34InIiwesNW2ij8TFfajsvRhnmcaJW2vXAj6nkokr7R/K5o9BsoGdVbnySZgsvtTLSa7uh4rdfoUt8YjY9JLUdpK1CocZqvqW2jQMhwHDqkNp7EjqTWWE7Wf6E8EIxGEXHdMFZ6RNoa6kV71W0PeDakc1bwhZ\u002Bjk9IC0fL4c5nhXS9WkuvjKfHDqqNeWoPhxwdrl5w1VYzSOZ2EeHPoIXasmXc\u002BueVKwEplLdv8RDhPIArqjdz8rAeig1lOX7B\u002B2oksssALow0hIdZRzyex1vVkNFdo/pOar\u002B1wmzWM\u002B2GZ5lJRz5F3Q339yGsGq9zf8a1j6ipZFdz1kgPTmwjXlSZ1uOjUXwZj7PDZazUolAQRkKmHKBA2QNB2XDyOpKh1JTNFkfLzC5KnAP05f6qnzP7/wgteT2wVPngXXgLK1EhIZEUB4gIRHYUW4CgT/MAmz48\u002Bj\u002BKdFtXHL1J63KyQ3Cu08Rpkper77qWFRw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "ENpmFB2c3mXfo\u002BFo3rJGjg==",
+        "Date": "Thu, 12 Dec 2019 23:15:26 GMT",
+        "ETag": "\u00220x8D77F592C3E0899\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:15:26 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "574b366b-ad64-6ac1-47a4-37113066cd49",
+        "x-ms-content-crc64": "LUVkQyK9C98=",
+        "x-ms-request-id": "d8bca4d1-b01e-0037-1c42-b1757a000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-3789d9cd-23c4-dfed-20f0-eb6b24f2e405?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A15%3A25Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "traceparent": "00-165d3890f416e9448373ad290fc0c94d-3f4823987e42f84e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "6ebdccd8-49f7-6ad8-0dfc-3b88d8b1bab6",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Connection": "close",
+        "Content-Length": "0",
+        "Date": "Thu, 12 Dec 2019 23:15:26 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6ebdccd8-49f7-6ad8-0dfc-3b88d8b1bab6",
+        "x-ms-request-id": "d8bca4db-b01e-0037-2342-b1757a000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-ec962067-640e-5b47-fc33-583fda8104c9?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A15%3A25Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "traceparent": "00-0c3591d360858847a94b5c6c21cbcbbf-5a5dd8acd894ca4f-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "63397293-5ea8-5b52-5028-700c7cfdc721",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 12 Dec 2019 23:15:26 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "63397293-5ea8-5b52-5028-700c7cfdc721",
+        "x-ms-request-id": "1b40f0eb-f01e-0054-6b42-b1e881000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2019-12-12T15:15:25.7451195-08:00",
+    "RandomSeed": "1855166071",
+    "Storage_TestConfigDefault": "ProductionTenant\nstoragedotnettesting\nU2FuaXRpemVk\nhttps://storagedotnettesting.blob.core.windows.net\nhttps://storagedotnettesting.file.core.windows.net\nhttps://storagedotnettesting.queue.core.windows.net\nhttps://storagedotnettesting.table.core.windows.net\n\n\n\n\nhttps://storagedotnettesting-secondary.blob.core.windows.net\nhttps://storagedotnettesting-secondary.file.core.windows.net\nhttps://storagedotnettesting-secondary.queue.core.windows.net\nhttps://storagedotnettesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://storagedotnettesting.blob.core.windows.net/;QueueEndpoint=https://storagedotnettesting.queue.core.windows.net/;FileEndpoint=https://storagedotnettesting.file.core.windows.net/;BlobSecondaryEndpoint=https://storagedotnettesting-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://storagedotnettesting-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://storagedotnettesting-secondary.file.core.windows.net/;AccountName=storagedotnettesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Perform_Ctor_ConnectionString_Sas(True)Async.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/Perform_Ctor_ConnectionString_Sas(True)Async.json
@@ -1,0 +1,195 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-ecd397fb-b7fa-939e-d57a-dbe894d4b1ad?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A14%3A13Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "traceparent": "00-52eb37dcdffa1f468eac19b2571101ec-d9486308ea138e4f-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "a05907f9-c951-8e99-58b8-94649a814ded",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 12 Dec 2019 23:14:12 GMT",
+        "ETag": "\u00220x8D77F590056A5A7\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:14:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a05907f9-c951-8e99-58b8-94649a814ded",
+        "x-ms-request-id": "8a9387d3-601e-009d-2641-b1556c000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-ec8534e0-6dcd-1a3e-5795-1c1d46e7f765?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A14%3A13Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "traceparent": "00-68f3fb86b14cb1479bead9aa64ccf0ad-28e318a67cc9584f-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "62938a50-b321-f26e-8b5b-f9ca2d699930",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 12 Dec 2019 23:14:12 GMT",
+        "ETag": "\u00220x8D77F5900593E60\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:14:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "62938a50-b321-f26e-8b5b-f9ca2d699930",
+        "x-ms-request-id": "8a9387ea-601e-009d-3a41-b1556c000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-ecd397fb-b7fa-939e-d57a-dbe894d4b1ad/test-blob-550e7583-07db-fd7b-a786-9b2ff4274327?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A14%3A13Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Content-Length": "1024",
+        "traceparent": "00-46ac78eb74bbd8429db7014bf1c4ac60-a1e2de21caa72043-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "b20401f5-e904-eed7-b2a1-c102e1b41f39",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "IsvfapPgBdhlMbMxXUrjO9EgA\u002BBQnHJBKmcBIwP9PImseqdhii\u002BdlGf/YitbLs4WGnSelP7OLoZZnT8s3\u002BLVZ/UpheOigbCig294UTpG5fuY6giPX6eK3UwhCO3vcLSFKvo2MajrdJjD\u002BxGPVtxLErdDk/TaRQdOn6eWgXnDshK68yc/D7RSrHZvy2SW\u002Bodv1fU1q92/q\u002BTz6JIBVfIf/0j\u002B1WK1CwMD8OZ\u002Banqjt6UgJquEjgc1\u002BkhDTCciUVeDUMsblyQkusnyMbr2QUBpUDDs4C5Hm3FByNsacr/b4Z\u002BO\u002BhquhyCA/GzhkV1MP7gH2fz2NXEpPLRa2s9JCUgKFk8bZ0clu8gQbOPCZQkU9YkiEpjC5awtZb1mVK1QN/Ij1nsNMNdx4R4z5smNZ9eqReVFJvevRzCj7gGJv2YbvzTxno6OBsSxsTB6j//in/7muw7HCxD7dI9KakLV5yK3FyaUnMhIGz8glHXGNbgxwE4DowRYVLQk9Sn/RJyC28oOwnjYTgM1np/Pp3abNT/WGKnz0kMdX8Nyb6aeSNeinriqt3JAWHFLzQVkiKw9icDqKCvyjgmH8WK0Zt5cllXHLAi98H3Mlr83qAU\u002BuNYWNObmtB\u002BrrxCvI8YPi/KT7jawnFujgJhDHpJru\u002BUDSTiMnjL4deI1G334Dc22vArNpLnOjRt6crRNo5WNQPQqq9qOg\u002B2/mnlUeoDeq3LLjGGHnRYrNbscESt\u002Bq9JMqNuIzmHzKDgdDQpAeRObnMdBgRYzBaLe/nYecXLCQe6mB9KlVdwQ2GMpao8L67uogXRkPCm7GKM5qs/r1LbGWswbmnJB9UbqMamyCpoS0hO6dvD9XgXF6u4va6oNJAOtYw/D8FBJZ4sueQp/CA4IJti7MV7FyPzGVq\u002BDEomb3Q2mBaeKTuHCcA9lz\u002BT6ReHgJkXRUfKl55sS/ZmhxVQBkpz92QNmftf2\u002BcBOYPgYzBHOo\u002BtEyYsaAR4Md1FIIaq6Yz1H/Gzeeadt21gxVoai\u002BjCI0yJovcgR49jkWgeFrtcVk/260M\u002Bl7ypE1u4z6KqXaX0gv06IUaZ1NhmU\u002BR\u002Bg5yyAG8OJ6Clh4\u002BP3JObZ3fstTfCKZe6IjUJWRJq1EfULpO/CssznDoFTv9xrkS3AnFkeZqwuFoI9946AMqOPrNLt7ID2FyouRj5vNqYSHfsUlqhBl6pJ3I1shLo9ZtvdxBMJfaSsyYQu7yBtvt/cK9qSbJv6ThQnow/yiZNw8d9jkXKTCJ9XaMwjE6iK3B2tkFjgqvo/43b\u002B4tmUuT/xvf5ACi1tSSM6OwPP1jtsncfxRPk6j0blI678lCbGwq6NMlWpSdLwQEY1pm72cAw6kkQSonRGtw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "SK4qs4VfVGdQbHuWzzk2QQ==",
+        "Date": "Thu, 12 Dec 2019 23:14:12 GMT",
+        "ETag": "\u00220x8D77F59005CA1B8\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:14:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b20401f5-e904-eed7-b2a1-c102e1b41f39",
+        "x-ms-content-crc64": "YXdKi7qUA68=",
+        "x-ms-request-id": "8a9387f6-601e-009d-4441-b1556c000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-ec8534e0-6dcd-1a3e-5795-1c1d46e7f765/test-blob-c7d86d75-0e5d-2c60-60fe-af70b502af7e?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A14%3A13Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Content-Length": "1024",
+        "traceparent": "00-91e35b05bdaa854e8256735cef5ecb21-929df0a1de986546-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "a11cefcf-9370-45b2-e06d-34ddafb21ac0",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "IsvfapPgBdhlMbMxXUrjO9EgA\u002BBQnHJBKmcBIwP9PImseqdhii\u002BdlGf/YitbLs4WGnSelP7OLoZZnT8s3\u002BLVZ/UpheOigbCig294UTpG5fuY6giPX6eK3UwhCO3vcLSFKvo2MajrdJjD\u002BxGPVtxLErdDk/TaRQdOn6eWgXnDshK68yc/D7RSrHZvy2SW\u002Bodv1fU1q92/q\u002BTz6JIBVfIf/0j\u002B1WK1CwMD8OZ\u002Banqjt6UgJquEjgc1\u002BkhDTCciUVeDUMsblyQkusnyMbr2QUBpUDDs4C5Hm3FByNsacr/b4Z\u002BO\u002BhquhyCA/GzhkV1MP7gH2fz2NXEpPLRa2s9JCUgKFk8bZ0clu8gQbOPCZQkU9YkiEpjC5awtZb1mVK1QN/Ij1nsNMNdx4R4z5smNZ9eqReVFJvevRzCj7gGJv2YbvzTxno6OBsSxsTB6j//in/7muw7HCxD7dI9KakLV5yK3FyaUnMhIGz8glHXGNbgxwE4DowRYVLQk9Sn/RJyC28oOwnjYTgM1np/Pp3abNT/WGKnz0kMdX8Nyb6aeSNeinriqt3JAWHFLzQVkiKw9icDqKCvyjgmH8WK0Zt5cllXHLAi98H3Mlr83qAU\u002BuNYWNObmtB\u002BrrxCvI8YPi/KT7jawnFujgJhDHpJru\u002BUDSTiMnjL4deI1G334Dc22vArNpLnOjRt6crRNo5WNQPQqq9qOg\u002B2/mnlUeoDeq3LLjGGHnRYrNbscESt\u002Bq9JMqNuIzmHzKDgdDQpAeRObnMdBgRYzBaLe/nYecXLCQe6mB9KlVdwQ2GMpao8L67uogXRkPCm7GKM5qs/r1LbGWswbmnJB9UbqMamyCpoS0hO6dvD9XgXF6u4va6oNJAOtYw/D8FBJZ4sueQp/CA4IJti7MV7FyPzGVq\u002BDEomb3Q2mBaeKTuHCcA9lz\u002BT6ReHgJkXRUfKl55sS/ZmhxVQBkpz92QNmftf2\u002BcBOYPgYzBHOo\u002BtEyYsaAR4Md1FIIaq6Yz1H/Gzeeadt21gxVoai\u002BjCI0yJovcgR49jkWgeFrtcVk/260M\u002Bl7ypE1u4z6KqXaX0gv06IUaZ1NhmU\u002BR\u002Bg5yyAG8OJ6Clh4\u002BP3JObZ3fstTfCKZe6IjUJWRJq1EfULpO/CssznDoFTv9xrkS3AnFkeZqwuFoI9946AMqOPrNLt7ID2FyouRj5vNqYSHfsUlqhBl6pJ3I1shLo9ZtvdxBMJfaSsyYQu7yBtvt/cK9qSbJv6ThQnow/yiZNw8d9jkXKTCJ9XaMwjE6iK3B2tkFjgqvo/43b\u002B4tmUuT/xvf5ACi1tSSM6OwPP1jtsncfxRPk6j0blI678lCbGwq6NMlWpSdLwQEY1pm72cAw6kkQSonRGtw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "SK4qs4VfVGdQbHuWzzk2QQ==",
+        "Date": "Thu, 12 Dec 2019 23:14:12 GMT",
+        "ETag": "\u00220x8D77F59005F8893\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:14:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a11cefcf-9370-45b2-e06d-34ddafb21ac0",
+        "x-ms-content-crc64": "YXdKi7qUA68=",
+        "x-ms-request-id": "8a938808-601e-009d-5341-b1556c000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-ecd397fb-b7fa-939e-d57a-dbe894d4b1ad?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A14%3A13Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "traceparent": "00-dc94189952fce64dbf0ca8e10ede9e69-839ea39c906b4141-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "f2326c38-7d97-b3c9-c7e1-1080b5931fde",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 12 Dec 2019 23:14:12 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f2326c38-7d97-b3c9-c7e1-1080b5931fde",
+        "x-ms-request-id": "8a93880e-601e-009d-5941-b1556c000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storagedotnettesting.blob.core.windows.net/test-container-ec8534e0-6dcd-1a3e-5795-1c1d46e7f765?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A14%3A13Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "traceparent": "00-53e96d1004d9824688b3b1032c57194e-67a6e6b9fc24fa4c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
+          "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "43a4b220-2880-db28-5246-61ddc0e654fc",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 12 Dec 2019 23:14:13 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "43a4b220-2880-db28-5246-61ddc0e654fc",
+        "x-ms-request-id": "8a938812-601e-009d-5d41-b1556c000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2019-12-12T15:14:13.0827507-08:00",
+    "RandomSeed": "1093056167",
+    "Storage_TestConfigDefault": "ProductionTenant\nstoragedotnettesting\nU2FuaXRpemVk\nhttps://storagedotnettesting.blob.core.windows.net\nhttps://storagedotnettesting.file.core.windows.net\nhttps://storagedotnettesting.queue.core.windows.net\nhttps://storagedotnettesting.table.core.windows.net\n\n\n\n\nhttps://storagedotnettesting-secondary.blob.core.windows.net\nhttps://storagedotnettesting-secondary.file.core.windows.net\nhttps://storagedotnettesting-secondary.queue.core.windows.net\nhttps://storagedotnettesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://storagedotnettesting.blob.core.windows.net/;QueueEndpoint=https://storagedotnettesting.queue.core.windows.net/;FileEndpoint=https://storagedotnettesting.file.core.windows.net/;BlobSecondaryEndpoint=https://storagedotnettesting-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://storagedotnettesting-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://storagedotnettesting-secondary.file.core.windows.net/;AccountName=storagedotnettesting;AccountKey=Sanitized"
+  }
+}

--- a/sdk/storage/Azure.Storage.Common/api/Azure.Storage.Common.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Common/api/Azure.Storage.Common.netstandard2.0.cs
@@ -75,6 +75,7 @@ namespace Azure.Storage.Sas
         Blobs = 1,
         Queues = 2,
         Files = 4,
+        Tables = 8,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct SasIPRange : System.IEquatable<Azure.Storage.Sas.SasIPRange>

--- a/sdk/storage/Azure.Storage.Common/src/Sas/AccountSasServices.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Sas/AccountSasServices.cs
@@ -32,6 +32,12 @@ namespace Azure.Storage.Sas
         Files = 4,
 
         /// <summary>
+        /// Indicates whether Azure Table Storage resources are
+        /// accessible from the shared access signature.
+        /// </summary>
+        Tables = 8,
+
+        /// <summary>
         /// Indicates all services are accessible from the shared
         /// access signature.
         /// </summary>

--- a/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs
@@ -544,6 +544,7 @@ namespace Azure.Storage
                 public const char Blob = 'b';
                 public const char Queue = 'q';
                 public const char File = 'f';
+                public const char Table = 't';
             }
 
             internal static class AccountResources

--- a/sdk/storage/Azure.Storage.Common/src/Shared/SasExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/SasExtensions.cs
@@ -158,12 +158,21 @@ namespace Azure.Storage.Sas
             AccountSasServices svcs = default;
             foreach (var ch in s)
             {
-                svcs |= ch switch
+                switch (ch)
                 {
-                    Constants.Sas.AccountServices.Blob => AccountSasServices.Blobs,
-                    Constants.Sas.AccountServices.Queue => AccountSasServices.Queues,
-                    Constants.Sas.AccountServices.File => AccountSasServices.Files,
-                    _ => throw Errors.InvalidService(ch),
+                    case Constants.Sas.AccountServices.Blob:
+                        svcs |= AccountSasServices.Blobs;
+                        break;
+                    case Constants.Sas.AccountServices.Queue:
+                        svcs |= AccountSasServices.Queues;
+                        break;
+                    case Constants.Sas.AccountServices.File:
+                        svcs |= AccountSasServices.Files;
+                        break;
+                    case Constants.Sas.AccountServices.Table:
+                        break; //no-op; we don't support table but we don't want to fail on default connection string from portal
+                    default:
+                        throw Errors.InvalidService(ch);
                 };
             }
             return svcs;

--- a/sdk/storage/Azure.Storage.Common/src/Shared/SasExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/SasExtensions.cs
@@ -140,6 +140,10 @@ namespace Azure.Storage.Sas
             {
                 sb.Append(Constants.Sas.AccountServices.Queue);
             }
+            if ((services & AccountSasServices.Tables) == AccountSasServices.Tables)
+            {
+                sb.Append(Constants.Sas.AccountServices.Table);
+            }
             return sb.ToString();
         }
 
@@ -158,22 +162,15 @@ namespace Azure.Storage.Sas
             AccountSasServices svcs = default;
             foreach (var ch in s)
             {
-                switch (ch)
+                svcs |= ch switch
                 {
-                    case Constants.Sas.AccountServices.Blob:
-                        svcs |= AccountSasServices.Blobs;
-                        break;
-                    case Constants.Sas.AccountServices.Queue:
-                        svcs |= AccountSasServices.Queues;
-                        break;
-                    case Constants.Sas.AccountServices.File:
-                        svcs |= AccountSasServices.Files;
-                        break;
-                    case Constants.Sas.AccountServices.Table:
-                        break; //no-op; we don't support table but we don't want to fail on default connection string from portal
-                    default:
-                        throw Errors.InvalidService(ch);
+                    Constants.Sas.AccountServices.Blob => AccountSasServices.Blobs,
+                    Constants.Sas.AccountServices.Queue => AccountSasServices.Queues,
+                    Constants.Sas.AccountServices.File => AccountSasServices.Files,
+                    Constants.Sas.AccountServices.Table => AccountSasServices.Tables,
+                    _ => throw Errors.InvalidService(ch),
                 };
+                ;
             }
             return svcs;
         }

--- a/sdk/storage/Azure.Storage.Common/tests/SasExtensionsTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/SasExtensionsTests.cs
@@ -10,13 +10,14 @@ namespace Azure.Storage.Tests
     public class SasExtensionsTests
     {
         [Test]
-        public void TableSasPermission_Does_Not_Throw()
+        public void AccountSasPermission_Round_Trip()
         {
             AccountSasServices services = SasExtensions.ParseAccountServices("bfqt");
             Assert.IsTrue(services.HasFlag(AccountSasServices.Blobs));
             Assert.IsTrue(services.HasFlag(AccountSasServices.Files));
             Assert.IsTrue(services.HasFlag(AccountSasServices.Queues));
-            Assert.AreEqual(services.ToPermissionsString(), "bfq"); // tables is not a supported permission, but we shouldn't throw
+            Assert.IsTrue(services.HasFlag(AccountSasServices.Tables));
+            Assert.AreEqual(services.ToPermissionsString(), "bfqt"); // tables is not a supported permission, but we shouldn't throw
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Common/tests/SasExtensionsTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/SasExtensionsTests.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Storage.Sas;
+using NUnit.Framework;
+
+namespace Azure.Storage.Tests
+{
+    [TestFixture]
+    public class SasExtensionsTests
+    {
+        [Test]
+        public void TableSasPermission_Does_Not_Throw()
+        {
+            AccountSasServices services = SasExtensions.ParseAccountServices("bfqt");
+            Assert.IsTrue(services.HasFlag(AccountSasServices.Blobs));
+            Assert.IsTrue(services.HasFlag(AccountSasServices.Files));
+            Assert.IsTrue(services.HasFlag(AccountSasServices.Queues));
+            Assert.AreEqual(services.ToPermissionsString(), "bfq"); // tables is not a supported permission, but we shouldn't throw
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Common/tests/SasExtensionsTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/SasExtensionsTests.cs
@@ -17,7 +17,7 @@ namespace Azure.Storage.Tests
             Assert.IsTrue(services.HasFlag(AccountSasServices.Files));
             Assert.IsTrue(services.HasFlag(AccountSasServices.Queues));
             Assert.IsTrue(services.HasFlag(AccountSasServices.Tables));
-            Assert.AreEqual(services.ToPermissionsString(), "bfqt"); // tables is not a supported permission, but we shouldn't throw
+            Assert.AreEqual(services.ToPermissionsString(), "bfqt");
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/TenantConfiguration.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/TenantConfiguration.cs
@@ -54,6 +54,7 @@ namespace Azure.Storage.Test
                 storageCredentials: new StorageSharedKeyCredential(AccountName, AccountKey),
                 blobStorageUri: (AsUri(BlobServiceEndpoint), AsUri(BlobServiceSecondaryEndpoint)),
                 fileStorageUri: (AsUri(FileServiceEndpoint), AsUri(FileServiceSecondaryEndpoint)),
+                tableStorageUri: (AsUri(TableServiceEndpoint), AsUri(TableServiceSecondaryEndpoint)),
                 queueStorageUri: (AsUri(QueueServiceEndpoint), AsUri(QueueServiceSecondaryEndpoint)));
             return connection.ToString(exportSecrets: !sanitize);
             Uri AsUri(string text) => !string.IsNullOrWhiteSpace(text) ? new Uri(text) : default;

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/TestExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/TestExtensions.cs
@@ -102,7 +102,7 @@ namespace Azure.Storage
             string endpointSuffix = Constants.ConnectionStrings.DefaultEndpointSuffix,
             bool useHttps = true)
         {
-            var conn = new StorageConnectionString(storageCredentials, default, default, default);
+            var conn = new StorageConnectionString(storageCredentials);
             if (storageCredentials == null)
             {
                 throw Errors.ArgumentNull(nameof(storageCredentials));

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
@@ -34,7 +34,7 @@ namespace Azure.Storage.Files.Shares.Test
             var fileEndpoint = new Uri("http://127.0.0.1/" + accountName);
             var fileSecondaryEndpoint = new Uri("http://127.0.0.1/" + accountName + "-secondary");
 
-            var connectionString = new StorageConnectionString(credentials, (default, default), (default, default), (fileEndpoint, fileSecondaryEndpoint));
+            var connectionString = new StorageConnectionString(credentials, fileStorageUri: (fileEndpoint, fileSecondaryEndpoint));
 
             var shareName = GetNewShareName();
             var filePath = GetNewFileName();

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
@@ -199,9 +199,7 @@ namespace Azure.Storage.Files.Shares.Tests
 
             return new StorageConnectionString(
                     credentials,
-                    (default, default),
-                    (default, default),
-                    fileUri);
+                    fileStorageUri: fileUri);
         }
 
         public static void AssertValidStorageFileInfo(ShareFileInfo storageFileInfo)

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ServiceClientTests.cs
@@ -30,7 +30,7 @@ namespace Azure.Storage.Files.Shares.Test
             var fileEndpoint = new Uri("http://127.0.0.1/" + accountName);
             var fileSecondaryEndpoint = new Uri("http://127.0.0.1/" + accountName + "-secondary");
 
-            var connectionString = new StorageConnectionString(credentials, (default, default), (default, default), (fileEndpoint, fileSecondaryEndpoint));
+            var connectionString = new StorageConnectionString(credentials, (default, default), (default, default), (default, default), (fileEndpoint, fileSecondaryEndpoint));
 
             ShareServiceClient service = InstrumentClient(new ShareServiceClient(connectionString.ToString(true), GetOptions()));
 

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/Ctor_ConnectionString_Sas.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/Ctor_ConnectionString_Sas.json
@@ -1,12 +1,12 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jolovstorage.file.core.windows.net/test-share-2864f41f-e291-c6bd-0ab0-e32ff88290c8?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A47%3A51Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=share",
+      "RequestUri": "https://storagedotnettesting.file.core.windows.net/test-share-2864f41f-e291-c6bd-0ab0-e32ff88290c8?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A30Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=share",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-2812208242a7c743ab1b7cf693ddd974-496cc8b921290c47-00",
+        "traceparent": "00-96e8f28aa2a22249b972b2e16b93702c-ae17013c36ff6a42-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "6f2132a4-b0ee-8eef-f1c8-50870b96d005",
@@ -17,26 +17,26 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 21:47:52 GMT",
-        "ETag": "\u00220x8D77771481BD1C9\u0022",
-        "Last-Modified": "Mon, 02 Dec 2019 21:47:52 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:31 GMT",
+        "ETag": "\u00220x8D77F5952E46496\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:16:31 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "6f2132a4-b0ee-8eef-f1c8-50870b96d005",
-        "x-ms-request-id": "8f1702d3-f01a-0039-045a-a9b10b000000",
+        "x-ms-request-id": "6bdc4842-f01a-008f-3242-b12ebc000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.file.core.windows.net/test-share-2864f41f-e291-c6bd-0ab0-e32ff88290c8/test-directory-3dba99fc-a50c-b5bc-61b4-0069cfa2291f?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A47%3A51Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=directory",
+      "RequestUri": "https://storagedotnettesting.file.core.windows.net/test-share-2864f41f-e291-c6bd-0ab0-e32ff88290c8/test-directory-3dba99fc-a50c-b5bc-61b4-0069cfa2291f?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A30Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-1c6b7f9ef3623a47bf61c0f847e9f35f-44b99914bcf7ac4b-00",
+        "traceparent": "00-177b3609b6f40f498e5724bc24bf4836-21b1125e966f1b4e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "d863bc5c-ddfe-ff1f-766b-0d39af86be4e",
@@ -51,34 +51,34 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 21:47:52 GMT",
-        "ETag": "\u00220x8D77771482C9299\u0022",
-        "Last-Modified": "Mon, 02 Dec 2019 21:47:52 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:31 GMT",
+        "ETag": "\u00220x8D77F5952EDF785\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:16:31 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "d863bc5c-ddfe-ff1f-766b-0d39af86be4e",
         "x-ms-file-attributes": "Directory",
-        "x-ms-file-change-time": "2019-12-02T21:47:52.2104985Z",
-        "x-ms-file-creation-time": "2019-12-02T21:47:52.2104985Z",
+        "x-ms-file-change-time": "2019-12-12T23:16:31.6358533Z",
+        "x-ms-file-creation-time": "2019-12-12T23:16:31.6358533Z",
         "x-ms-file-id": "13835128424026341376",
-        "x-ms-file-last-write-time": "2019-12-02T21:47:52.2104985Z",
+        "x-ms-file-last-write-time": "2019-12-12T23:16:31.6358533Z",
         "x-ms-file-parent-id": "0",
-        "x-ms-file-permission-key": "2514336555444402195*5350155227445161882",
-        "x-ms-request-id": "8f1702d6-f01a-0039-055a-a9b10b000000",
+        "x-ms-file-permission-key": "13364076805927166033*15108902883422697432",
+        "x-ms-request-id": "6bdc4845-f01a-008f-3342-b12ebc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.file.core.windows.net/test-share-b6825d3f-9196-9b02-d809-d727f604b349?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A47%3A51Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=share",
+      "RequestUri": "https://storagedotnettesting.file.core.windows.net/test-share-b6825d3f-9196-9b02-d809-d727f604b349?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A30Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=share",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-bc053ca59364d245b5d0b2a9e1211859-0054c9c44152674a-00",
+        "traceparent": "00-054184cac84c304b9b63f94569709b3d-cbd896d99f507742-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "09a4aa2a-62d9-500b-9aab-99086bfb52fd",
@@ -89,26 +89,26 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 21:47:52 GMT",
-        "ETag": "\u00220x8D777714836FFCC\u0022",
-        "Last-Modified": "Mon, 02 Dec 2019 21:47:52 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:31 GMT",
+        "ETag": "\u00220x8D77F5952F6DFA4\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:16:31 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "09a4aa2a-62d9-500b-9aab-99086bfb52fd",
-        "x-ms-request-id": "8f1702d8-f01a-0039-065a-a9b10b000000",
+        "x-ms-request-id": "6bdc4847-f01a-008f-3442-b12ebc000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.file.core.windows.net/test-share-b6825d3f-9196-9b02-d809-d727f604b349/test-directory-ce471fef-aa7a-4e10-0f88-d291bfa9821b?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A47%3A51Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=directory",
+      "RequestUri": "https://storagedotnettesting.file.core.windows.net/test-share-b6825d3f-9196-9b02-d809-d727f604b349/test-directory-ce471fef-aa7a-4e10-0f88-d291bfa9821b?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A30Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-5cb65bed0db652449c3195af0cf62f79-03202394c8981249-00",
+        "traceparent": "00-44de45048264f94d9da1c0213ae66fba-83b9b39e479c844d-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "16885030-45db-7fca-9955-fa51907a91f1",
@@ -123,34 +123,34 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 21:47:52 GMT",
-        "ETag": "\u00220x8D777714846FD49\u0022",
-        "Last-Modified": "Mon, 02 Dec 2019 21:47:52 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:31 GMT",
+        "ETag": "\u00220x8D77F5952F9A05A\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:16:31 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "16885030-45db-7fca-9955-fa51907a91f1",
         "x-ms-file-attributes": "Directory",
-        "x-ms-file-change-time": "2019-12-02T21:47:52.3836233Z",
-        "x-ms-file-creation-time": "2019-12-02T21:47:52.3836233Z",
+        "x-ms-file-change-time": "2019-12-12T23:16:31.7122650Z",
+        "x-ms-file-creation-time": "2019-12-12T23:16:31.7122650Z",
         "x-ms-file-id": "13835128424026341376",
-        "x-ms-file-last-write-time": "2019-12-02T21:47:52.3836233Z",
+        "x-ms-file-last-write-time": "2019-12-12T23:16:31.7122650Z",
         "x-ms-file-parent-id": "0",
-        "x-ms-file-permission-key": "2514336555444402195*5350155227445161882",
-        "x-ms-request-id": "8f1702dc-f01a-0039-075a-a9b10b000000",
+        "x-ms-file-permission-key": "13364076805927166033*15108902883422697432",
+        "x-ms-request-id": "6bdc4849-f01a-008f-3542-b12ebc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.file.core.windows.net/test-share-2864f41f-e291-c6bd-0ab0-e32ff88290c8/test-directory-3dba99fc-a50c-b5bc-61b4-0069cfa2291f/test-file-5f99309f-0c13-b821-3ef6-7223ac797bee?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A47%3A51Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestUri": "https://storagedotnettesting.file.core.windows.net/test-share-2864f41f-e291-c6bd-0ab0-e32ff88290c8/test-directory-3dba99fc-a50c-b5bc-61b4-0069cfa2291f/test-file-5f99309f-0c13-b821-3ef6-7223ac797bee?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A30Z\u0026sp=rwdlacup\u0026sig=Sanitized",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-796c34dca8829843a72f638fbb9caa86-02db5a20b84b2d41-00",
+        "traceparent": "00-e582d1502f0804448c1f37bc0216339c-7108af8461eeba4c-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "5300d304-e6a8-24eb-15e7-668db512fbea",
@@ -167,34 +167,34 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 21:47:52 GMT",
-        "ETag": "\u00220x8D77771484D66FE\u0022",
-        "Last-Modified": "Mon, 02 Dec 2019 21:47:52 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:31 GMT",
+        "ETag": "\u00220x8D77F5952FDB2C0\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:16:31 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "5300d304-e6a8-24eb-15e7-668db512fbea",
         "x-ms-file-attributes": "Archive",
-        "x-ms-file-change-time": "2019-12-02T21:47:52.4256510Z",
-        "x-ms-file-creation-time": "2019-12-02T21:47:52.4256510Z",
+        "x-ms-file-change-time": "2019-12-12T23:16:31.7389504Z",
+        "x-ms-file-creation-time": "2019-12-12T23:16:31.7389504Z",
         "x-ms-file-id": "11529285414812647424",
-        "x-ms-file-last-write-time": "2019-12-02T21:47:52.4256510Z",
+        "x-ms-file-last-write-time": "2019-12-12T23:16:31.7389504Z",
         "x-ms-file-parent-id": "13835128424026341376",
-        "x-ms-file-permission-key": "16329904453874124564*5350155227445161882",
-        "x-ms-request-id": "8f1702dd-f01a-0039-085a-a9b10b000000",
+        "x-ms-file-permission-key": "8722754904279818070*15108902883422697432",
+        "x-ms-request-id": "6bdc484a-f01a-008f-3642-b12ebc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.file.core.windows.net/test-share-b6825d3f-9196-9b02-d809-d727f604b349/test-directory-ce471fef-aa7a-4e10-0f88-d291bfa9821b/test-file-3e257d28-5001-7e27-0ab7-f9be317c96f6?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A47%3A51Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestUri": "https://storagedotnettesting.file.core.windows.net/test-share-b6825d3f-9196-9b02-d809-d727f604b349/test-directory-ce471fef-aa7a-4e10-0f88-d291bfa9821b/test-file-3e257d28-5001-7e27-0ab7-f9be317c96f6?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A30Z\u0026sp=rwdlacup\u0026sig=Sanitized",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-8ab923cad304a342a2eea153b58d8fa7-39fad10f5441a943-00",
+        "traceparent": "00-5c67fca8310e1040beada2d8d78e14e6-368e4304c145e24f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "f008d432-b301-ad88-f1c6-7edb62507d51",
@@ -211,35 +211,35 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 21:47:52 GMT",
-        "ETag": "\u00220x8D777714852BF2F\u0022",
-        "Last-Modified": "Mon, 02 Dec 2019 21:47:52 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:31 GMT",
+        "ETag": "\u00220x8D77F595301B8A4\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:16:31 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "f008d432-b301-ad88-f1c6-7edb62507d51",
         "x-ms-file-attributes": "Archive",
-        "x-ms-file-change-time": "2019-12-02T21:47:52.4606767Z",
-        "x-ms-file-creation-time": "2019-12-02T21:47:52.4606767Z",
+        "x-ms-file-change-time": "2019-12-12T23:16:31.7653156Z",
+        "x-ms-file-creation-time": "2019-12-12T23:16:31.7653156Z",
         "x-ms-file-id": "11529285414812647424",
-        "x-ms-file-last-write-time": "2019-12-02T21:47:52.4606767Z",
+        "x-ms-file-last-write-time": "2019-12-12T23:16:31.7653156Z",
         "x-ms-file-parent-id": "13835128424026341376",
-        "x-ms-file-permission-key": "16329904453874124564*5350155227445161882",
-        "x-ms-request-id": "8f1702de-f01a-0039-095a-a9b10b000000",
+        "x-ms-file-permission-key": "8722754904279818070*15108902883422697432",
+        "x-ms-request-id": "6bdc484b-f01a-008f-3742-b12ebc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.file.core.windows.net/test-share-2864f41f-e291-c6bd-0ab0-e32ff88290c8/test-directory-3dba99fc-a50c-b5bc-61b4-0069cfa2291f/test-file-5f99309f-0c13-b821-3ef6-7223ac797bee?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A47%3A51Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026comp=range",
+      "RequestUri": "https://storagedotnettesting.file.core.windows.net/test-share-2864f41f-e291-c6bd-0ab0-e32ff88290c8/test-directory-3dba99fc-a50c-b5bc-61b4-0069cfa2291f/test-file-5f99309f-0c13-b821-3ef6-7223ac797bee?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A30Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026comp=range",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Content-Length": "1024",
-        "traceparent": "00-b9cdb5c77bebdc49be931175c1b33c86-80aaed0550f70f41-00",
+        "traceparent": "00-2dae15e0135cb1428d540546640d0936-7d34ee3f29aeae4b-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "e05bcef8-0a0a-6ee9-f909-0596538f600e",
@@ -253,28 +253,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "uiBh1V1gtpB32tgwiw1QzQ==",
-        "Date": "Mon, 02 Dec 2019 21:47:52 GMT",
-        "ETag": "\u00220x8D77771485EA836\u0022",
-        "Last-Modified": "Mon, 02 Dec 2019 21:47:52 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:31 GMT",
+        "ETag": "\u00220x8D77F59530703C8\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:16:31 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "e05bcef8-0a0a-6ee9-f909-0596538f600e",
-        "x-ms-request-id": "8f1702e0-f01a-0039-0a5a-a9b10b000000",
+        "x-ms-request-id": "6bdc484c-f01a-008f-3842-b12ebc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.file.core.windows.net/test-share-b6825d3f-9196-9b02-d809-d727f604b349/test-directory-ce471fef-aa7a-4e10-0f88-d291bfa9821b/test-file-3e257d28-5001-7e27-0ab7-f9be317c96f6?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A47%3A51Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026comp=range",
+      "RequestUri": "https://storagedotnettesting.file.core.windows.net/test-share-b6825d3f-9196-9b02-d809-d727f604b349/test-directory-ce471fef-aa7a-4e10-0f88-d291bfa9821b/test-file-3e257d28-5001-7e27-0ab7-f9be317c96f6?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A30Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026comp=range",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Content-Length": "1024",
-        "traceparent": "00-aae7d747c8c80145b3a0ce920688fcf4-8d2896f466a6a14d-00",
+        "traceparent": "00-139f52c62ac11e4f97eef033621c815a-cc17d5f7e4f48944-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "93e35706-9df4-5747-bfc2-59be67f3e0d9",
@@ -288,27 +288,27 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "uiBh1V1gtpB32tgwiw1QzQ==",
-        "Date": "Mon, 02 Dec 2019 21:47:52 GMT",
-        "ETag": "\u00220x8D7777148636405\u0022",
-        "Last-Modified": "Mon, 02 Dec 2019 21:47:52 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:31 GMT",
+        "ETag": "\u00220x8D77F59530A9467\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:16:31 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "93e35706-9df4-5747-bfc2-59be67f3e0d9",
-        "x-ms-request-id": "8f1702e1-f01a-0039-0b5a-a9b10b000000",
+        "x-ms-request-id": "6bdc484d-f01a-008f-3942-b12ebc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.file.core.windows.net/test-share-2864f41f-e291-c6bd-0ab0-e32ff88290c8?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A47%3A51Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=share",
+      "RequestUri": "https://storagedotnettesting.file.core.windows.net/test-share-2864f41f-e291-c6bd-0ab0-e32ff88290c8?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A30Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=share",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
-        "traceparent": "00-8accd773fe7c624c8bd1810e9af19ae1-79d2e87e6486d54a-00",
+        "traceparent": "00-33e98b1e183b34409bc44e749e042352-fd0b849fb0ca2b4a-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "fb8f84d6-ccac-5019-d2c0-fcfb41115d57",
@@ -320,24 +320,24 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 21:47:52 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:31 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "fb8f84d6-ccac-5019-d2c0-fcfb41115d57",
-        "x-ms-request-id": "8f1702e2-f01a-0039-0c5a-a9b10b000000",
+        "x-ms-request-id": "6bdc484e-f01a-008f-3a42-b12ebc000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.file.core.windows.net/test-share-b6825d3f-9196-9b02-d809-d727f604b349?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A47%3A51Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=share",
+      "RequestUri": "https://storagedotnettesting.file.core.windows.net/test-share-b6825d3f-9196-9b02-d809-d727f604b349?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A30Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=share",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
-        "traceparent": "00-f9fa68975b30124aaf331bc743a585ba-f71694616d734c49-00",
+        "traceparent": "00-0a6086646632714b8681a178b1ea25c2-120ddd5c4a7e1848-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "e3e7ab13-e563-102d-ccff-8d97066c1bee",
@@ -349,21 +349,21 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 21:47:52 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:31 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "e3e7ab13-e563-102d-ccff-8d97066c1bee",
-        "x-ms-request-id": "8f1702e3-f01a-0039-0d5a-a9b10b000000",
+        "x-ms-request-id": "6bdc484f-f01a-008f-3b42-b12ebc000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2019-12-02T13:47:51.5431442-08:00",
+    "DateTimeOffsetNow": "2019-12-12T15:16:30.9153598-08:00",
     "RandomSeed": "1150665275",
-    "Storage_TestConfigDefault": "ProductionTenant\njolovstorage\nU2FuaXRpemVk\nhttps://jolovstorage.blob.core.windows.net\nhttps://jolovstorage.file.core.windows.net\nhttps://jolovstorage.queue.core.windows.net\nhttps://jolovstorage.table.core.windows.net\n\n\n\n\nhttps://jolovstorage-secondary.blob.core.windows.net\nhttps://jolovstorage-secondary.file.core.windows.net\nhttps://jolovstorage-secondary.queue.core.windows.net\nhttps://jolovstorage-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://jolovstorage.blob.core.windows.net/;QueueEndpoint=https://jolovstorage.queue.core.windows.net/;FileEndpoint=https://jolovstorage.file.core.windows.net/;BlobSecondaryEndpoint=https://jolovstorage-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://jolovstorage-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://jolovstorage-secondary.file.core.windows.net/;AccountName=jolovstorage;AccountKey=Sanitized"
+    "Storage_TestConfigDefault": "ProductionTenant\nstoragedotnettesting\nU2FuaXRpemVk\nhttps://storagedotnettesting.blob.core.windows.net\nhttps://storagedotnettesting.file.core.windows.net\nhttps://storagedotnettesting.queue.core.windows.net\nhttps://storagedotnettesting.table.core.windows.net\n\n\n\n\nhttps://storagedotnettesting-secondary.blob.core.windows.net\nhttps://storagedotnettesting-secondary.file.core.windows.net\nhttps://storagedotnettesting-secondary.queue.core.windows.net\nhttps://storagedotnettesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://storagedotnettesting.blob.core.windows.net/;QueueEndpoint=https://storagedotnettesting.queue.core.windows.net/;FileEndpoint=https://storagedotnettesting.file.core.windows.net/;BlobSecondaryEndpoint=https://storagedotnettesting-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://storagedotnettesting-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://storagedotnettesting-secondary.file.core.windows.net/;AccountName=storagedotnettesting;AccountKey=Sanitized"
   }
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/Ctor_ConnectionString_SasAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/Ctor_ConnectionString_SasAsync.json
@@ -1,12 +1,12 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jolovstorage.file.core.windows.net/test-share-45af3231-e881-4260-bb85-b6bfde626ef1?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A47%3A44Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=share",
+      "RequestUri": "https://storagedotnettesting.file.core.windows.net/test-share-45af3231-e881-4260-bb85-b6bfde626ef1?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A32Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=share",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-3e0c688b3d6ca24eb5363c3c76bbc436-44db472eed5adf47-00",
+        "traceparent": "00-be5bfbb19030794e82e9287a1bb7ea4e-f207f0128b4dd24b-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "d71047ee-a281-42f1-0b1a-0b0fbf7b7281",
@@ -17,26 +17,26 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 21:47:44 GMT",
-        "ETag": "\u00220x8D77771443FA345\u0022",
-        "Last-Modified": "Mon, 02 Dec 2019 21:47:45 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:31 GMT",
+        "ETag": "\u00220x8D77F5953265F83\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:16:32 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "d71047ee-a281-42f1-0b1a-0b0fbf7b7281",
-        "x-ms-request-id": "7614b483-301a-006b-185a-a9acf9000000",
+        "x-ms-request-id": "6bdc4850-f01a-008f-3c42-b12ebc000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.file.core.windows.net/test-share-45af3231-e881-4260-bb85-b6bfde626ef1/test-directory-cd05117d-1c1b-4826-3e4a-1ad7bdef3ecf?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A47%3A44Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=directory",
+      "RequestUri": "https://storagedotnettesting.file.core.windows.net/test-share-45af3231-e881-4260-bb85-b6bfde626ef1/test-directory-cd05117d-1c1b-4826-3e4a-1ad7bdef3ecf?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A32Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-c58bb9abbe0a97479a29dc681b91039a-3f982f0f8914d043-00",
+        "traceparent": "00-f5e92503f8de5e41ad7afb60ec65fcdf-39ac5ea948684a44-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "45b9ae67-2564-d185-20c8-9936881a851c",
@@ -51,34 +51,34 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 21:47:44 GMT",
-        "ETag": "\u00220x8D777714450794A\u0022",
-        "Last-Modified": "Mon, 02 Dec 2019 21:47:45 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:31 GMT",
+        "ETag": "\u00220x8D77F595329BCBE\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:16:32 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "45b9ae67-2564-d185-20c8-9936881a851c",
         "x-ms-file-attributes": "Directory",
-        "x-ms-file-change-time": "2019-12-02T21:47:45.7348938Z",
-        "x-ms-file-creation-time": "2019-12-02T21:47:45.7348938Z",
+        "x-ms-file-change-time": "2019-12-12T23:16:32.0275646Z",
+        "x-ms-file-creation-time": "2019-12-12T23:16:32.0275646Z",
         "x-ms-file-id": "13835128424026341376",
-        "x-ms-file-last-write-time": "2019-12-02T21:47:45.7348938Z",
+        "x-ms-file-last-write-time": "2019-12-12T23:16:32.0275646Z",
         "x-ms-file-parent-id": "0",
-        "x-ms-file-permission-key": "2514336555444402195*5350155227445161882",
-        "x-ms-request-id": "7614b486-301a-006b-195a-a9acf9000000",
+        "x-ms-file-permission-key": "13364076805927166033*15108902883422697432",
+        "x-ms-request-id": "6bdc4852-f01a-008f-3d42-b12ebc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.file.core.windows.net/test-share-b58cbe9b-eeb1-9526-3972-29e5d03907a5?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A47%3A44Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=share",
+      "RequestUri": "https://storagedotnettesting.file.core.windows.net/test-share-b58cbe9b-eeb1-9526-3972-29e5d03907a5?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A32Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=share",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-6b65b4f0a582714f8d072276705eb823-2ec9df304f05a949-00",
+        "traceparent": "00-2a9f5ef01d783a46bd059ed62a77dacf-4e778165f5c77c4c-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "0cd4297e-4bdf-7e9c-556c-5777766cfbaa",
@@ -89,26 +89,26 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 21:47:45 GMT",
-        "ETag": "\u00220x8D77771445C7EEA\u0022",
-        "Last-Modified": "Mon, 02 Dec 2019 21:47:45 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:31 GMT",
+        "ETag": "\u00220x8D77F59532C2D46\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:16:32 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "0cd4297e-4bdf-7e9c-556c-5777766cfbaa",
-        "x-ms-request-id": "7614b487-301a-006b-1a5a-a9acf9000000",
+        "x-ms-request-id": "6bdc4853-f01a-008f-3e42-b12ebc000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.file.core.windows.net/test-share-b58cbe9b-eeb1-9526-3972-29e5d03907a5/test-directory-8e6ecbc8-76aa-e2e7-d038-345e81f8b601?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A47%3A44Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=directory",
+      "RequestUri": "https://storagedotnettesting.file.core.windows.net/test-share-b58cbe9b-eeb1-9526-3972-29e5d03907a5/test-directory-8e6ecbc8-76aa-e2e7-d038-345e81f8b601?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A32Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-daa7227ea9bb354eb655e0a8dff19f01-8e5c1faf1f9d734c-00",
+        "traceparent": "00-de3b2ce2676dfc4abb7919da0d2d2773-2ceeb3f533178942-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "cb97bd2a-017e-0859-41f1-3ba6163dfc5c",
@@ -123,34 +123,34 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 21:47:45 GMT",
-        "ETag": "\u00220x8D7777144616C46\u0022",
-        "Last-Modified": "Mon, 02 Dec 2019 21:47:45 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:31 GMT",
+        "ETag": "\u00220x8D77F59532F8A7B\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:16:32 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "cb97bd2a-017e-0859-41f1-3ba6163dfc5c",
         "x-ms-file-attributes": "Directory",
-        "x-ms-file-change-time": "2019-12-02T21:47:45.8459718Z",
-        "x-ms-file-creation-time": "2019-12-02T21:47:45.8459718Z",
+        "x-ms-file-change-time": "2019-12-12T23:16:32.0655995Z",
+        "x-ms-file-creation-time": "2019-12-12T23:16:32.0655995Z",
         "x-ms-file-id": "13835128424026341376",
-        "x-ms-file-last-write-time": "2019-12-02T21:47:45.8459718Z",
+        "x-ms-file-last-write-time": "2019-12-12T23:16:32.0655995Z",
         "x-ms-file-parent-id": "0",
-        "x-ms-file-permission-key": "2514336555444402195*5350155227445161882",
-        "x-ms-request-id": "7614b48a-301a-006b-1b5a-a9acf9000000",
+        "x-ms-file-permission-key": "13364076805927166033*15108902883422697432",
+        "x-ms-request-id": "6bdc4855-f01a-008f-3f42-b12ebc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.file.core.windows.net/test-share-45af3231-e881-4260-bb85-b6bfde626ef1/test-directory-cd05117d-1c1b-4826-3e4a-1ad7bdef3ecf/test-file-37913bdc-e983-4d59-eded-af18d676ffce?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A47%3A44Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestUri": "https://storagedotnettesting.file.core.windows.net/test-share-45af3231-e881-4260-bb85-b6bfde626ef1/test-directory-cd05117d-1c1b-4826-3e4a-1ad7bdef3ecf/test-file-37913bdc-e983-4d59-eded-af18d676ffce?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A32Z\u0026sp=rwdlacup\u0026sig=Sanitized",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-f023cb102807c5489db9dc74f32b35bb-78fa8841b754964a-00",
+        "traceparent": "00-576f6936fb45c9498e5addb1b354d176-d0e6f5f807083848-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "aa212ae2-6c74-1fbb-57b2-7a197b175ec7",
@@ -167,34 +167,34 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 21:47:45 GMT",
-        "ETag": "\u00220x8D77771446A206E\u0022",
-        "Last-Modified": "Mon, 02 Dec 2019 21:47:45 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:32 GMT",
+        "ETag": "\u00220x8D77F59533334E3\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:16:32 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "aa212ae2-6c74-1fbb-57b2-7a197b175ec7",
         "x-ms-file-attributes": "Archive",
-        "x-ms-file-change-time": "2019-12-02T21:47:45.9030126Z",
-        "x-ms-file-creation-time": "2019-12-02T21:47:45.9030126Z",
+        "x-ms-file-change-time": "2019-12-12T23:16:32.0896227Z",
+        "x-ms-file-creation-time": "2019-12-12T23:16:32.0896227Z",
         "x-ms-file-id": "11529285414812647424",
-        "x-ms-file-last-write-time": "2019-12-02T21:47:45.9030126Z",
+        "x-ms-file-last-write-time": "2019-12-12T23:16:32.0896227Z",
         "x-ms-file-parent-id": "13835128424026341376",
-        "x-ms-file-permission-key": "16329904453874124564*5350155227445161882",
-        "x-ms-request-id": "7614b48b-301a-006b-1c5a-a9acf9000000",
+        "x-ms-file-permission-key": "8722754904279818070*15108902883422697432",
+        "x-ms-request-id": "6bdc4856-f01a-008f-4042-b12ebc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.file.core.windows.net/test-share-b58cbe9b-eeb1-9526-3972-29e5d03907a5/test-directory-8e6ecbc8-76aa-e2e7-d038-345e81f8b601/test-file-cb1955b5-4ed2-d507-dcf1-30b8bc1f41dd?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A47%3A44Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestUri": "https://storagedotnettesting.file.core.windows.net/test-share-b58cbe9b-eeb1-9526-3972-29e5d03907a5/test-directory-8e6ecbc8-76aa-e2e7-d038-345e81f8b601/test-file-cb1955b5-4ed2-d507-dcf1-30b8bc1f41dd?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A32Z\u0026sp=rwdlacup\u0026sig=Sanitized",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-315edceb1d8bcd45a1fdce7d7c3fdd4e-f132b08abab9bf49-00",
+        "traceparent": "00-16e714caf7215c4caeb383b04af604e0-ea1bdaac910cb545-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "025e56e1-c294-3c9e-12a3-9b0effbc5935",
@@ -211,35 +211,35 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 21:47:45 GMT",
-        "ETag": "\u00220x8D777714470D86C\u0022",
-        "Last-Modified": "Mon, 02 Dec 2019 21:47:45 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:32 GMT",
+        "ETag": "\u00220x8D77F59533642DC\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:16:32 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "025e56e1-c294-3c9e-12a3-9b0effbc5935",
         "x-ms-file-attributes": "Archive",
-        "x-ms-file-change-time": "2019-12-02T21:47:45.9470444Z",
-        "x-ms-file-creation-time": "2019-12-02T21:47:45.9470444Z",
+        "x-ms-file-change-time": "2019-12-12T23:16:32.1096412Z",
+        "x-ms-file-creation-time": "2019-12-12T23:16:32.1096412Z",
         "x-ms-file-id": "11529285414812647424",
-        "x-ms-file-last-write-time": "2019-12-02T21:47:45.9470444Z",
+        "x-ms-file-last-write-time": "2019-12-12T23:16:32.1096412Z",
         "x-ms-file-parent-id": "13835128424026341376",
-        "x-ms-file-permission-key": "16329904453874124564*5350155227445161882",
-        "x-ms-request-id": "7614b48c-301a-006b-1d5a-a9acf9000000",
+        "x-ms-file-permission-key": "8722754904279818070*15108902883422697432",
+        "x-ms-request-id": "6bdc4857-f01a-008f-4142-b12ebc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.file.core.windows.net/test-share-45af3231-e881-4260-bb85-b6bfde626ef1/test-directory-cd05117d-1c1b-4826-3e4a-1ad7bdef3ecf/test-file-37913bdc-e983-4d59-eded-af18d676ffce?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A47%3A44Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026comp=range",
+      "RequestUri": "https://storagedotnettesting.file.core.windows.net/test-share-45af3231-e881-4260-bb85-b6bfde626ef1/test-directory-cd05117d-1c1b-4826-3e4a-1ad7bdef3ecf/test-file-37913bdc-e983-4d59-eded-af18d676ffce?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A32Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026comp=range",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Content-Length": "1024",
-        "traceparent": "00-6689ef6e01b34d48aba994f3e74abc6c-094380b27180bd45-00",
+        "traceparent": "00-a46a36e785260542a2183b0ece5eaa94-bfda85384882984f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "25381ef8-5bb8-dd33-154f-58d8038eb0b5",
@@ -253,28 +253,28 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "kwndMBGN63kS7Dkngogpqg==",
-        "Date": "Mon, 02 Dec 2019 21:47:45 GMT",
-        "ETag": "\u00220x8D777714479657B\u0022",
-        "Last-Modified": "Mon, 02 Dec 2019 21:47:46 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:32 GMT",
+        "ETag": "\u00220x8D77F59533977F6\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:16:32 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "25381ef8-5bb8-dd33-154f-58d8038eb0b5",
-        "x-ms-request-id": "7614b48d-301a-006b-1e5a-a9acf9000000",
+        "x-ms-request-id": "6bdc4858-f01a-008f-4242-b12ebc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.file.core.windows.net/test-share-b58cbe9b-eeb1-9526-3972-29e5d03907a5/test-directory-8e6ecbc8-76aa-e2e7-d038-345e81f8b601/test-file-cb1955b5-4ed2-d507-dcf1-30b8bc1f41dd?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A47%3A44Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026comp=range",
+      "RequestUri": "https://storagedotnettesting.file.core.windows.net/test-share-b58cbe9b-eeb1-9526-3972-29e5d03907a5/test-directory-8e6ecbc8-76aa-e2e7-d038-345e81f8b601/test-file-cb1955b5-4ed2-d507-dcf1-30b8bc1f41dd?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A32Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026comp=range",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Content-Length": "1024",
-        "traceparent": "00-afc9d22ca6f28b41ac1e822a0a2efc8e-08e178f34dfe824a-00",
+        "traceparent": "00-6f3906489222e148885f9f9bd5846c0e-dfaf5d631fb9e446-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "e1164094-3384-387d-90d5-7bb77c1740fe",
@@ -288,27 +288,27 @@
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "kwndMBGN63kS7Dkngogpqg==",
-        "Date": "Mon, 02 Dec 2019 21:47:45 GMT",
-        "ETag": "\u00220x8D77771447E2142\u0022",
-        "Last-Modified": "Mon, 02 Dec 2019 21:47:46 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:32 GMT",
+        "ETag": "\u00220x8D77F59533BC275\u0022",
+        "Last-Modified": "Thu, 12 Dec 2019 23:16:32 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "e1164094-3384-387d-90d5-7bb77c1740fe",
-        "x-ms-request-id": "7614b48e-301a-006b-1f5a-a9acf9000000",
+        "x-ms-request-id": "6bdc4859-f01a-008f-4342-b12ebc000000",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.file.core.windows.net/test-share-45af3231-e881-4260-bb85-b6bfde626ef1?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A47%3A44Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=share",
+      "RequestUri": "https://storagedotnettesting.file.core.windows.net/test-share-45af3231-e881-4260-bb85-b6bfde626ef1?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A32Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=share",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
-        "traceparent": "00-d37c19142b88b640b0313967255fa977-0e0d6c6fcd37f54b-00",
+        "traceparent": "00-3ebc92ec8ecdcd48876aad54e18707b0-6506bca5493bc44e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "c2447782-ce77-f431-49bb-bc73ad9f904e",
@@ -320,24 +320,24 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 21:47:45 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:32 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "c2447782-ce77-f431-49bb-bc73ad9f904e",
-        "x-ms-request-id": "7614b48f-301a-006b-205a-a9acf9000000",
+        "x-ms-request-id": "6bdc485a-f01a-008f-4442-b12ebc000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.file.core.windows.net/test-share-b58cbe9b-eeb1-9526-3972-29e5d03907a5?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T22%3A47%3A44Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=share",
+      "RequestUri": "https://storagedotnettesting.file.core.windows.net/test-share-b58cbe9b-eeb1-9526-3972-29e5d03907a5?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A32Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026restype=share",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
-        "traceparent": "00-ab867921cc172a46bd1ab528490f20aa-f091105c994fb64a-00",
+        "traceparent": "00-c807752ef1c86b4b9383ef1c9a4083f0-9f855a9f25613640-00",
         "User-Agent": [
-          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Files.Shares/12.0.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "04341182-7ed3-f287-50d6-5f82059d2228",
@@ -349,21 +349,21 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 21:47:45 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:32 GMT",
         "Server": [
           "Windows-Azure-File/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-client-request-id": "04341182-7ed3-f287-50d6-5f82059d2228",
-        "x-ms-request-id": "7614b490-301a-006b-215a-a9acf9000000",
+        "x-ms-request-id": "6bdc485b-f01a-008f-4542-b12ebc000000",
         "x-ms-version": "2019-02-02"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2019-12-02T13:47:44.9116640-08:00",
+    "DateTimeOffsetNow": "2019-12-12T15:16:32.0176905-08:00",
     "RandomSeed": "1031896606",
-    "Storage_TestConfigDefault": "ProductionTenant\njolovstorage\nU2FuaXRpemVk\nhttps://jolovstorage.blob.core.windows.net\nhttps://jolovstorage.file.core.windows.net\nhttps://jolovstorage.queue.core.windows.net\nhttps://jolovstorage.table.core.windows.net\n\n\n\n\nhttps://jolovstorage-secondary.blob.core.windows.net\nhttps://jolovstorage-secondary.file.core.windows.net\nhttps://jolovstorage-secondary.queue.core.windows.net\nhttps://jolovstorage-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://jolovstorage.blob.core.windows.net/;QueueEndpoint=https://jolovstorage.queue.core.windows.net/;FileEndpoint=https://jolovstorage.file.core.windows.net/;BlobSecondaryEndpoint=https://jolovstorage-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://jolovstorage-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://jolovstorage-secondary.file.core.windows.net/;AccountName=jolovstorage;AccountKey=Sanitized"
+    "Storage_TestConfigDefault": "ProductionTenant\nstoragedotnettesting\nU2FuaXRpemVk\nhttps://storagedotnettesting.blob.core.windows.net\nhttps://storagedotnettesting.file.core.windows.net\nhttps://storagedotnettesting.queue.core.windows.net\nhttps://storagedotnettesting.table.core.windows.net\n\n\n\n\nhttps://storagedotnettesting-secondary.blob.core.windows.net\nhttps://storagedotnettesting-secondary.file.core.windows.net\nhttps://storagedotnettesting-secondary.queue.core.windows.net\nhttps://storagedotnettesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://storagedotnettesting.blob.core.windows.net/;QueueEndpoint=https://storagedotnettesting.queue.core.windows.net/;FileEndpoint=https://storagedotnettesting.file.core.windows.net/;BlobSecondaryEndpoint=https://storagedotnettesting-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://storagedotnettesting-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://storagedotnettesting-secondary.file.core.windows.net/;AccountName=storagedotnettesting;AccountKey=Sanitized"
   }
 }

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueTestBase.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueTestBase.cs
@@ -192,9 +192,7 @@ namespace Azure.Storage.Queues.Tests
 
             return new StorageConnectionString(
                     credentials,
-                    (default, default),
-                    queueUri,
-                    (default, default));
+                    queueStorageUri: queueUri);
         }
 
         public class DisposingQueue : IAsyncDisposable

--- a/sdk/storage/Azure.Storage.Queues/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/ServiceClientTests.cs
@@ -32,7 +32,7 @@ namespace Azure.Storage.Queues.Test
             var queueEndpoint = new Uri("http://127.0.0.1/" + accountName);
             var queueSecondaryEndpoint = new Uri("http://127.0.0.1/" + accountName + "-secondary");
 
-            var connectionString = new StorageConnectionString(credentials, (default, default), (queueEndpoint, queueSecondaryEndpoint), (default, default));
+            var connectionString = new StorageConnectionString(credentials, queueStorageUri: (queueEndpoint, queueSecondaryEndpoint));
 
             QueueServiceClient client1 = InstrumentClient(new QueueServiceClient(connectionString.ToString(true), GetOptions()));
 

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueClientTests/Ctor_ConnectionString_Sas.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueClientTests/Ctor_ConnectionString_Sas.json
@@ -1,12 +1,12 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jolovstorage.queue.core.windows.net/test-queue-359b5ba3-2225-b7a4-35ff-4335674a13b0?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T21%3A35%3A47Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestUri": "https://storagedotnettesting.queue.core.windows.net/test-queue-359b5ba3-2225-b7a4-35ff-4335674a13b0?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A46Z\u0026sp=rwdlacup\u0026sig=Sanitized",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-67b070301c4b784d8d5b2e543ac7b45e-b1a31a04aca9d04c-00",
+        "traceparent": "00-6ffa70884eabe142a3c1d2879ed2ea3f-2e038fddaddb4446-00",
         "User-Agent": [
-          "azsdk-net-Storage.Queues/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Queues/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "e1b87e30-c273-e55f-85b3-34d26cb81fe5",
@@ -17,23 +17,23 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 20:35:46 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:46 GMT",
         "Server": [
           "Windows-Azure-Queue/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-request-id": "47baff0a-e003-000f-2150-a91c59000000",
+        "x-ms-request-id": "3269c36e-5003-004d-2342-b1683a000000",
         "x-ms-version": "2018-11-09"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.queue.core.windows.net/test-queue-f8a29d0b-bd4c-e7d5-0052-b6ec974f747b?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T21%3A35%3A47Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestUri": "https://storagedotnettesting.queue.core.windows.net/test-queue-f8a29d0b-bd4c-e7d5-0052-b6ec974f747b?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A46Z\u0026sp=rwdlacup\u0026sig=Sanitized",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-983710061bb9124fa86a32804c805701-b28fa95f2031c844-00",
+        "traceparent": "00-9ec7a7db3e8bee4b8d3b1b45b24690f8-88168da6c2ea954b-00",
         "User-Agent": [
-          "azsdk-net-Storage.Queues/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Queues/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "18bc054f-9296-2008-0767-dcdbbf5d788a",
@@ -44,23 +44,23 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 20:35:47 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:46 GMT",
         "Server": [
           "Windows-Azure-Queue/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-request-id": "47baff15-e003-000f-2a50-a91c59000000",
+        "x-ms-request-id": "3269c3ba-5003-004d-6942-b1683a000000",
         "x-ms-version": "2018-11-09"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.queue.core.windows.net/test-queue-359b5ba3-2225-b7a4-35ff-4335674a13b0?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T21%3A35%3A47Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestUri": "https://storagedotnettesting.queue.core.windows.net/test-queue-359b5ba3-2225-b7a4-35ff-4335674a13b0?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A46Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026comp=metadata",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-64e8df916f89d5439f6a98414fab2370-7dda8c49aa8f0440-00",
+        "traceparent": "00-8c14bf1109c6b14885ff18630ff19ecf-47998ce38382514e-00",
         "User-Agent": [
-          "azsdk-net-Storage.Queues/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Queues/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "6e8079b6-b347-508a-371d-e1617cab88e0",
@@ -72,24 +72,24 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 20:35:47 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:46 GMT",
         "Server": [
           "Windows-Azure-Queue/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-approximate-messages-count": "0",
-        "x-ms-request-id": "47baff1a-e003-000f-2e50-a91c59000000",
+        "x-ms-request-id": "3269c3ca-5003-004d-7642-b1683a000000",
         "x-ms-version": "2018-11-09"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.queue.core.windows.net/test-queue-f8a29d0b-bd4c-e7d5-0052-b6ec974f747b?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T21%3A35%3A47Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestUri": "https://storagedotnettesting.queue.core.windows.net/test-queue-f8a29d0b-bd4c-e7d5-0052-b6ec974f747b?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A46Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026comp=metadata",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-d13ccbe8b2aeca4d8d14256f75b99dad-eade9480ac157c46-00",
+        "traceparent": "00-fe9acebc52a8ef429c02bab6fd8be684-7c2844604565c840-00",
         "User-Agent": [
-          "azsdk-net-Storage.Queues/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Queues/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "91df1e4b-0faf-f432-9e9e-309931ec052f",
@@ -101,24 +101,24 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 20:35:47 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:46 GMT",
         "Server": [
           "Windows-Azure-Queue/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-approximate-messages-count": "0",
-        "x-ms-request-id": "47baff1b-e003-000f-2f50-a91c59000000",
+        "x-ms-request-id": "3269c3d4-5003-004d-8042-b1683a000000",
         "x-ms-version": "2018-11-09"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.queue.core.windows.net/test-queue-359b5ba3-2225-b7a4-35ff-4335674a13b0?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T21%3A35%3A47Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestUri": "https://storagedotnettesting.queue.core.windows.net/test-queue-359b5ba3-2225-b7a4-35ff-4335674a13b0?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A46Z\u0026sp=rwdlacup\u0026sig=Sanitized",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
-        "traceparent": "00-f49135150fee72409bb583a6eb82dfa7-da99e95c404f9e43-00",
+        "traceparent": "00-04c19c11f9b1174f82c7f854ccae2601-1c98fd61414c4f46-00",
         "User-Agent": [
-          "azsdk-net-Storage.Queues/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Queues/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "5e1597a4-f6cb-6d31-4ec6-8a50d21ca79a",
@@ -129,23 +129,23 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 20:35:47 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:46 GMT",
         "Server": [
           "Windows-Azure-Queue/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-request-id": "47baff24-e003-000f-3850-a91c59000000",
+        "x-ms-request-id": "3269c3e9-5003-004d-1442-b1683a000000",
         "x-ms-version": "2018-11-09"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.queue.core.windows.net/test-queue-f8a29d0b-bd4c-e7d5-0052-b6ec974f747b?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T21%3A35%3A47Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestUri": "https://storagedotnettesting.queue.core.windows.net/test-queue-f8a29d0b-bd4c-e7d5-0052-b6ec974f747b?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A46Z\u0026sp=rwdlacup\u0026sig=Sanitized",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
-        "traceparent": "00-98d4a00dcb6fc542aaf48e3183718556-c31c95760b8f9a4f-00",
+        "traceparent": "00-e8cc0e11f84c0b41bf1c3a8b7c08e16a-1ed2ef21c50ea440-00",
         "User-Agent": [
-          "azsdk-net-Storage.Queues/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Queues/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "9af423f2-a6d6-ef63-8536-287cebcbe1a6",
@@ -156,20 +156,20 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 20:35:47 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:46 GMT",
         "Server": [
           "Windows-Azure-Queue/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-request-id": "47baff27-e003-000f-3b50-a91c59000000",
+        "x-ms-request-id": "3269c3fc-5003-004d-2142-b1683a000000",
         "x-ms-version": "2018-11-09"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2019-12-02T12:35:47.1837593-08:00",
+    "DateTimeOffsetNow": "2019-12-12T15:16:46.4819531-08:00",
     "RandomSeed": "342794282",
-    "Storage_TestConfigDefault": "ProductionTenant\njolovstorage\nU2FuaXRpemVk\nhttps://jolovstorage.blob.core.windows.net\nhttps://jolovstorage.file.core.windows.net\nhttps://jolovstorage.queue.core.windows.net\nhttps://jolovstorage.table.core.windows.net\n\n\n\n\nhttps://jolovstorage-secondary.blob.core.windows.net\nhttps://jolovstorage-secondary.file.core.windows.net\nhttps://jolovstorage-secondary.queue.core.windows.net\nhttps://jolovstorage-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://jolovstorage.blob.core.windows.net/;QueueEndpoint=https://jolovstorage.queue.core.windows.net/;FileEndpoint=https://jolovstorage.file.core.windows.net/;BlobSecondaryEndpoint=https://jolovstorage-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://jolovstorage-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://jolovstorage-secondary.file.core.windows.net/;AccountName=jolovstorage;AccountKey=Sanitized"
+    "Storage_TestConfigDefault": "ProductionTenant\nstoragedotnettesting\nU2FuaXRpemVk\nhttps://storagedotnettesting.blob.core.windows.net\nhttps://storagedotnettesting.file.core.windows.net\nhttps://storagedotnettesting.queue.core.windows.net\nhttps://storagedotnettesting.table.core.windows.net\n\n\n\n\nhttps://storagedotnettesting-secondary.blob.core.windows.net\nhttps://storagedotnettesting-secondary.file.core.windows.net\nhttps://storagedotnettesting-secondary.queue.core.windows.net\nhttps://storagedotnettesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://storagedotnettesting.blob.core.windows.net/;QueueEndpoint=https://storagedotnettesting.queue.core.windows.net/;FileEndpoint=https://storagedotnettesting.file.core.windows.net/;BlobSecondaryEndpoint=https://storagedotnettesting-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://storagedotnettesting-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://storagedotnettesting-secondary.file.core.windows.net/;AccountName=storagedotnettesting;AccountKey=Sanitized"
   }
 }

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueClientTests/Ctor_ConnectionString_SasAsync.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueClientTests/Ctor_ConnectionString_SasAsync.json
@@ -1,12 +1,12 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://jolovstorage.queue.core.windows.net/test-queue-65b452dc-a36a-309c-41c8-6c7145e07d31?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T21%3A37%3A32Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestUri": "https://storagedotnettesting.queue.core.windows.net/test-queue-65b452dc-a36a-309c-41c8-6c7145e07d31?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A47Z\u0026sp=rwdlacup\u0026sig=Sanitized",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-0a782ca582449544b51bd92488a0e28c-a380734588033348-00",
+        "traceparent": "00-1797113d132dff4cb0986e6ffc3a8182-22ed11a1499da940-00",
         "User-Agent": [
-          "azsdk-net-Storage.Queues/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Queues/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "f0c6d923-6b3e-a1e9-9737-1b2c2623cba0",
@@ -17,23 +17,23 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 20:37:33 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:46 GMT",
         "Server": [
           "Windows-Azure-Queue/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-request-id": "7487a147-3003-0024-5b50-a968e1000000",
+        "x-ms-request-id": "3269c45e-5003-004d-7a42-b1683a000000",
         "x-ms-version": "2018-11-09"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.queue.core.windows.net/test-queue-2f3b1b78-3b0d-7dba-493d-7d7964a0b151?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T21%3A37%3A32Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestUri": "https://storagedotnettesting.queue.core.windows.net/test-queue-2f3b1b78-3b0d-7dba-493d-7d7964a0b151?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A47Z\u0026sp=rwdlacup\u0026sig=Sanitized",
       "RequestMethod": "PUT",
       "RequestHeaders": {
-        "traceparent": "00-66c60eb8b77ee8428c99ccc169af2403-6adee1a360c30b44-00",
+        "traceparent": "00-1657968fa7893c468f4eb2e14dbf134c-49132484b4c7494d-00",
         "User-Agent": [
-          "azsdk-net-Storage.Queues/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Queues/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "8b56c8f4-c1da-d612-eac7-1d12ba99f038",
@@ -44,23 +44,23 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 20:37:33 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:46 GMT",
         "Server": [
           "Windows-Azure-Queue/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-request-id": "7487a14e-3003-0024-6050-a968e1000000",
+        "x-ms-request-id": "3269c473-5003-004d-0d42-b1683a000000",
         "x-ms-version": "2018-11-09"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.queue.core.windows.net/test-queue-65b452dc-a36a-309c-41c8-6c7145e07d31?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T21%3A37%3A32Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestUri": "https://storagedotnettesting.queue.core.windows.net/test-queue-65b452dc-a36a-309c-41c8-6c7145e07d31?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A47Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026comp=metadata",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-ad14dd721478a7469867f32feed0d3ec-79ec187d191a1247-00",
+        "traceparent": "00-d933c54d4d7bcf489ee992444235bcb1-2ec3dfdd449db84f-00",
         "User-Agent": [
-          "azsdk-net-Storage.Queues/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Queues/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "d63bd8ae-b1fc-c7cd-4518-479a9fefe35d",
@@ -72,24 +72,24 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 20:37:33 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:46 GMT",
         "Server": [
           "Windows-Azure-Queue/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-approximate-messages-count": "0",
-        "x-ms-request-id": "7487a153-3003-0024-6350-a968e1000000",
+        "x-ms-request-id": "3269c489-5003-004d-2142-b1683a000000",
         "x-ms-version": "2018-11-09"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.queue.core.windows.net/test-queue-2f3b1b78-3b0d-7dba-493d-7d7964a0b151?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T21%3A37%3A32Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026comp=metadata",
+      "RequestUri": "https://storagedotnettesting.queue.core.windows.net/test-queue-2f3b1b78-3b0d-7dba-493d-7d7964a0b151?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A47Z\u0026sp=rwdlacup\u0026sig=Sanitized\u0026comp=metadata",
       "RequestMethod": "GET",
       "RequestHeaders": {
-        "traceparent": "00-23b4505ad1605a44b7d1a82d94c4ff51-a1fcaf8686e24d4e-00",
+        "traceparent": "00-9f667b20228f244b81a504fb2226ad30-59708baa00c2dd46-00",
         "User-Agent": [
-          "azsdk-net-Storage.Queues/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Queues/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "91936ecd-0b4b-164e-b1ab-b6e40fc0c649",
@@ -101,24 +101,24 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 20:37:33 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:46 GMT",
         "Server": [
           "Windows-Azure-Queue/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-approximate-messages-count": "0",
-        "x-ms-request-id": "7487a154-3003-0024-6450-a968e1000000",
+        "x-ms-request-id": "3269c499-5003-004d-3042-b1683a000000",
         "x-ms-version": "2018-11-09"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.queue.core.windows.net/test-queue-65b452dc-a36a-309c-41c8-6c7145e07d31?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T21%3A37%3A32Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestUri": "https://storagedotnettesting.queue.core.windows.net/test-queue-65b452dc-a36a-309c-41c8-6c7145e07d31?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A47Z\u0026sp=rwdlacup\u0026sig=Sanitized",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
-        "traceparent": "00-7b5ff68b0403df4b81ffe69cf59cdc35-2000d6a33a191947-00",
+        "traceparent": "00-348d8040f3c7b04e844d1d2e6a976d62-02b33b346913164d-00",
         "User-Agent": [
-          "azsdk-net-Storage.Queues/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Queues/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "31cd71af-515b-bb12-1947-3b8934e807c8",
@@ -129,23 +129,23 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 20:37:33 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:46 GMT",
         "Server": [
           "Windows-Azure-Queue/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-request-id": "7487a158-3003-0024-6850-a968e1000000",
+        "x-ms-request-id": "3269c4a4-5003-004d-3b42-b1683a000000",
         "x-ms-version": "2018-11-09"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://jolovstorage.queue.core.windows.net/test-queue-2f3b1b78-3b0d-7dba-493d-7d7964a0b151?sv=2019-02-02\u0026ss=bfq\u0026srt=sco\u0026spr=https\u0026se=2019-12-02T21%3A37%3A32Z\u0026sp=rwdlacup\u0026sig=Sanitized",
+      "RequestUri": "https://storagedotnettesting.queue.core.windows.net/test-queue-2f3b1b78-3b0d-7dba-493d-7d7964a0b151?sv=2019-02-02\u0026ss=bfqt\u0026srt=sco\u0026spr=https\u0026se=2019-12-13T00%3A16%3A47Z\u0026sp=rwdlacup\u0026sig=Sanitized",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
-        "traceparent": "00-114f0aabe45ee743b7923b3cba55d3f6-f4346ae71b073f48-00",
+        "traceparent": "00-e76eca7ee0f47d45b155b3e1216aa71b-8a239a3cb435b847-00",
         "User-Agent": [
-          "azsdk-net-Storage.Queues/12.1.0-dev.20191202.1\u002Bb6509581fa5af80856252dcf37a17912898b8746",
+          "azsdk-net-Storage.Queues/12.1.0-dev.20191212.1\u002B365544065ca906ef785471b4d22b09dc4a3b54b2",
           "(.NET Core 4.6.28008.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "9e3406fe-94f3-75ed-10b0-88b5025a8f23",
@@ -156,20 +156,20 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 02 Dec 2019 20:37:33 GMT",
+        "Date": "Thu, 12 Dec 2019 23:16:47 GMT",
         "Server": [
           "Windows-Azure-Queue/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-request-id": "7487a15a-3003-0024-6a50-a968e1000000",
+        "x-ms-request-id": "3269c4b7-5003-004d-4c42-b1683a000000",
         "x-ms-version": "2018-11-09"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2019-12-02T12:37:32.7794670-08:00",
+    "DateTimeOffsetNow": "2019-12-12T15:16:47.3352504-08:00",
     "RandomSeed": "627936628",
-    "Storage_TestConfigDefault": "ProductionTenant\njolovstorage\nU2FuaXRpemVk\nhttps://jolovstorage.blob.core.windows.net\nhttps://jolovstorage.file.core.windows.net\nhttps://jolovstorage.queue.core.windows.net\nhttps://jolovstorage.table.core.windows.net\n\n\n\n\nhttps://jolovstorage-secondary.blob.core.windows.net\nhttps://jolovstorage-secondary.file.core.windows.net\nhttps://jolovstorage-secondary.queue.core.windows.net\nhttps://jolovstorage-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://jolovstorage.blob.core.windows.net/;QueueEndpoint=https://jolovstorage.queue.core.windows.net/;FileEndpoint=https://jolovstorage.file.core.windows.net/;BlobSecondaryEndpoint=https://jolovstorage-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://jolovstorage-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://jolovstorage-secondary.file.core.windows.net/;AccountName=jolovstorage;AccountKey=Sanitized"
+    "Storage_TestConfigDefault": "ProductionTenant\nstoragedotnettesting\nU2FuaXRpemVk\nhttps://storagedotnettesting.blob.core.windows.net\nhttps://storagedotnettesting.file.core.windows.net\nhttps://storagedotnettesting.queue.core.windows.net\nhttps://storagedotnettesting.table.core.windows.net\n\n\n\n\nhttps://storagedotnettesting-secondary.blob.core.windows.net\nhttps://storagedotnettesting-secondary.file.core.windows.net\nhttps://storagedotnettesting-secondary.queue.core.windows.net\nhttps://storagedotnettesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://storagedotnettesting.blob.core.windows.net/;QueueEndpoint=https://storagedotnettesting.queue.core.windows.net/;FileEndpoint=https://storagedotnettesting.file.core.windows.net/;BlobSecondaryEndpoint=https://storagedotnettesting-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://storagedotnettesting-secondary.queue.core.windows.net/;FileSecondaryEndpoint=https://storagedotnettesting-secondary.file.core.windows.net/;AccountName=storagedotnettesting;AccountKey=Sanitized"
   }
 }


### PR DESCRIPTION
The portal includes Table Endpoint and Sas Permissions by default in the Sas connection string. The Storage SDK doesn't support table operations, but we don't want to throw exceptions by default.

As part of this change, we are adding Tables to AccountSasServices enum so that we can correctly parse the connection string coming from the portal. Although the SDK doesn't support table operations, customers would be able to use the AccountSasBuilder to build a SAS token that does include table permissions that they could use elsewhere, such as directly against the REST endpoint.

Fixes #9110 