### PR TITLE
Decrease size of upload for progress reporting test to avoid memory issues on devops agents; Fix progress test flakiness

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
@@ -568,11 +568,6 @@ namespace Azure.Storage.Blobs.Test
             // Assert
             Assert.IsFalse(progress.List.Count == 0);
 
-            for (int i = 1; i < progress.List.Count; i++)
-            {
-                Assert.IsTrue(progress.List[i] >= progress.List[i - 1]);
-            }
-
             Assert.AreEqual(blobSize, progress.List[progress.List.Count - 1]);
         }
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
@@ -746,6 +746,7 @@ namespace Azure.Storage.Blobs.Test
 
         [LiveOnly]
         [Test]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/9120")]
         public async Task UploadAsync_ProgressReporting()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
@@ -766,11 +766,6 @@ namespace Azure.Storage.Blobs.Test
             // Assert
             Assert.IsFalse(progress.List.Count == 0);
 
-            for ( int i = 1; i < progress.List.Count; i++)
-            {
-                Assert.IsTrue(progress.List[i] >= progress.List[i - 1]);
-            }
-
             Assert.AreEqual(size, progress.List[progress.List.Count - 1]);
         }
         #endregion Upload

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
@@ -744,6 +744,7 @@ namespace Azure.Storage.Blobs.Test
             }
         }
 
+        [LiveOnly]
         [Test]
         public async Task UploadAsync_ProgressReporting()
         {

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
@@ -744,9 +744,7 @@ namespace Azure.Storage.Blobs.Test
             }
         }
 
-        [LiveOnly]
         [Test]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/9120")]
         public async Task UploadAsync_ProgressReporting()
         {
             // Arrange
@@ -758,10 +756,11 @@ namespace Azure.Storage.Blobs.Test
                 MaximumTransferLength = Constants.MB,
                 MaximumConcurrency = 16
             };
-            using var stream = new MemoryStream(GetRandomBuffer(Constants.GB));
+            int size = Constants.Blob.Block.MaxUploadBytes + 1; // ensure that the Parallel upload code path is hit
+            using var stream = new MemoryStream(GetRandomBuffer(size));
 
             // Act
-            await blob.UploadAsync(content: stream, progressHandler: progress);
+            await blob.UploadAsync(content: stream, progressHandler: progress, transferOptions: options);
 
             // Assert
             Assert.IsFalse(progress.List.Count == 0);
@@ -771,7 +770,7 @@ namespace Azure.Storage.Blobs.Test
                 Assert.IsTrue(progress.List[i] >= progress.List[i - 1]);
             }
 
-            Assert.AreEqual(Constants.GB, progress.List[progress.List.Count - 1]);
+            Assert.AreEqual(size, progress.List[progress.List.Count - 1]);
         }
         #endregion Upload
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
@@ -327,11 +327,6 @@ namespace Azure.Storage.Blobs.Test
             // Assert
             Assert.IsFalse(progress.List.Count == 0);
 
-            for (int i = 1; i < progress.List.Count; i++)
-            {
-                Assert.IsTrue(progress.List[i] >= progress.List[i - 1]);
-            }
-
             Assert.AreEqual(100 * Constants.MB, progress.List[progress.List.Count - 1]);
         }
 
@@ -1365,11 +1360,6 @@ namespace Azure.Storage.Blobs.Test
 
             // Assert
             Assert.IsFalse(progress.List.Count == 0);
-
-            for (int i = 1; i < progress.List.Count; i++)
-            {
-                Assert.IsTrue(progress.List[i] >= progress.List[i - 1]);
-            }
 
             Assert.AreEqual(blobSize, progress.List[progress.List.Count - 1]);
         }

--- a/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
@@ -526,11 +526,6 @@ namespace Azure.Storage.Blobs.Test
             // Assert
             Assert.IsFalse(progress.List.Count == 0);
 
-            for (int i = 1; i < progress.List.Count; i++)
-            {
-                Assert.IsTrue(progress.List[i] >= progress.List[i - 1]);
-            }
-
             Assert.AreEqual(blobSize, progress.List[progress.List.Count - 1]);
         }
 

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
@@ -325,9 +325,25 @@ namespace Azure.Storage.Test.Shared
         /// get processed.
         /// </param>
         /// <returns>A task that will (optionally) delay.</returns>
