### PR TITLE
Make Cancellation tests reliable

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
@@ -883,12 +883,8 @@ namespace Azure.Storage.Blobs.Test
 
             async Task AssertDownloadAsync()
             {
-                // Create a CancellationToken that times out after .01s
-                CancellationTokenSource source = new CancellationTokenSource(TimeSpan.FromSeconds(.01));
-                CancellationToken token = source.Token;
-                // Delay 1s to ensure that the Download operation should be canceled since DownloadAsync doesn't
-                // buffer the response.
-                await Delay(1000);
+                // Create a CancellationToken that is already cancelled
+                CancellationToken token = new CancellationToken(canceled: true);
 
                 // Verifying Download will cancel
                 await TestHelper.CatchAsync<OperationCanceledException>(


### PR DESCRIPTION
Fixes live test failure https://dev.azure.com/azure-sdk/internal/_build/results?buildId=237824&view=ms.vss-test-web.build-test-results-tab&runId=8134986&resultId=100253&paneView=attachments

The test failed because the Download API doesn't buffer the response - if the initial response returned within the timeout, the cancellation token would not be cancelled. In the logs, we do see the download took .1s which is more than the cancellationToken time of .01s. However, we aren't trying to test that cancellationToken is accurate to the level of milliseconds, but rather chose .01s as a time that we would expect the download to easily surpass.

Also, adding coverage for DownloadTo.