### PR TITLE
This is an APICompat prototype

### DIFF
--- a/eng/ApiCompat/ApiCompat.csproj
+++ b/eng/ApiCompat/ApiCompat.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="VerifyCompat">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <RunApiCompatForSrc>true</RunApiCompatForSrc>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.DotNet.ApiCompat" />
+        <PackageReference Include="Azure.Security.KeyVault.Secrets" />
+    </ItemGroup>
+
+    <Import Project="..\Packages.Data.props" />
+
+    <Target Name="VerifyCompat" DependsOnTargets="_ResolveResolvedMatchingContract;$(TargetsTriggeredByCompilation)">
+    </Target>
+
+    <Target Name="_ResolveResolvedMatchingContract" DependsOnTargets="ResolveReferences">
+        <PropertyGroup>
+            <TargetPackageDll Condition="'%(ResolvedCompileFileDefinitions.NuGetPackageId)' == '$(TargetPackageName)'" >%(ResolvedCompileFileDefinitions.Identity)</TargetPackageDll>
+        </PropertyGroup>
+        
+        <ItemGroup>
+            <ResolvedMatchingContract Include="$(TargetPackageDll)" />
+            <_DependencyDirectories Include="$(TargetOutputPath)" />
+            <ReferencePath Remove="$(TargetPackageDll)" />
+        </ItemGroup>
+
+        <Message Text="Checking API Compat against $(TargetPackageDll)" Importance="High" />
+    </Target>
+
+</Project>

--- a/eng/ApiCompat/ApiCompat.csproj
+++ b/eng/ApiCompat/ApiCompat.csproj
@@ -26,7 +26,7 @@
             <ReferencePath Remove="$(TargetPackageDll)" />
         </ItemGroup>
 
-        <Message Text="Checking API Compat against $(TargetPackageDll)" Importance="High" />
+        <Message Text="Checking API Compat against $(TargetPackageDll) using assemblies from $(TargetOutputPath)" Importance="High" />
     </Target>
 
 </Project>

--- a/eng/ApiCompat/Directory.Build.targets
+++ b/eng/ApiCompat/Directory.Build.targets
@@ -1,0 +1,6 @@
+<Project>
+
+    <!-- Avoid actually building anything -->
+    <Target Name="CoreBuild" />
+    
+</Project>

--- a/eng/Directory.Build.Data.targets
+++ b/eng/Directory.Build.Data.targets
@@ -116,5 +116,12 @@
            Text="When UseProjectReferenceToAzureClients=true all Azure.* references should be Project References, but the following are not [@(ShouldBeProjectReference)]" />
   </Target>
 
+  <Target Name="RunApiCompat" AfterTargets="CoreBuild">
+    <MSBuild
+      Projects="$(MSBuildThisFileDirectory)/ApiCompat/ApiCompat.csproj"
+      Properties="TargetPackageName=$(PackageId);TargetOutputPath=$(IntermediateOutputPath)"
+     />
+  </Target>
+
   <Import Project="$(CentralPackageVersionPackagePath)\Sdk.targets" />
 </Project>

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -40,6 +40,7 @@
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.6.1" />
     <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" />
     <PackageReference Update="Microsoft.CodeAnalysis" Version="2.3.0" />
+    <PackageReference Update="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.19552.1" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.0" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="2.1.0" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />


### PR DESCRIPTION
Referencing package directly doesn't work so I did this.

Calling dotnet build on `KeyVault.Secrets` runs APICompat against the package defined in packages.props.