### PR TITLE
Enable parallel upload tests

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
@@ -579,12 +579,21 @@ namespace Azure.Storage.Blobs.Test
         [TestCase(257 * Constants.MB, 8)]
         [TestCase(257 * Constants.MB, 16)]
         [TestCase(257 * Constants.MB, null)]
-        [TestCase(1 * Constants.GB, 1)]
-        [TestCase(1 * Constants.GB, 4)]
         [TestCase(1 * Constants.GB, 8)]
         [TestCase(1 * Constants.GB, 16)]
-        [TestCase(1 * Constants.GB, null)]
         public async Task UploadStreamAsync_LargeBlobs(long size, int? maximumThreadCount)
+        {
+            // TODO: #6781 We don't want to add 1GB of random data in the recordings
+            await UploadStreamAndVerify(size, 16 * Constants.MB, new StorageTransferOptions { MaximumConcurrency = maximumThreadCount });
+        }
+
+        [Test]
+        [LiveOnly]
+        [Explicit("These tests are particularly slow and often hit our 20 minute per test time limit.")]
+        [TestCase(1 * Constants.GB, 1)]
+        [TestCase(1 * Constants.GB, 4)]
+        [TestCase(1 * Constants.GB, null)]
+        public async Task UploadStreamAsync_LargeBlobs_Explicit(long size, int? maximumThreadCount)
         {
             // TODO: #6781 We don't want to add 1GB of random data in the recordings
             await UploadStreamAndVerify(size, 16 * Constants.MB, new StorageTransferOptions { MaximumConcurrency = maximumThreadCount });
@@ -602,12 +611,21 @@ namespace Azure.Storage.Blobs.Test
         [TestCase(257 * Constants.MB, 8)]
         [TestCase(257 * Constants.MB, 16)]
         [TestCase(257 * Constants.MB, null)]
-        [TestCase(1 * Constants.GB, 1)]
-        [TestCase(1 * Constants.GB, 4)]
         [TestCase(1 * Constants.GB, 8)]
         [TestCase(1 * Constants.GB, 16)]
-        [TestCase(1 * Constants.GB, null)]
         public async Task UploadFileAsync_LargeBlobs(long size, int? maximumThreadCount)
+        {
+            // TODO: #6781 We don't want to add 1GB of random data in the recordings
+            await UploadFileAndVerify(size, 16 * Constants.MB, new StorageTransferOptions { MaximumConcurrency = maximumThreadCount });
+        }
+
+        [Test]
+        [LiveOnly]
+        [Explicit("These tests are particularly slow and often hit our 20 minute per test time limit.")]
+        [TestCase(1 * Constants.GB, 1)]
+        [TestCase(1 * Constants.GB, 4)]
+        [TestCase(1 * Constants.GB, null)]
+        public async Task UploadFileAsync_LargeBlobs_Explicit(long size, int? maximumThreadCount)
         {
             // TODO: #6781 We don't want to add 1GB of random data in the recordings
             await UploadFileAndVerify(size, 16 * Constants.MB, new StorageTransferOptions { MaximumConcurrency = maximumThreadCount });

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
@@ -579,7 +579,6 @@ namespace Azure.Storage.Blobs.Test
         [TestCase(257 * Constants.MB, 8)]
         [TestCase(257 * Constants.MB, 16)]
         [TestCase(257 * Constants.MB, null)]
-        [TestCase(1 * Constants.GB, 8)]
         [TestCase(1 * Constants.GB, 16)]
         public async Task UploadStreamAsync_LargeBlobs(long size, int? maximumThreadCount)
         {
@@ -592,6 +591,7 @@ namespace Azure.Storage.Blobs.Test
         [Explicit("These tests are particularly slow and often hit our 20 minute per test time limit.")]
         [TestCase(1 * Constants.GB, 1)]
         [TestCase(1 * Constants.GB, 4)]
+        [TestCase(1 * Constants.GB, 8)]
         [TestCase(1 * Constants.GB, null)]
         public async Task UploadStreamAsync_LargeBlobs_Explicit(long size, int? maximumThreadCount)
         {
@@ -611,7 +611,6 @@ namespace Azure.Storage.Blobs.Test
         [TestCase(257 * Constants.MB, 8)]
         [TestCase(257 * Constants.MB, 16)]
         [TestCase(257 * Constants.MB, null)]
-        [TestCase(1 * Constants.GB, 8)]
         [TestCase(1 * Constants.GB, 16)]
         public async Task UploadFileAsync_LargeBlobs(long size, int? maximumThreadCount)
         {
@@ -624,6 +623,7 @@ namespace Azure.Storage.Blobs.Test
         [Explicit("These tests are particularly slow and often hit our 20 minute per test time limit.")]
         [TestCase(1 * Constants.GB, 1)]
         [TestCase(1 * Constants.GB, 4)]
+        [TestCase(1 * Constants.GB, 8)]
         [TestCase(1 * Constants.GB, null)]
         public async Task UploadFileAsync_LargeBlobs_Explicit(long size, int? maximumThreadCount)
         {

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
@@ -465,34 +465,6 @@ namespace Azure.Storage.Blobs.Test
             await DownloadAndAssertAsync(stream, blob);
         }
 
-        private async Task<Stream> CreateLimitedMemoryStream(long size)
-        {
-            Stream stream;
-            if (size < Constants.MB * 100)
-            {
-                var data = GetRandomBuffer(size);
-                stream = new MemoryStream(data);
-            }
-            else
-            {
-                var path = Path.GetTempFileName();
-                stream = new TemporaryFileStream(path, FileMode.Create);
-                var bufferSize = 4 * Constants.KB;
-
-                while (stream.Position + bufferSize < size)
-                {
-                    await stream.WriteAsync(GetRandomBuffer(bufferSize), 0, bufferSize);
-                }
-                if (stream.Position < size)
-                {
-                    await stream.WriteAsync(GetRandomBuffer(size - stream.Position), 0, (int)(size - stream.Position));
-                }
-                // reset the stream
-                stream.Seek(0, SeekOrigin.Begin);
-            }
-            return stream;
-        }
-
         private async Task UploadFileAndVerify(
             long size,
             long singleBlockThreshold,

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
@@ -596,6 +596,7 @@ namespace Azure.Storage.Blobs.Test
             await UploadFileAndVerify(size, Constants.KB, new StorageTransferOptions { MaximumTransferLength = Constants.KB });
 
         [Test]
+        [LiveOnly]
         [TestCase(33 * Constants.MB, 1)]
         [TestCase(33 * Constants.MB, 4)]
         [TestCase(33 * Constants.MB, 8)]
@@ -618,6 +619,7 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [Test]
+        [LiveOnly]
         [TestCase(33 * Constants.MB, 1)]
         [TestCase(33 * Constants.MB, 4)]
         [TestCase(33 * Constants.MB, 8)]

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -524,55 +524,5 @@ namespace Azure.Storage.Test.Shared
                 }
             }
         }
-
-        public class DisposingFileStream : Stream
-        {
-            private readonly FileStream _innerStream;
-            private readonly string _path;
-
-            public DisposingFileStream(string path)
-            {
-                _path = path;
-                _innerStream = File.Create(_path);
-            }
-
-            public override bool CanRead => _innerStream.CanRead;
-
-            public override bool CanSeek => _innerStream.CanSeek;
-
-            public override bool CanWrite => _innerStream.CanWrite;
-
-            public override long Length => _innerStream.Length;
-
-            public override long Position
-            {
-                get => _innerStream.Position;
-                set => _innerStream.Position = value;
-            }
-
-            public override void Flush() =>
-                _innerStream.Flush();
-
-            public override int Read(byte[] buffer, int offset, int count) =>
-                _innerStream.Read(buffer, offset, count);
-
-            public override long Seek(long offset, SeekOrigin origin) =>
-                _innerStream.Seek(offset, origin);
-
-            public override void SetLength(long value) =>
-                _innerStream.SetLength(value);
-
-            public override void Write(byte[] buffer, int offset, int count) =>
-                _innerStream.Write(buffer, offset, count);
-
-            protected override void Dispose(bool isDisposing)
-            {
-                _innerStream.Dispose();
-                if (File.Exists(_path))
-                {
-                    File.Delete(_path);
-                }
-            }
-        }
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
@@ -520,6 +521,56 @@ namespace Azure.Storage.Test.Shared
                     {
                         // swallow the exception to avoid hiding another test failure
                     }
+                }
+            }
+        }
+
+        public class DisposingFileStream : Stream
+        {
+            private readonly FileStream _innerStream;
+            private readonly string _path;
+
+            public DisposingFileStream(string path)
+            {
+                _path = path;
+                _innerStream = File.Create(_path);
+            }
+
+            public override bool CanRead => _innerStream.CanRead;
+
+            public override bool CanSeek => _innerStream.CanSeek;
+
+            public override bool CanWrite => _innerStream.CanWrite;
+
+            public override long Length => _innerStream.Length;
+
+            public override long Position
+            {
+                get => _innerStream.Position;
+                set => _innerStream.Position = value;
+            }
+
+            public override void Flush() =>
+                _innerStream.Flush();
+
+            public override int Read(byte[] buffer, int offset, int count) =>
+                _innerStream.Read(buffer, offset, count);
+
+            public override long Seek(long offset, SeekOrigin origin) =>
+                _innerStream.Seek(offset, origin);
+
+            public override void SetLength(long value) =>
+                _innerStream.SetLength(value);
+
+            public override void Write(byte[] buffer, int offset, int count) =>
+                _innerStream.Write(buffer, offset, count);
+
+            protected override void Dispose(bool isDisposing)
+            {
+                _innerStream.Dispose();
+                if (File.Exists(_path))
+                {
+                    File.Delete(_path);
                 }
             }
         }

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -14,6 +15,7 @@ using Azure.Core.Pipeline;
 using Azure.Core.Testing;
 using Azure.Identity;
 using Azure.Storage.Sas;
