### PR TITLE
[Event Hubs Client] Track Two (Test Timing Tweaks)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
@@ -25,7 +25,7 @@ namespace Azure.Messaging.EventHubs.Tests
     public sealed class LiveResourceManager
     {
         /// <summary>The maximum number of attempts to retry a management operation.</summary>
-        private const int RetryMaximumAttemps = 15;
+        private const int RetryMaximumAttempts  = 20;
 
         /// <summary>The number of seconds to use as the basis for backing off on retry attempts.</summary>
         private const double RetryExponentialBackoffSeconds = 3.0;
@@ -128,7 +128,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         /// <returns>The retry policy in which to execute the management operation.</returns>
         ///
-        public IAsyncPolicy<T> CreateRetryPolicy<T>(int maxRetryAttempts = RetryMaximumAttemps,
+        public IAsyncPolicy<T> CreateRetryPolicy<T>(int maxRetryAttempts = RetryMaximumAttempts,
                                                     double exponentialBackoffSeconds = RetryExponentialBackoffSeconds,
                                                     double baseJitterSeconds = RetryBaseJitterSeconds) =>
            Policy<T>
@@ -146,7 +146,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         /// <returns>The retry policy in which to execute the management operation.</returns>
         ///
-        public IAsyncPolicy CreateRetryPolicy(int maxRetryAttempts = RetryMaximumAttemps,
+        public IAsyncPolicy CreateRetryPolicy(int maxRetryAttempts = RetryMaximumAttempts,
                                               double exponentialBackoffSeconds = RetryExponentialBackoffSeconds,
                                               double baseJitterSeconds = RetryBaseJitterSeconds) =>
             Policy

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
@@ -140,7 +140,15 @@ namespace Azure.Messaging.EventHubs.Tests
                             }
                             else if (++consecutiveEmpties >= 5)
                             {
-                                break;
+                                if (consecutiveEmpties >= 15)
+                                {
+                                    break;
+                                }
+
+                                if (receivedEvents.Count < 1)
+                                {
+                                    await Task.Delay(50);
+                                }
                             }
                         }
 
@@ -210,7 +218,15 @@ namespace Azure.Messaging.EventHubs.Tests
                             }
                             else if (++consecutiveEmpties >= 5)
                             {
-                                break;
+                                if (consecutiveEmpties >= 15)
+                                {
+                                    break;
+                                }
+
+                                if (receivedEvents.Count < 1)
+                                {
+                                    await Task.Delay(50);
+                                }
                             }
                         }
 
@@ -282,7 +298,15 @@ namespace Azure.Messaging.EventHubs.Tests
                             }
                             else if (++consecutiveEmpties >= 5)
                             {
-                                break;
+                                if (consecutiveEmpties >= 15)
+                                {
+                                    break;
+                                }
+
+                                if (receivedEvents.Count < eventSet.Length)
+                                {
+                                    await Task.Delay(50);
+                                }
                             }
                         }
 
@@ -358,7 +382,15 @@ namespace Azure.Messaging.EventHubs.Tests
                             }
                             else if (++consecutiveEmpties >= 5)
                             {
-                                break;
+                                if (consecutiveEmpties >= 15)
+                                {
+                                    break;
+                                }
+
+                                if (receivedEvents.Count < eventBatch.Length)
+                                {
+                                    await Task.Delay(50);
+                                }
                             }
                         }
 
@@ -437,7 +469,15 @@ namespace Azure.Messaging.EventHubs.Tests
                             }
                             else if (++consecutiveEmpties >= 5)
                             {
-                                break;
+                                if (consecutiveEmpties >= 15)
+                                {
+                                    break;
+                                }
+
+                                if (receivedEvents.Count < eventBatch.Length)
+                                {
+                                    await Task.Delay(50);
+                                }
                             }
                         }
 
@@ -511,7 +551,15 @@ namespace Azure.Messaging.EventHubs.Tests
                             }
                             else if (++consecutiveEmpties >= 5)
                             {
-                                break;
+                                if (consecutiveEmpties >= 15)
+                                {
+                                    break;
+                                }
+
+                                if (receivedEvents.Count < expectedEventsCount)
+                                {
+                                    await Task.Delay(50);
+                                }
                             }
                         }
 
@@ -561,7 +609,15 @@ namespace Azure.Messaging.EventHubs.Tests
                             }
                             else if (++consecutiveEmpties >= 5)
                             {
-                                break;
+                                if (consecutiveEmpties >= 15)
+                                {
+                                    break;
+                                }
+
+                                if (receivedEvents.Count < expectedEventsCount)
+                                {
+                                    await Task.Delay(50);
+                                }
                             }
                         }
 
@@ -625,7 +681,15 @@ namespace Azure.Messaging.EventHubs.Tests
                                 }
                                 else if (++consecutiveEmpties >= 5)
                                 {
-                                    break;
+                                    if (consecutiveEmpties >= 15)
+                                    {
+                                        break;
+                                    }
+
+                                    if (receivedEvents.Count < expectedEventsCount)
+                                    {
+                                        await Task.Delay(50);
+                                    }
                                 }
                             }
 
