### PR TITLE
[HDInsight] Add new feature: supports creating cluster with minSupportedTlsVersion

### DIFF
--- a/eng/mgmt/mgmtmetadata/hdinsight_resource-manager.txt
+++ b/eng/mgmt/mgmtmetadata/hdinsight_resource-manager.txt
@@ -4,11 +4,11 @@ Commencing code generation
 Generating CSharp code
 Executing AutoRest command
 cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/hdinsight/resource-manager/readme.md --csharp --version=latest --reflect-api-versions --csharp-sdks-folder=F:\source\azure-sdk-for-net\sdk
-2019-12-05 07:03:12 UTC
+2020-01-15 08:14:49 UTC
 Azure-rest-api-specs repository information
 GitHub fork: Azure
 Branch:      master
-Commit:      fbc094f3097e954f008f8f415a2f95a6dfa3c13b
+Commit:      3ee786a44139e0be0613cb705f78d66b5166fc78
 AutoRest information
 Requested version: latest
 Bootstrapper version:    autorest@2.0.4407

--- a/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/src/Generated/Models/ClusterCreateProperties.cs
+++ b/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/src/Generated/Models/ClusterCreateProperties.cs
@@ -42,7 +42,9 @@ namespace Microsoft.Azure.Management.HDInsight.Models
         /// <param name="storageProfile">The storage profile.</param>
         /// <param name="diskEncryptionProperties">The disk encryption
         /// properties.</param>
-        public ClusterCreateProperties(string clusterVersion = default(string), OSType? osType = default(OSType?), Tier? tier = default(Tier?), ClusterDefinition clusterDefinition = default(ClusterDefinition), KafkaRestProperties kafkaRestProperties = default(KafkaRestProperties), SecurityProfile securityProfile = default(SecurityProfile), ComputeProfile computeProfile = default(ComputeProfile), StorageProfile storageProfile = default(StorageProfile), DiskEncryptionProperties diskEncryptionProperties = default(DiskEncryptionProperties))
+        /// <param name="minSupportedTlsVersion">The minimal supported tls
+        /// version.</param>
+        public ClusterCreateProperties(string clusterVersion = default(string), OSType? osType = default(OSType?), Tier? tier = default(Tier?), ClusterDefinition clusterDefinition = default(ClusterDefinition), KafkaRestProperties kafkaRestProperties = default(KafkaRestProperties), SecurityProfile securityProfile = default(SecurityProfile), ComputeProfile computeProfile = default(ComputeProfile), StorageProfile storageProfile = default(StorageProfile), DiskEncryptionProperties diskEncryptionProperties = default(DiskEncryptionProperties), string minSupportedTlsVersion = default(string))
         {
             ClusterVersion = clusterVersion;
             OsType = osType;
@@ -53,6 +55,7 @@ namespace Microsoft.Azure.Management.HDInsight.Models
             ComputeProfile = computeProfile;
             StorageProfile = storageProfile;
             DiskEncryptionProperties = diskEncryptionProperties;
+            MinSupportedTlsVersion = minSupportedTlsVersion;
             CustomInit();
         }
 
@@ -116,6 +119,12 @@ namespace Microsoft.Azure.Management.HDInsight.Models
         /// </summary>
         [JsonProperty(PropertyName = "diskEncryptionProperties")]
         public DiskEncryptionProperties DiskEncryptionProperties { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimal supported tls version.
+        /// </summary>
+        [JsonProperty(PropertyName = "minSupportedTlsVersion")]
+        public string MinSupportedTlsVersion { get; set; }
 
     }
 }

--- a/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/src/Generated/Models/ClusterGetProperties.cs
+++ b/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/src/Generated/Models/ClusterGetProperties.cs
@@ -54,7 +54,9 @@ namespace Microsoft.Azure.Management.HDInsight.Models
         /// endpoints.</param>
         /// <param name="diskEncryptionProperties">The disk encryption
         /// properties.</param>
