### PR TITLE
[Event Hubs Client] Track Two (Timer Dispose Fix)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
@@ -543,7 +543,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                     endpoint.AbsoluteUri,
                     authClaims,
                     AuthorizationRefreshTimeout,
-                    () => refreshTimer
+                    () => (ActiveLinks.ContainsKey(link) ? refreshTimer : null)
                 );
 
                 refreshTimer = new Timer(refreshHandler, null, CalculateLinkAuthorizationRefreshInterval(authExpirationUtc), Timeout.InfiniteTimeSpan);
@@ -754,6 +754,11 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                 try
                 {
+                    if (refreshTimer == null)
+                    {
+                        return;
+                    }
+
                     var authExpirationUtc = await RequestAuthorizationUsingCbsAsync(connection, tokenProvider, endpoint, audience, resource, requiredClaims, refreshTimeout).ConfigureAwait(false);
 
                     // Reset the timer for the next refresh.
@@ -762,6 +767,12 @@ namespace Azure.Messaging.EventHubs.Amqp
                     {
                         refreshTimer.Change(CalculateLinkAuthorizationRefreshInterval(authExpirationUtc), Timeout.InfiniteTimeSpan);
                     }
+                }
+                catch (ObjectDisposedException)
+                {
+                    // This can occur if the connection is closed or the scope disposed after the factory
+                    // is called but before the timer is updated.  The callback may also fire while the timer is
+                    // in the act of disposing.  Do not consider it an error.
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
# Summary

The focus of these changes is to address a race condition that could cause the authorization refresh timer callback to throw an `ObjectDisposedException` due to a set of benign race conditions.  These changes attempt to make those conditions less likely but cannot eliminate them completely without introducing synchronization overhead.  Because the condition is benign, accept the resulting exception as an expected case rather than paying that cost.

# Last Upstream Rebase

Monday,  December 16, 3:18pm (EST)

# Related and Follow-Up Issues

- [Event Hubs Client Library for .NET - January Milestone](https://github.com/Azure/azure-sdk-for-net/issues/9040) (#9040)  
- [Stress and Stability Testing](https://github.com/Azure/azure-sdk-for-net/issues/9044) (#9044) 