@@ -692,7 +756,15 @@ namespace Azure.Messaging.EventHubs.Tests
                                 }
                                 else if (++consecutiveEmpties >= 5)
                                 {
-                                    break;
+                                    if (consecutiveEmpties >= 15)
+                                    {
+                                        break;
+                                    }
+
+                                    if (receivedEvents.Count < expectedEventsCount)
+                                    {
+                                        await Task.Delay(50);
+                                    }
                                 }
                             }
 
@@ -760,7 +832,15 @@ namespace Azure.Messaging.EventHubs.Tests
                                 }
                                 else if (++consecutiveEmpties >= 5)
                                 {
-                                    break;
+                                    if (consecutiveEmpties >= 15)
+                                    {
+                                        break;
+                                    }
+
+                                    if (receivedEvents.Count < expectedEventsCount)
+                                    {
+                                        await Task.Delay(50);
+                                    }
                                 }
                             }
 
@@ -795,7 +875,8 @@ namespace Azure.Messaging.EventHubs.Tests
                     var expectedCount = (eventsPerPartition * partitions.Length);
                     var readCount = 0;
                     var consecutiveEmpties = 0;
-                    var maximumConsecutiveEmpties = 10;
+                    var maximumConsecutiveEmpties = 15;
+                    var maximumConsecutiveEmptiesBeforeDelay = 5;
 
                     // Send events to each partition.  Because reading begins at the beginning of the partition by
                     // default, these should be observed without publishing in the read loop.
@@ -829,9 +910,17 @@ namespace Azure.Messaging.EventHubs.Tests
                                 break;
                             }
                         }
-                        else if (++consecutiveEmpties >= maximumConsecutiveEmpties)
+                        else if (++consecutiveEmpties >= maximumConsecutiveEmptiesBeforeDelay)
                         {
-                            break;
+                            if (consecutiveEmpties >= maximumConsecutiveEmpties)
+                            {
+                                break;
+                            }
+
+                            if (receivedEvents.Count < expectedCount)
+                            {
+                                await Task.Delay(50);
+                            }
                         }
                     }
 
@@ -873,7 +962,8 @@ namespace Azure.Messaging.EventHubs.Tests
                     var expectedCount = (eventsPerPartition * partitions.Length);
                     var readCount = 0;
                     var consecutiveEmpties = 0;
-                    var maximumConsecutiveEmpties = 10;
+                    var maximumConsecutiveEmpties = 15;
+                    var maximumConsecutiveEmptiesBeforeDelay = 5;
                     var wereEventsPublished = false;
 
                     // Define a local function to publish events, since it will be done multiple times.
@@ -909,9 +999,17 @@ namespace Azure.Messaging.EventHubs.Tests
                                 break;
                             }
                         }
-                        else if (++consecutiveEmpties >= maximumConsecutiveEmpties)
+                        else if (++consecutiveEmpties >= (maximumConsecutiveEmptiesBeforeDelay))
                         {
-                            break;
+                            if (consecutiveEmpties >= maximumConsecutiveEmpties)
+                            {
+                                break;
+                            }
+
+                            if (receivedEvents.Count < expectedCount)
+                            {
+                                await Task.Delay(50);
+                            }
                         }
                     }
 
@@ -943,9 +1041,17 @@ namespace Azure.Messaging.EventHubs.Tests
                                 break;
                             }
                         }
-                        else if (++consecutiveEmpties >= maximumConsecutiveEmpties)
+                        else if (++consecutiveEmpties >= maximumConsecutiveEmptiesBeforeDelay)
                         {
-                            break;
+                            if (consecutiveEmpties >= maximumConsecutiveEmpties)
+                            {
+                                break;
+                            }
+
+                            if (receivedEvents.Count < expectedCount)
+                            {
+                                await Task.Delay(50);
+                            }
                         }
                     }
 
@@ -985,7 +1091,8 @@ namespace Azure.Messaging.EventHubs.Tests
                     var expectedCount = (eventsPerPartition * partitions.Length);
                     var readCount = 0;
                     var consecutiveEmpties = 0;
-                    var maximumConsecutiveEmpties = 10;
+                    var maximumConsecutiveEmpties = 15;
+                    var maximumConsecutiveEmptiesBeforeDelay = 5;
 
                     // Send events using a set of partition keys.  Routing is controlled by the service and partitions may not
                     // receive an even distribution.  Because reading begins at the beginning of the partition by default, these
@@ -1019,9 +1126,17 @@ namespace Azure.Messaging.EventHubs.Tests
                                 break;
                             }
                         }
-                        else if (++consecutiveEmpties >= maximumConsecutiveEmpties)
+                        else if (++consecutiveEmpties >= maximumConsecutiveEmptiesBeforeDelay)
                         {
-                            break;
+                            if (consecutiveEmpties >= maximumConsecutiveEmpties)
+                            {
+                                break;
+                            }
+
+                            if (readCount < expectedCount)
+                            {
+                                await Task.Delay(50);
+                            }
                         }
                     }
 
