### PR TITLE
[Event Hubs Client] Track Two (Publishing Tweaks)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
@@ -777,7 +777,12 @@ namespace Azure.Messaging.EventHubs.Amqp
                 catch (Exception ex)
                 {
                     EventHubsEventSource.Log.AmqpLinkAuthorizationRefreshError(EventHubName, endpoint.AbsoluteUri, ex.Message);
-                    refreshTimer.Change(Timeout.Infinite, Timeout.Infinite);
+
+                    // Attempt to unset the timer; there's a decent chance that it has been disposed at this point or
+                    // that the connection has been closed.  Ignore potential exceptions, as they won't impact operation.
+                    // At worse, another timer tick will occur and the operation will be retried.
+
+                    try { refreshTimer.Change(Timeout.Infinite, Timeout.Infinite); } catch {}
                 }
                 finally
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/ExceptionExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/ExceptionExtensions.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Core;
+using Microsoft.Azure.Amqp;
+
+namespace Azure.Messaging.EventHubs.Amqp
+{
+    /// <summary>
+    ///   The set of extension methods for the <see cref="Exception" /> class.
+    /// </summary>
+    ///
+    internal static class ExceptionExtensions
+    {
+        /// <summary>
+        ///   Considers an exception surfaced during an AMQP-based service operation, unwrapping
+        ///   and translating it into the form that should be considered for error handling
+        ///   decisions.
+        /// </summary>
+        ///
+        /// <param name="instance">The instance that this method was invoked on.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the service operation was targeting.</param>
+        ///
+        /// <returns>The <see cref="Exception" /> that corresponds to the <paramref name="instance" /> and which represents the service error.</returns>
+        ///
+        public static Exception TranslateServiceException(this Exception instance,
+                                                          string eventHubName)
+        {
+            Argument.AssertNotNull(instance, nameof(instance));
+
+            switch (instance)
+            {
+                case AmqpException amqpEx:
+                    return AmqpError.CreateExceptionForError(amqpEx.Error, eventHubName);
+
+                case OperationCanceledException operationEx when (operationEx.InnerException is AmqpException):
+                    return AmqpError.CreateExceptionForError(((AmqpException)operationEx.InnerException).Error, eventHubName);
+
+                case OperationCanceledException operationEx when (operationEx.InnerException != null):
+                    return operationEx.InnerException;
+
+                case OperationCanceledException operationEx when (!(operationEx is TaskCanceledException)):
+                    return new EventHubsException(eventHubName, operationEx.Message, EventHubsException.FailureReason.ServiceTimeout);
+
+                default:
+                    return instance;
+            }
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
@@ -772,7 +772,7 @@ namespace Azure.Messaging.EventHubs.Consumer
                 {
                     await transportConsumer.CloseAsync(CancellationToken.None).ConfigureAwait(false);
                     transportConsumer = null;
-                    throw new EventHubsException(false, EventHubName, String.Format(CultureInfo.CurrentCulture, Resources.FailedToCreateReader, EventHubName, partitionId, ConsumerGroup));
+                    throw new EventHubsException(false, EventHubName, string.Format(CultureInfo.CurrentCulture, Resources.FailedToCreateReader, EventHubName, partitionId, ConsumerGroup));
                 }
 
                 void exceptionCallback(Exception ex)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
@@ -9,6 +9,8 @@ using Azure.Core;
 using Azure.Messaging.EventHubs.Amqp;
 using Azure.Messaging.EventHubs.Consumer;
 using Azure.Messaging.EventHubs.Core;
+using Microsoft.Azure.Amqp;
+using Microsoft.Azure.Amqp.Framing;
 using Moq;
 using NUnit.Framework;
 
@@ -189,7 +191,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         [Test]
         [TestCaseSource(nameof(RetryOptionTestCases))]
-        public void ReceiveAsyncRespectsTheRetryPolicy(EventHubsRetryOptions retryOptions)
+        public void ReceiveAsyncAppliesTheRetryPolicy(EventHubsRetryOptions retryOptions)
         {
             var eventHub = "eventHubName";
             var consumerGroup = "$DEFAULT";
@@ -236,6 +238,229 @@ namespace Azure.Messaging.EventHubs.Tests
                     It.Is<bool>(value => value == trackLastEnqueued),
                     It.IsAny<CancellationToken>()),
                 Times.Exactly(1 + retryOptions.MaximumRetries));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConsumer.ReceiveAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(RetryOptionTestCases))]
