### PR TITLE
[Event Hubs Client] Track Two (Fix Processor Resume from Checkpoint)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -1212,7 +1212,11 @@ namespace Azure.Messaging.EventHubs
             {
                 if (checkpoint.PartitionId == partitionId)
                 {
-                    startingPosition = EventPosition.FromOffset(checkpoint.Offset);
+                    // When resuming from a checkpoint, the intent to process the next available event in the stream which
+                    // follows the one that was used to create the checkpoint.  Because the offset is inclusive, increment
+                    // the value from the checkpoint in order to force a shift to the next available event in the stream.
+
+                    startingPosition = EventPosition.FromOffset(checkpoint.Offset + 1);
                     break;
                 }
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Infrastructure/MockCheckPointStorage.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Infrastructure/MockCheckPointStorage.cs
@@ -24,17 +24,23 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         /// <summary>The primitive for synchronizing access during ownership update.</summary>
         private readonly object _ownershipLock = new object();
 
-        /// <summary>The set of stored ownership.</summary>
-        private readonly Dictionary<(string, string, string, string), PartitionOwnership> _ownership;
-
         /// <summary>The primitive for synchronizing access during checkpoint update.</summary>
         private readonly object _checkpointLock = new object();
 
-        /// <summary>The set of stored checkpoints.</summary>
-        private readonly Dictionary<(string, string, string, string), Checkpoint> _checkpoints;
-
         /// <summary>Logs activities performed by this partition manager.</summary>
         private readonly Action<string> _logger;
+
+        /// <summary>
+        ///   The set of checkpoints held for this instance.
+        /// </summary>
+        ///
+        public Dictionary<(string, string, string, string), Checkpoint> Checkpoints { get; }
+
+        /// <summary>
+        ///   The set of stored ownership.
+        /// </summary>
+        ///
+        public Dictionary<(string, string, string, string), PartitionOwnership> Ownership { get; }
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="MockCheckPointStorage"/> class.
@@ -46,8 +52,8 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         {
             _logger = logger;
 
-            _ownership = new Dictionary<(string, string, string, string), PartitionOwnership>();
-            _checkpoints = new Dictionary<(string, string, string, string), Checkpoint>();
+            Ownership = new Dictionary<(string, string, string, string), PartitionOwnership>();
+            Checkpoints = new Dictionary<(string, string, string, string), Checkpoint>();
         }
 
         /// <summary>
@@ -70,7 +76,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             lock (_ownershipLock)
             {
-                ownershipList = _ownership.Values
+                ownershipList = Ownership.Values
                     .Where(ownership => ownership.FullyQualifiedNamespace == fullyQualifiedNamespace
                         && ownership.EventHubName == eventHubName
                         && ownership.ConsumerGroup == consumerGroup)
@@ -106,7 +112,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
                     // In case the partition already has an owner, the ETags must match in order to claim it.
 
-                    if (_ownership.TryGetValue(key, out PartitionOwnership currentOwnership))
+                    if (Ownership.TryGetValue(key, out PartitionOwnership currentOwnership))
                     {
                         isClaimable = string.Equals(ownership.ETag, currentOwnership.ETag, StringComparison.InvariantCultureIgnoreCase);
                     }
@@ -115,7 +121,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                     {
                         ownership.ETag = Guid.NewGuid().ToString();
 
-                        _ownership[key] = ownership;
+                        Ownership[key] = ownership;
                         claimedOwnership.Add(ownership);
 
                         Log($"Ownership with partition id = '{ownership.PartitionId}' claimed by OwnershipIdentifier = '{ownership.OwnerIdentifier}'.");
@@ -150,7 +156,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             lock (_checkpointLock)
             {
-                checkpointList = _checkpoints.Values
+                checkpointList = Checkpoints.Values
                     .Where(checkpoint => checkpoint.FullyQualifiedNamespace == fullyQualifiedNamespace
                         && checkpoint.EventHubName == eventHubName
                         && checkpoint.ConsumerGroup == consumerGroup)
@@ -173,7 +179,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             lock (_checkpointLock)
             {
                 var key = (checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, checkpoint.PartitionId);
-                _checkpoints[key] = checkpoint;
+                Checkpoints[key] = checkpoint;
 
                 Log($"Checkpoint with partition id = '{checkpoint.PartitionId}' updated successfully.");
             }


### PR DESCRIPTION
# Summary

The focus of these changes is to correct an issue where the Event Processor client would resume from a checkpoint using the event that the checkpoint was based on, resulting in that event being processed multiple times.  Instead, the processor should assume the checkpoint is based on the event last processed and should, therefore, resume from the next event available in the stream.

# Last Upstream Rebase

Tuesday, December 17, 11:01am (EST)

# Related and Follow-Up Issues

- [Event Hubs Client Library for .NET - January Milestone](https://github.com/Azure/azure-sdk-for-net/issues/9040) (#9040)  
- [[EventHub Track 2] Checkpoint should use exclusive not inclusive offset](https://github.com/Azure/azure-sdk-for-net/issues/9158) (#9158) 