### PR TITLE
Add ability to rotate subscription keys for Text Analytics service

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -49,7 +49,7 @@ With the value of the endpoint and a `TextAnalyticsSubscriptionKeyCredential`, y
 
 ```C# Snippet:CreateTextAnalyticsClient
 string endpoint = "<endpoint>";
-TextAnalyticsSubscriptionKeyCredential credential = "<credential>";
+string subscriptionKey = "<subscriptionKey>";
 var credential = new TextAnalyticsSubscriptionKeyCredential(subscriptionKey);
 var client = new TextAnalyticsClient(new Uri(endpoint), credential);
 ```

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -46,9 +46,9 @@ Once you have the values for endpoint and subscription key, you can create the [
 
 ```C# Snippet:CreateTextAnalyticsClient
 string endpoint = "<endpoint>";
-ServiceSubscriptionKey credentials = "<credentials>";
-var credentials = new ServiceSubscriptionKey(subscriptionKey);
-var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+TextAnalyticsSubscriptionKeyCredential credential = "<credential>";
+var credential = new TextAnalyticsSubscriptionKeyCredential(subscriptionKey);
+var client = new TextAnalyticsClient(new Uri(endpoint), credential);
 ```
 
 #### Create TextAnalyticsClient with Azure Active Directory Credential

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -41,8 +41,11 @@ az cognitiveservices account keys list --resource-group <your-resource-group-nam
 
 Alternatively, you can get the endpoint and subscription key from the resource information in the [Azure Portal][azure_portal].
 
-#### Create TextAnalyticsClient with Subscription Key
-Once you have the values for endpoint and subscription key, you can create the [TextAnalyticsClient][textanalytics_client_class]:
+#### Create TextAnalyticsClient with Subscription Key Credential
+Once you have the value for the subscription key, create a `TextAnalyticsSubscriptionKeyCredential`. This will allow you to
+update the subscription key by using the `UpdateCredential` method without creating a new client.
+
+With the value of the endpoint and a `TextAnalyticsSubscriptionKeyCredential`, you can create the [TextAnalyticsClient][textanalytics_client_class]:
 
 ```C# Snippet:CreateTextAnalyticsClient
 string endpoint = "<endpoint>";

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -46,8 +46,9 @@ Once you have the values for endpoint and subscription key, you can create the [
 
 ```C# Snippet:CreateTextAnalyticsClient
 string endpoint = "<endpoint>";
-string subscriptionKey = "<subscriptionKey>";
-var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+ServiceSubscriptionKey credentials = "<credentials>";
+var credentials = new ServiceSubscriptionKey(subscriptionKey);
+var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
 ```
 
 #### Create TextAnalyticsClient with Azure Active Directory Credential

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample1_DetectLanguage.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample1_DetectLanguage.md
@@ -4,7 +4,9 @@ This sample demonstrates how to detect the language that one or more text inputs
 
 ## Creating a `TextAnalyticsClient`
 
-To create a new `TextAnalyticsClient` to detect the language a text input is written in, you need a Text Analytics endpoint and credentials.  You can use the [DefaultAzureCredential][DefaultAzureCredential] to try a number of common authentication methods optimized for both running as a service and development.  In the sample below, however, you'll use a Text Analytics subscription key.  You can set `endpoint` and `subscriptionKey` based on an environment variable, a configuration setting, or any way that works for your application.
+To create a new `TextAnalyticsClient` to detect the language a text input is written in, you need a Text Analytics endpoint and credentials.  You can use the [DefaultAzureCredential][DefaultAzureCredential] to try a number of common authentication methods optimized for both running as a service and development.  In the sample below, however, you'll use a Text Analytics subscription key credential by creating a `TextAnalyticsSubscriptionKeyCredential` object, that if neded, will allow you to update the subscription key without creating a new client.
+
+You can set `endpoint` and `subscriptionKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
 ```C# Snippet:TextAnalyticsSample1CreateClient
 var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample1_DetectLanguage.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample1_DetectLanguage.md
@@ -7,8 +7,7 @@ This sample demonstrates how to detect the language that one or more text inputs
 To create a new `TextAnalyticsClient` to detect the language a text input is written in, you need a Text Analytics endpoint and credentials.  You can use the [DefaultAzureCredential][DefaultAzureCredential] to try a number of common authentication methods optimized for both running as a service and development.  In the sample below, however, you'll use a Text Analytics subscription key.  You can set `endpoint` and `subscriptionKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
 ```C# Snippet:TextAnalyticsSample1CreateClient
-var credentials = new ServiceSubscriptionKey(subscriptionKey);
-var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
 ```
 
 ## Detecting a language for a single text input

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample1_DetectLanguage.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample1_DetectLanguage.md
@@ -7,7 +7,8 @@ This sample demonstrates how to detect the language that one or more text inputs
 To create a new `TextAnalyticsClient` to detect the language a text input is written in, you need a Text Analytics endpoint and credentials.  You can use the [DefaultAzureCredential][DefaultAzureCredential] to try a number of common authentication methods optimized for both running as a service and development.  In the sample below, however, you'll use a Text Analytics subscription key.  You can set `endpoint` and `subscriptionKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
 ```C# Snippet:TextAnalyticsSample1CreateClient
-var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+var credentials = new ServiceSubscriptionKey(subscriptionKey);
+var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
 ```
 
 ## Detecting a language for a single text input

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample2_AnalyzeSentiment.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample2_AnalyzeSentiment.md
@@ -7,8 +7,7 @@ This sample demonstrates how to analyze the sentiment in one or more text inputs
 To create a new `TextAnalyticsClient` to analyze the sentiment in a text input, you need a Text Analytics endpoint and credentials.  You can use the [DefaultAzureCredential][DefaultAzureCredential] to try a number of common authentication methods optimized for both running as a service and development.  In the sample below, however, you'll use a Text Analytics subscription key.  You can set `endpoint` and `subscriptionKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
 ```C# Snippet:TextAnalyticsSample2CreateClient
-var credentials = new ServiceSubscriptionKey(subscriptionKey);
-var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
 ```
 
 ## Analyzing the sentiment of a single text input

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample2_AnalyzeSentiment.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample2_AnalyzeSentiment.md
@@ -7,7 +7,8 @@ This sample demonstrates how to analyze the sentiment in one or more text inputs
 To create a new `TextAnalyticsClient` to analyze the sentiment in a text input, you need a Text Analytics endpoint and credentials.  You can use the [DefaultAzureCredential][DefaultAzureCredential] to try a number of common authentication methods optimized for both running as a service and development.  In the sample below, however, you'll use a Text Analytics subscription key.  You can set `endpoint` and `subscriptionKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
 ```C# Snippet:TextAnalyticsSample2CreateClient
-var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+var credentials = new ServiceSubscriptionKey(subscriptionKey);
+var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
 ```
 
 ## Analyzing the sentiment of a single text input

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample2_AnalyzeSentiment.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample2_AnalyzeSentiment.md
@@ -4,7 +4,9 @@ This sample demonstrates how to analyze the sentiment in one or more text inputs
 
 ## Creating a `TextAnalyticsClient`
 
-To create a new `TextAnalyticsClient` to analyze the sentiment in a text input, you need a Text Analytics endpoint and credentials.  You can use the [DefaultAzureCredential][DefaultAzureCredential] to try a number of common authentication methods optimized for both running as a service and development.  In the sample below, however, you'll use a Text Analytics subscription key.  You can set `endpoint` and `subscriptionKey` based on an environment variable, a configuration setting, or any way that works for your application.
+To create a new `TextAnalyticsClient` to analyze the sentiment in a text input, you need a Text Analytics endpoint and credentials.  You can use the [DefaultAzureCredential][DefaultAzureCredential] to try a number of common authentication methods optimized for both running as a service and development.  In the sample below, however, you'll use a Text Analytics subscription key credential by creating a `TextAnalyticsSubscriptionKeyCredential` object, that if neded, will allow you to update the subscription key without creating a new client.
+
+You can set `endpoint` and `subscriptionKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
 ```C# Snippet:TextAnalyticsSample2CreateClient
 var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample3_ExtractKeyPhrases.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample3_ExtractKeyPhrases.md
@@ -7,8 +7,7 @@ This sample demonstrates how to extract key phrases from one or more text inputs
 To create a new `TextAnalyticsClient` to extract key phrases from text input, you need a Text Analytics endpoint and credentials.  You can use the [DefaultAzureCredential][DefaultAzureCredential] to try a number of common authentication methods optimized for both running as a service and development.  In the sample below, however, you'll use a Text Analytics subscription key.  You can set `endpoint` and `subscriptionKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
 ```C# Snippet:TextAnalyticsSample3CreateClient
-var credentials = new ServiceSubscriptionKey(subscriptionKey);
-var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
 ```
 
 ## Extracting key phrases from a single input

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample3_ExtractKeyPhrases.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample3_ExtractKeyPhrases.md
@@ -7,7 +7,8 @@ This sample demonstrates how to extract key phrases from one or more text inputs
 To create a new `TextAnalyticsClient` to extract key phrases from text input, you need a Text Analytics endpoint and credentials.  You can use the [DefaultAzureCredential][DefaultAzureCredential] to try a number of common authentication methods optimized for both running as a service and development.  In the sample below, however, you'll use a Text Analytics subscription key.  You can set `endpoint` and `subscriptionKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
 ```C# Snippet:TextAnalyticsSample3CreateClient
-var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+var credentials = new ServiceSubscriptionKey(subscriptionKey);
+var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
 ```
 
 ## Extracting key phrases from a single input

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample3_ExtractKeyPhrases.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample3_ExtractKeyPhrases.md
@@ -4,7 +4,9 @@ This sample demonstrates how to extract key phrases from one or more text inputs
 
 ## Creating a `TextAnalyticsClient`
 
-To create a new `TextAnalyticsClient` to extract key phrases from text input, you need a Text Analytics endpoint and credentials.  You can use the [DefaultAzureCredential][DefaultAzureCredential] to try a number of common authentication methods optimized for both running as a service and development.  In the sample below, however, you'll use a Text Analytics subscription key.  You can set `endpoint` and `subscriptionKey` based on an environment variable, a configuration setting, or any way that works for your application.
+To create a new `TextAnalyticsClient` to extract key phrases from text input, you need a Text Analytics endpoint and credentials.  You can use the [DefaultAzureCredential][DefaultAzureCredential] to try a number of common authentication methods optimized for both running as a service and development.  In the sample below, however, you'll use a Text Analytics subscription key credential by creating a `TextAnalyticsSubscriptionKeyCredential` object, that if neded, will allow you to update the subscription key without creating a new client.
+
+You can set `endpoint` and `subscriptionKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
 ```C# Snippet:TextAnalyticsSample3CreateClient
 var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample4_RecognizeEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample4_RecognizeEntities.md
@@ -6,8 +6,7 @@ This sample demonstrates how to recognize entities in one or more text inputs us
 To create a new `TextAnalyticsClient` to recognize entities in an input text, you need a Text Analytics endpoint and credentials.  You can use the [DefaultAzureCredential][DefaultAzureCredential] to try a number of common authentication methods optimized for both running as a service and development.  In the sample below, however, you'll use a Text Analytics subscription key.  You can set `endpoint` and `subscriptionKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
 ```C# Snippet:TextAnalyticsSample4CreateClient
-var credentials = new ServiceSubscriptionKey(subscriptionKey);
-var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
 ```
 
 ## Recognizing entities in a single input

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample4_RecognizeEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample4_RecognizeEntities.md
@@ -6,7 +6,8 @@ This sample demonstrates how to recognize entities in one or more text inputs us
 To create a new `TextAnalyticsClient` to recognize entities in an input text, you need a Text Analytics endpoint and credentials.  You can use the [DefaultAzureCredential][DefaultAzureCredential] to try a number of common authentication methods optimized for both running as a service and development.  In the sample below, however, you'll use a Text Analytics subscription key.  You can set `endpoint` and `subscriptionKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
 ```C# Snippet:TextAnalyticsSample4CreateClient
-var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+var credentials = new ServiceSubscriptionKey(subscriptionKey);
+var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
 ```
 
 ## Recognizing entities in a single input

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample4_RecognizeEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample4_RecognizeEntities.md
@@ -3,7 +3,9 @@ This sample demonstrates how to recognize entities in one or more text inputs us
 
 ## Creating a `TextAnalyticsClient`
 
-To create a new `TextAnalyticsClient` to recognize entities in an input text, you need a Text Analytics endpoint and credentials.  You can use the [DefaultAzureCredential][DefaultAzureCredential] to try a number of common authentication methods optimized for both running as a service and development.  In the sample below, however, you'll use a Text Analytics subscription key.  You can set `endpoint` and `subscriptionKey` based on an environment variable, a configuration setting, or any way that works for your application.
+To create a new `TextAnalyticsClient` to recognize entities in an input text, you need a Text Analytics endpoint and credentials.  You can use the [DefaultAzureCredential][DefaultAzureCredential] to try a number of common authentication methods optimized for both running as a service and development.  In the sample below, however, you'll use a Text Analytics subscription key credential by creating a `TextAnalyticsSubscriptionKeyCredential` object, that if neded, will allow you to update the subscription key without creating a new client.
+
+You can set `endpoint` and `subscriptionKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
 ```C# Snippet:TextAnalyticsSample4CreateClient
 var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample5_RecognizePiiEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample5_RecognizePiiEntities.md
@@ -3,7 +3,9 @@ This sample demonstrates how to recognize personally identifiable information (P
 
 ## Creating a `TextAnalyticsClient`
 
-To create a new `TextAnalyticsClient` to recognize personally identifiable information in an input text, you need a Text Analytics endpoint and credentials.  You can use the [DefaultAzureCredential][DefaultAzureCredential] to try a number of common authentication methods optimized for both running as a service and development.  In the sample below, however, you'll use a Text Analytics subscription key.  You can set `endpoint` and `subscriptionKey` based on an environment variable, a configuration setting, or any way that works for your application.
+To create a new `TextAnalyticsClient` to recognize personally identifiable information in an input text, you need a Text Analytics endpoint and credentials.  You can use the [DefaultAzureCredential][DefaultAzureCredential] to try a number of common authentication methods optimized for both running as a service and development.  In the sample below, however, you'll use a Text Analytics subscription key credential by creating a `TextAnalyticsSubscriptionKeyCredential` object, that if neded, will allow you to update the subscription key without creating a new client.
+
+You can set `endpoint` and `subscriptionKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
 ```C# Snippet:TextAnalyticsSample5CreateClient
 var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample5_RecognizePiiEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample5_RecognizePiiEntities.md
@@ -6,8 +6,7 @@ This sample demonstrates how to recognize personally identifiable information (P
 To create a new `TextAnalyticsClient` to recognize personally identifiable information in an input text, you need a Text Analytics endpoint and credentials.  You can use the [DefaultAzureCredential][DefaultAzureCredential] to try a number of common authentication methods optimized for both running as a service and development.  In the sample below, however, you'll use a Text Analytics subscription key.  You can set `endpoint` and `subscriptionKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
 ```C# Snippet:TextAnalyticsSample5CreateClient
-var credentials = new ServiceSubscriptionKey(subscriptionKey);
-var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
 ```
 
 ## Recognizing personally identifiable information in a single input

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample5_RecognizePiiEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample5_RecognizePiiEntities.md
@@ -6,7 +6,8 @@ This sample demonstrates how to recognize personally identifiable information (P
 To create a new `TextAnalyticsClient` to recognize personally identifiable information in an input text, you need a Text Analytics endpoint and credentials.  You can use the [DefaultAzureCredential][DefaultAzureCredential] to try a number of common authentication methods optimized for both running as a service and development.  In the sample below, however, you'll use a Text Analytics subscription key.  You can set `endpoint` and `subscriptionKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
 ```C# Snippet:TextAnalyticsSample5CreateClient
-var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+var credentials = new ServiceSubscriptionKey(subscriptionKey);
+var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
 ```
 
 ## Recognizing personally identifiable information in a single input

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
@@ -6,8 +6,7 @@ This sample demonstrates how to recognize linked entities in one or more text in
 To create a new `TextAnalyticsClient` to recognize linked entities in an input text, you need a Text Analytics endpoint and credentials.  You can use the [DefaultAzureCredential][DefaultAzureCredential] to try a number of common authentication methods optimized for both running as a service and development.  In the sample below, however, you'll use a Text Analytics subscription key.  You can set `endpoint` and `subscriptionKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
 ```C# Snippet:TextAnalyticsSample6CreateClient
-var credentials = new ServiceSubscriptionKey(subscriptionKey);
-var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
 ```
 
 ## Recognizing linked entities in a single input

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
@@ -6,7 +6,8 @@ This sample demonstrates how to recognize linked entities in one or more text in
 To create a new `TextAnalyticsClient` to recognize linked entities in an input text, you need a Text Analytics endpoint and credentials.  You can use the [DefaultAzureCredential][DefaultAzureCredential] to try a number of common authentication methods optimized for both running as a service and development.  In the sample below, however, you'll use a Text Analytics subscription key.  You can set `endpoint` and `subscriptionKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
 ```C# Snippet:TextAnalyticsSample6CreateClient
-var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+var credentials = new ServiceSubscriptionKey(subscriptionKey);
+var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
 ```
 
 ## Recognizing linked entities in a single input

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
@@ -3,7 +3,9 @@ This sample demonstrates how to recognize linked entities in one or more text in
 
 ## Creating a `TextAnalyticsClient`
 
-To create a new `TextAnalyticsClient` to recognize linked entities in an input text, you need a Text Analytics endpoint and credentials.  You can use the [DefaultAzureCredential][DefaultAzureCredential] to try a number of common authentication methods optimized for both running as a service and development.  In the sample below, however, you'll use a Text Analytics subscription key.  You can set `endpoint` and `subscriptionKey` based on an environment variable, a configuration setting, or any way that works for your application.
+To create a new `TextAnalyticsClient` to recognize linked entities in an input text, you need a Text Analytics endpoint and credentials.  You can use the [DefaultAzureCredential][DefaultAzureCredential] to try a number of common authentication methods optimized for both running as a service and development. In the sample below, however, you'll use a Text Analytics subscription key credential by creating a `TextAnalyticsSubscriptionKeyCredential` object, that if neded, will allow you to update the subscription key without creating a new client.
+
+You can set `endpoint` and `subscriptionKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
 ```C# Snippet:TextAnalyticsSample6CreateClient
 var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceSubscriptionKey.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ServiceSubscriptionKey.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+
+namespace Azure.AI.TextAnalytics
+{
+    /// <summary>
+    /// A <see cref="ServiceSubscriptionKey"/> is a subscription key use to authenticate
+    /// against a Cognitive Service.
+    /// </summary>
+    public class ServiceSubscriptionKey
+    {
+        private string _subscriptionKey;
+
+        /// <summary>
+        /// Service subscription key.
+        /// </summary>
+        public string SubscriptionKey
+        {
+            get => Volatile.Read(ref _subscriptionKey);
+            private set => Volatile.Write(ref _subscriptionKey, value);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceSubscriptionKey"/> class.
+        /// </summary>
+        /// <param name="subscriptionKey">Subscription key to athenticate the service against.</param>
+        public ServiceSubscriptionKey(string subscriptionKey)
+        {
+            SetSubscriptionKey(subscriptionKey);
+        }
+
+        /// <summary>
+        /// Updates the Cognitive Service subscription key.
+        /// This is intended to be used when you've regenerated your service subscription key
+        /// and want to update long lived clients.
+        /// </summary>
+        /// <param name="subscriptionKey">Subscription key to athenticate the service against.</param>
+        public void SetSubscriptionKey(string subscriptionKey) =>
+            SubscriptionKey = subscriptionKey;
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
@@ -75,7 +75,8 @@ namespace Azure.AI.TextAnalytics
         /// <param name="endpoint">A <see cref="Uri"/> to the service the client
         /// sends requests to.  Endpoint can be found in the Azure portal.</param>
         /// <param name="credential">The subscription key used to access
-        /// the service.</param>
+        /// the service. This will allow you to update the subscription key
+        /// without creating a new client.</param>
         public TextAnalyticsClient(Uri endpoint, TextAnalyticsSubscriptionKeyCredential credential)
             : this(endpoint, credential, new TextAnalyticsClientOptions())
         {
@@ -88,7 +89,8 @@ namespace Azure.AI.TextAnalytics
         /// <param name="endpoint">A <see cref="Uri"/> to the service the client
         /// sends requests to.  Endpoint can be found in the Azure portal.</param>
         /// <param name="credential">The subscription key used to access
-        /// the service.</param>
+        /// the service. This will allow you to update the subscription key
+        /// without creating a new client.</param>
         /// <param name="options"><see cref="TextAnalyticsClientOptions"/> that allow
         /// callers to configure how requests are sent to the service.</param>
         public TextAnalyticsClient(Uri endpoint, TextAnalyticsSubscriptionKeyCredential credential, TextAnalyticsClientOptions options)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
@@ -19,11 +19,27 @@ namespace Azure.AI.TextAnalytics
         private readonly Uri _baseUri;
         private readonly HttpPipeline _pipeline;
         private readonly ClientDiagnostics _clientDiagnostics;
-        private readonly string _subscriptionKey;
         private readonly string _apiVersion;
         private readonly TextAnalyticsClientOptions _options;
 
         private readonly string DefaultCognitiveScope = "https://cognitiveservices.azure.com/.default";
+
+        private string _subscriptionKey;
+
+        private string SubscriptionKey
+        {
+            get => Volatile.Read(ref _subscriptionKey);
+            set => Volatile.Write(ref _subscriptionKey, value);
+        }
+
+        /// <summary>
+        /// Updates the Text Analytics subscription key.
+        /// This is intended to be used when you've regenerated your service subscription key
+        /// and want to update long lived clients.
+        /// </summary>
+        /// <param name="subscriptionKey">A Text Analytics subscription key.</param>
+        public void SetSubscriptionKey(string subscriptionKey) =>
+            SubscriptionKey = subscriptionKey;
 
         /// <summary>
         /// Protected constructor to allow mocking.
@@ -98,7 +114,7 @@ namespace Azure.AI.TextAnalytics
             Argument.AssertNotNull(options, nameof(options));
 
             _baseUri = endpoint;
-            _subscriptionKey = subscriptionKey;
+            SetSubscriptionKey(subscriptionKey);
             _apiVersion = options.GetVersionString();
             _pipeline = HttpPipelineBuilder.Build(options);
             _clientDiagnostics = new ClientDiagnostics(options);
@@ -1739,7 +1755,7 @@ namespace Azure.AI.TextAnalytics
             request.Headers.Add(HttpHeader.Common.JsonContentType);
             request.Content = RequestContent.Create(content);
 
-            request.Headers.Add("Ocp-Apim-Subscription-Key", _subscriptionKey);
+            request.Headers.Add("Ocp-Apim-Subscription-Key", SubscriptionKey);
 
             return request;
         }
@@ -1756,7 +1772,7 @@ namespace Azure.AI.TextAnalytics
             request.Headers.Add(HttpHeader.Common.JsonContentType);
             request.Content = RequestContent.Create(content);
 
-            request.Headers.Add("Ocp-Apim-Subscription-Key", _subscriptionKey);
+            request.Headers.Add("Ocp-Apim-Subscription-Key", SubscriptionKey);
 
             return request;
         }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
@@ -23,7 +23,7 @@ namespace Azure.AI.TextAnalytics
         private readonly TextAnalyticsClientOptions _options;
         private readonly string DefaultCognitiveScope = "https://cognitiveservices.azure.com/.default";
 
-        private ServiceSubscriptionKey _textAnalyticsSubscriptionKey;
+        private TextAnalyticsSubscriptionKeyCredential _textAnalyticsSubscriptionKey;
 
         /// <summary>
         /// Protected constructor to allow mocking.
@@ -74,10 +74,10 @@ namespace Azure.AI.TextAnalytics
         /// </summary>
         /// <param name="endpoint">A <see cref="Uri"/> to the service the client
         /// sends requests to.  Endpoint can be found in the Azure portal.</param>
-        /// <param name="credentials">The subscription key used to access
+        /// <param name="credential">The subscription key used to access
         /// the service.</param>
-        public TextAnalyticsClient(Uri endpoint, ServiceSubscriptionKey credentials)
-            : this(endpoint, credentials, new TextAnalyticsClientOptions())
+        public TextAnalyticsClient(Uri endpoint, TextAnalyticsSubscriptionKeyCredential credential)
+            : this(endpoint, credential, new TextAnalyticsClientOptions())
         {
         }
 
@@ -87,19 +87,19 @@ namespace Azure.AI.TextAnalytics
         /// </summary>
         /// <param name="endpoint">A <see cref="Uri"/> to the service the client
         /// sends requests to.  Endpoint can be found in the Azure portal.</param>
-        /// <param name="credentials">The subscription key used to access
+        /// <param name="credential">The subscription key used to access
         /// the service.</param>
         /// <param name="options"><see cref="TextAnalyticsClientOptions"/> that allow
         /// callers to configure how requests are sent to the service.</param>
-        public TextAnalyticsClient(Uri endpoint, ServiceSubscriptionKey credentials, TextAnalyticsClientOptions options)
+        public TextAnalyticsClient(Uri endpoint, TextAnalyticsSubscriptionKeyCredential credential, TextAnalyticsClientOptions options)
         {
             Argument.AssertNotNull(endpoint, nameof(endpoint));
-            Argument.AssertNotNull(credentials, nameof(credentials));
+            Argument.AssertNotNull(credential, nameof(credential));
             Argument.AssertNotNull(options, nameof(options));
 
             _baseUri = endpoint;
             _apiVersion = options.GetVersionString();
-            _textAnalyticsSubscriptionKey = credentials;
+            _textAnalyticsSubscriptionKey = credential;
             _pipeline = HttpPipelineBuilder.Build(options);
             _clientDiagnostics = new ClientDiagnostics(options);
             _options = options;

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsSubscriptionKeyCredential.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsSubscriptionKeyCredential.cs
@@ -6,29 +6,29 @@ using System.Threading;
 namespace Azure.AI.TextAnalytics
 {
     /// <summary>
-    /// A <see cref="ServiceSubscriptionKey"/> is a subscription key use to authenticate
+    /// A <see cref="TextAnalyticsSubscriptionKeyCredential"/> is a subscription key use to authenticate
     /// against a Cognitive Service.
     /// </summary>
-    public class ServiceSubscriptionKey
+    public class TextAnalyticsSubscriptionKeyCredential
     {
         private string _subscriptionKey;
 
         /// <summary>
         /// Service subscription key.
         /// </summary>
-        public string SubscriptionKey
+        internal string SubscriptionKey
         {
             get => Volatile.Read(ref _subscriptionKey);
             private set => Volatile.Write(ref _subscriptionKey, value);
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ServiceSubscriptionKey"/> class.
+        /// Initializes a new instance of the <see cref="TextAnalyticsSubscriptionKeyCredential"/> class.
         /// </summary>
         /// <param name="subscriptionKey">Subscription key to athenticate the service against.</param>
-        public ServiceSubscriptionKey(string subscriptionKey)
+        public TextAnalyticsSubscriptionKeyCredential(string subscriptionKey)
         {
-            SetSubscriptionKey(subscriptionKey);
+            UpdateCredential(subscriptionKey);
         }
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace Azure.AI.TextAnalytics
         /// and want to update long lived clients.
         /// </summary>
         /// <param name="subscriptionKey">Subscription key to athenticate the service against.</param>
-        public void SetSubscriptionKey(string subscriptionKey) =>
+        public void UpdateCredential(string subscriptionKey) =>
             SubscriptionKey = subscriptionKey;
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsSubscriptionKeyCredential.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsSubscriptionKeyCredential.cs
@@ -7,7 +7,9 @@ namespace Azure.AI.TextAnalytics
 {
     /// <summary>
     /// A <see cref="TextAnalyticsSubscriptionKeyCredential"/> is a subscription key use to authenticate
-    /// against a Cognitive Service.
+    /// against the Text Analytics service.
+    /// It provides the ability to update the subscription key
+    /// without creating a new client.
     /// </summary>
     public class TextAnalyticsSubscriptionKeyCredential
     {
@@ -25,7 +27,7 @@ namespace Azure.AI.TextAnalytics
         /// <summary>
         /// Initializes a new instance of the <see cref="TextAnalyticsSubscriptionKeyCredential"/> class.
         /// </summary>
-        /// <param name="subscriptionKey">Subscription key to athenticate the service against.</param>
+        /// <param name="subscriptionKey">Subscription key to use to authenticate with the service.</param>
         public TextAnalyticsSubscriptionKeyCredential(string subscriptionKey)
         {
             UpdateCredential(subscriptionKey);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AuthenticationTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AuthenticationTests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Core.Testing;
+using NUnit.Framework;
+
+namespace Azure.AI.TextAnalytics.Tests
+{
+    public class AuthenticationTests : ClientTestBase
+    {
+        public AuthenticationTests(bool async) : base(async)
+        {
+        }
+
+        [Test]
+        public async Task RotateSubscriptionKey()
+        {
+            string endpoint = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_ENDPOINT");
+            string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
+
+            // Instantiate a client that will be used to call the service.
+            var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+
+            string input = "Este documento está en español.";
+
+            // Verify the credential works (i.e., doesn't throw)
+            await client.DetectLanguageAsync(input);
+
+            // Rotate the subscription key to an invalid value and make sure it fails
+            client.SetSubscriptionKey("Invalid");
+            Assert.ThrowsAsync<RequestFailedException>(
+                   async () => await client.DetectLanguageAsync(input));
+
+            // Re-rotate the subscription key and make sure it succeeds again
+            client.SetSubscriptionKey(subscriptionKey);
+            await client.DetectLanguageAsync(input);
+        }
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AuthenticationTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AuthenticationTests.cs
@@ -22,8 +22,8 @@ namespace Azure.AI.TextAnalytics.Tests
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             // Instantiate a client that will be used to call the service.
-            var credentials = new ServiceSubscriptionKey(subscriptionKey);
-            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+            var credential = new TextAnalyticsSubscriptionKeyCredential(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credential);
 
             string input = "Este documento está en español.";
 
@@ -31,12 +31,12 @@ namespace Azure.AI.TextAnalytics.Tests
             await client.DetectLanguageAsync(input);
 
             // Rotate the subscription key to an invalid value and make sure it fails
-            credentials.SetSubscriptionKey("Invalid");
+            credential.UpdateCredential("Invalid");
             Assert.ThrowsAsync<RequestFailedException>(
                    async () => await client.DetectLanguageAsync(input));
 
             // Re-rotate the subscription key and make sure it succeeds again
-            credentials.SetSubscriptionKey(subscriptionKey);
+            credential.UpdateCredential(subscriptionKey);
             await client.DetectLanguageAsync(input);
         }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AuthenticationTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AuthenticationTests.cs
@@ -15,6 +15,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [Test]
+        [Ignore ("Need to add recordings. Part of https://github.com/Azure/azure-sdk-for-net/issues/9091")]
         public async Task RotateSubscriptionKey()
         {
             string endpoint = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_ENDPOINT");

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AuthenticationTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AuthenticationTests.cs
@@ -21,7 +21,8 @@ namespace Azure.AI.TextAnalytics.Tests
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             // Instantiate a client that will be used to call the service.
-            var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+            var credentials = new ServiceSubscriptionKey(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
 
             string input = "Este documento está en español.";
 
@@ -29,12 +30,12 @@ namespace Azure.AI.TextAnalytics.Tests
             await client.DetectLanguageAsync(input);
 
             // Rotate the subscription key to an invalid value and make sure it fails
-            client.SetSubscriptionKey("Invalid");
+            credentials.SetSubscriptionKey("Invalid");
             Assert.ThrowsAsync<RequestFailedException>(
                    async () => await client.DetectLanguageAsync(input));
 
             // Re-rotate the subscription key and make sure it succeeds again
-            client.SetSubscriptionKey(subscriptionKey);
+            credentials.SetSubscriptionKey(subscriptionKey);
             await client.DetectLanguageAsync(input);
         }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientMockTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientMockTests.cs
@@ -28,7 +28,7 @@ namespace Azure.AI.TextAnalytics.Tests
                 Transport = transport
             };
 
-            var client = InstrumentClient(new TextAnalyticsClient(new Uri(s_endpoint), s_subscriptionKey, options));
+            var client = InstrumentClient(new TextAnalyticsClient(new Uri(s_endpoint), new TextAnalyticsSubscriptionKeyCredential(s_subscriptionKey), options));
 
             return client;
         }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientTests.cs
@@ -20,8 +20,7 @@ namespace Azure.AI.TextAnalytics.Tests
                 Transport = new MockTransport(),
             };
 
-            var credentials = new ServiceSubscriptionKey(s_subscriptionKey);
-            Client = InstrumentClient(new TextAnalyticsClient(new Uri(s_endpoint), credentials, options));
+             Client = InstrumentClient(new TextAnalyticsClient(new Uri("http://localhost"), new DefaultAzureCredential(), options));
         }
 
         public TextAnalyticsClient Client { get; set; }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientTests.cs
@@ -20,7 +20,8 @@ namespace Azure.AI.TextAnalytics.Tests
                 Transport = new MockTransport(),
             };
 
-            Client = InstrumentClient(new TextAnalyticsClient(new Uri("http://localhost"), new DefaultAzureCredential(), options));
+            var credentials = new ServiceSubscriptionKey(s_subscriptionKey);
+            Client = InstrumentClient(new TextAnalyticsClient(new Uri(s_endpoint), credentials, options));
         }
 
         public TextAnalyticsClient Client { get; set; }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientTests.cs
@@ -30,9 +30,8 @@ namespace Azure.AI.TextAnalytics.Tests
         {
             var uri = new Uri("http://localhost");
 
-            Assert.Throws<ArgumentNullException>(() => new TextAnalyticsClient(null, "subscriptionKey"));
-            Assert.Throws<ArgumentException>(() => new TextAnalyticsClient(uri, ""));
-            Assert.Throws<ArgumentNullException>(() => new TextAnalyticsClient(uri, (string)null));
+            Assert.Throws<ArgumentNullException>(() => new TextAnalyticsClient(null, new TextAnalyticsSubscriptionKeyCredential("subscriptionKey")));
+            Assert.Throws<ArgumentNullException>(() => new TextAnalyticsClient(uri, (TextAnalyticsSubscriptionKeyCredential)null));
             Assert.Throws<ArgumentNullException>(() => new TextAnalyticsClient(uri, (TokenCredential)null));
             Assert.Throws<ArgumentNullException>(() => new TextAnalyticsClient(null, new DefaultAzureCredential()));
         }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguage.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguage.cs
@@ -17,8 +17,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             #region Snippet:TextAnalyticsSample1CreateClient
-            var credentials = new ServiceSubscriptionKey(subscriptionKey);
-            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+            var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
             #endregion
 
             #region Snippet:DetectLanguage

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguage.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguage.cs
@@ -17,7 +17,8 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             #region Snippet:TextAnalyticsSample1CreateClient
-            var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+            var credentials = new ServiceSubscriptionKey(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
             #endregion
 
             #region Snippet:DetectLanguage

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageAsync.cs
@@ -18,8 +18,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             // Instantiate a client that will be used to call the service.
-            var credentials = new ServiceSubscriptionKey(subscriptionKey);
-            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+            var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
 
             #region Snippet:DetectLanguageAsync
             string input = "Este documento está en español.";

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageAsync.cs
@@ -17,7 +17,9 @@ namespace Azure.AI.TextAnalytics.Samples
             string endpoint = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_ENDPOINT");
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
-            var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+            // Instantiate a client that will be used to call the service.
+            var credentials = new ServiceSubscriptionKey(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
 
             #region Snippet:DetectLanguageAsync
             string input = "Este documento está en español.";

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatch.cs
@@ -19,8 +19,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             // Instantiate a client that will be used to call the service.
-            var credentials = new ServiceSubscriptionKey(subscriptionKey);
-            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+            var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
 
             #region Snippet:TextAnalyticsSample1DetectLanguagesBatch
             var inputs = new List<DetectLanguageInput>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatch.cs
@@ -18,7 +18,9 @@ namespace Azure.AI.TextAnalytics.Samples
             string endpoint = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_ENDPOINT");
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
-            var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+            // Instantiate a client that will be used to call the service.
+            var credentials = new ServiceSubscriptionKey(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
 
             #region Snippet:TextAnalyticsSample1DetectLanguagesBatch
             var inputs = new List<DetectLanguageInput>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatchConvenience.cs
@@ -18,7 +18,9 @@ namespace Azure.AI.TextAnalytics.Samples
             string endpoint = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_ENDPOINT");
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
-            var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+            // Instantiate a client that will be used to call the service.
+            var credentials = new ServiceSubscriptionKey(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
 
             var inputs = new List<string>
             {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatchConvenience.cs
@@ -19,8 +19,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             // Instantiate a client that will be used to call the service.
-            var credentials = new ServiceSubscriptionKey(subscriptionKey);
-            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+            var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
 
             var inputs = new List<string>
             {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentiment.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentiment.cs
@@ -17,8 +17,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             #region Snippet:TextAnalyticsSample2CreateClient
-            var credentials = new ServiceSubscriptionKey(subscriptionKey);
-            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+            var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
             #endregion
 
             #region Snippet:AnalyzeSentiment

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentiment.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentiment.cs
@@ -17,7 +17,8 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             #region Snippet:TextAnalyticsSample2CreateClient
-            var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+            var credentials = new ServiceSubscriptionKey(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
             #endregion
 
             #region Snippet:AnalyzeSentiment

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatch.cs
@@ -18,7 +18,9 @@ namespace Azure.AI.TextAnalytics.Samples
             string endpoint = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_ENDPOINT");
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
-            var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+            // Instantiate a client that will be used to call the service.
+            var credentials = new ServiceSubscriptionKey(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
 
             #region Snippet:TextAnalyticsSample2AnalyzeSentimentBatch
             var inputs = new List<TextDocumentInput>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatch.cs
@@ -19,8 +19,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             // Instantiate a client that will be used to call the service.
-            var credentials = new ServiceSubscriptionKey(subscriptionKey);
-            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+            var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
 
             #region Snippet:TextAnalyticsSample2AnalyzeSentimentBatch
             var inputs = new List<TextDocumentInput>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchConvenience.cs
@@ -18,7 +18,9 @@ namespace Azure.AI.TextAnalytics.Samples
             string endpoint = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_ENDPOINT");
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
-            var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+            // Instantiate a client that will be used to call the service.
+            var credentials = new ServiceSubscriptionKey(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
 
             var inputs = new List<string>
             {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchConvenience.cs
@@ -19,8 +19,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             // Instantiate a client that will be used to call the service.
-            var credentials = new ServiceSubscriptionKey(subscriptionKey);
-            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+            var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
 
             var inputs = new List<string>
             {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrases.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrases.cs
@@ -19,7 +19,8 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             #region Snippet:TextAnalyticsSample3CreateClient
-            var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+            var credentials = new ServiceSubscriptionKey(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
             #endregion
 
             #region Snippet:ExtractKeyPhrases

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrases.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrases.cs
@@ -19,8 +19,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             #region Snippet:TextAnalyticsSample3CreateClient
-            var credentials = new ServiceSubscriptionKey(subscriptionKey);
-            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+            var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
             #endregion
 
             #region Snippet:ExtractKeyPhrases

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatch.cs
@@ -20,8 +20,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             // Instantiate a client that will be used to call the service.
-            var credentials = new ServiceSubscriptionKey(subscriptionKey);
-            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+            var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
 
             #region Snippet:TextAnalyticsSample3ExtractKeyPhrasesBatch
             var inputs = new List<TextDocumentInput>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatch.cs
@@ -19,7 +19,9 @@ namespace Azure.AI.TextAnalytics.Samples
             string endpoint = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_ENDPOINT");
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
-            var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+            // Instantiate a client that will be used to call the service.
+            var credentials = new ServiceSubscriptionKey(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
 
             #region Snippet:TextAnalyticsSample3ExtractKeyPhrasesBatch
             var inputs = new List<TextDocumentInput>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatchConvenience.cs
@@ -20,8 +20,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             // Instantiate a client that will be used to call the service.
-            var credentials = new ServiceSubscriptionKey(subscriptionKey);
-            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+            var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
 
             var inputs = new List<string>
             {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatchConvenience.cs
@@ -19,7 +19,9 @@ namespace Azure.AI.TextAnalytics.Samples
             string endpoint = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_ENDPOINT");
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
-            var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+            // Instantiate a client that will be used to call the service.
+            var credentials = new ServiceSubscriptionKey(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
 
             var inputs = new List<string>
             {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntities.cs
@@ -19,7 +19,8 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             #region Snippet:TextAnalyticsSample4CreateClient
-            var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+            var credentials = new ServiceSubscriptionKey(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
             #endregion
 
             #region Snippet:RecognizeEntities

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntities.cs
@@ -19,8 +19,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             #region Snippet:TextAnalyticsSample4CreateClient
-            var credentials = new ServiceSubscriptionKey(subscriptionKey);
-            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+            var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
             #endregion
 
             #region Snippet:RecognizeEntities

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesAsync.cs
@@ -21,8 +21,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             // Instantiate a client that will be used to call the service.
-            var credentials = new ServiceSubscriptionKey(subscriptionKey);
-            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+            var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
 
             #region Snippet:RecognizeEntitiesAsync
             string input = "Microsoft was founded by Bill Gates and Paul Allen.";

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesAsync.cs
@@ -20,7 +20,9 @@ namespace Azure.AI.TextAnalytics.Samples
             string endpoint = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_ENDPOINT");
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
-            var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+            // Instantiate a client that will be used to call the service.
+            var credentials = new ServiceSubscriptionKey(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
 
             #region Snippet:RecognizeEntitiesAsync
             string input = "Microsoft was founded by Bill Gates and Paul Allen.";

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatch.cs
@@ -20,8 +20,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             // Instantiate a client that will be used to call the service.
-            var credentials = new ServiceSubscriptionKey(subscriptionKey);
-            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+            var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
 
             #region Snippet:TextAnalyticsSample4RecognizeEntitiesBatch
             var inputs = new List<TextDocumentInput>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatch.cs
@@ -19,7 +19,9 @@ namespace Azure.AI.TextAnalytics.Samples
             string endpoint = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_ENDPOINT");
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
-            var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+            // Instantiate a client that will be used to call the service.
+            var credentials = new ServiceSubscriptionKey(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
 
             #region Snippet:TextAnalyticsSample4RecognizeEntitiesBatch
             var inputs = new List<TextDocumentInput>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchConvenience.cs
@@ -20,8 +20,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             // Instantiate a client that will be used to call the service.
-            var credentials = new ServiceSubscriptionKey(subscriptionKey);
-            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+            var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
 
             var inputs = new List<string>
             {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchConvenience.cs
@@ -19,7 +19,9 @@ namespace Azure.AI.TextAnalytics.Samples
             string endpoint = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_ENDPOINT");
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
-            var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+            // Instantiate a client that will be used to call the service.
+            var credentials = new ServiceSubscriptionKey(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
 
             var inputs = new List<string>
             {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntities.cs
@@ -19,8 +19,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             #region Snippet:TextAnalyticsSample5CreateClient
-            var credentials = new ServiceSubscriptionKey(subscriptionKey);
-            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+            var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
             #endregion
 
             #region Snippet:RecognizePiiEntities

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntities.cs
@@ -19,7 +19,8 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             #region Snippet:TextAnalyticsSample5CreateClient
-            var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+            var credentials = new ServiceSubscriptionKey(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
             #endregion
 
             #region Snippet:RecognizePiiEntities

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatch.cs
@@ -19,7 +19,9 @@ namespace Azure.AI.TextAnalytics.Samples
             string endpoint = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_ENDPOINT");
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
-            var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+            // Instantiate a client that will be used to call the service.
+            var credentials = new ServiceSubscriptionKey(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
 
             #region Snippet:TextAnalyticsSample5RecognizePiiEntitiesBatch
             var inputs = new List<TextDocumentInput>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatch.cs
@@ -20,8 +20,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             // Instantiate a client that will be used to call the service.
-            var credentials = new ServiceSubscriptionKey(subscriptionKey);
-            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+            var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
 
             #region Snippet:TextAnalyticsSample5RecognizePiiEntitiesBatch
             var inputs = new List<TextDocumentInput>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatchConvenience.cs
@@ -20,8 +20,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             // Instantiate a client that will be used to call the service.
-            var credentials = new ServiceSubscriptionKey(subscriptionKey);
-            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+            var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
 
             var inputs = new List<string>
             {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatchConvenience.cs
@@ -19,7 +19,9 @@ namespace Azure.AI.TextAnalytics.Samples
             string endpoint = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_ENDPOINT");
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
-            var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+            // Instantiate a client that will be used to call the service.
+            var credentials = new ServiceSubscriptionKey(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
 
             var inputs = new List<string>
             {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntities.cs
@@ -18,7 +18,8 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             #region Snippet:TextAnalyticsSample6CreateClient
-            var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+            var credentials = new ServiceSubscriptionKey(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
             #endregion
 
             #region Snippet:RecognizeLinkedEntities

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntities.cs
@@ -18,8 +18,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             #region Snippet:TextAnalyticsSample6CreateClient
-            var credentials = new ServiceSubscriptionKey(subscriptionKey);
-            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+            var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
             #endregion
 
             #region Snippet:RecognizeLinkedEntities

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatch.cs
@@ -19,7 +19,9 @@ namespace Azure.AI.TextAnalytics.Samples
             string endpoint = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_ENDPOINT");
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
-            var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+            // Instantiate a client that will be used to call the service.
+            var credentials = new ServiceSubscriptionKey(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
 
             #region Snippet:TextAnalyticsSample6RecognizeLinkedEntitiesBatch
             var inputs = new List<TextDocumentInput>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatch.cs
@@ -20,8 +20,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             // Instantiate a client that will be used to call the service.
-            var credentials = new ServiceSubscriptionKey(subscriptionKey);
-            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+            var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
 
             #region Snippet:TextAnalyticsSample6RecognizeLinkedEntitiesBatch
             var inputs = new List<TextDocumentInput>

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenience.cs
@@ -20,8 +20,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
             // Instantiate a client that will be used to call the service.
-            var credentials = new ServiceSubscriptionKey(subscriptionKey);
-            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+            var client = new TextAnalyticsClient(new Uri(endpoint), new TextAnalyticsSubscriptionKeyCredential(subscriptionKey));
 
             var inputs = new List<string>
             {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenience.cs
@@ -19,7 +19,9 @@ namespace Azure.AI.TextAnalytics.Samples
             string endpoint = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_ENDPOINT");
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
-            var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+            // Instantiate a client that will be used to call the service.
+            var credentials = new ServiceSubscriptionKey(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
 
             var inputs = new List<string>
             {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/SampleSnippets.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/SampleSnippets.cs
@@ -22,9 +22,9 @@ namespace Azure.AI.TextAnalytics.Samples
 
             #region Snippet:CreateTextAnalyticsClient
             //@@ string endpoint = "<endpoint>";
-            //@@ ServiceSubscriptionKey credentials = "<credentials>";
-            var credentials = new ServiceSubscriptionKey(subscriptionKey);
-            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
+            //@@ TextAnalyticsSubscriptionKeyCredential credential = "<credential>";
+            var credential = new TextAnalyticsSubscriptionKeyCredential(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credential);
             #endregion
         }
 
@@ -45,7 +45,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string endpoint = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_ENDPOINT");
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
-            var credentials = new ServiceSubscriptionKey(subscriptionKey);
+            var credentials = new TextAnalyticsSubscriptionKeyCredential(subscriptionKey);
             var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
             string input = "Este documento está en español.";
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/SampleSnippets.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/SampleSnippets.cs
@@ -22,8 +22,9 @@ namespace Azure.AI.TextAnalytics.Samples
 
             #region Snippet:CreateTextAnalyticsClient
             //@@ string endpoint = "<endpoint>";
-            //@@ string subscriptionKey = "<subscriptionKey>";
-            var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+            //@@ ServiceSubscriptionKey credentials = "<credentials>";
+            var credentials = new ServiceSubscriptionKey(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
             #endregion
         }
 
@@ -44,7 +45,8 @@ namespace Azure.AI.TextAnalytics.Samples
             string endpoint = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_ENDPOINT");
             string subscriptionKey = Environment.GetEnvironmentVariable("TEXT_ANALYTICS_SUBSCRIPTION_KEY");
 
-            var client = new TextAnalyticsClient(new Uri(endpoint), subscriptionKey);
+            var credentials = new ServiceSubscriptionKey(subscriptionKey);
+            var client = new TextAnalyticsClient(new Uri(endpoint), credentials);
             string input = "Este documento está en español.";
 
             #region Snippet:BadRequest

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/SampleSnippets.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/SampleSnippets.cs
@@ -22,7 +22,7 @@ namespace Azure.AI.TextAnalytics.Samples
 
             #region Snippet:CreateTextAnalyticsClient
             //@@ string endpoint = "<endpoint>";
-            //@@ TextAnalyticsSubscriptionKeyCredential credential = "<credential>";
+            //@@ string subscriptionKey = "<subscriptionKey>";
             var credential = new TextAnalyticsSubscriptionKeyCredential(subscriptionKey);
             var client = new TextAnalyticsClient(new Uri(endpoint), credential);
             #endregion


### PR DESCRIPTION
Issue: https://github.com/Azure/azure-sdk-for-net/issues/8863

Following the patter done for Azure.Storage with [SharedKeyCredentials](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/storage/Azure.Storage.Common/src/StorageSharedKeyCredential.cs).

To keep this PR simple, test is not configure for recording. Plan to address it when we work on https://github.com/Azure/azure-sdk-for-net/issues/9091