### PR TITLE
[EventHubs] Add notes on AAD Authentication

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/README.md
@@ -171,6 +171,24 @@ private async Task ProcessUntilCanceled(CancellationToken cancellationToken)
 }
 ```
 
+### Authenticating with Azure.Identity
+
+The [Azure Identity library](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/identity/Azure.Identity/README.md) provides easy Azure Active Directory support for authentication.
+
+```csharp
+var storageConnectionString = "<< CONNECTION STRING FOR THE STORAGE ACCOUNT >>";
+var blobContainerName = "<< NAME OF THE BLOBS CONTAINER >>";
+var fullyQualifiedNamespace = "<< FULLY QUALIFED EVENT HUBS NAMESPACE >>";
+var eventHubName = "<< NAME OF THE EVENT HUB >>";
+var consumerGroup = "<< NAME OF THE EVENT HUB CONSUMER GROUP >>";
+
+var storageClient = new BlobContainerClient(storageConnectionString, blobContainerName);
+var processor = new EventProcessorClient(storageClient, consumerGroup, fullyQualifiedNamespace, eventHubName, new DefaultAzureIdentity());
+
+// Now the processor may be used like in the above examples.
+```
+When using Azure Active Directory, you must ensure your principal is assigned a role which allows consumer access to Event Hubs (e.g. the Azure Event Hubs Data receiver role). Learn more about enabling Azure Active Directory for authentication with Azure Storage in [our documentation](https://docs.microsoft.com/en-us/azure/event-hubs/authorize-access-azure-active-directory).
+
 ## Troubleshooting
 
 ### Common exceptions

--- a/sdk/eventhub/Azure.Messaging.EventHubs/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/README.md
@@ -153,6 +153,22 @@ For the majority of production scenarios, it is recommended that the [Event Proc
 
 More details can be found in the Event Processor Client [README](./../Azure.Messaging.EventHubs.Processor/README.md) and the accompanying [samples](./../Azure.Messaging.EventHubs.Processor/samples).
 
+### Authenticating with Azure.Identity
+
+The [Azure Identity library](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/identity/Azure.Identity/README.md) provides easy Azure Active Directory support for authentication.
+
+```csharp
+var fullyQualifiedNamespace = "<< FULLY QUALIFED EVENT HUBS NAMESPACE >>"
+var eventHubName = "<< NAME OF THE EVENT HUB >>";
+
+await using (var producer = new EventHubProducerClient(fullyQualifiedNamespace, eventHubName, new DefaultAzureIdentity()))
+{
+   // Now the producer may be used like in the above examples.
+}
+```
+
+When using Azure Active Directory, you must ensure your principal is assigned a role which allows access to Event Hubs (e.g. the Azure Event Hubs Data owner role). Learn more about enabling Azure Active Directory for authentication with Azure Storage in [our documentation](https://docs.microsoft.com/en-us/azure/event-hubs/authorize-access-azure-active-directory).
+
 ## Troubleshooting
 
 ### Common exceptions


### PR DESCRIPTION
For users who would rather use AAD to connect to their Event Hubs, add a
small note that this library supports using Azure Identity to do so. In
addition, make a note about needing to assign specific roles to the AAD
principal used, and provide a link to the service's documentation on AAD
so users can learn more about what role they may want to use and how to
assign it to a principal.