-        public ClusterGetProperties(ClusterDefinition clusterDefinition, string clusterVersion = default(string), OSType? osType = default(OSType?), Tier? tier = default(Tier?), KafkaRestProperties kafkaRestProperties = default(KafkaRestProperties), SecurityProfile securityProfile = default(SecurityProfile), ComputeProfile computeProfile = default(ComputeProfile), HDInsightClusterProvisioningState? provisioningState = default(HDInsightClusterProvisioningState?), string createdDate = default(string), string clusterState = default(string), QuotaInfo quotaInfo = default(QuotaInfo), IList<Errors> errors = default(IList<Errors>), IList<ConnectivityEndpoint> connectivityEndpoints = default(IList<ConnectivityEndpoint>), DiskEncryptionProperties diskEncryptionProperties = default(DiskEncryptionProperties))
+        /// <param name="minSupportedTlsVersion">The minimal supported tls
+        /// version.</param>
+        public ClusterGetProperties(ClusterDefinition clusterDefinition, string clusterVersion = default(string), OSType? osType = default(OSType?), Tier? tier = default(Tier?), KafkaRestProperties kafkaRestProperties = default(KafkaRestProperties), SecurityProfile securityProfile = default(SecurityProfile), ComputeProfile computeProfile = default(ComputeProfile), HDInsightClusterProvisioningState? provisioningState = default(HDInsightClusterProvisioningState?), string createdDate = default(string), string clusterState = default(string), QuotaInfo quotaInfo = default(QuotaInfo), IList<Errors> errors = default(IList<Errors>), IList<ConnectivityEndpoint> connectivityEndpoints = default(IList<ConnectivityEndpoint>), DiskEncryptionProperties diskEncryptionProperties = default(DiskEncryptionProperties), string minSupportedTlsVersion = default(string))
         {
             ClusterVersion = clusterVersion;
             OsType = osType;
@@ -70,6 +72,7 @@ namespace Microsoft.Azure.Management.HDInsight.Models
             Errors = errors;
             ConnectivityEndpoints = connectivityEndpoints;
             DiskEncryptionProperties = diskEncryptionProperties;
+            MinSupportedTlsVersion = minSupportedTlsVersion;
             CustomInit();
         }
 
@@ -165,6 +168,12 @@ namespace Microsoft.Azure.Management.HDInsight.Models
         /// </summary>
         [JsonProperty(PropertyName = "diskEncryptionProperties")]
         public DiskEncryptionProperties DiskEncryptionProperties { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimal supported tls version.
+        /// </summary>
+        [JsonProperty(PropertyName = "minSupportedTlsVersion")]
+        public string MinSupportedTlsVersion { get; set; }
 
         /// <summary>
         /// Validate the object.

--- a/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/src/Generated/SdkInfo_HDInsightManagementClient.cs
+++ b/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/src/Generated/SdkInfo_HDInsightManagementClient.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Management.HDInsight
       public static readonly String AutoRestCmdExecuted = "cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/hdinsight/resource-manager/readme.md --csharp --version=latest --reflect-api-versions --csharp-sdks-folder=F:\\source\\azure-sdk-for-net\\sdk";
       public static readonly String GithubForkName = "Azure";
       public static readonly String GithubBranchName = "master";
-      public static readonly String GithubCommidId = "fbc094f3097e954f008f8f415a2f95a6dfa3c13b";
+      public static readonly String GithubCommidId = "3ee786a44139e0be0613cb705f78d66b5166fc78";
       public static readonly String CodeGenerationErrors = "";
       public static readonly String GithubRepoName = "azure-rest-api-specs";
       // END: Code Generation Metadata Section

--- a/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/src/Microsoft.Azure.Management.HDInsight.csproj
+++ b/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/src/Microsoft.Azure.Management.HDInsight.csproj
@@ -7,12 +7,12 @@
 		<PackageId>Microsoft.Azure.Management.HDInsight</PackageId>
 		<Description>Azure HDInsight Management SDK Library</Description>
 		<AssemblyName>Microsoft.Azure.Management.HDInsight</AssemblyName>
-		<Version>5.2.0</Version>
+		<Version>5.3.0</Version>
 		<PackageTags>Microsoft Azure HDInsight Management;HDInsight;HDInsight Management</PackageTags>
 		<PackageReleaseNotes>
 			<![CDATA[
 This release adds a new feature:
-Added support for creating kafka cluster with kafka rest proxy
+Added support for creating cluster with minSupportedTlsVersion
       ]]>
 		</PackageReleaseNotes>
     

--- a/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/src/Properties/AssemblyInfo.cs
+++ b/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/src/Properties/AssemblyInfo.cs
@@ -22,7 +22,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("Microsoft Azure HDInsight Management Library")]
 [assembly: AssemblyDescription("Provides management functionality for Microsoft Azure HDInsight.")]
 [assembly: AssemblyVersion("5.0.0.0")]