+        public void ReceiveAsyncConsidersOperationCanceledExceptionAsRetriable(EventHubsRetryOptions retryOptions)
+        {
+            var eventHub = "eventHubName";
+            var consumerGroup = "$DEFAULT";
+            var partition = "3";
+            var eventPosition = EventPosition.FromOffset(123);
+            var trackLastEnqueued = false;
+            var ownerLevel = 123L;
+            var tokenValue = "123ABC";
+            var retryPolicy = new BasicRetryPolicy(retryOptions);
+            var retriableException = new OperationCanceledException();
+            var mockConverter = new Mock<AmqpMessageConverter>();
+            var mockCredential = new Mock<TokenCredential>();
+            var mockScope = new Mock<AmqpConnectionScope>();
+
+            using var cancellationSource = new CancellationTokenSource();
+
+            mockCredential
+                .Setup(credential => credential.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.Is<CancellationToken>(value => value == cancellationSource.Token)))
+                .Returns(new ValueTask<AccessToken>(new AccessToken(tokenValue, DateTimeOffset.MaxValue)));
+
+            mockScope
+               .Setup(scope => scope.OpenConsumerLinkAsync(
+                   It.IsAny<string>(),
+                   It.IsAny<string>(),
+                   It.IsAny<EventPosition>(),
+                   It.IsAny<TimeSpan>(),
+                   It.IsAny<uint>(),
+                   It.IsAny<long?>(),
+                   It.IsAny<bool>(),
+                   It.IsAny<CancellationToken>()))
+               .Throws(retriableException);
+
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, trackLastEnqueued, ownerLevel, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf(retriableException.GetType()));
+
+            mockScope
+                .Verify(scope => scope.OpenConsumerLinkAsync(
+                    It.Is<string>(value => value == consumerGroup),
+                    It.Is<string>(value => value == partition),
+                    It.Is<EventPosition>(value => value == eventPosition),
+                    It.IsAny<TimeSpan>(),
+                    It.IsAny<uint>(),
+                    It.Is<long?>(value => value == ownerLevel),
+                    It.Is<bool>(value => value == trackLastEnqueued),
+                    It.IsAny<CancellationToken>()),
+                Times.Exactly(1 + retryOptions.MaximumRetries));
+        }
+
+        /// <summary>
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConsumer.ReceiveAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(RetryOptionTestCases))]
+        public void ReceiveAsyncAppliesTheRetryPolicyForAmqpErrors(EventHubsRetryOptions retryOptions)
+        {
+            var eventHub = "eventHubName";
+            var consumerGroup = "$DEFAULT";
+            var partition = "3";
+            var eventPosition = EventPosition.FromOffset(123);
+            var trackLastEnqueued = false;
+            var ownerLevel = 123L;
+            var tokenValue = "123ABC";
+            var retryPolicy = new BasicRetryPolicy(retryOptions);
+            var retriableException = AmqpError.CreateExceptionForError(new Error { Value = AmqpError.ServerBusyError }, "dummy");
+            var mockConverter = new Mock<AmqpMessageConverter>();
+            var mockCredential = new Mock<TokenCredential>();
+            var mockScope = new Mock<AmqpConnectionScope>();
+
+            using var cancellationSource = new CancellationTokenSource();
+
+            mockCredential
+                .Setup(credential => credential.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.Is<CancellationToken>(value => value == cancellationSource.Token)))
+                .Returns(new ValueTask<AccessToken>(new AccessToken(tokenValue, DateTimeOffset.MaxValue)));
+
+            mockScope
+               .Setup(scope => scope.OpenConsumerLinkAsync(
+                   It.IsAny<string>(),
+                   It.IsAny<string>(),
+                   It.IsAny<EventPosition>(),
+                   It.IsAny<TimeSpan>(),
+                   It.IsAny<uint>(),
+                   It.IsAny<long?>(),
+                   It.IsAny<bool>(),
+                   It.IsAny<CancellationToken>()))
+               .Throws(retriableException);
+
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, trackLastEnqueued, ownerLevel, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf(retriableException.GetType()));
+
+            mockScope
+                .Verify(scope => scope.OpenConsumerLinkAsync(
+                    It.Is<string>(value => value == consumerGroup),
+                    It.Is<string>(value => value == partition),
+                    It.Is<EventPosition>(value => value == eventPosition),
+                    It.IsAny<TimeSpan>(),
+                    It.IsAny<uint>(),
+                    It.Is<long?>(value => value == ownerLevel),
+                    It.Is<bool>(value => value == trackLastEnqueued),
+                    It.IsAny<CancellationToken>()),
+                Times.Exactly(1 + retryOptions.MaximumRetries));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConsumer.ReceiveAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void ReceiveAsyncDetectsAnEmbeddedErrorForOperationCanceled()
+        {
+            var eventHub = "eventHubName";
+            var consumerGroup = "$DEFAULT";
+            var partition = "3";
+            var eventPosition = EventPosition.FromOffset(123);
+            var trackLastEnqueued = false;
+            var ownerLevel = 123L;
+            var tokenValue = "123ABC";
+            var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
+            var embeddedException = new OperationCanceledException("", new ArgumentNullException());
+            var mockConverter = new Mock<AmqpMessageConverter>();
+            var mockCredential = new Mock<TokenCredential>();
+            var mockScope = new Mock<AmqpConnectionScope>();
+
+            using var cancellationSource = new CancellationTokenSource();
+
+            mockCredential
+                .Setup(credential => credential.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.Is<CancellationToken>(value => value == cancellationSource.Token)))
+                .Returns(new ValueTask<AccessToken>(new AccessToken(tokenValue, DateTimeOffset.MaxValue)));
+
+            mockScope
+               .Setup(scope => scope.OpenConsumerLinkAsync(
+                   It.IsAny<string>(),
+                   It.IsAny<string>(),
+                   It.IsAny<EventPosition>(),
+                   It.IsAny<TimeSpan>(),
+                   It.IsAny<uint>(),
+                   It.IsAny<long?>(),
+                   It.IsAny<bool>(),
+                   It.IsAny<CancellationToken>()))
+               .Throws(embeddedException);
+
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, trackLastEnqueued, ownerLevel, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf<OperationCanceledException>());
+
+            mockScope
+                .Verify(scope => scope.OpenConsumerLinkAsync(
+                    It.Is<string>(value => value == consumerGroup),
+                    It.Is<string>(value => value == partition),
+                    It.Is<EventPosition>(value => value == eventPosition),
+                    It.IsAny<TimeSpan>(),
+                    It.IsAny<uint>(),
+                    It.Is<long?>(value => value == ownerLevel),
+                    It.Is<bool>(value => value == trackLastEnqueued),
+                    It.IsAny<CancellationToken>()),
+                Times.Once());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpConsumer.ReceiveAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void ReceiveAsyncDetectsAnEmbeddedAmqpErrorForOperationCanceled()
+        {
+            var eventHub = "eventHubName";
+            var consumerGroup = "$DEFAULT";
+            var partition = "3";
+            var eventPosition = EventPosition.FromOffset(123);
+            var trackLastEnqueued = false;
+            var ownerLevel = 123L;
+            var tokenValue = "123ABC";
+            var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
+            var embeddedException = new OperationCanceledException("", new AmqpException(new Error { Condition = AmqpError.ArgumentError }));
+            var mockConverter = new Mock<AmqpMessageConverter>();
+            var mockCredential = new Mock<TokenCredential>();
+            var mockScope = new Mock<AmqpConnectionScope>();
+
+            using var cancellationSource = new CancellationTokenSource();
+
+            mockCredential
+                .Setup(credential => credential.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.Is<CancellationToken>(value => value == cancellationSource.Token)))
+                .Returns(new ValueTask<AccessToken>(new AccessToken(tokenValue, DateTimeOffset.MaxValue)));
+
+            mockScope
+               .Setup(scope => scope.OpenConsumerLinkAsync(
+                   It.IsAny<string>(),
+                   It.IsAny<string>(),
+                   It.IsAny<EventPosition>(),
+                   It.IsAny<TimeSpan>(),
+                   It.IsAny<uint>(),
+                   It.IsAny<long?>(),
+                   It.IsAny<bool>(),
+                   It.IsAny<CancellationToken>()))
+               .Throws(embeddedException);
+
+            var consumer = new AmqpConsumer(eventHub, consumerGroup, partition, eventPosition, trackLastEnqueued, ownerLevel, null, mockScope.Object, Mock.Of<AmqpMessageConverter>(), retryPolicy);
+            Assert.That(async () => await consumer.ReceiveAsync(100, null, cancellationSource.Token), Throws.InstanceOf<OperationCanceledException>());
+
+            mockScope
+                .Verify(scope => scope.OpenConsumerLinkAsync(
+                    It.Is<string>(value => value == consumerGroup),
+                    It.Is<string>(value => value == partition),
+                    It.Is<EventPosition>(value => value == eventPosition),
+                    It.IsAny<TimeSpan>(),
+                    It.IsAny<uint>(),
+                    It.Is<long?>(value => value == ownerLevel),
+                    It.Is<bool>(value => value == trackLastEnqueued),
+                    It.IsAny<CancellationToken>()),
+                Times.Once());
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventBatchTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventBatchTests.cs
@@ -312,7 +312,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(0);
 
             var batch = new AmqpEventBatch(mockConverter, options);
