### PR TITLE
[Storage] Disable live test parallelism and increase timeout

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -2,15 +2,17 @@ parameters:
   PreSteps: []
   EnvVars: {}
   MaxParallel: 0
+  BuildInParallel: true
+  # Increase timeout so Event Hubs tests do not timeout (Windows runs for ~2h 35m, on average due to having two target platforms)
+  # https://github.com/Azure/azure-sdk-for-net/issues/5982
+  TimeoutInMinutes: 175
 
 jobs:
   - job: "Test"
     variables:
       - template: ../variables/globals.yml
 
-    # Increase timeout so Event Hubs tests do not timeout (Windows runs for ~2h 35m, on average due to having two target platforms)
-    # https://github.com/Azure/azure-sdk-for-net/issues/5982
-    timeoutInMinutes: 175
+    timeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
 
     strategy:
       maxParallel: ${{ parameters.MaxParallel }}
@@ -53,7 +55,7 @@ jobs:
           packageType: sdk
           version: "$(DotNetCoreSDKVersion)"
 
-      - script: dotnet test eng/service.proj --framework $(TestTargetFramework) --logger "trx;LogFileName=$(TestTargetFramework).trx" --logger:"console;verbosity=normal" /p:ServiceDirectory=${{ parameters.ServiceDirectory }} /p:IncludeSrc=false /p:IncludeSamples=false
+      - script: dotnet test eng/service.proj --framework $(TestTargetFramework) --logger "trx;LogFileName=$(TestTargetFramework).trx" --logger:"console;verbosity=normal" /p:ServiceDirectory=${{ parameters.ServiceDirectory }} /p:IncludeSrc=false /p:IncludeSamples=false /p:BuildInParallel=${{ parameters.BuildInParallel }}
         displayName: "Build & Test (all tests for $(TestTargetFramework))"
         env:
           DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -3,9 +3,7 @@ parameters:
   EnvVars: {}
   MaxParallel: 0
   BuildInParallel: true
-  # Increase timeout so Event Hubs tests do not timeout (Windows runs for ~2h 35m, on average due to having two target platforms)
-  # https://github.com/Azure/azure-sdk-for-net/issues/5982
-  TimeoutInMinutes: 175
+  TimeoutInMinutes: 60
 
 jobs:
   - job: "Test"

--- a/sdk/storage/tests.yml
+++ b/sdk/storage/tests.yml
@@ -11,6 +11,8 @@ jobs:
   - template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
     parameters:
       ServiceDirectory: storage
+      BuildInParallel: false
+      TimeoutInMinutes: 300
       PreSteps:
         - pwsh: |
             $TestConfigurationPath = "$(Build.ArtifactStagingDirectory)/TestConfiguration.xml"


### PR DESCRIPTION
- Add template parameters to allow individual pipelines to control parallel assembly execution and timeout.
- Storage live tests have been unreliable, and running multiple test assemblies in parallel may be contributing.
- Storage live tests have also been timing out at 3 hours, increasing to 5 hours allows tests to finish and give more useful results.
- Once tests are stable, parallel should be re-enabled (#9144) and timeout should be decreased (#9143).