-[assembly: AssemblyFileVersion("5.2.0.0")]
+[assembly: AssemblyFileVersion("5.3.0.0")]
 
 [assembly: InternalsVisibleTo("Microsoft.Azure.Management.HDInsight.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
 

--- a/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/tests/ScenarioTests/ClusterOperationTests.cs
+++ b/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/tests/ScenarioTests/ClusterOperationTests.cs
@@ -640,5 +640,18 @@ namespace Management.HDInsight.Tests
             gatewaySettings = HDInsightClient.Clusters.GetGatewaySettings(CommonData.ResourceGroupName, clusterName);
             ValidateGatewaySettings(expectedUserName, newExpectedPassword, gatewaySettings);
         }
+
+        [Fact]
+        public void TestCreateClusterWithTLS12()
+        {
+            TestInitialize();
+
+            string clusterName = TestUtilities.GenerateName("hdisdk-tls12");
+            var createParams = CommonData.PrepareClusterCreateParamsForWasb();
+            createParams.Properties.MinSupportedTlsVersion = "1.2";
+            var cluster = HDInsightClient.Clusters.Create(CommonData.ResourceGroupName, clusterName, createParams);
+            Assert.Equal("1.2", cluster.Properties.MinSupportedTlsVersion);
+            ValidateCluster(clusterName, createParams, cluster);
+        }
     }
 }

