### PR TITLE
[Event Hubs Client] Track Two (Test Stability)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample03_BasicEventProcessing.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample03_BasicEventProcessing.cs
@@ -209,7 +209,7 @@ namespace Azure.Messaging.EventHubs.Processor.Samples
                 // error be encountered, we'll also add a timed cancellation.
 
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+                cancellationSource.CancelAfter(TimeSpan.FromSeconds(60));
 
                 while ((!cancellationSource.IsCancellationRequested) && (eventIndex <= expectedEvents.Count))
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample04_BasicCheckpointing.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample04_BasicCheckpointing.cs
@@ -204,7 +204,7 @@ namespace Azure.Messaging.EventHubs.Processor.Samples
                 // error be encountered, we'll also add a timed cancellation.
 
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+                cancellationSource.CancelAfter(TimeSpan.FromSeconds(60));
 
                 while ((!cancellationSource.IsCancellationRequested) && (eventIndex <= expectedEvents.Count))
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample05_InitializeAPartition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample05_InitializeAPartition.cs
@@ -144,7 +144,7 @@ namespace Azure.Messaging.EventHubs.Processor.Samples
                 // cancellation.
 
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromSeconds(12));
+                cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
 
                 while (!cancellationSource.IsCancellationRequested)
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample06_TrackWhenAPartitionIsClosed.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample06_TrackWhenAPartitionIsClosed.cs
@@ -232,7 +232,7 @@ namespace Azure.Messaging.EventHubs.Processor.Samples
                 // error be encountered, we'll also add a timed cancellation.
 
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+                cancellationSource.CancelAfter(TimeSpan.FromSeconds(60));
 
                 while ((!cancellationSource.IsCancellationRequested) && (eventsProcessed <= expectedEvents.Count))
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample08_EventProcessingHeartbeat.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample08_EventProcessingHeartbeat.cs
@@ -134,7 +134,7 @@ namespace Azure.Messaging.EventHubs.Processor.Samples
                 await processor.StartProcessingAsync();
 
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromSeconds(45));
+                cancellationSource.CancelAfter(TimeSpan.FromSeconds(90));
 
                 // We'll publish a batch of events for our processor to receive. We'll split the events into a couple of batches to
                 // increase the chance they'll be spread around to different partitions and introduce a delay between batches to

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample09_ProcessEventsByBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample09_ProcessEventsByBatch.cs
@@ -180,7 +180,7 @@ namespace Azure.Messaging.EventHubs.Processor.Samples
                 await processor.StartProcessingAsync();
 
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromSeconds(45));
+                cancellationSource.CancelAfter(TimeSpan.FromSeconds(90));
 
                 // We'll publish a batch of events for our processor to receive. We'll split the events into a couple of batches to
                 // increase the chance they'll be spread around to different partitions and introduce a delay between batches to

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample04_ReadEvents.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample04_ReadEvents.cs
@@ -81,7 +81,7 @@ namespace Azure.Messaging.EventHubs.Samples
                 // safe.
 
                 using CancellationTokenSource cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+                cancellationSource.CancelAfter(TimeSpan.FromSeconds(90));
 
                 int eventsRead = 0;
                 int maximumEvents = 3;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample08_ReadOnlyNewEvents.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample08_ReadOnlyNewEvents.cs
@@ -77,7 +77,7 @@ namespace Azure.Messaging.EventHubs.Samples
                 // in the event of a service error where the events we've published cannot be read.
 
                 using CancellationTokenSource cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+                cancellationSource.CancelAfter(TimeSpan.FromSeconds(90));
 
                 // The reading of all events will default to the earliest events available in each partition; in order to begin reading at the
                 // latest event, we'll need to specify that reading should not start at earliest.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample09_ReadEventsFromAKnownPosition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample09_ReadEventsFromAKnownPosition.cs
@@ -87,7 +87,7 @@ namespace Azure.Messaging.EventHubs.Samples
                 // in the event of a service error where the events we've published cannot be read.
 
                 using CancellationTokenSource cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+                cancellationSource.CancelAfter(TimeSpan.FromSeconds(60));
 
                 List<EventData> receivedEvents = new List<EventData>();
                 bool wereEventsPublished = false;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample11_AuthenticateWithClientSecretCredential.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample11_AuthenticateWithClientSecretCredential.cs
