### PR TITLE
[Event Hubs] Track Two (Release Readiness)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 5.0.0
+## 5.0.1
 
 ### Acknowledgements
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/README.md
@@ -37,7 +37,7 @@ If you'd like to run samples that use [Azure.Identity](https://github.com/Azure/
 Install the Azure Event Hubs client library for .NET with [NuGet](https://www.nuget.org/):
 
 ```PowerShell
-Install-Package Azure.Messaging.EventHubs -Version 5.0.0
+Install-Package Azure.Messaging.EventHubs
 ```
 
 ### Obtain a connection string

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This client library allows for both publishing and consuming events using Azure Event Hubs. For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>5.0.0</Version>
+    <Version>5.0.1</Version>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;AMQP;IoT;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <EnableFxCopAnalyzers>false</EnableFxCopAnalyzers>


### PR DESCRIPTION
# Summary

The focus of these changes is to set the proper version information for the next release and ensure materials are up-to-date.

# Last Upstream Rebase

Thursday, January 23, 3:17pm (EST)