### PR TITLE
Correcting Azure.ApplicationModel.Configuration package name to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The libraries released in the November 2019 GA release:
 * [Azure.Storage.Queues](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/storage/Azure.Storage.Queues/README.md)
 
 The libraries released in the November 2019 preview:
-* [Azure.ApplicationModel.Configuration](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/appconfiguration/Azure.Data.AppConfiguration/README.md)
+* [Azure.Data.AppConfiguration](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/appconfiguration/Azure.Data.AppConfiguration/README.md)
 * [Azure.Security.KeyVault.Certificates](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/keyvault/Azure.Security.KeyVault.Certificates/README.md)
 * [Azure.Messaging.EventHubs](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/README.md)
 * [Azure.Storage.Files.Shares](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/storage/Azure.Storage.Files.Shares/README.md)


### PR DESCRIPTION
Azure.ApplicationModel.Configuration package is delisted from Nuget after rename to Azure.Data.AppConfiguration