-        public async Task Delay(int milliseconds = 1000, int? playbackDelayMilliseconds = null)
+        public async Task Delay(int milliseconds = 1000, int? playbackDelayMilliseconds = null) =>
+            await Delay(Mode, milliseconds, playbackDelayMilliseconds);
+
+        /// <summary>
+        /// A number of our tests have built in delays while we wait an expected
+        /// amount of time for a service operation to complete and this method
+        /// allows us to wait (unless we're playing back recordings, which can
+        /// complete immediately).
+        /// </summary>
+        /// <param name="milliseconds">The number of milliseconds to wait.</param>
+        /// <param name="playbackDelayMilliseconds">
+        /// An optional number of milliseconds to wait if we're playing back a
+        /// recorded test.  This is useful for allowing client side events to
+        /// get processed.
+        /// </param>
+        /// <returns>A task that will (optionally) delay.</returns>
+        public static async Task Delay(RecordedTestMode mode, int milliseconds = 1000, int? playbackDelayMilliseconds = null)
         {
-            if (Mode != RecordedTestMode.Playback)
+            if (mode != RecordedTestMode.Playback)
             {
                 await Task.Delay(milliseconds);
             }
@@ -393,9 +409,8 @@ namespace Azure.Storage.Test.Shared
 
         protected async Task<T> EnsurePropagatedAsync<T>(
             Func<Task<T>> getResponse,
-            Func<T,bool> hasResponse)
+            Func<T, bool> hasResponse)
         {
-            int delayDuration = 10000;
             bool responseReceived = false;
             T response = default;
             // end time of 16 minutes from now to allow for propagation to secondary host
@@ -405,7 +420,7 @@ namespace Azure.Storage.Test.Shared
                 response = await getResponse();
                 if (!hasResponse(response))
                 {
-                    await this.Delay(delayDuration);
+                    await Delay(TestConstants.RetryDelay);
                 }
                 else
                 {
@@ -422,6 +437,32 @@ namespace Azure.Storage.Test.Shared
             Assert.AreEqual(constants.Sas.ContentEncoding, sasQueryParameters.ContentEncoding);
             Assert.AreEqual(constants.Sas.ContentLanguage, sasQueryParameters.ContentLanguage);
             Assert.AreEqual(constants.Sas.ContentType, sasQueryParameters.ContentType);
+        }
+
+        protected async Task<T> RetryAsync<T>(
+            Func<Task<T>> operation,
+            Func<RequestFailedException, bool> shouldRetry,
+            int retryDelay = TestConstants.RetryDelay) =>
+            await RetryAsync(Mode, operation, shouldRetry);
+
+        public static async Task<T> RetryAsync<T>(
+            RecordedTestMode mode,
+            Func<Task<T>> operation,
+            Func<RequestFailedException, bool> shouldRetry,
+            int retryDelay = TestConstants.RetryDelay)
+        {
+            for (int attempt = 0; ;)
+            {
+                try
+                {
+                    return await operation();
+                }
+                catch (RequestFailedException ex)
+                    when (attempt++ < Constants.MaxReliabilityRetries && shouldRetry(ex))
+                {
+                    await Delay(mode, retryDelay);
+                }
+            }
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
@@ -443,7 +443,7 @@ namespace Azure.Storage.Test.Shared
             Func<Task<T>> operation,
             Func<RequestFailedException, bool> shouldRetry,
             int retryDelay = TestConstants.RetryDelay) =>
-            await RetryAsync(Mode, operation, shouldRetry);
+            await RetryAsync(Mode, operation, shouldRetry, retryDelay);
 
         public static async Task<T> RetryAsync<T>(
             RecordedTestMode mode,

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
@@ -442,14 +442,16 @@ namespace Azure.Storage.Test.Shared
         protected async Task<T> RetryAsync<T>(
             Func<Task<T>> operation,
             Func<RequestFailedException, bool> shouldRetry,
-            int retryDelay = TestConstants.RetryDelay) =>
-            await RetryAsync(Mode, operation, shouldRetry, retryDelay);
+            int retryDelay = TestConstants.RetryDelay,
+            int retryAttempts = Constants.MaxReliabilityRetries) =>
+            await RetryAsync(Mode, operation, shouldRetry, retryDelay, retryAttempts);
 
         public static async Task<T> RetryAsync<T>(
             RecordedTestMode mode,
             Func<Task<T>> operation,
             Func<RequestFailedException, bool> shouldRetry,
-            int retryDelay = TestConstants.RetryDelay)
+            int retryDelay = TestConstants.RetryDelay,
+            int retryAttempts = Constants.MaxReliabilityRetries)
         {
             for (int attempt = 0; ;)
             {
@@ -458,7 +460,7 @@ namespace Azure.Storage.Test.Shared
                     return await operation();
                 }
                 catch (RequestFailedException ex)
-                    when (attempt++ < Constants.MaxReliabilityRetries && shouldRetry(ex))
+                    when (attempt++ < retryAttempts && shouldRetry(ex))
                 {
                     await Delay(mode, retryDelay);
                 }

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/TestConstants.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/TestConstants.cs
@@ -19,6 +19,10 @@ namespace Azure.Storage.Test
         public const string Https = "https";
         public const int HttpPort = 443;
 
+        // service cache timeout is 60s, but adding a buffer to be safe
+        public const int DataLakeRetryDelay = 70000;
+        public const int RetryDelay = 10000;
+
         public string CacheControl { get; private set; }
         public string ContentDisposition { get; private set; }
         public string ContentEncoding { get; private set; }


### PR DESCRIPTION
We don't actually need to upload 1GB to hit the parallel code path.

Update ProgressReporting tests to remove the monotonic increasing assertions, as retries will reset the streams to 0.

Add retry after to datalake container creation to work around service bug.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/9282