### PR TITLE
Processor host changes to fix a race and better init performance

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/Microsoft.Azure.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/Microsoft.Azure.EventHubs.Processor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>This is the next generation Azure Event Hubs .NET Standard Event Processor Host library. For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <VersionPrefix>4.1.0</VersionPrefix>
+    <VersionPrefix>4.1.1</VersionPrefix>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;AMQP;IoT;Event Processor Host</PackageTags>
     <PackageReleaseNotes>https://github.com/Azure/azure-sdk-for-net/releases</PackageReleaseNotes>
     <DocumentationFile>$(OutputPath)$(TargetFramework)\Microsoft.Azure.EventHubs.Processor.xml</DocumentationFile>


### PR DESCRIPTION
Changes involved:

1. Update owner in metadata of blob before uploading deserialized lease content. This avoids a potential race where hosts honor metadata while checking ownership during lease acquisition.
2. Parallelism at initializing leases and checkpoints.
3. Don't renew lease as part of checkpointing. Host should rely on PartitionManager's renew job and save storage I/O.
4. Move IsExpired check in PartitionManager outside of task at expired lease acquisition code. This helps to avoid spinning up hundreds of tasks for large number of partitions cases.
5. Spin up less number of tasks while adding and removing pumps.