### PR TITLE
Output event logs for failed live tests

### DIFF
--- a/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
@@ -71,13 +71,8 @@ namespace Azure.Storage.Test.Shared
         /// This will run prior to the start of each test.
         /// </summary>
         [SetUp]
-        public void SetupEventsForTest()
-        {
-            if (s_listener != null)
-            {
-                TestEventListener.SetupEventsForTest();
-            }
-        }
+        public void SetupEventsForTest() =>
+            s_listener?.SetupEventsForTest();
 
         /// <summary>
         /// Output the Events to the console in the case of test failure.
@@ -85,13 +80,8 @@ namespace Azure.Storage.Test.Shared
         /// This will run after each test finishes.
         /// </summary>
         [TearDown]
-        public void OutputEventsForTest()
-        {
-            if (s_listener != null)
-            {
-                TestEventListener.OutputEventsForTest();
-            }
-        }
+        public void OutputEventsForTest() =>
+            s_listener?.OutputEventsForTest();
 
         /// <summary>
         /// Gets the tenant to use by default for our tests.

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
@@ -63,6 +63,7 @@ namespace Azure.Storage.Test.Shared
         public void StopLoggingEvents()
         {
             s_listener?.Dispose();
+            s_listener = null;
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/TestConfigurations.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/TestConfigurations.cs
@@ -212,15 +212,5 @@ namespace Azure.Storage.Test
                     .ToDictionary(tenant => tenant.TenantName)
             };
         }
-
-        /// <summary>
-        /// Add a static TestEventListener which will redirect SDK logging
-        /// to Console.Out for easy debugging.
-        ///
-        /// This is only here to run before any of our tests make requests.
-        /// </summary>
-#pragma warning disable IDE0052 // Remove unread private members
-        private static readonly TestEventListener s_logging = new TestEventListener();
-#pragma warning restore IDE0052 // Remove unread private members
     }
 }

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/TestEventListener.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/TestEventListener.cs
@@ -49,7 +49,7 @@ namespace Azure.Storage.Test
         {
             if (TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Failed)
             {
-                TestContext.Progress.WriteLine(_eventBuffer.ToString());
+                TestContext.Error.WriteLine(_eventBuffer.ToString());
             }
         }
 

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/TestEventListener.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/TestEventListener.cs
@@ -20,31 +20,36 @@ namespace Azure.Storage.Test
     /// Simply create an instance of the TestEventListener before you start
     /// running your tests.
     /// </summary>
-    internal class TestEventListener : AzureEventSourceListener
+    internal class TestEventListener : IDisposable
     {
-        private static StringBuilder s_eventBuffer;
+        private StringBuilder _eventBuffer;
 
-        public TestEventListener() : base((e, _) => LogEvent(e), EventLevel.Verbose)
+        private readonly AzureEventSourceListener _eventSourceListener;
+
+        public TestEventListener()
         {
+            _eventSourceListener = new AzureEventSourceListener(
+                (e, _) => LogEvent(e),
+                EventLevel.Verbose);
         }
 
         /// <summary>
         /// Sets up the Event listener buffer for the test about to run.
         /// </summary>
-        public static void SetupEventsForTest()
+        public void SetupEventsForTest()
         {
-            s_eventBuffer = new StringBuilder();
+            _eventBuffer = new StringBuilder();
         }
 
         /// <summary>
         /// Output the Events to the console in the case of test failure.
         /// This will include the HTTP requests and responses.
         /// </summary>
-        public static void OutputEventsForTest()
+        public void OutputEventsForTest()
         {
             if (TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Failed)
             {
-                TestContext.Progress.WriteLine(s_eventBuffer.ToString());
+                TestContext.Progress.WriteLine(_eventBuffer.ToString());
             }
         }
 
@@ -52,7 +57,7 @@ namespace Azure.Storage.Test
         /// Trace any SDK events.
         /// </summary>
         /// <param name="args">Event arguments.</param>
-        public static void LogEvent(EventWrittenEventArgs args)
+        public void LogEvent(EventWrittenEventArgs args)
         {
             var category = args.EventName;
             IDictionary<string, string> payload = GetPayload(args);
@@ -99,8 +104,11 @@ namespace Azure.Storage.Test
             Trace.WriteLine(message, category);
 
             // Add the message to event buffer
-            s_eventBuffer.Append(message);
-            s_eventBuffer.AppendLine();
+            Assert.IsNotNull(
+                _eventBuffer,
+                "SetupEventsForTest needs to be called before each test when using TestEventListener.");
+            _eventBuffer.Append(message);
+            _eventBuffer.AppendLine();
         }
 
         /// <summary>
@@ -136,5 +144,10 @@ namespace Azure.Storage.Test
             }
             return payload;
         }
+
+        /// <summary>
+        /// Cleans up the <see cref="AzureEventSourceListener"/> instance.
+        /// </summary>
+        public void Dispose() => _eventSourceListener.Dispose();
     }
 }

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/TestEventListener.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/TestEventListener.cs
@@ -49,7 +49,7 @@ namespace Azure.Storage.Test
         {
             if (TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Failed)
             {
-                TestContext.Error.WriteLine(_eventBuffer.ToString());
+                TestContext.Out.WriteLine(_eventBuffer.ToString());
             }
         }
 


### PR DESCRIPTION
Peeling off the event logging changes from https://github.com/Azure/azure-sdk-for-net/pull/9150 into separate PR, so we can merge this in while working on resolution for DataLake errors.