-            Assert.That(() => batch.AsEnumerable<EventData>(), Throws.InstanceOf<FormatException>());
+            Assert.That(() => batch.AsEnumerable<AmqpMessage>(), Throws.InstanceOf<FormatException>());
         }
 
         /// <summary>
@@ -321,12 +321,13 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public void AsEnumerableReturnsTheMessages()
+        public void AsEnumerableReturnsTheEvents()
         {
             var currentIndex = -1;
             var maximumSize = 5000;
             var options = new CreateBatchOptions { MaximumSizeInBytes = maximumSize };
             var eventMessages = new AmqpMessage[5];
+            var batchEvents = new EventData[5];
             var mockEnvelope = new Mock<AmqpMessage>();
             var mockConverter = new InjectableMockConverter
             {
@@ -349,18 +350,19 @@ namespace Azure.Messaging.EventHubs.Tests
 
             for (var index = 0; index < eventMessages.Length; ++index)
             {
-                batch.TryAdd(new EventData(new byte[0]));
+                batchEvents[index] = new EventData(new byte[0]);
+                batch.TryAdd(batchEvents[index]);
             }
 
-            IEnumerable<AmqpMessage> batchEnumerable = batch.AsEnumerable<AmqpMessage>();
+            IEnumerable<EventData> batchEnumerable = batch.AsEnumerable<EventData>();
             Assert.That(batchEnumerable, Is.Not.Null, "The batch enumerable should have been populated.");
 
             var batchEnumerableList = batchEnumerable.ToList();
-            Assert.That(batchEnumerableList.Count, Is.EqualTo(batch.Count), "The wrong number of messages was in the enumerable.");
+            Assert.That(batchEnumerableList.Count, Is.EqualTo(batch.Count), "The wrong number of events was in the enumerable.");
 
-            for (var index = 0; index < eventMessages.Length; ++index)
+            for (var index = 0; index < batchEvents.Length; ++index)
             {
-                Assert.That(batchEnumerableList.Contains(eventMessages[index]), $"The event message at index: { index } was not in the enumerable.");
+                Assert.That(batchEnumerableList.Contains(batchEvents[index]), $"The event at index: { index } was not in the enumerable.");
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/ExceptionExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/ExceptionExtensionsTests.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Amqp;
+using Microsoft.Azure.Amqp.Framing;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="ExceptionExtensions" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class ExceptionExtensionsTests
+    {
+        /// <summary>
+        ///   The set of test cases for "normal" exceptions that do not get
+        ///   translated.
+        /// </summary>
+        ///
+        public static IEnumerable<object[]> GeneralExceptionCases()
+        {
+            yield return new[] { new ArgumentNullException("blah") };
+            yield return new[] { new EventHubsException(false, "thing") };
+            yield return new[] { new TimeoutException() };
+            yield return new[] { new TaskCanceledException() };
+            yield return new[] { new Exception() };
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ExceptionExtensions.TranslateServiceException" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void TranslateServiceExceptionValidatesTheInstance()
+        {
+            Assert.That(() => ((Exception)null).TranslateServiceException("dummy"), Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ExceptionExtensions.TranslateServiceException" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void TranslateServiceExceptionTranslatesAmqpExceptions()
+        {
+            var eventHub = "someHub";
+            var exception = AmqpError.CreateExceptionForError(new Error { Condition = AmqpError.ServerBusyError }, eventHub);
+            var translated = exception.TranslateServiceException(eventHub);
+
+            Assert.That(translated, Is.Not.Null, "An exception should have been returned.");
+
+            var eventHubsException = translated as EventHubsException;
+            Assert.That(eventHubsException, Is.Not.Null, "The exception type should be appropriate for the `Server Busy` scenario.");
+            Assert.That(eventHubsException.Reason, Is.EqualTo(EventHubsException.FailureReason.ServiceBusy), "The exception reason should indicate `Server Busy`.");
+            Assert.That(eventHubsException.EventHubName, Is.EqualTo(eventHub), "The Event Hub name should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ExceptionExtensions.TranslateServiceException" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void TranslateServiceExceptionTranslatesOperationCanceledWithoutEmbeddedExceptions()
+        {
+            var eventHub = "someHub";
+            var exception = new OperationCanceledException();
+            var translated = exception.TranslateServiceException(eventHub);
+
+            Assert.That(translated, Is.Not.Null, "An exception should have been returned.");
+
+            var eventHubsException = translated as EventHubsException;
+            Assert.That(eventHubsException, Is.Not.Null, "The exception type should be appropriate for the `Server Busy` scenario.");
+            Assert.That(eventHubsException.Reason, Is.EqualTo(EventHubsException.FailureReason.ServiceTimeout), "The exception reason should indicate a service timeout.");
+            Assert.That(eventHubsException.EventHubName, Is.EqualTo(eventHub), "The Event Hub name should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ExceptionExtensions.TranslateServiceException" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void TranslateServiceExceptionTranslatesOperationCanceledWithEmbeddedAmqpException()
+        {
+            var eventHub = "someHub";
+            var exception = new OperationCanceledException("oops", AmqpError.CreateExceptionForError(new Error { Condition = AmqpError.ServerBusyError }, eventHub));
+            var translated = exception.TranslateServiceException(eventHub);
+
+            Assert.That(translated, Is.Not.Null, "An exception should have been returned.");
+
+            var eventHubsException = translated as EventHubsException;
+            Assert.That(eventHubsException, Is.Not.Null, "The exception type should be appropriate for the `Server Busy` scenario.");
+            Assert.That(eventHubsException.Reason, Is.EqualTo(EventHubsException.FailureReason.ServiceBusy), "The exception reason should indicate `Server Busy`.");
+            Assert.That(eventHubsException.EventHubName, Is.EqualTo(eventHub), "The Event Hub name should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ExceptionExtensions.TranslateServiceException" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void TranslateServiceExceptionTranslatesOperationCanceledWithEmbeddedGeneralException()
+        {
+            var eventHub = "someHub";
+            var embedded = new ArgumentException();
+            var exception = new OperationCanceledException("oops", embedded);
+            var translated = exception.TranslateServiceException(eventHub);
+
+            Assert.That(translated, Is.Not.Null, "An exception should have been returned.");
+            Assert.That(translated, Is.SameAs(embedded), "The embedded (inner) exception should have been returned.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ExceptionExtensions.TranslateServiceException" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(GeneralExceptionCases))]
+        public void TranslateServiceExceptionDoesNotTranslateGeneralExceptions(Exception generalException)
+        {
+            var eventHub = "someHub";
+            var translated = generalException.TranslateServiceException(eventHub);
+
+            Assert.That(translated, Is.Not.Null, "An exception should have been returned.");
+            Assert.That(translated, Is.SameAs(generalException), "The general exception should have been returned.");
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
@@ -1363,7 +1363,6 @@ namespace Azure.Messaging.EventHubs.Tests
             }
         }
 
-
         /// <summary>
         ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
         ///   connect to the Event Hubs service and perform operations.


### PR DESCRIPTION
# Summary

The focus of these changes is to tweak some of the behaviors around the publishing of events to increase reliability during a corner case scenario where a batch with single event at maximum size is published by multiple producer clients with a high degree of concurrency over time.  This triggered the service to begin throttling, which caused some instability in the producer's use of the AMQP link for publishing.

These changes introduce:

  - A more fine-grained processing of AMQP-triggered exceptions so that retry decisions can be made more intelligently.

  - An adjustment to the calculated retry delay when the service signals throttling, ensuring that the recommended minimum backoff will be respected.  This delay has some minor randomization to avoid the "thundering herd" problem when multiple operations are taking place concurrently.

  - A change to the approach used when building event batches to better guard against a race condition in disposal of AMQP messages.  Previously, the message used to measure the size when building the batch was cached and then copied for Send operations.  This caused some non-deterministic behavior when the AMQP link was under load and was performing its own buffering.  The non-volatile event data is now cached with the batch and used to generate the AMQP message to be sent.

# Last Upstream Rebase

Sunday, January 19, 1:58pm (EST)