### PR TITLE
DocWarden version lock-down.

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -54,7 +54,7 @@ jobs:
           versionSpec: "3.6"
       - script: |
           pip install setuptools wheel
-          pip install doc-warden
+          pip install doc-warden==$(DocWardenVersion)
           ward scan -d $(Build.SourcesDirectory) -c $(Build.SourcesDirectory)/eng/.docsettings.yml
         displayName: "Verify Readmes"
       - task: DotNetCoreInstaller@2

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,4 +1,5 @@
 variables:
+  DocWardenVersion: '0.4.2'
   DotNetCoreSDKVersion: '3.1.100'
   DotNetCoreRuntimeVersion: '2.1.10'
   OfficialBuildId: $(Build.BuildNumber)


### PR DESCRIPTION
This PR adds the logic to lock down the version of ```doc-warden``` that is being used in the build pipeline. We are doing this because we want to be able to update the ```doc-warden``` package and we don't want a bug to blow up all the pipelines, instead, when we publish doc-warden we can flight usage of the new version with a PR by updating the version in the global variables.