### PR TITLE
Fix for broken cognitive service docs

### DIFF
--- a/doc/ApiDocGeneration/Generate-Api-Docs.ps1
+++ b/doc/ApiDocGeneration/Generate-Api-Docs.ps1
@@ -11,15 +11,22 @@ Param (
     $DocGenDir
 )
 
-Write-Verbose "Create variables for identifying package location and package safe names"
-$PackageLocation = "${ServiceDirectory}/${ArtifactName}"
+Write-Verbose "Name Reccuring paths with variable names"
+if ($ArtifactsDirectoryName -eq '') {$ArtifactsDirectoryName = $ArtifactName}
+$PackageLocation = "${ServiceDirectory}/${ArtifactsDirectoryName}"
+$FrameworkDir = "${BinDirectory}/${ArtifactsDirectoryName}/dll-docs"
+$ApiDir = "${FrameworkDir}/my-api"
+$ApiDependenciesDir = "${FrameworkDir}/dependencies/my-api"
+$XmlOutDir = "${BinDirectory}/${ArtifactsDirectoryName}/dll-xml-output"
+$YamlOutDir = "${BinDirectory}/${ArtifactsDirectoryName}/dll-yaml-output"
+$DocOutDir = "${BinDirectory}/${ArtifactsDirectoryName}/docfx-output/docfx_project"
+$DocOutApiDir = "${DocOutDir}/api"
+$DocOutHtmlDir = "${DocOutDir}/_site"
+$MDocTool = "${BinDirectory}/mdoc/mdoc.exe"
+$DocFxTool = "${BinDirectory}/docfx/docfx.exe"
 
 if ($ServiceDirectory -eq '*') {
     $PackageLocation = "core/${ArtifactName}"
-}
-
-if ($ServiceDirectory -eq 'cognitiveservices') {
-    $PackageLocation = "cognitiveservices/${ArtifactsDirectoryName}"
 }
 
 if ($LibType -eq 'Management') {
@@ -27,18 +34,6 @@ if ($LibType -eq 'Management') {
 }
 
 Write-Verbose "Package Location ${PackageLocation}"
-
-Write-Verbose "Name Reccuring paths with variable names"
-$FrameworkDir = "${BinDirectory}/${ArtifactName}/dll-docs"
-$ApiDir = "${FrameworkDir}/my-api"
-$ApiDependenciesDir = "${FrameworkDir}/dependencies/my-api"
-$XmlOutDir = "${BinDirectory}/${ArtifactName}/dll-xml-output"
-$YamlOutDir = "${BinDirectory}/${ArtifactName}/dll-yaml-output"
-$DocOutDir = "${BinDirectory}/${ArtifactName}/docfx-output/docfx_project"
-$DocOutApiDir = "${DocOutDir}/api"
-$DocOutHtmlDir = "${DocOutDir}/_site"
-$MDocTool = "${BinDirectory}/mdoc/mdoc.exe"
-$DocFxTool = "${BinDirectory}/docfx/docfx.exe"
 
 Write-Verbose "Create Directories Required for Doc Generation"
 mkdir $ApiDir

--- a/sdk/cognitiveservices/Language.TextAnalytics.README.txt
+++ b/sdk/cognitiveservices/Language.TextAnalytics.README.txt
@@ -1,2 +1,0 @@
-The official Azure SDK Track 2 library for the Cognitive Services Text Analytics service can be found under the path: azure-sdk-for-net\sdk\textanalytics
-

--- a/sdk/cognitiveservices/Language.TextAnalytics/src/README.md
+++ b/sdk/cognitiveservices/Language.TextAnalytics/src/README.md
@@ -3,6 +3,8 @@
 
  This SDK allows you to build applications that consumes Microsoft Cognitive Services Language APIs.
 
+ **Note:** The new, preview version for the Cognitive Services Text Analytics Azure SDK can be found under the path: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/textanalytics
+
  ### APIs
 
  For a full list of APIs under Language, please see our [list of language APIs](https://azure.microsoft.com/en-us/services/cognitive-services/?v=17.29#lang).


### PR DESCRIPTION
Cognitive services was running into long path issues when the package named is used for directories during doc generation. Switching to shorter names to resolve the issue.