### PR TITLE
Update TextAnalytics README's link to the reference docs

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -7,7 +7,7 @@ Azure Cognitive Services Text Analytics is a cloud service that provides advance
 * Recognition of Personally Identifiable Information 
 * Linked Entity Recognition
 
-[Source code][textanalytics_client_src] | [Package (NuGet)][textanalytics_nuget_package] | [API reference documentation](textanalytics_refdocs) | [Product documentation][textanalytics_docs] | [Samples][textanalytics_samples]
+[Source code][textanalytics_client_src] | [Package (NuGet)][textanalytics_nuget_package] | [API reference documentation][textanalytics_refdocs] | [Product documentation][textanalytics_docs] | [Samples][textanalytics_samples]
 
 ## Getting started
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -7,7 +7,7 @@ Azure Cognitive Services Text Analytics is a cloud service that provides advance
 * Recognition of Personally Identifiable Information 
 * Linked Entity Recognition
 
-[Source code][textanalytics_client_src] | [Package (NuGet)][textanalytics_nuget_package] | [API reference documentation]() | [Product documentation][textanalytics_docs] | [Samples][textanalytics_samples]
+[Source code][textanalytics_client_src] | [Package (NuGet)][textanalytics_nuget_package] | [API reference documentation](textanalytics_refdocs) | [Product documentation][textanalytics_docs] | [Samples][textanalytics_samples]
 
 ## Getting started
 
@@ -323,6 +323,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 <!-- LINKS -->
 [textanalytics_client_src]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/textanalytics/Azure.AI.TextAnalytics/src
 [textanalytics_docs]: https://docs.microsoft.com/en-us/azure/cognitive-services/Text-Analytics/
+[textanalytics_refdocs]: https://aka.ms/azsdk-net-textanalytics-ref-docs
 [textanalytics_nuget_package]: https://www.nuget.org/packages/Azure.AI.TextAnalytics
 [textanalytics_samples]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples
 [textanalytics_rest_api]: https://westus.dev.cognitive.microsoft.com/docs/services/TextAnalytics-v3-0-Preview-1/operations/Languages

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
@@ -63,6 +63,6 @@ To see the full example source files, see:
 
 * [Sample6_RecognizeLinkedEntities.cs](../tests/samples/Sample6_RecognizeLinkedEntities.cs)
 * [Sample6_RecognizeLinkedEntitiesBatch.cs](../tests/samples/Sample6_RecognizeLinkedEntitiesBatch.cs)
-* [Sample6_RecognizeLinkedEntitiesBatchConvienice.cs](../tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvienice.cs)
+* [Sample6_RecognizeLinkedEntitiesBatchConvenience.cs](../tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenience.cs)
 
 [DefaultAzureCredential]: ../../../identity/Azure.Identity/README.md


### PR DESCRIPTION
Using an aka.ms link so we can change where it points to later without updating the README.

Also including a fix to a broken link in a sample .md file.