@@ -94,7 +94,7 @@ namespace Azure.Messaging.EventHubs.Samples
                 // safe.
 
                 using CancellationTokenSource cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+                cancellationSource.CancelAfter(TimeSpan.FromSeconds(60));
 
                 await foreach (PartitionEvent partitionEvent in consumerClient.ReadEventsAsync(cancellationSource.Token))
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/PartitionContextTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/PartitionContextTests.cs
@@ -69,6 +69,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(information.Offset, Is.EqualTo(lastEvent.LastPartitionOffset), "The offset should match.");
             Assert.That(information.EnqueuedTime, Is.EqualTo(lastEvent.LastPartitionEnqueuedTime), "The last enqueue time should match.");
             Assert.That(information.LastReceivedTime, Is.EqualTo(lastEvent.LastPartitionPropertiesRetrievalTime), "The retrieval time should match.");
+            Assert.That(mockConsumer.IsClosed, Is.False, "The consumer should not have been closed or disposed of.");
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumerClient/EventHubConsumerClientLiveTests.cs
@@ -1956,7 +1956,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     var receivedEvents = new List<EventData>();
                     var wereEventsPublished = false;
-                    var maximumConsecutiveEmpties = 5;
+                    var maximumConsecutiveEmpties = 10;
                     var consecutiveEmpties = 0;
 
                     await foreach (var partitionEvent in consumer.ReadEventsFromPartitionAsync(partitionIds[1], EventPosition.Latest, DefaultReadOptions, cancellationSource.Token))
@@ -2030,7 +2030,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     // Read back the events from two different consumer groups.
 
-                    var maximumConsecutiveEmpties = 5;
+                    var maximumConsecutiveEmpties = 10;
                     var consecutiveEmpties = 0;
                     var consumerReceivedEvents = new List<EventData>();
                     var anotherReceivedEvents = new List<EventData>();
@@ -2116,7 +2116,6 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [Ignore("Consistently failing on Linux and macOS.  To be fixed with the upcoming test stabilization.")]
         public async Task ConsumerCannotReadWhenProxyIsInvalid()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
@@ -2140,7 +2139,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     await using (var invalidProxyConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString, options))
                     {
-                        var readOptions = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(250) };
+                        var readOptions = new ReadEventOptions { MaximumWaitTime = null };
                         Assert.That(async () => await ReadNothingAsync(invalidProxyConsumer, partition, EventPosition.Latest, readOptions, 25), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
                     }
                 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducerClient/EventHubProducerClientLiveTests.cs
@@ -856,7 +856,7 @@ namespace Azure.Messaging.EventHubs.Tests
                         {
                             var receivedEvents = new List<EventData>();
                             var consecutiveEmpties = 0;
-                            var maximumConsecutiveEmpties = 5;
+                            var maximumConsecutiveEmpties = 10;
 
                             await foreach (var partitionEvent in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.Earliest, DefaultReadOptions, cancellationSource.Token))
                             {
@@ -923,7 +923,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     {
                         var receivedEvents = new List<EventData>();
                         var consecutiveEmpties = 0;
-                        var maximumConsecutiveEmpties = 5;
+                        var maximumConsecutiveEmpties = 10;
 
                         await foreach (var partitionEvent in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.Earliest, DefaultReadOptions, cancellationSource.Token))
                         {
@@ -993,7 +993,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     {
                         var receivedEvents = new List<EventData>();
                         var consecutiveEmpties = 0;
-                        var maximumConsecutiveEmpties = 5;
+                        var maximumConsecutiveEmpties = 10;
 
                         await foreach (var partitionEvent in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.Earliest, DefaultReadOptions, cancellationSource.Token))
                         {


### PR DESCRIPTION
# Summary

The focus of these changes is to tweak some of the timings and loosen some assumptions around the non-deterministic areas of the tests to offer better stability in the nightly runs, where there is a higher resource contention and timing tends to vary more than with local runs.

# Last Upstream Rebase

Wednesday, December 18, 3:39pm (EST)

# Related and Follow-Up Issues

- [Event Hubs Client Library for .NET - January Milestone](https://github.com/Azure/azure-sdk-for-net/issues/9040) (#9040)  
- [Test Stabilization](https://github.com/Azure/azure-sdk-for-net/issues/9047) (#9047) 