### PR TITLE
Add support for multi service version testing to test framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,9 @@ _ReSharper*/
 
 *.[Rr]e[Ss]harper
 
+# Rider IDE
+.idea
+
 # NCrunch
 *.ncrunch*
 .*crunch*.local.xml

--- a/sdk/core/Azure.Core/tests/ClientTestBaseMultiVersionTests.cs
+++ b/sdk/core/Azure.Core/tests/ClientTestBaseMultiVersionTests.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core.Testing;
+using NUnit.Framework;
+
+namespace Azure.Core.Tests
+{
+    [ClientTestFixture(FakeClientVersion.V1, FakeClientVersion.V2, FakeClientVersion.V3)]
+    public class ClientTestBaseMultiVersionTests : ClientTestBase
+    {
+        private readonly FakeClientVersion _version;
+
+        public ClientTestBaseMultiVersionTests(bool isAsync, FakeClientVersion version) : base(isAsync)
+        {
+            _version = version;
+        }
+
+        [Test]
+        public void HasValidVersion()
+        {
+            Assert.IsTrue(
+                _version == FakeClientVersion.V1 ||
+                          _version == FakeClientVersion.V2 ||
+                           _version == FakeClientVersion.V3);
+        }
+
+        [Test]
+        [ServiceVersion(Min = FakeClientVersion.V2)]
+        public void MinVersionWorks()
+        {
+            Assert.IsTrue(
+                _version == FakeClientVersion.V2 ||
+                _version == FakeClientVersion.V3);
+        }
+
+        [Test]
+        [ServiceVersion(Max = FakeClientVersion.V2)]
+        public void MaxVersionWorks()
+        {
+            Assert.IsTrue(
+                _version == FakeClientVersion.V2 ||
+                _version == FakeClientVersion.V1);
+        }
+
+        [Test]
+        [AsyncOnly]
+        public void AsyncOnlyWorks()
+        {
+            Assert.IsTrue(IsAsync);
+        }
+
+        public enum FakeClientVersion
+        {
+            V1 = 1,
+            V2 = 2,
+            V3 = 3
+        }
+    }
+}

--- a/sdk/core/Azure.Core/tests/TestFramework/AsyncOnlyAttribute.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/AsyncOnlyAttribute.cs
@@ -3,34 +3,11 @@
 
 using System;
 using NUnit.Framework;
-using NUnit.Framework.Interfaces;
-using NUnit.Framework.Internal;
 
 namespace Azure.Core.Testing
 {
-
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
-    public class AsyncOnlyAttribute : NUnitAttribute, IApplyToTest
+    public class AsyncOnlyAttribute : NUnitAttribute
     {
-        #region IApplyToTest members
-
-        /// <summary>
-        /// Modifies a test by marking it as Ignored.
-        /// </summary>
-        /// <param name="test">The test to modify</param>
-        public void ApplyToTest(Test test)
-        {
-            if (test.RunState != RunState.NotRunnable)
-            {
-                // This is an unfortunate implementation but it's the only one I was able to figure out
-                string testParameters = test.FullName.Substring(test.ClassName.Length);
-                if (testParameters.StartsWith("(False"))
-                {
-                    test.RunState = RunState.Ignored;
-                }
-            }
-        }
-
-        #endregion
     }
 }

