### PR TITLE
[Event Hubs] Track Two (Link Close Fix)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
@@ -156,7 +156,14 @@ namespace Azure.Messaging.EventHubs.Amqp
                 Credential = credential;
                 MessageConverter = messageConverter ?? new AmqpMessageConverter();
                 ConnectionScope = connectionScope ?? new AmqpConnectionScope(ServiceEndpoint, eventHubName, credential, clientOptions.TransportType, clientOptions.Proxy);
-                ManagementLink = new FaultTolerantAmqpObject<RequestResponseAmqpLink>(timeout => ConnectionScope.OpenManagementLinkAsync(timeout, CancellationToken.None), link => link.SafeClose());
+
+                ManagementLink = new FaultTolerantAmqpObject<RequestResponseAmqpLink>(
+                    timeout => ConnectionScope.OpenManagementLinkAsync(timeout, CancellationToken.None),
+                    link =>
+                    {
+                        link.Session?.SafeClose();
+                        link.SafeClose();
+                    });
             }
             finally
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
@@ -159,17 +159,22 @@ namespace Azure.Messaging.EventHubs.Amqp
             RetryPolicy = retryPolicy;
             MessageConverter = messageConverter;
 
-            ReceiveLink = new FaultTolerantAmqpObject<ReceivingAmqpLink>(timeout =>
-                ConnectionScope.OpenConsumerLinkAsync(
-                    consumerGroup,
-                    partitionId,
-                    CurrentEventPosition,
-                    timeout,
-                    prefetchCount ?? DefaultPrefetchCount,
-                    ownerLevel,
-                    trackLastEnqueuedEventProperties,
-                    CancellationToken.None),
-                link => link.SafeClose());
+            ReceiveLink = new FaultTolerantAmqpObject<ReceivingAmqpLink>(
+                timeout =>
+                    ConnectionScope.OpenConsumerLinkAsync(
+                        consumerGroup,
+                        partitionId,
+                        CurrentEventPosition,
+                        timeout,
+                        prefetchCount ?? DefaultPrefetchCount,
+                        ownerLevel,
+                        trackLastEnqueuedEventProperties,
+                        CancellationToken.None),
+                link =>
+                {
+                    link.Session?.SafeClose();
+                    link.SafeClose();
+                });
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
@@ -125,7 +125,14 @@ namespace Azure.Messaging.EventHubs.Amqp
             RetryPolicy = retryPolicy;
             ConnectionScope = connectionScope;
             MessageConverter = messageConverter;
-            SendLink = new FaultTolerantAmqpObject<SendingAmqpLink>(timeout => CreateLinkAndEnsureProducerStateAsync(partitionId, timeout, CancellationToken.None), link => link.SafeClose());
+
+            SendLink = new FaultTolerantAmqpObject<SendingAmqpLink>(
+                timeout => CreateLinkAndEnsureProducerStateAsync(partitionId, timeout, CancellationToken.None),
+                link =>
+                {
+                    link.Session?.SafeClose();
+                    link.SafeClose();
+                });
         }
 
         /// <summary>


### PR DESCRIPTION
# Summary

The focus of these changes is to explicitly close the session associated with an AMQP link when the link itself is closed via the `FaultTolerantAmqpObject` abstraction.

# Last Upstream Rebase

Tuesday, January 7, 11:28am (EST)

# Related and Follow-Up Issues

- [Event Hubs Client Library for .NET - January Milestone](https://github.com/Azure/azure-sdk-for-net/issues/9040) (#9040)  