### PR TITLE
[Storage] Disable test UploadAsync_LargeFile

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
@@ -1150,6 +1150,7 @@ namespace Azure.Storage.Blobs.Test
 
         [LiveOnly]
         [Test]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/9487")]
         public async Task UploadAsync_LargeFile()
         {
             await using DisposingContainer test = await GetTestContainerAsync();


### PR DESCRIPTION
- Test is failing in live test runs with OutOfMemoryException
- Introduced in #9260
- Tracking issue to fix test: #9487
