### PR TITLE
Fix case of env name Dogfood in Azure-Test-Framework doc

### DIFF
--- a/doc/dev/Using-Azure-TestFramework.md
+++ b/doc/dev/Using-Azure-TestFramework.md
@@ -107,7 +107,7 @@ Ensure that the `HttpRecorderMode` in the `TEST_CSM_ORGID_AUTHENTICATION` enviro
 	* Password
 	* ServicePrincipal
 	* ServicePrincipalSecret
-	* Environment={Prod | DogFood | Next | Current | Custom}
+	* Environment={Prod | Dogfood | Next | Current | Custom}
 	* RawToken
 	* RawGraphToken
 	* HttpRecorderMode={Record | Playback}


### PR DESCRIPTION
The environment name for the Azure-Test-Framework connection string is case-sensitive, and was documented with the incorrect case.