### PR TITLE
Check if container exists before creating

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -233,6 +233,11 @@ namespace Azure.Storage.Test.Shared
                 publicAccessType = premium ? PublicAccessType.None : PublicAccessType.BlobContainer;
             }
 
+            if (await service.GetBlobContainersAsync(prefix: containerName).GetAsyncEnumerator().MoveNextAsync())
+            {
+                throw new InvalidOperationException($"Container already exists: {containerName}");
+            }
+
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(containerName));
             await container.CreateAsync(metadata: metadata, publicAccessType: publicAccessType);
             return new DisposingContainer(container);


### PR DESCRIPTION
- Ensures test code is not generating duplicate GUIDs