### PR TITLE
Enable Changelog verification on CI

### DIFF
--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -24,6 +24,7 @@ required_readme_sections:
 known_presence_issues:
   - ['sdk/alertsmanagement/Microsoft.Azure.Management.AlertsManagement','#5499']
   - ['sdk/applicationinsights/Microsoft.Azure.ApplicationInsights.Query','#5499']
+  - ['sdk/attestation/Microsoft.Azure.Attestation','#5499']
   - ['sdk/batch/Microsoft.Azure.Batch.FileStaging','#5499']
   - ['sdk/batch/Microsoft.Azure.Batch/Tools','#5499']
   - ['sdk/batch/Microsoft.Azure.Batch/Tools','#5499']
@@ -69,10 +70,10 @@ known_presence_issues:
   - ['sdk/search','#5499']
   - ['sdk/keyvault','#5499']
   - ['sdk/eventhub','#5499']
-  - ['sdk/attestation/Microsoft.Azure.Attestation','#5499']
 
 # List for changelogs begins here
   - ['sdk/applicationinsights/Microsoft.Azure.ApplicationInsights.Query/CHANGELOG.md','#5499']
+  - ['sdk/attestation/Microsoft.Azure.Attestation/CHANGELOG.md','#5499']
   - ['sdk/batch/Microsoft.Azure.Batch.Conventions.Files/CHANGELOG.md','#5499']
   - ['sdk/batch/Microsoft.Azure.Batch.FileStaging/CHANGELOG.md','#5499']
   - ['sdk/batch/Microsoft.Azure.Batch/Tools/CHANGELOG.md','#5499']

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -54,9 +54,16 @@ jobs:
           versionSpec: "3.6"
       - script: |
           pip install setuptools wheel
-          pip install doc-warden
-          ward scan -d $(Build.SourcesDirectory) -c $(Build.SourcesDirectory)/eng/.docsettings.yml
-        displayName: "Verify Readmes"
+          pip install doc-warden==0.4.2
+          ward scan -d $(Build.SourcesDirectory) -c $(Build.SourcesDirectory)/eng/.docsettings.yml -t all
+        displayName: "Verify Readmes and changelogs"
+        condition: ne(variables['Build.Reason'],'Manual')
+      - script: |
+          pip install setuptools wheel
+          pip install doc-warden==0.4.2
+          ward scan -d $(Build.SourcesDirectory) -c $(Build.SourcesDirectory)/eng/.docsettings.yml -t all -s release
+        displayName: "Verify Readmes, changelogs and latest release notes"
+        condition: eq(variables['Build.Reason'],'Manual')
       - task: DownloadPipelineArtifact@2
         displayName: "Download Build Artifacts"
         condition: succeededOrFailed()


### PR DESCRIPTION
- Switch to the latest version of Doc-Warden
- Verify changelogs (presence and content)
- Verify release note entry on manually queued builds