--- a/sdk/core/Azure.Core/tests/TestFramework/ClientTestBase.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/ClientTestBase.cs
@@ -6,13 +6,11 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using Castle.DynamicProxy;
-using NUnit.Framework;
 
 namespace Azure.Core.Testing
 {
-    [TestFixture(true)]
-    [TestFixture(false)]
-    public class ClientTestBase
+    [ClientTestFixtureAttribute]
+    public abstract class ClientTestBase
     {
         private static readonly ProxyGenerator s_proxyGenerator = new ProxyGenerator();
 

--- a/sdk/core/Azure.Core/tests/TestFramework/ClientTestFixtureAttribute.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/ClientTestFixtureAttribute.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+
+namespace Azure.Core.Testing
+{
+    public class ClientTestFixtureAttribute : NUnitAttribute, IFixtureBuilder2, IPreFilter
+    {
+        private readonly object[] _serviceVersions;
+        private readonly int? _maxServiceVersion;
+
+        public ClientTestFixtureAttribute(params object[] serviceVersions)
+        {
+            _serviceVersions = serviceVersions;
+
+            _maxServiceVersion = _serviceVersions.Any() ? _serviceVersions.Max(s => Convert.ToInt32(s)) : (int?)null;
+        }
+
+        public IEnumerable<TestSuite> BuildFrom(ITypeInfo typeInfo)
+        {
+            return BuildFrom(typeInfo, this);
+        }
+
+        public IEnumerable<TestSuite> BuildFrom(ITypeInfo typeInfo, IPreFilter filter)
+        {
+            if (_serviceVersions.Any())
+            {
+                foreach (object serviceVersion in _serviceVersions)
+                {
+                    var syncFixture = new TestFixtureAttribute(false, serviceVersion);
+                    var asyncFixture = new TestFixtureAttribute(true, serviceVersion);
+
+                    foreach (TestSuite testSuite in asyncFixture.BuildFrom(typeInfo, filter))
+                    {
+                        Process(testSuite, serviceVersion, true);
+                        yield return testSuite;
+                    }
+
+                    foreach (TestSuite testSuite in syncFixture.BuildFrom(typeInfo, filter))
+                    {
+                        Process(testSuite, serviceVersion, false);
+                        yield return testSuite;
+                    }
+                }
+            }
+            else
+            {
+                // No service versions defined
+                var syncFixture = new TestFixtureAttribute(false);
+                var asyncFixture = new TestFixtureAttribute(true);
+
+                foreach (TestSuite testSuite in asyncFixture.BuildFrom(typeInfo, filter))
+                {
+                    Process(testSuite, null, true);
+                    yield return testSuite;
+                }
+
+                foreach (TestSuite testSuite in syncFixture.BuildFrom(typeInfo, filter))
+                {
+                    Process(testSuite, null, false);
+                    yield return testSuite;
+                }
+            }
+        }
+
+        private void Process(TestSuite testSuite, object serviceVersion, bool isAsync)
+        {
+            var serviceVersionNumber = Convert.ToInt32(serviceVersion);
+            foreach (Test test in testSuite.Tests)
+            {
+                if (test is ParameterizedMethodSuite parameterizedMethodSuite)
+                {
+                    foreach (Test parameterizedTest in parameterizedMethodSuite.Tests)
+                    {
+                        ProcessTest(serviceVersion, isAsync, serviceVersionNumber, parameterizedTest);
+                    }
+                }
+                else
+                {
+                    ProcessTest(serviceVersion, isAsync, serviceVersionNumber, test);
+                }
+            }
+        }
+
+        private void ProcessTest(object serviceVersion, bool isAsync, int serviceVersionNumber, Test test)
+        {
+            if (serviceVersionNumber != _maxServiceVersion)
+            {
+                test.Properties.Add("SkipRecordings", $"Test is ignored when not running live because the service version {serviceVersion} is not the latest.");
+            }
+
+            if (!isAsync && test.GetCustomAttributes<AsyncOnlyAttribute>(true).Any())
+            {
+                test.RunState = RunState.Ignored;
+                test.Properties.Set("_SKIPREASON", $"Test ignored in sync run because it's marked with {nameof(AsyncOnlyAttribute)}");
+            }
+
+            var minServiceVersion = test.GetCustomAttributes<ServiceVersionAttribute>(true);
+            foreach (ServiceVersionAttribute serviceVersionAttribute in minServiceVersion)
+            {
+                if (serviceVersionAttribute.Min != null &&
+                    Convert.ToInt32(serviceVersionAttribute.Min) > serviceVersionNumber)
+                {
+                    test.RunState = RunState.Ignored;
+                    test.Properties.Set("_SKIPREASON", $"Test ignored because it's minimum service version is set to {serviceVersionAttribute.Min}");
+                }
+
+                if (serviceVersionAttribute.Max != null &&
+                    Convert.ToInt32(serviceVersionAttribute.Max) < serviceVersionNumber)
+                {
+                    test.RunState = RunState.Ignored;
+                    test.Properties.Set("_SKIPREASON", $"Test ignored because it's maximum service version is set to {serviceVersionAttribute.Max}");
+                }
+            }
+        }
+
+        bool IPreFilter.IsMatch(Type type) => true;
+
+        bool IPreFilter.IsMatch(Type type, MethodInfo method)  => true;
+    }
+}

--- a/sdk/core/Azure.Core/tests/TestFramework/RecordedTestBase.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/RecordedTestBase.cs
@@ -39,14 +39,15 @@ namespace Azure.Core.Testing
             return Path.Combine(TestContext.CurrentContext.TestDirectory, "SessionRecords", className, fileName);
         }
 
-        public TestRecording StartRecording(string name)
-        {
-            return new TestRecording(Mode, GetSessionFilePath(name), Sanitizer, Matcher);
-        }
-
         [SetUp]
         public virtual void StartTestRecording()
         {
+            TestContext.TestAdapter test = TestContext.CurrentContext.Test;
+            if (Mode != RecordedTestMode.Live &&
+                test.Properties.ContainsKey("SkipRecordings"))
+            {
+                throw new IgnoreException((string) test.Properties.Get("SkipRecordings"));
+            }
             Recording = new TestRecording(Mode, GetSessionFilePath(), Sanitizer, Matcher);
         }
 

--- a/sdk/core/Azure.Core/tests/TestFramework/RecordedTestBase.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/RecordedTestBase.cs
@@ -42,6 +42,7 @@ namespace Azure.Core.Testing
         [SetUp]
         public virtual void StartTestRecording()
         {
+            // Only create test recordings for the latest version of the service
             TestContext.TestAdapter test = TestContext.CurrentContext.Test;
             if (Mode != RecordedTestMode.Live &&
                 test.Properties.ContainsKey("SkipRecordings"))

--- a/sdk/core/Azure.Core/tests/TestFramework/ServiceVersionAttribute.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/ServiceVersionAttribute.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using NUnit.Framework;
+
+namespace Azure.Core.Testing
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+    public class ServiceVersionAttribute : NUnitAttribute
+    {
+        public object Min { get; set; }
+        public object Max { get; set; }
+    }
+}

--- a/sdk/storage/Azure.Storage.Blobs.Batch/tests/BlobBatchClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/tests/BlobBatchClientTests.cs
@@ -17,8 +17,8 @@ namespace Azure.Storage.Blobs.Test
 {
     public class BlobBatchClientTests : BlobTestBase
     {
-        public BlobBatchClientTests(bool async)
-            : base(async, null /* RecordedTestMode.Record /* to re-record */)
+        public BlobBatchClientTests(bool async, BlobClientOptions.ServiceVersion serviceVersion)
+            : base(async, serviceVersion, null /* RecordedTestMode.Record /* to re-record */)
         {
         }
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
@@ -20,8 +20,8 @@ namespace Azure.Storage.Blobs.Test
 {
     public class AppendBlobClientTests : BlobTestBase
     {
-        public AppendBlobClientTests(bool async)
-            : base(async, null /* RecordedTestMode.Record /* to re-record */)
+        public AppendBlobClientTests(bool async, BlobClientOptions.ServiceVersion serviceVersion)
+            : base(async, serviceVersion, null /* RecordedTestMode.Record /* to re-record */)
         {
         }
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -26,8 +26,8 @@ namespace Azure.Storage.Blobs.Test
 {
     public class BlobBaseClientTests : BlobTestBase
     {
-        public BlobBaseClientTests(bool async)
-            : base(async, null /* RecordedTestMode.Record /* to re-record */)
+        public BlobBaseClientTests(bool async, BlobClientOptions.ServiceVersion serviceVersion)
+            : base(async, serviceVersion, null /* RecordedTestMode.Record /* to re-record */)
         {
         }
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
@@ -20,8 +20,8 @@ namespace Azure.Storage.Blobs.Test
 {
     public class BlobClientTests : BlobTestBase
     {
-        public BlobClientTests(bool async)
-            : base(async, null /* RecordedTestMode.Record /* to re-record */)
+        public BlobClientTests(bool async, BlobClientOptions.ServiceVersion serviceVersion)
+            : base(async, serviceVersion, null /* RecordedTestMode.Record /* to re-record */)
         {
         }
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobSasBuilderTests.cs
@@ -17,8 +17,8 @@ namespace Azure.Storage.Blobs.Test
         private const string Permissions = "rwd";
         private static readonly string Snapshot = "snapshot";
 
-        public BlobSasBuilderTests(bool async)
-            : base(async, null /* RecordedTestMode.Record /* to re-record */)
+        public BlobSasBuilderTests(bool async, BlobClientOptions.ServiceVersion serviceVersion)
+            : base(async, serviceVersion, null /* RecordedTestMode.Record /* to re-record */)
         {
         }
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -16,8 +16,10 @@ using Azure.Storage.Sas;
 
 namespace Azure.Storage.Test.Shared
 {
+    [ClientTestFixture(BlobClientOptions.ServiceVersion.V2019_02_02)]
     public abstract class BlobTestBase : StorageTestBase
     {
+        private readonly BlobClientOptions.ServiceVersion _serviceVersion;
         public readonly string ReceivedETag = "\"received\"";
         public readonly string GarbageETag = "\"garbage\"";
         public readonly string ReceivedLeaseId = "received";
@@ -28,11 +30,10 @@ namespace Azure.Storage.Test.Shared
         protected string SecondaryStorageTenantSecondaryHost() =>
             new Uri(TestConfigSecondary.BlobServiceSecondaryEndpoint).Host;
 
-        public BlobTestBase(bool async) : this(async, null) { }
-
-        public BlobTestBase(bool async, RecordedTestMode? mode = null)
+        public BlobTestBase(bool async, BlobClientOptions.ServiceVersion serviceVersion, RecordedTestMode? mode = null)
             : base(async, mode)
         {
+            _serviceVersion = serviceVersion;
         }
 
         public DateTimeOffset OldDate => Recording.Now.AddDays(-1);
@@ -45,7 +46,7 @@ namespace Azure.Storage.Test.Shared
 
         public BlobClientOptions GetOptions(bool parallelRange = false)
         {
-            var options = new BlobClientOptions
+            var options = new BlobClientOptions((BlobClientOptions.ServiceVersion) _serviceVersion)
             {
                 Diagnostics = { IsLoggingEnabled = true },
                 Retry =

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -46,7 +46,7 @@ namespace Azure.Storage.Test.Shared
 
         public BlobClientOptions GetOptions(bool parallelRange = false)
         {
-            var options = new BlobClientOptions((BlobClientOptions.ServiceVersion) _serviceVersion)
+            var options = new BlobClientOptions(_serviceVersion)
             {
                 Diagnostics = { IsLoggingEnabled = true },
                 Retry =

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobUriBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobUriBuilderTests.cs
@@ -12,8 +12,8 @@ namespace Azure.Storage.Blobs.Test
 {
     public class BlobUriBuilderTests : BlobTestBase
     {
-        public BlobUriBuilderTests(bool async)
-            : base(async, null /* RecordedTestMode.Record /* to re-record */)
+        public BlobUriBuilderTests(bool async, BlobClientOptions.ServiceVersion serviceVersion)
+            : base(async, serviceVersion, null /* RecordedTestMode.Record /* to re-record */)
         {
         }
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
@@ -27,8 +27,8 @@ namespace Azure.Storage.Blobs.Test
         private readonly Func<RequestFailedException, bool> _retryStageBlockFromUri =
             ex => ex.Status == 500 && ex.ErrorCode == BlobErrorCode.CannotVerifyCopySource.ToString();
 
-        public BlockBlobClientTests(bool async)
-            : base(async, null /* RecordedTestMode.Record /* to re-record */)
+        public BlockBlobClientTests(bool async, BlobClientOptions.ServiceVersion serviceVersion)
+            : base(async, serviceVersion, null /* RecordedTestMode.Record /* to re-record */)
         {
         }
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
@@ -22,12 +22,13 @@ namespace Azure.Storage.Blobs.Test
 {
     public class ContainerClientTests : BlobTestBase
     {
-        public ContainerClientTests(bool async)
-            : base(async, null /* RecordedTestMode.Record /* to re-record */)
+        public ContainerClientTests(bool async, BlobClientOptions.ServiceVersion serviceVersion)
+            : base(async, serviceVersion, null /* RecordedTestMode.Record /* to re-record */)
         {
         }
 
         [Test]
+        [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2019_02_02)]
         public void Ctor_ConnectionString()
         {
             var accountName = "accountName";

--- a/sdk/storage/Azure.Storage.Blobs/tests/EncryptedBlockBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/EncryptedBlockBlobClientTests.cs
@@ -13,8 +13,8 @@ namespace Azure.Storage.Blobs.Test
 {
     public class EncryptedBlockBlobClientTests : BlobTestBase
     {
-        public EncryptedBlockBlobClientTests(bool async)
-            : base(async, null /* RecordedTestMode.Record /* to re-record */)
+        public EncryptedBlockBlobClientTests(bool async, BlobClientOptions.ServiceVersion serviceVersion)
+            : base(async, serviceVersion, null /* RecordedTestMode.Record /* to re-record */)
         {
         }
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
@@ -28,8 +28,8 @@ namespace Azure.Storage.Blobs.Test
         private const string ContentLanguage = "language";
         private const string ContentType = "type";
 
-        public PageBlobClientTests(bool async)
-            : base(async, null /* RecordedTestMode.Record /* to re-record */)
+        public PageBlobClientTests(bool async, BlobClientOptions.ServiceVersion serviceVersion)
+            : base(async, serviceVersion, null /* RecordedTestMode.Record /* to re-record */)
         {
         }
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/SasQueryParametersTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SasQueryParametersTests.cs
@@ -9,13 +9,8 @@ using NUnit.Framework;
 namespace Azure.Storage.Blobs.Test
 {
     //TODO consider added SASQueryParametersTest for File and Queue
-    public class SasQueryParametersTests : BlobTestBase
+    public class SasQueryParametersTests
     {
-        public SasQueryParametersTests(bool async)
-            : base(async, null /* RecordedTestMode.Record /* to re-record */)
-        {
-        }
-
         [Test]
         public void SasQueryParameters_RoundTrip()
         {

--- a/sdk/storage/Azure.Storage.Blobs/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ServiceClientTests.cs
@@ -15,8 +15,8 @@ namespace Azure.Storage.Blobs.Test
 {
     public class ServiceClientTests : BlobTestBase
     {
-        public ServiceClientTests(bool async)
-            : base(async, null /* RecordedTestMode.Record /* to re-record */)
+        public ServiceClientTests(bool async, BlobClientOptions.ServiceVersion serviceVersion)
+            : base(async, serviceVersion, null /* RecordedTestMode.Record /* to re-record */)
         {
         }
 


### PR DESCRIPTION
To enable multi-version testing add the `ClientTestFixture` attribute listing all the service versions to the test class itself or a base class:

```C#
[ClientTestFixture(
    BlobClientOptions.ServiceVersion.V2019_02_02,
    BlobClientOptions.ServiceVersion.V2019_07_07)]
public abstract class BlobTestBase : StorageTestBase
{
    private readonly BlobClientOptions.ServiceVersion _serviceVersion;

    public BlobTestBase(bool async, BlobClientOptions.ServiceVersion serviceVersion, RecordedTestMode? mode = null)
        : base(async, mode)
    {
        _serviceVersion = serviceVersion;
    }

    // ...
}
```

Add a service version attribute to the test class ctor and use the provided service version to create the `ClientOptions` instance.

```C#
public BlobClientOptions GetOptions() =>
    new BlobClientOptions(_serviceVersion) { /* ... */ };
```

To control what service versions test would run against use the `ServiceVersion` attribute by setting it's `Mix` or `Max` properties (inclusive).

```C#
[Test]
[ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2019_02_02)]
public void Ctor_ConnectionString()
{
    // ...
}
```

How it looks it the test explorer:

![image](https://user-images.githubusercontent.com/1697911/72942831-52c7ca00-3d29-11ea-9b7e-2e54198d800d.png)