--- a/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/tests/SessionRecords/ClusterOperationTests/TestCreateClusterWithTLS12.json
+++ b/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/tests/SessionRecords/ClusterOperationTests/TestCreateClusterWithTLS12.json
@@ -1,0 +1,1730 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274?api-version=2018-06-01-preview",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"location\": \"East US 2\",\r\n  \"properties\": {\r\n    \"clusterVersion\": \"3.6\",\r\n    \"osType\": \"Linux\",\r\n    \"tier\": \"Standard\",\r\n    \"clusterDefinition\": {\r\n      \"kind\": \"Hadoop\",\r\n      \"configurations\": {\r\n        \"gateway\": {\r\n          \"restAuthCredential.isEnabled\": \"true\",\r\n          \"restAuthCredential.username\": \"admin3025\",\r\n          \"restAuthCredential.password\": \"Password1!1581\"\r\n        }\r\n      }\r\n    },\r\n    \"computeProfile\": {\r\n      \"roles\": [\r\n        {\r\n          \"name\": \"headnode\",\r\n          \"targetInstanceCount\": 2,\r\n          \"hardwareProfile\": {\r\n            \"vmSize\": \"Large\"\r\n          },\r\n          \"osProfile\": {\r\n            \"linuxOperatingSystemProfile\": {\r\n              \"username\": \"sshuser9235\",\r\n              \"password\": \"Password1!8936\"\r\n            }\r\n          }\r\n        },\r\n        {\r\n          \"name\": \"workernode\",\r\n          \"targetInstanceCount\": 3,\r\n          \"hardwareProfile\": {\r\n            \"vmSize\": \"Large\"\r\n          },\r\n          \"osProfile\": {\r\n            \"linuxOperatingSystemProfile\": {\r\n              \"username\": \"sshuser9235\",\r\n              \"password\": \"Password1!8936\"\r\n            }\r\n          }\r\n        },\r\n        {\r\n          \"name\": \"zookeepernode\",\r\n          \"targetInstanceCount\": 3,\r\n          \"hardwareProfile\": {\r\n            \"vmSize\": \"Small\"\r\n          },\r\n          \"osProfile\": {\r\n            \"linuxOperatingSystemProfile\": {\r\n              \"username\": \"sshuser9235\",\r\n              \"password\": \"Password1!8936\"\r\n            }\r\n          }\r\n        }\r\n      ]\r\n    },\r\n    \"storageProfile\": {\r\n      \"storageaccounts\": [\r\n        {\r\n          \"name\": \"hdicsharpstorage5029.blob.core.windows.net\",\r\n          \"isDefault\": true,\r\n          \"container\": \"default6715\",\r\n          \"key\": \"MCkWRXhMNffe3xbAO144Z1R2Bqiok8YlK3+jNZnx/0BhjLEX7lfG8wcbJognCOwQ+QzSwHTWdrbahjAJ6qVx5g==\"\r\n        }\r\n      ]\r\n    },\r\n    \"minSupportedTlsVersion\": \"1.2\"\r\n  }\r\n}",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "5588ea43-76c4-4d05-8fac-11c98c36723a"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "1930"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:34:28 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "ETag": [
+          "\"633903e4-08b9-45af-a8e0-70c1da9fcaa7\""
+        ],
+        "x-ms-hdi-clusteruri": [
+          "https://management.azure.com/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274?api-version=2018-06-01-preview"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com:443/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview"
+        ],
+        "x-ms-request-id": [
+          "24e8d86a-c102-40c7-b848-ae65120379ba"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "22da25da-a842-4cca-abfd-8811eb9e7916"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1199"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T023428Z:22da25da-a842-4cca-abfd-8811eb9e7916"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "1526"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274\",\r\n  \"name\": \"hdisdk-tls127274\",\r\n  \"type\": \"Microsoft.HDInsight/clusters\",\r\n  \"location\": \"East US 2\",\r\n  \"etag\": \"633903e4-08b9-45af-a8e0-70c1da9fcaa7\",\r\n  \"tags\": null,\r\n  \"properties\": {\r\n    \"clusterVersion\": \"3.6.1000.67\",\r\n    \"clusterHdpVersion\": \"\",\r\n    \"osType\": \"Linux\",\r\n    \"clusterDefinition\": {\r\n      \"blueprint\": \"https://blueprints.azurehdinsight.net/hadoop-3.6.1000.67.2001080246.json\",\r\n      \"kind\": \"Hadoop\",\r\n      \"componentVersion\": {\r\n        \"Hadoop\": \"2.7\"\r\n      }\r\n    },\r\n    \"computeProfile\": {\r\n      \"roles\": [\r\n        {\r\n          \"name\": \"headnode\",\r\n          \"targetInstanceCount\": 2,\r\n          \"hardwareProfile\": {\r\n            \"vmSize\": \"standard_a4_v2\"\r\n          },\r\n          \"osProfile\": {\r\n            \"linuxOperatingSystemProfile\": {\r\n              \"username\": \"sshuser9235\"\r\n            }\r\n          },\r\n          \"encryptDataDisks\": false\r\n        },\r\n        {\r\n          \"name\": \"workernode\",\r\n          \"targetInstanceCount\": 3,\r\n          \"hardwareProfile\": {\r\n            \"vmSize\": \"standard_a4_v2\"\r\n          },\r\n          \"osProfile\": {\r\n            \"linuxOperatingSystemProfile\": {\r\n              \"username\": \"sshuser9235\"\r\n            }\r\n          },\r\n          \"encryptDataDisks\": false\r\n        },\r\n        {\r\n          \"name\": \"zookeepernode\",\r\n          \"targetInstanceCount\": 3,\r\n          \"hardwareProfile\": {\r\n            \"vmSize\": \"standard_a2_v2\"\r\n          },\r\n          \"osProfile\": {\r\n            \"linuxOperatingSystemProfile\": {\r\n              \"username\": \"sshuser9235\"\r\n            }\r\n          },\r\n          \"encryptDataDisks\": false\r\n        }\r\n      ]\r\n    },\r\n    \"provisioningState\": \"InProgress\",\r\n    \"clusterState\": \"Accepted\",\r\n    \"createdDate\": \"2020-01-13T02:34:26.6\",\r\n    \"quotaInfo\": {\r\n      \"coresUsed\": 20\r\n    },\r\n    \"tier\": \"standard\",\r\n    \"storageProfile\": {\r\n      \"storageaccounts\": [\r\n        {\r\n          \"name\": \"hdicsharpstorage5029.blob.core.windows.net\",\r\n          \"resourceId\": null,\r\n          \"msiResourceId\": null,\r\n          \"key\": null,\r\n          \"fileSystem\": null,\r\n          \"container\": \"default6715\",\r\n          \"saskey\": null,\r\n          \"isDefault\": true\r\n        }\r\n      ]\r\n    },\r\n    \"minSupportedTlsVersion\": \"1.2\"\r\n  }\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:34:59 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "a2755997-0d5d-4606-97a6-068e8b95d46f"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "a13ae007-64e7-4af9-a8b2-66b7b3b1a575"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11999"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T023459Z:a13ae007-64e7-4af9-a8b2-66b7b3b1a575"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:35:29 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "2edf6de9-14b0-4cc7-ac74-02b2492f98cb"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "1b9077e4-c536-41c5-ba0d-2016ffbc51f0"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11998"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T023530Z:1b9077e4-c536-41c5-ba0d-2016ffbc51f0"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:36:00 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "2689fa95-fd8e-4fa5-90c9-503a3366c8bb"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "b699fe56-1ac9-4558-bda0-73becd4464fe"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11997"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T023601Z:b699fe56-1ac9-4558-bda0-73becd4464fe"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:36:32 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "e1a61dd8-9c43-4b6f-ae11-5b761ccd6416"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "23a3d4c6-8397-4a8f-b23d-4efcb91b2895"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11996"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T023632Z:23a3d4c6-8397-4a8f-b23d-4efcb91b2895"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:37:02 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "1490ab29-904a-4cb9-bbbe-d2654f1cc001"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "9ac179f7-92bb-4e40-bbdd-b9723f982baf"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11995"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T023703Z:9ac179f7-92bb-4e40-bbdd-b9723f982baf"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:37:34 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "9a822393-9262-40c6-b3b4-83b895f0f367"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "b92e769d-04fd-4ba7-93f6-45575e9f9630"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11994"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T023734Z:b92e769d-04fd-4ba7-93f6-45575e9f9630"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:38:04 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "fde0983b-b103-4947-b7bd-a8f4dd772c4d"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "643bc04e-064e-42ef-87c0-efca75c7765a"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11993"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T023805Z:643bc04e-064e-42ef-87c0-efca75c7765a"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:38:36 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "1c86c5c6-27ed-45aa-9b36-971b94947b2a"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "1337271f-6622-444d-bbf9-c560c2986a33"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11992"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T023836Z:1337271f-6622-444d-bbf9-c560c2986a33"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:39:07 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "35206e36-b26a-4c17-ab3c-93a3d962cf70"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "8c2c212b-58f0-4c45-8e5e-5979c0a9394c"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11991"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T023907Z:8c2c212b-58f0-4c45-8e5e-5979c0a9394c"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:39:37 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "d16b1b0b-cc17-4bdc-a05f-32d0803d7dd9"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "a0cd3b25-e123-4009-82eb-d1822ed1c94e"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11990"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T023938Z:a0cd3b25-e123-4009-82eb-d1822ed1c94e"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:40:09 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "25b2daea-0e41-4e8f-b2b6-e6d4920fdab4"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "cf09cdd3-8f3a-4d0e-b877-a1534d447a3f"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11989"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T024009Z:cf09cdd3-8f3a-4d0e-b877-a1534d447a3f"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:40:40 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "fc42d7b0-d39b-4eeb-91c7-592485fde777"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "241579c3-4e3e-4ab9-b776-82baa9e55ece"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11988"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T024040Z:241579c3-4e3e-4ab9-b776-82baa9e55ece"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:41:12 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "9e10b8b2-5ee9-4527-a12b-8e2013878921"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "ea056ca7-269e-408e-989e-c72beae8cbe8"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11999"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T024112Z:ea056ca7-269e-408e-989e-c72beae8cbe8"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:41:43 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "67dad13c-6c2f-46c1-833f-817076a65f4a"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "8da0637a-5659-4ee7-afa6-4dbc1db45bc8"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11999"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T024144Z:8da0637a-5659-4ee7-afa6-4dbc1db45bc8"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:42:14 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "abe95910-0b8b-402f-ab06-b1bb5f7c5a57"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "8c7351e4-bd8b-43b3-b97f-d32320f4d3a1"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11998"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T024214Z:8c7351e4-bd8b-43b3-b97f-d32320f4d3a1"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:42:44 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "836d83e8-1aad-4718-a16e-bb8a2e7dbbbc"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "a51f4e47-7b90-4f12-acc4-b81aa46a5baa"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11997"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T024245Z:a51f4e47-7b90-4f12-acc4-b81aa46a5baa"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:43:16 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "ee3cb5c0-99ff-4914-8f1f-d30c668d23f6"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "43ba42dc-aa51-4634-aa31-a3a732d52a45"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11996"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T024317Z:43ba42dc-aa51-4634-aa31-a3a732d52a45"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:43:47 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "852df120-12e8-46e1-a6c4-2df73dab441a"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "b3648269-d59a-4cba-a548-b8f989e97263"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11995"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T024347Z:b3648269-d59a-4cba-a548-b8f989e97263"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:44:17 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "ab8f2d85-5434-40e7-9dda-08160e4b2356"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "fc64011c-0247-419b-9190-bdca34062a1c"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11994"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T024418Z:fc64011c-0247-419b-9190-bdca34062a1c"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:44:50 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "7183d9bb-d1b1-4c72-aeaa-40deae3839ff"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "c1fac92d-33de-44d0-95b1-f3efdbc6abd6"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11993"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T024450Z:c1fac92d-33de-44d0-95b1-f3efdbc6abd6"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:45:20 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "5c3bcd87-636d-47bb-8f33-76dbc91a9f08"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "a21ff1e7-6412-478b-917e-dfc49ae43cb6"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11992"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T024521Z:a21ff1e7-6412-478b-917e-dfc49ae43cb6"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:45:51 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "ec132664-4c86-402b-8a13-7a4b99e23e8e"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "135c4418-4e94-4198-aa72-12aeaad492ac"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11991"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T024551Z:135c4418-4e94-4198-aa72-12aeaad492ac"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:46:22 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "a35fe938-bdb8-4cb7-a1ad-dcf99357820b"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "42877071-2958-4b5f-b314-c8d245a65d0d"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11990"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T024623Z:42877071-2958-4b5f-b314-c8d245a65d0d"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:46:54 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "76432601-2174-43a7-98c3-293c902560f9"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "5e55aa6a-104a-4ba3-a26a-4385cff4d54f"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11998"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T024655Z:5e55aa6a-104a-4ba3-a26a-4385cff4d54f"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:47:25 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "5e4c425f-79a3-402e-8f2a-76afe7a22e1e"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "4bdda703-76d4-4850-ada6-1883e4b6df80"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11997"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T024725Z:4bdda703-76d4-4850-ada6-1883e4b6df80"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:47:56 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "477e13bc-08c1-4800-b1a1-68ff2cc552dd"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "6c44a3c1-c78f-443b-8863-c218cffc6db0"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11989"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T024757Z:6c44a3c1-c78f-443b-8863-c218cffc6db0"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:48:28 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "557a516f-7fcb-48ca-b47e-7e8bb926524c"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "c82733b4-e361-4742-bb89-378d006706e0"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11996"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T024829Z:c82733b4-e361-4742-bb89-378d006706e0"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274/azureasyncoperations/create?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:48:59 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "cb865dbb-ec24-4ff0-99f3-ba73b6f6891f"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "f3a3c210-1384-4315-aa31-edfe3a35e8a8"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11995"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T024859Z:f3a3c210-1384-4315-aa31-edfe3a35e8a8"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "22"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"Succeeded\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274?api-version=2018-06-01-preview",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26614.01",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.18363.",
+          "Microsoft.Azure.Management.HDInsight.HDInsightManagementClient/5.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 13 Jan 2020 02:48:59 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "f7396b4b-e918-463e-a296-bd1e2d062b8d"
+        ],
+        "x-ms-hdi-served-by": [
+          "Eastus2"
+        ],
+        "x-ms-correlation-request-id": [
+          "16c5d179-6bdc-4def-bb67-b597c93fc925"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11994"
+        ],
+        "x-ms-routing-request-id": [
+          "AUSTRALIAEAST:20200113T024900Z:16c5d179-6bdc-4def-bb67-b597c93fc925"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Content-Length": [
+          "1751"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/af49334f-cbb8-43d4-89bd-ab11ca50a185/resourceGroups/hdicsharprg9451/providers/Microsoft.HDInsight/clusters/hdisdk-tls127274\",\r\n  \"name\": \"hdisdk-tls127274\",\r\n  \"type\": \"Microsoft.HDInsight/clusters\",\r\n  \"location\": \"East US 2\",\r\n  \"etag\": \"633903e4-08b9-45af-a8e0-70c1da9fcaa7\",\r\n  \"tags\": null,\r\n  \"properties\": {\r\n    \"clusterVersion\": \"3.6.1000.67\",\r\n    \"clusterHdpVersion\": \"2.6.5.3016-3\",\r\n    \"osType\": \"Linux\",\r\n    \"clusterDefinition\": {\r\n      \"blueprint\": \"https://blueprints.azurehdinsight.net/hadoop-3.6.1000.67.2001080246.json\",\r\n      \"kind\": \"Hadoop\",\r\n      \"componentVersion\": {\r\n        \"Hadoop\": \"2.7\"\r\n      }\r\n    },\r\n    \"computeProfile\": {\r\n      \"roles\": [\r\n        {\r\n          \"name\": \"headnode\",\r\n          \"targetInstanceCount\": 2,\r\n          \"hardwareProfile\": {\r\n            \"vmSize\": \"standard_a4_v2\"\r\n          },\r\n          \"osProfile\": {\r\n            \"linuxOperatingSystemProfile\": {\r\n              \"username\": \"sshuser9235\"\r\n            }\r\n          },\r\n          \"encryptDataDisks\": false\r\n        },\r\n        {\r\n          \"name\": \"workernode\",\r\n          \"targetInstanceCount\": 3,\r\n          \"hardwareProfile\": {\r\n            \"vmSize\": \"standard_a4_v2\"\r\n          },\r\n          \"osProfile\": {\r\n            \"linuxOperatingSystemProfile\": {\r\n              \"username\": \"sshuser9235\"\r\n            }\r\n          },\r\n          \"encryptDataDisks\": false\r\n        },\r\n        {\r\n          \"name\": \"zookeepernode\",\r\n          \"targetInstanceCount\": 3,\r\n          \"hardwareProfile\": {\r\n            \"vmSize\": \"standard_a2_v2\"\r\n          },\r\n          \"osProfile\": {\r\n            \"linuxOperatingSystemProfile\": {\r\n              \"username\": \"sshuser9235\"\r\n            }\r\n          },\r\n          \"encryptDataDisks\": false\r\n        }\r\n      ]\r\n    },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"clusterState\": \"Running\",\r\n    \"createdDate\": \"2020-01-13T02:34:26.6\",\r\n    \"quotaInfo\": {\r\n      \"coresUsed\": 20\r\n    },\r\n    \"connectivityEndpoints\": [\r\n      {\r\n        \"name\": \"SSH\",\r\n        \"protocol\": \"TCP\",\r\n        \"location\": \"hdisdk-tls127274-ssh.azurehdinsight.net\",\r\n        \"port\": 22\r\n      },\r\n      {\r\n        \"name\": \"HTTPS\",\r\n        \"protocol\": \"TCP\",\r\n        \"location\": \"hdisdk-tls127274.azurehdinsight.net\",\r\n        \"port\": 443\r\n      }\r\n    ],\r\n    \"tier\": \"standard\",\r\n    \"storageProfile\": {\r\n      \"storageaccounts\": [\r\n        {\r\n          \"name\": \"hdicsharpstorage5029.blob.core.windows.net\",\r\n          \"resourceId\": null,\r\n          \"msiResourceId\": null,\r\n          \"key\": null,\r\n          \"fileSystem\": null,\r\n          \"container\": \"default6715\",\r\n          \"saskey\": null,\r\n          \"isDefault\": true\r\n        }\r\n      ]\r\n    },\r\n    \"minSupportedTlsVersion\": \"1.2\"\r\n  }\r\n}",
+      "StatusCode": 200
+    }
+  ],
+  "Names": {
+    ".ctor": [
+      "admin3025",
+      "Password1!1581",
+      "sshuser9235",
+      "Password1!8936",
+      "f35b07aa-8e82-4ddc-9456-967d3c8b1579",
+      "hdicsharprg9451",
+      "hdicsharpstorage5029",
+      "hdicsharpmsi3077",
+      "hdicsharpvault3894",
+      "hdicsharpadls1304",
+      "default6715",
+      "storageaccountkey5472"
+    ],
+    "TestInitialize": [
+      "af49334f-cbb8-43d4-89bd-ab11ca50a185"
+    ],
+    "TestCreateClusterWithTLS12": [
+      "hdisdk-tls127274"
+    ]
+  },
+  "Variables": {
+    "SubscriptionId": "af49334f-cbb8-43d4-89bd-ab11ca50a185"
+  }
+}


### PR DESCRIPTION
This PR is related with Swagger PR: [Supports for minSupportedTlsVersion feature](https://github.com/Azure/azure-rest-api-specs/pull/8129)
1. Add new feature: supports creating cluster with minSupportedTlsVersion