### PR TITLE
[Event Hubs Client] Track Two (Processor Event Members Tweak)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -791,7 +791,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <param name="eventArgs">The set of arguments to identify the context of the partition that will be processed.</param>
         ///
-        protected virtual Task OnPartitionInitializingAsync(PartitionInitializingEventArgs eventArgs)
+        private Task OnPartitionInitializingAsync(PartitionInitializingEventArgs eventArgs)
         {
             if (_partitionInitializingAsync != null)
             {
@@ -807,7 +807,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <param name="eventArgs">The set of arguments to identify the context of the partition that was being processed.</param>
         ///
-        protected virtual Task OnPartitionClosingAsync(PartitionClosingEventArgs eventArgs)
+        private Task OnPartitionClosingAsync(PartitionClosingEventArgs eventArgs)
         {
             if (_partitionClosingAsync != null)
             {
@@ -823,7 +823,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <param name="eventArgs">The set of arguments to identify the context of the event to be processed.</param>
         ///
-        protected virtual Task OnProcessEventAsync(ProcessEventArgs eventArgs) => _processEventAsync(eventArgs);
+        private Task OnProcessEventAsync(ProcessEventArgs eventArgs) => _processEventAsync(eventArgs);
 
         /// <summary>
         ///   Called when a 'process error' event is triggered.
@@ -831,7 +831,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <param name="eventArgs">The set of arguments to identify the context of the error to be processed.</param>
         ///
-        protected virtual Task OnProcessErrorAsync(ProcessErrorEventArgs eventArgs) => _processErrorAsync(eventArgs);
+        private Task OnProcessErrorAsync(ProcessErrorEventArgs eventArgs) => _processErrorAsync(eventArgs);
 
         /// <summary>
         ///   Performs load balancing between multiple <see cref="EventProcessorClient" /> instances, claiming others' partitions to enforce


### PR DESCRIPTION
# Summary

The focus of these changes is to re-scope visibility for the `On[[ EVENT]]` methods used for raising events within the processor.  Previously, these followed the expected .NET event pattern of being protected/virtual.

After discussion, it was decided that these should not be exposed, as we do not have intended scenarios around extending the processor client.

# Last Upstream Rebase

Thursday,  December 12, 2:53pm (EST)

# Related and Follow-Up Issues

- [Event Hubs Client Library for .NET - January Milestone](https://github.com/Azure/azure-sdk-for-net/issues/9040) (#9040)  