### PR TITLE
Event Processor: Set OwnerLevel "0" when creating an instance of ReadEventOptions

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/EventProcessorEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/EventProcessorEventSource.cs
@@ -363,7 +363,7 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// <param name="partitionId">The identifier of the Event Hub partition whose processing has stopped.</param>
         /// <param name="reason">The reason why the processing for the specified partition has stopped.</param>
         ///
-        [Event(21, Level = EventLevel.Verbose, Message = "Stopped partition processing task for partition id '{0}' with reason '{1}'.")]
+        [Event(21, Level = EventLevel.Informational, Message = "Stopped partition processing task for partition id '{0}' with reason '{1}'.")]
         public virtual void StopPartitionProcessingComplete(string partitionId,
                                                             ProcessingStoppedReason reason)
         {
@@ -411,7 +411,7 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         ///
         /// <param name="identifier">A unique name used to identify the event processor.</param>
         ///
-        [Event(24, Level = EventLevel.Verbose, Message = "Stopped processing events. (Identifier '{0}')")]
+        [Event(24, Level = EventLevel.Informational, Message = "Stopped processing events. (Identifier '{0}')")]
         public virtual void EventProcessorStopComplete(string identifier)
         {
             if (IsEnabled())

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -429,6 +429,7 @@ namespace Azure.Messaging.EventHubs
 
             ProcessingReadEventOptions = new ReadEventOptions
             {
+                OwnerLevel = 0,
                 MaximumWaitTime = clientOptions.MaximumWaitTime,
                 TrackLastEnqueuedEventProperties = clientOptions.TrackLastEnqueuedEventProperties
             };
@@ -477,6 +478,7 @@ namespace Azure.Messaging.EventHubs
 
             ProcessingReadEventOptions = new ReadEventOptions
             {
+                OwnerLevel = 0,
                 MaximumWaitTime = clientOptions.MaximumWaitTime,
                 TrackLastEnqueuedEventProperties = clientOptions.TrackLastEnqueuedEventProperties
             };
@@ -533,6 +535,7 @@ namespace Azure.Messaging.EventHubs
 
             ProcessingReadEventOptions = new ReadEventOptions
             {
+                OwnerLevel = 0,
                 MaximumWaitTime = clientOptions.MaximumWaitTime,
                 TrackLastEnqueuedEventProperties = clientOptions.TrackLastEnqueuedEventProperties
             };

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
@@ -241,6 +241,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(readOptions, Is.Not.Null, "The constructor should have set the processing read event options.");
             Assert.That(readOptions.TrackLastEnqueuedEventProperties, Is.EqualTo(options.TrackLastEnqueuedEventProperties), "The tracking of last event information of the processing read event options should match.");
             Assert.That(readOptions.MaximumWaitTime, Is.EqualTo(options.MaximumWaitTime), "The constructor should have set the correct maximum wait time.");
+            Assert.That(readOptions.OwnerLevel, Is.EqualTo(0), "The constructor should have set the owner level as 0.");
         }
 
         /// <summary>


### PR DESCRIPTION
We found a bug when testing Event Processor functionality across all 4 languages by balancing load and reading/updating checkpoints from common store and .Net sdk was not able to steal partitions from other sdks. 

Fixed this issue by setting `OwnerLevel = 0` when creating an instance of `ReadEventOptions` .

