### PR TITLE
[Event Hubs Client] Track Two (Test Stability)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
@@ -28,10 +28,10 @@ namespace Azure.Messaging.EventHubs.Tests
         private const int RetryMaximumAttemps = 15;
 
         /// <summary>The number of seconds to use as the basis for backing off on retry attempts.</summary>
-        private const double RetryExponentialBackoffSeconds = 2.5;
+        private const double RetryExponentialBackoffSeconds = 3.0;
 
         /// <summary>The number of seconds to use as the basis for applying jitter to retry back-off calculations.</summary>
-        private const double RetryBaseJitterSeconds = 20.0;
+        private const double RetryBaseJitterSeconds = 30.0;
 
         /// <summary>The buffer to apply when considering refreshing; credentials that expire less than this duration will be refreshed.</summary>
         private static readonly TimeSpan CredentialRefreshBuffer = TimeSpan.FromMinutes(5);

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -12,6 +12,7 @@ jobs:
   parameters:
     MaxParallel: 1
     ServiceDirectory: eventhub
+    TimeoutInMinutes: 120
     EnvVars:
       EVENT_HUBS_CLIENT: $(aad-azure-sdk-test-client-id)
       EVENT_HUBS_SECRET: $(aad-azure-sdk-test-client-secret)


### PR DESCRIPTION
# Summary

The focus of these changes is to improve test stability, especially for Live tests in the nightly runs.  Timing has been adjusted to allow for instability in ARM, which is notoriously cranky when resources are manipulated on-the-fly and to ensure all tests are using timed cancellation to ensure that they do not hang.

# Last Upstream Rebase

Monday, December 30, 2:28pm (EST)

# Related and Follow-Up Issues

- [Event Hubs Client Library for .NET - January Milestone](https://github.com/Azure/azure-sdk-for-net/issues/9040) (#9040)  
- [Stress and Stability Testing](https://github.com/Azure/azure-sdk-for-net/issues/9044) (#9044)