@@ -1057,7 +1172,8 @@ namespace Azure.Messaging.EventHubs.Tests
                     var eventsBatched = 0;
                     var readCount = 0;
                     var consecutiveEmpties = 0;
-                    var maximumConsecutiveEmpties = 10;
+                    var maximumConsecutiveEmpties = 15;
+                    var maximumConsecutiveEmptiesBeforeDelay = 5;
 
                     // Send events without influencing the partition.  Routing is controlled by the service and partitions may not
                     // receive an even distribution.  Because reading begins at the beginning of the partition by default, these
@@ -1091,9 +1207,17 @@ namespace Azure.Messaging.EventHubs.Tests
                                 break;
                             }
                         }
-                        else if (++consecutiveEmpties >= maximumConsecutiveEmpties)
+                        else if (++consecutiveEmpties >= maximumConsecutiveEmptiesBeforeDelay)
                         {
-                            break;
+                            if (consecutiveEmpties >= maximumConsecutiveEmpties)
+                            {
+                                break;
+                            }
+
+                            if (readCount < expectedCount)
+                            {
+                                await Task.Delay(50);
+                            }
                         }
                     }
 
@@ -1143,7 +1267,15 @@ namespace Azure.Messaging.EventHubs.Tests
                         }
                         else if (++consecutiveEmpties >= 5)
                         {
-                            break;
+                            if (consecutiveEmpties >= 15)
+                            {
+                                break;
+                            }
+
+                            if (receivedEvents.Count < expectedEventsCount)
+                            {
+                                await Task.Delay(50);
+                            }
                         }
                     }
 
@@ -1174,7 +1306,8 @@ namespace Azure.Messaging.EventHubs.Tests
                     var expectedCount = (eventsPerPartition * partitions.Length);
                     var readCount = 0;
                     var consecutiveEmpties = 0;
-                    var maximumConsecutiveEmpties = 10;
+                    var maximumConsecutiveEmpties = 15;
+                    var maximumConsecutiveEmptiesBeforeDelay = 5;
 
                     // Send events to each partition.  Because reading begins at the beginning of the partition by
                     // default, these should be observed without publishing in the read loop.
@@ -1207,9 +1340,17 @@ namespace Azure.Messaging.EventHubs.Tests
                                 break;
                             }
                         }
-                        else if (++consecutiveEmpties >= maximumConsecutiveEmpties)
+                        else if (++consecutiveEmpties >= maximumConsecutiveEmptiesBeforeDelay)
                         {
-                            break;
+                            if (consecutiveEmpties >= maximumConsecutiveEmpties)
+                            {
+                                break;
+                            }
+
+                            if (readCount < expectedCount)
+                            {
+                                await Task.Delay(50);
+                            }
                         }
                     }
 
@@ -2030,7 +2171,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     // Read back the events from two different consumer groups.
 
-                    var maximumConsecutiveEmpties = 10;
+                    var maximumConsecutiveEmpties = 15;
+                    var maximumConsecutiveEmptiesBeforeDelay = 5;
                     var consecutiveEmpties = 0;
                     var consumerReceivedEvents = new List<EventData>();
                     var anotherReceivedEvents = new List<EventData>();
@@ -2043,9 +2185,17 @@ namespace Azure.Messaging.EventHubs.Tests
                             consumerReceivedEvents.Add(consumerEvent.Data);
                             consecutiveEmpties = 0;
                         }
-                        else if (++consecutiveEmpties >= maximumConsecutiveEmpties)
+                        else if (++consecutiveEmpties >= maximumConsecutiveEmptiesBeforeDelay)
                         {
-                            break;
+                            if (consecutiveEmpties >= maximumConsecutiveEmpties)
+                            {
+                                break;
+                            }
+
+                            if (consumerReceivedEvents.Count < eventBatch.Length)
+                            {
+                                await Task.Delay(50);
+                            }
                         }
                     }
 
@@ -2057,9 +2207,17 @@ namespace Azure.Messaging.EventHubs.Tests
                             anotherReceivedEvents.Add(anotherEvent.Data);
                             consecutiveEmpties = 0;
                         }
-                        else if (++consecutiveEmpties >= maximumConsecutiveEmpties)
+                        else if (++consecutiveEmpties >= maximumConsecutiveEmptiesBeforeDelay)
                         {
-                            break;
+                            if (consecutiveEmpties >= maximumConsecutiveEmpties)
+                            {
+                                break;
+                            }
+
+                            if (anotherReceivedEvents.Count < eventBatch.Length)
+                            {
+                                await Task.Delay(50);
+                            }
                         }
                     }
 


### PR DESCRIPTION
# Summary

The focus of these changes is to tweak the retries and timings around live tests for the Event Hubs client library that have been flaky during nightly runs over the last couple of weeks.

# Last Upstream Rebase

Thursday, January 15, 4:18pm (EST)