### PR TITLE
[Event Hubs Client] Track Two (Telemetry Name Casing)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/ClientLibraryInformation.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/ClientLibraryInformation.cs
@@ -52,7 +52,7 @@ namespace Azure.Messaging.EventHubs.Core
         ///  user agents when interacting with Azure services.
         /// </summary>
         ///
-        [Description("User-Agent")]
+        [Description("user-agent")]
         public string UserAgent => $"azsdk-net-{ Product }/{ Version } ({ Framework }; { Platform })";
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace Azure.Messaging.EventHubs.Core
         private static string GetTelemetryName(PropertyInfo property)
         {
             string name = property.GetCustomAttribute<DescriptionAttribute>(false)?.Description;
-            return (string.IsNullOrEmpty(name)) ? property.Name : name;
+            return ((string.IsNullOrEmpty(name)) ? property.Name : name).ToLowerInvariant();
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ClientLibraryInformationTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ClientLibraryInformationTests.cs
@@ -93,7 +93,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             Dictionary<string, string> expectedNames = typeof(ClientLibraryInformation)
                 .GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                .ToDictionary(property => property.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(false)?.Description ?? property.Name, property => property.Name);
+                .ToDictionary(property => (property.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(false)?.Description ?? property.Name).ToLowerInvariant(), property => property.Name);
 
             foreach (KeyValuePair<string, string> property in ClientLibraryInformation.Current.EnumerateProperties())
             {
@@ -120,7 +120,7 @@ namespace Azure.Messaging.EventHubs.Tests
             HashSet<string> expectedNames = new HashSet<string>(
                 typeof(ClientLibraryInformation)
                     .GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                    .Select(property => property.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(false)?.Description ?? property.Name));
+                    .Select(property => (property.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>(false)?.Description ?? property.Name).ToLowerInvariant()));
 
             foreach (KeyValuePair<string, string> property in ClientLibraryInformation.Current.EnumerateProperties())
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientLiveTests.cs
@@ -2116,6 +2116,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        [Ignore("Consistently failing on Linux and macOS.  To be fixed with the upcoming test stabilization.")]
         public async Task ConsumerCannotReadWhenProxyIsInvalid()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
@@ -2293,7 +2294,6 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [Ignore("Consistently failing on Linux and macOS.  To be fixed with the upcoming test stabilization.")]
         public async Task ConsumerCannotRetrieveMetadataWhenProxyIsInvalid()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))


### PR DESCRIPTION
# Summary

The focus of these changes is to normalize the names for telemetry properties to lower-case, to match the format used across other languages and in the track one client.

# Last Upstream Rebase

Thursday,  December 12, 4:18pm (EST)

# Related and Follow-Up Issues

- [Event Hubs Client Library for .NET - January Milestone](https://github.com/Azure/azure-sdk-for-net/issues/9040) (#9040)  