### PR TITLE
[Event Hubs Client] Track Two (Event Position Offset Inclusivity)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -1240,10 +1240,9 @@ namespace Azure.Messaging.EventHubs
                 if (checkpoint.PartitionId == partitionId)
                 {
                     // When resuming from a checkpoint, the intent to process the next available event in the stream which
-                    // follows the one that was used to create the checkpoint.  Because the offset is inclusive, increment
-                    // the value from the checkpoint in order to force a shift to the next available event in the stream.
+                    // follows the one that was used to create the checkpoint.  Create the position using an exclusive offset.
 
-                    startingPosition = EventPosition.FromOffset(checkpoint.Offset + 1);
+                    startingPosition = EventPosition.FromOffset(checkpoint.Offset, false);
                     break;
                 }
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
@@ -1331,7 +1331,7 @@ namespace Azure.Messaging.EventHubs.Tests
             mockConsumer
                 .Setup(consumer => consumer.ReadEventsFromPartitionAsync(
                     partitionId,
-                    EventPosition.FromOffset(checkpointOffset + 1),
+                    EventPosition.FromOffset(checkpointOffset, false),
                     It.IsAny<ReadEventOptions>(),
                     It.IsAny<CancellationToken>()))
                 .Returns<string, EventPosition, ReadEventOptions, CancellationToken>((partition, position, options, token) => MockPartitionEventEnumerable(20, token))

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventPosition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventPosition.cs
@@ -80,16 +80,12 @@ namespace Azure.Messaging.EventHubs.Consumer
         /// </summary>
         ///
         /// <param name="offset">The offset of an event with respect to its relative position in the partition.</param>
+        /// <param name="isInclusive">If true, the event with the <paramref name="offset"/> is included; otherwise the next event in sequence will be received.</param>
         ///
         /// <returns>The position of the specified event.</returns>
         ///
-        /// <remarks>
-        ///   The offset is the relative position for event in the context of the stream.  The offset
-        ///   should not be considered a stable value, as the same offset may refer to a different event
-        ///   as events reach the age limit for retention and are no longer visible within the stream.
-        /// </remarks>
-        ///
-        public static EventPosition FromOffset(long offset) => FromOffset(offset.ToString(), true);
+        public static EventPosition FromOffset(long offset,
+                                               bool isInclusive = true) => FromOffset(offset.ToString(), isInclusive);
 
         /// <summary>
         ///   Corresponds to the event in the partition having a specified sequence number associated with it.
@@ -101,7 +97,7 @@ namespace Azure.Messaging.EventHubs.Consumer
         /// <returns>The position of the specified event.</returns>
         ///
         public static EventPosition FromSequenceNumber(long sequenceNumber,
-                                                       bool isInclusive = false)
+                                                       bool isInclusive = true)
         {
             return new EventPosition
             {
@@ -124,33 +120,6 @@ namespace Azure.Messaging.EventHubs.Consumer
             return new EventPosition
             {
                 EnqueuedTime = enqueuedTime
-            };
-        }
-
-        /// <summary>
-        ///   Corresponds to the event in the partition at the provided offset.
-        /// </summary>
-        ///
-        /// <param name="offset">The offset of an event with respect to its relative position in the partition.</param>
-        /// <param name="isInclusive">If true, the event at the <paramref name="offset"/> is included; otherwise the next event in sequence will be received.</param>
-        ///
-        /// <returns>The position of the specified event.</returns>
-        ///
-        /// <remarks>
-        ///   The offset is the relative position for event in the context of the stream.  The offset
-        ///   should not be considered a stable value, as the same offset may refer to a different event
-        ///   as events reach the age limit for retention and are no longer visible within the stream.
-        /// </remarks>
-        ///
-        private static EventPosition FromOffset(string offset,
-                                                bool isInclusive = false)
-        {
-            Argument.AssertNotNullOrWhiteSpace(nameof(offset), offset);
-
-            return new EventPosition
-            {
-                Offset = offset,
-                IsInclusive = isInclusive
             };
         }
 
@@ -218,6 +187,27 @@ namespace Azure.Messaging.EventHubs.Consumer
         ///
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override string ToString() => base.ToString();
+
+        /// <summary>
+        ///   Corresponds to the event in the partition at the provided offset.
+        /// </summary>
+        ///
+        /// <param name="offset">The offset of an event with respect to its relative position in the partition.</param>
+        /// <param name="isInclusive">If true, the event at the <paramref name="offset"/> is included; otherwise the next event in sequence will be received.</param>
+        ///
+        /// <returns>The position of the specified event.</returns>
+        ///
+        private static EventPosition FromOffset(string offset,
+                                                bool isInclusive)
+        {
+            Argument.AssertNotNullOrWhiteSpace(nameof(offset), offset);
+
+            return new EventPosition
+            {
+                Offset = offset,
+                IsInclusive = isInclusive
+            };
+        }
 
         /// <summary>
         ///   Determines whether the specified <see cref="EventPosition" /> instances are equal to each other.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConnectionScopeTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConnectionScopeTests.cs
@@ -1432,6 +1432,8 @@ namespace Azure.Messaging.EventHubs.Tests
                     // No action needed.
                 }
 
+                await Task.Delay(250);
+
                 Assert.That(mockScope.IsDisposed, Is.True, "The scope should have been disposed.");
                 Assert.That(mockScope.CallbackInvoked, Is.True, "The authorization timer callback should have been invoked.");
             }
@@ -1740,8 +1742,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             public bool CallbackInvoked = false;
 
-            private AmqpConnection _mockConnection;
-            private AmqpSession _mockSession;
+            private readonly AmqpConnection _mockConnection;
 
             public DisposeOnAuthorizationTimerCallbackMockScope(Uri serviceEndpoint,
                                                                 string eventHubName,
@@ -1750,7 +1751,6 @@ namespace Azure.Messaging.EventHubs.Tests
                                                                 IWebProxy proxy) : base(serviceEndpoint, eventHubName, credential, transport, proxy)
             {
                 _mockConnection = new AmqpConnection(new MockTransport(), CreateMockAmqpSettings(), new AmqpConnectionSettings());
-                _mockSession = new AmqpSession(_mockConnection, new AmqpSessionSettings(), Mock.Of<ILinkFactory>());
             }
 
             protected override Task<AmqpConnection> CreateAndOpenConnectionAsync(Version amqpVersion,


### PR DESCRIPTION
# Summary

The focus of these changes is to reintroduce the ability to specify that an offset-based `EventPosition` is inclusive or not.

The `EventProcessorClient` has been updated to use this approach.  Because incrementing an offset when the associated event was the last in the  stream causes an error, there was no reliable means resume from a checkpoint and start with the next event in the stream without potentially triggering an error.

# Last Upstream Rebase

Friday, December 20, 11:16apm (EST)

# Related and Follow-Up Issues

- [Event Hubs Client Library for .NET - January Milestone](https://github.com/Azure/azure-sdk-for-net/issues/9040) (#9040)  
- [Exception when resuming processing from a checkpoint](https://github.com/Azure/azure-sdk-for-net/issues/9213) (#9213)