### PR TITLE
[Event Hubs Client] Track Two (Release Fixes)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample08_EventProcessingHeartbeat.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample08_EventProcessingHeartbeat.cs
@@ -81,13 +81,8 @@ namespace Azure.Messaging.EventHubs.Processor.Samples
                     // may be created.
                     //
                     // If the "HasEvent" property is unset, the event will be empty and checkpoints may not be created.
-                    //
-                    // NOTE:  There is a bug in the Event Hubs preview 6 library causing "HasEvents" to return the
-                    //        wrong value.  We'll substitute a check against the "Data" property to work around it.
-                    //
-                    //        if (eventArgs.HasEvents) {} is the preferred snippet.
 
-                    if (eventArgs.Data != null)
+                    if (eventArgs.HasEvent)
                     {
                         Console.WriteLine($"Event Received: { Encoding.UTF8.GetString(eventArgs.Data.Body.ToArray()) }");
                     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample09_ProcessEventsByBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample09_ProcessEventsByBatch.cs
@@ -98,10 +98,6 @@ namespace Azure.Messaging.EventHubs.Processor.Samples
                 try
                 {
                     // Retrieve or create the active batch for the current partition.
-                    //
-                    // NOTE:  There is a bug in the Event Hubs Processor preview 6 library causing the "Partition"
-                    //        property to be null when no event was available.  This sample will work when run against the
-                    //        referenced project but will require adjustments to work with the preview 6 package.
 
                     List<ProcessEventArgs> currentBatch = eventBatches.GetOrAdd(eventArgs.Partition.PartitionId, _ => new List<ProcessEventArgs>());
                     bool sendBatchForProcessing = false;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -30,7 +30,6 @@ namespace Azure.Messaging.EventHubs
         public string EventHubName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
         public string FullyQualifiedNamespace { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
         public bool IsClosed { get { throw null; } }
-        public virtual void Close(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { }
         public virtual System.Threading.Tasks.Task CloseAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnection.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnection.cs
@@ -252,14 +252,6 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
-        ///   Closes the connection to the Event Hubs namespace and associated Event Hub.
-        /// </summary>
-        ///
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        ///
-        public virtual void Close(CancellationToken cancellationToken = default) => CloseAsync(cancellationToken).GetAwaiter().GetResult();
-
-        /// <summary>
         ///   Performs the task needed to clean up resources used by the <see cref="EventHubConnection" />,
         ///   including ensuring that the connection itself has been closed.
         /// </summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Connection/EventHubConnectionLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Connection/EventHubConnectionLiveTests.cs
@@ -247,9 +247,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [TestCase(true)]
-        [TestCase(false)]
-        public async Task ConnectionTransportCannotRetrieveMetadataWhenClosed(bool sync)
+        public async Task ConnectionTransportCannotRetrieveMetadataWhenClosed()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
@@ -262,15 +260,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     Assert.That(async () => await connection.GetPropertiesAsync(), Throws.Nothing);
                     Assert.That(async () => await connection.GetPartitionPropertiesAsync(partition), Throws.Nothing);
 
-                    if (sync)
-                    {
-                        connection.Close();
-                    }
-                    else
-                    {
-                        await connection.CloseAsync();
-                    }
-
+                    await connection.CloseAsync();
                     await Task.Delay(TimeSpan.FromSeconds(5));
 
                     Assert.That(async () => await connection.GetPartitionIdsAsync(), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Connection/EventHubConnectionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Connection/EventHubConnectionTests.cs
@@ -453,20 +453,6 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="EventHubConnection.Close" />
-        ///   method.
-        /// </summary>
-        ///
-        [Test]
-        public void CloseDelegatesToCloseAsync()
-        {
-            var client = new ObservableOperationsMock("Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake");
-            client.Close();
-
-            Assert.That(client.WasCloseAsyncCalled, Is.True);
-        }
-
-        /// <summary>
         ///   Verifies functionality of the <see cref="EventHubConnection.DisposeAsync" />
         ///   method.
         /// </summary>
@@ -608,22 +594,6 @@ namespace Azure.Messaging.EventHubs.Tests
             var client = new InjectableTransportClientMock(transportClient, "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake");
 
             await client.CloseAsync();
-
-            Assert.That(transportClient.WasCloseCalled, Is.True);
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the <see cref="EventHubConnection.Close" />
-        ///   method.
-        /// </summary>
-        ///
-        [Test]
-        public void CloseClosesTheTransportClient()
-        {
-            var transportClient = new ObservableTransportClientMock();
-            var client = new InjectableTransportClientMock(transportClient, "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake");
-
-            client.Close();
 
             Assert.That(transportClient.WasCloseCalled, Is.True);
         }


### PR DESCRIPTION
# Summary

The focus of these changes is to revise comments that no longer apply with the January release and to remove a Close method that was intended to have been removed with an earlier set of changes.

# Last Upstream Rebase

Friday, January 3, 3:25pm (EST)

# Related and Follow-Up Issues

- [Event Hubs Client Library for .NET - January Milestone](https://github.com/Azure/azure-sdk-for-net/issues/9040) (#9040)  

