### PR TITLE
[Event Hubs Client] Track Two (Publish Resiliency)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -424,7 +424,7 @@ namespace Azure.Messaging.EventHubs.Producer
 
             using DiagnosticScope scope = CreateDiagnosticScope();
 
-            events = events.ToList();
+            events = (events as IList<EventData>) ?? events.ToList();
             InstrumentMessages(events);
 
             try
@@ -465,7 +465,7 @@ namespace Azure.Messaging.EventHubs.Producer
 
             TransportProducer activeProducer;
 
-            if (String.IsNullOrEmpty(eventBatch.SendOptions.PartitionId))
+            if (string.IsNullOrEmpty(eventBatch.SendOptions.PartitionId))
             {
                 activeProducer = EventHubProducer;
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
@@ -2060,6 +2060,153 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubConsumerClient.StartBackgroundChannelPublishingAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task StartBackgroundChannelPublishingAsyncToleratesRetriableExceptionsWhenPublishingToTheChannel()
+        {
+            var events = Enumerable
+                .Range(0, 350)
+                .Select(index => new EventData(new[] { (byte)index }))
+                .ToList();
+
+            var mockTransportConsumer = new PublishingTransportConsumerMock(events);
+            var mockConnection = new MockConnection(() => mockTransportConsumer);
+            var mockChannelWriter = new Mock<ChannelWriter<PartitionEvent>>();
+            var mockChannel = new MockChannel<PartitionEvent>(mockChannelWriter.Object, null);
+            var options = new EventHubConsumerClientOptions { RetryOptions = new EventHubsRetryOptions { MaximumRetries = 10, Delay = TimeSpan.FromMilliseconds(1) } };
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
+            var partitionContext = new PartitionContext("0", mockTransportConsumer);
+            var capturedException = default(Exception);
+            var publishedEvents = new List<EventData>();
+            var writeCount = 0;
+            var returnWriteException = false;
+
+            // Every 100 items, force an exception to trigger when writing to the channel.  These should be
+            // retried and publishing should not lose or duplicate events.
+
+            mockChannelWriter
+                .Setup(writer => writer.WriteAsync(It.IsAny<PartitionEvent>(), It.IsAny<CancellationToken>()))
+                .Callback<PartitionEvent, CancellationToken>((partEvent, token) =>
+                {
+                    returnWriteException = (++writeCount % 100 == 0);
+
+                    if ((!returnWriteException) && (partEvent.Data != null))
+                    {
+                        publishedEvents.Add(partEvent.Data);
+                    }
+                })
+                .Returns(() =>
+                {
+                    if (returnWriteException)
+                    {
+                        return new ValueTask(Task.FromException(new EventHubsException(true, "dummy")));
+                    }
+
+                    return new ValueTask();
+                });
+
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            var publishingTask = InvokeStartBackgroundChannelPublishingAsync(consumer, mockTransportConsumer, mockChannel, partitionContext, ex => capturedException = ex, cancellation.Token);
+
+            // Allow publishing to continue until the timeout is reached or until the right number of events was
+            // written.  If publishing sends duplicate events, there will be a mismatch when comparing the event
+            // sequences, so it is safe to stop at the exact expected count.
+
+            while ((!cancellation.IsCancellationRequested) && (publishedEvents.Count < events.Count))
+            {
+                await Task.Delay(25);
+            }
+
+            cancellation.Cancel();
+
+            Assert.That(async () => await publishingTask, Throws.Nothing, "There should be no exception when publishing completes.");
+            Assert.That(publishedEvents.Count, Is.EqualTo(events.Count), "All of the events should have been published.");
+            Assert.That(capturedException, Is.Null, "The captured exception should be null.");
+
+            for (var index = 0; index < events.Count; ++index)
+            {
+                Assert.That(events[index].Body.ToArray().Single(), Is.EqualTo(publishedEvents[index].Body.ToArray().Single()), $"The payload for index: { index } should match the event source.");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubConsumerClient.StartBackgroundChannelPublishingAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task StartBackgroundChannelPublishingAsyncStopsForNonRetriableExceptionsWhenPublishingToTheChannel()
+        {
+            var events = Enumerable
+                .Range(0, 350)
+                .Select(index => new EventData(new[] { (byte)index }))
+                .ToList();
+
+            var mockTransportConsumer = new PublishingTransportConsumerMock(events);
+            var mockConnection = new MockConnection(() => mockTransportConsumer);
+            var mockChannelWriter = new Mock<ChannelWriter<PartitionEvent>>();
+            var mockChannel = new MockChannel<PartitionEvent>(mockChannelWriter.Object, null);
+            var options = new EventHubConsumerClientOptions { RetryOptions = new EventHubsRetryOptions { MaximumRetries = 10, Delay = TimeSpan.FromMilliseconds(1) } };
+            var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
+            var partitionContext = new PartitionContext("0", mockTransportConsumer);
+            var capturedException = default(Exception);
+            var publishedEvents = new List<EventData>();
+            var writeCount = 0;
+            var returnWriteException = false;
+            var forceErrorAt = 100;
+
+            // When the limit is reached, force an exception to trigger when writing to the channel.  These should be
+            // retried and publishing should not lose or duplicate events.
+
+            mockChannelWriter
+                .Setup(writer => writer.WriteAsync(It.IsAny<PartitionEvent>(), It.IsAny<CancellationToken>()))
+                .Callback<PartitionEvent, CancellationToken>((partEvent, token) =>
+                {
+                    if ((!returnWriteException) && (partEvent.Data != null))
+                    {
+                        publishedEvents.Add(partEvent.Data);
+                    }
+
+                    returnWriteException = (++writeCount == forceErrorAt);
+                })
+                .Returns(() =>
+                {
+                    if (returnWriteException)
+                    {
+                        return new ValueTask(Task.FromException(new EventHubsException(false, "dummy")));
+                    }
+
+                    return new ValueTask();
+                });
+
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            var publishingTask = InvokeStartBackgroundChannelPublishingAsync(consumer, mockTransportConsumer, mockChannel, partitionContext, ex => capturedException = ex, cancellation.Token);
+
+            // Allow publishing to continue until the timeout is reached or until the right number of events was
+            // written.  If publishing sends duplicate events, there will be a mismatch when comparing the event
+            // sequences, so it is safe to stop at the exact expected count.
+
+            while (!cancellation.IsCancellationRequested)
+            {
+                await Task.Delay(25);
+            }
+
+            cancellation.Cancel();
+
+            Assert.That(async () => await publishingTask, Throws.Nothing, "There should be no exception when publishing completes.");
+            Assert.That(publishedEvents.Count, Is.EqualTo(forceErrorAt), "All of the events before failure should have been published.");
+            Assert.That(capturedException, Is.InstanceOf<EventHubsException>().And.Property("IsTransient").EqualTo(false), "The captured exception should be be a non-retriable Event Hubs exception.");
+
+            for (var index = 0; index < forceErrorAt; ++index)
+            {
+                Assert.That(events[index].Body.ToArray().Single(), Is.EqualTo(publishedEvents[index].Body.ToArray().Single()), $"The payload for index: { index } should match the event source.");
+            }
+        }
+
+        /// <summary>
         ///   Retrieves the Connection for the consumer using its private accessor.
         /// </summary>
         ///
@@ -2078,6 +2225,21 @@ namespace Azure.Messaging.EventHubs.Tests
                 typeof(EventHubConsumerClient)
                     .GetProperty("RetryPolicy", BindingFlags.Instance | BindingFlags.NonPublic)
                     .GetValue(consumer);
+
+        /// <summary>
+        ///   Invokes the StartBackgroundChannelPublishingAsync method of the consumer using its private accessor.
+        /// </summary>
+        ///
+        private static Task InvokeStartBackgroundChannelPublishingAsync(EventHubConsumerClient consumer,
+                                                                        TransportConsumer transportConsumer,
+                                                                        Channel<PartitionEvent> channel,
+                                                                        PartitionContext partitionContext,
+                                                                        Action<Exception> notifyException,
+                                                                        CancellationToken cancellationToken) =>
+            (Task)
+                typeof(EventHubConsumerClient)
+                    .GetMethod("StartBackgroundChannelPublishingAsync", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .Invoke(consumer, new object[] { transportConsumer, channel, partitionContext, notifyException, cancellationToken });
 
         /// <summary>
         ///   Retrieves the number of background publish event batch size for a consumer, using its private field.
@@ -2269,6 +2431,20 @@ namespace Azure.Messaging.EventHubs.Tests
                     .Returns(new Uri($"amgp://{ fullyQualifiedNamespace}.com/{eventHubName}"));
 
                 return client.Object;
+            }
+        }
+
+        /// <summary>
+        ///   Serves as an injectable channel for testing consumer functionality.
+        /// </summary>
+        ///
+        private class MockChannel<T> : Channel<T>
+        {
+            public MockChannel(ChannelWriter<T> writer,
+                               ChannelReader<T> reader) : base()
+            {
+                Writer = writer;
+                Reader = reader;
             }
         }
     }


### PR DESCRIPTION
# Summary

The focus of these changes is to address a corner case in which a failure when publishing events for the iterator to read would fail to publish any events that had been received from the Event Hub but not published to the iterator channel. Instead, a new receive request would be made upon recovery and a new set of events would be used.  This behavior would only manifest when the call to channel `WriteAsync` produced the failure; other exception and recovery paths were not impacted.

Publishing to the iterator channel will now resume with the most recently received batch of events and not make another receive request until that set is exhausted.

# Last Upstream Rebase

Friday, January 24, 4:51pm (EST)