### PR TITLE
countryHint default value should be "US" because "en" is a invalid co…

### DIFF
--- a/sdk/cognitiveservices/Language.TextAnalytics/src/Customizations/TextAnalytics/TextAnalyticsClientExtensions.cs
+++ b/sdk/cognitiveservices/Language.TextAnalytics/src/Customizations/TextAnalytics/TextAnalyticsClientExtensions.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         public static async Task<LanguageResult> DetectLanguageAsync(
             this ITextAnalyticsClient operations,
             string inputText = default,
-            string countryHint = "en",
+            string countryHint = "US",
             bool? showStats = default,
             CancellationToken cancellationToken = default)
         {
@@ -458,7 +458,7 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         public static LanguageResult DetectLanguage(
             this ITextAnalyticsClient operations,
             string inputText = default,
-            string countryHint = "en",
+            string countryHint = "US",
             bool? showStats = default,
             CancellationToken cancellationToken = default)
         {

--- a/sdk/cognitiveservices/Language.TextAnalytics/src/Microsoft.Azure.CognitiveServices.Language.TextAnalytics.csproj
+++ b/sdk/cognitiveservices/Language.TextAnalytics/src/Microsoft.Azure.CognitiveServices.Language.TextAnalytics.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyTitle>Microsoft Azure Cognitive Services Language Text Analytics Client Library</AssemblyTitle>
     <Description>Provides API functions for consuming Microsoft Azure Cognitive Services Language Text Analytics APIs.</Description>
-    <Version>4.1.0-preview.1</Version>
+    <Version>4.1.0-preview.2</Version>
     <PackageTags>Microsoft Cognitive Services;Cognitive Services;Cognitive Services SDK;Text Analytics API;Text Analytics;REST HTTP client;netcore451511</PackageTags>
     <PackageReleaseNotes>
     <![CDATA[


### PR DESCRIPTION
countryHint should be either be null, whitespace or ISO 3166-1 alpha-2 two letter country code. "en" is an invalid code so replacing it with "US"