+using Azure.Storage.Tests.Shared;
 using NUnit.Framework;
 
 namespace Azure.Storage.Test.Shared
@@ -465,6 +467,39 @@ namespace Azure.Storage.Test.Shared
                     await Delay(mode, retryDelay);
                 }
             }
+        }
+
+        /// <summary>
+        /// Create a stream of a given size that will not use more than maxMemory memory.
+        /// If the size is greater than maxMemory, a TemporaryFileStream will be used that
+        /// will delete the file in its Dispose method.
+        /// </summary>
+        protected async Task<Stream> CreateLimitedMemoryStream(long size, long maxMemory = Constants.MB * 100)
+        {
+            Stream stream;
+            if (size < maxMemory)
+            {
+                var data = GetRandomBuffer(size);
+                stream = new MemoryStream(data);
+            }
+            else
+            {
+                var path = Path.GetTempFileName();
+                stream = new TemporaryFileStream(path, FileMode.Create);
+                var bufferSize = 4 * Constants.KB;
+
+                while (stream.Position + bufferSize < size)
+                {
+                    await stream.WriteAsync(GetRandomBuffer(bufferSize), 0, bufferSize);
+                }
+                if (stream.Position < size)
+                {
+                    await stream.WriteAsync(GetRandomBuffer(size - stream.Position), 0, (int)(size - stream.Position));
+                }
+                // reset the stream
+                stream.Seek(0, SeekOrigin.Begin);
+            }
+            return stream;
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/TemporaryFileStream.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/TemporaryFileStream.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.IO;
+
+namespace Azure.Storage.Tests.Shared
+{
+    /// <summary>
+    /// A file stream that will have its corresponding file deleted
+    /// as part of its Dispose method.
+    /// </summary>
+    public class TemporaryFileStream : FileStream
+    {
+        public TemporaryFileStream(string path, FileMode mode)
+            : base(path, mode)
+        {
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (File.Exists(Name))
+            {
+                File.Delete(Name);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #9120 
Use a FileStream rather than MemoryStream for size > 100MB to avoid memory pressure on agents.