### PR TITLE
Remove artificial checkout path, test with updated verify path tool

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -5,8 +5,6 @@ jobs:
     pool:
       vmImage: windows-2019
     steps:
-      - checkout: self
-        path: SourceDirWith49CharsLengthTestForLongPaths
       - pwsh: |
           echo "##vso[build.addbuildtag]Scheduled"
         displayName: "Tag scheduled builds"
@@ -50,8 +48,6 @@ jobs:
     pool:
       vmImage: "windows-2019"
     steps:
-      - checkout: self
-        path: SourceDirWith49CharsLengthTestForLongPaths
       - task: UsePythonVersion@0
         displayName: "Use Python 3.6"
         inputs:
@@ -136,8 +132,6 @@ jobs:
     pool:
       vmImage: "$(OSVmImage)"
     steps:
-      - checkout: self
-        path: SourceDirWith49CharsLengthTestForLongPaths
       - template: eng/pipelines/templates/scripts/verify-agent-os.yml@azure-sdk-tools
         parameters:
           OSName: $(OSName)

--- a/eng/pipelines/templates/jobs/archetype-sdk-mgmt.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-mgmt.yml
@@ -4,8 +4,6 @@ jobs:
     pool:
       vmImage: windows-2019
     steps:
-      - checkout: self
-        path: SourceDirWith49CharsLengthTestForLongPaths
       - task: DotNetCoreInstaller@0
         displayName: "Use .NET Core sdk $(DotNetCoreSDKVersion)"
         inputs:
@@ -52,8 +50,6 @@ jobs:
     pool:
       vmImage: "$(OSVmImage)"
     steps:
-      - checkout: self
-        path: SourceDirWith49CharsLengthTestForLongPaths
       - template: eng/pipelines/templates/scripts/verify-agent-os.yml@azure-sdk-tools
         parameters:
           OSName: $(OSName)
@@ -88,8 +84,6 @@ jobs:
     pool:
       vmImage: windows-2019
     steps:
-      - checkout: self
-        path: SourceDirWith49CharsLengthTestForLongPaths
       - task: UsePythonVersion@0
         displayName: "Use Python 3.6"
         inputs:


### PR DESCRIPTION
Path length is still checked in the Analyze step.