### PR TITLE
Make completion of diagnostic scope more deterministic

### DIFF
--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -78,7 +78,7 @@ namespace Azure.Core.Pipeline
 
             if (_source != null)
             {
-                _source.StopActivity(_activity, null);
+                _source.StopActivity(_activity, _activity);
             }
             else
             {

--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -78,7 +78,7 @@ namespace Azure.Core.Pipeline
 
             if (_source != null)
             {
-                _source.StopActivity(_activity, _activity);
+                _source.StopActivity(_activity, null);
             }
             else
             {

--- a/sdk/core/Azure.Core/tests/TestFramework/ClientDiagnosticListener.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/ClientDiagnosticListener.cs
@@ -58,7 +58,6 @@ namespace Azure.Core.Tests
                     var name = value.Key.Substring(0, value.Key.Length - stopSuffix.Length);
                     PropertyInfo propertyInfo = value.Value.GetType().GetProperty("Id");
                     var activityId = propertyInfo?.GetValue(value.Value) as string ?? string.Empty;
-
                     foreach (ProducedDiagnosticScope producedDiagnosticScope in Scopes)
                     {
                         if (producedDiagnosticScope.Activity.Id == activityId)

--- a/sdk/core/Azure.Core/tests/TestFramework/ClientDiagnosticListener.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/ClientDiagnosticListener.cs
@@ -56,10 +56,11 @@ namespace Azure.Core.Tests
                 else if (value.Key.EndsWith(stopSuffix))
                 {
                     var name = value.Key.Substring(0, value.Key.Length - stopSuffix.Length);
+                    PropertyInfo propertyInfo = value.Value.GetType().GetProperty("Id");
+                    var activityId = propertyInfo?.GetValue(value.Value) as string ?? string.Empty;
+
                     foreach (ProducedDiagnosticScope producedDiagnosticScope in Scopes)
                     {
-                        PropertyInfo propertyInfo = value.Value.GetType().GetProperty("Id");
-                        var activityId = propertyInfo?.GetValue(value.Value) as string ?? string.Empty;
                         if (producedDiagnosticScope.Activity.Id == activityId)
                         {
                             producedDiagnosticScope.IsCompleted = true;

--- a/sdk/core/Azure.Core/tests/TestFramework/ClientDiagnosticListener.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/ClientDiagnosticListener.cs
@@ -58,7 +58,9 @@ namespace Azure.Core.Tests
                     var name = value.Key.Substring(0, value.Key.Length - stopSuffix.Length);
                     foreach (ProducedDiagnosticScope producedDiagnosticScope in Scopes)
                     {
-                        if (producedDiagnosticScope.Name == name)
+                        PropertyInfo propertyInfo = value.Value.GetType().GetProperty("Id");
+                        var activityId = propertyInfo?.GetValue(value.Value) as string ?? string.Empty;
+                        if (producedDiagnosticScope.Activity.Id == activityId)
                         {
                             producedDiagnosticScope.IsCompleted = true;
                             return;

--- a/sdk/core/Azure.Core/tests/TestFramework/ClientDiagnosticListener.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/ClientDiagnosticListener.cs
@@ -56,11 +56,9 @@ namespace Azure.Core.Tests
                 else if (value.Key.EndsWith(stopSuffix))
                 {
                     var name = value.Key.Substring(0, value.Key.Length - stopSuffix.Length);
-                    PropertyInfo propertyInfo = value.Value.GetType().GetProperty("Id");
-                    var activityId = propertyInfo?.GetValue(value.Value) as string ?? string.Empty;
                     foreach (ProducedDiagnosticScope producedDiagnosticScope in Scopes)
                     {
-                        if (producedDiagnosticScope.Activity.Id == activityId)
+                        if (producedDiagnosticScope.Activity.Id == Activity.Current.Id)
                         {
                             producedDiagnosticScope.IsCompleted = true;
                             return;

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
@@ -73,7 +73,6 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         /// </summary>
         ///
         [Test]
-        [Ignore("Diagnostic scope is not completing properly. Maybe the listener is being disposed of first.")]
         public async Task RunPartitionProcessingAsyncCreatesScopeForEventProcessing()
         {
             var mockStorage = new MockCheckPointStorage();
@@ -149,12 +148,10 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             // Validate diagnostics functionality.
 
-            ClientDiagnosticListener.ProducedDiagnosticScope scope = listener.Scopes.Single();
-
-            Assert.That(scope.Name, Is.EqualTo(DiagnosticProperty.EventProcessorProcessingActivityName));
-            Assert.That(scope.Links, Has.One.EqualTo("id"));
-            Assert.That(scope.Links, Has.One.EqualTo("id2"));
-            Assert.That(scope.Activity.Tags, Has.One.EqualTo(new KeyValuePair<string, string>(DiagnosticProperty.KindAttribute, DiagnosticProperty.ServerKind)), "The activities tag should be server.");
+            Assert.That(listener.Scopes.Select(s => s.Name), Has.All.EqualTo(DiagnosticProperty.EventProcessorProcessingActivityName));
+            Assert.That(listener.Scopes.SelectMany(s => s.Links), Has.One.EqualTo("id"));
+            Assert.That(listener.Scopes.SelectMany(s => s.Links), Has.One.EqualTo("id2"));
+            Assert.That(listener.Scopes.SelectMany(s => s.Activity.Tags), Has.Exactly(2).EqualTo(new KeyValuePair<string, string>(DiagnosticProperty.KindAttribute, DiagnosticProperty.ServerKind)), "The activities tag should be server.");
         }
 
         private class MockConnection : EventHubConnection


### PR DESCRIPTION
# Summary of Changes
- ClientDiagnosticListener.cs 
  - Using the `Activity.Current.Id`, `OnNext` can compare it to `producedDiagnosticScope.Activity.Id` to deterministically close the correct activity. 
- DiagnosticsTests.cs 
  - Test asserts refactored to handle the two scopes being created - one for each `PartitionEvent` received by `RunPartitionProcessingAsync`

# Notes on bug
Previously, when multiple`ProducedDiagnosticScope` were being evaluated for setting completion, the current state of `IsCompleted` was not being considered. This caused us to never set `IsCompleted` anything beyond the first scope with a matching name. 

A simple fix to this bug could have been to filter out scopes where `IsCompleted == true`, however it is less deterministic than the current approach. Although it would guarantee that all outstanding scopes would be completed, it would not accurately represent actual completion order or timing.

closes #9225 