### PR TITLE
[Event Hubs Client] Track Two (Live Test Reliability)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net;
+using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Threading;
 using System.Threading.Tasks;
@@ -134,6 +136,10 @@ namespace Azure.Messaging.EventHubs.Tests
            Policy<T>
                .Handle<ErrorResponseException>(ex => IsRetriableStatus(ex.Response.StatusCode))
                .Or<CloudException>(ex => IsRetriableStatus(ex.Response.StatusCode))
+               .Or<TaskCanceledException>()
+               .Or<OperationCanceledException>()
+               .Or<SocketException>()
+               .Or<IOException>()
                .WaitAndRetryAsync(maxRetryAttempts, attempt => CalculateRetryDelay(attempt, exponentialBackoffSeconds, baseJitterSeconds));
 
         /// <summary>
@@ -152,6 +158,10 @@ namespace Azure.Messaging.EventHubs.Tests
             Policy
                 .Handle<ErrorResponseException>(ex => IsRetriableStatus(ex.Response.StatusCode))
                 .Or<CloudException>(ex => IsRetriableStatus(ex.Response.StatusCode))
+                .Or<TaskCanceledException>()
+                .Or<OperationCanceledException>()
+                .Or<SocketException>()
+                .Or<IOException>()
                 .WaitAndRetryAsync(maxRetryAttempts, attempt => CalculateRetryDelay(attempt, exponentialBackoffSeconds, baseJitterSeconds));
 
         /// <summary>

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -10,7 +10,7 @@ resources:
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
   parameters:
-    MaxParallel: 1
+    MaxParallel: 4
     ServiceDirectory: eventhub
     TimeoutInMinutes: 120
     EnvVars:


### PR DESCRIPTION
# Summary

The focus of these changes is to make the Event Hubs live test suite more reliable and performant.  Recent results show an uptick in the transport exceptions where management operations begin but do not complete.  These should now be recognized as transient and eligible for retries.

The number of maximum parallel test runs has been changed to (hopefully) allow each of the test platforms (Linux, maxOS, Windows .NET Framework, and Windows .NET Core) to run at the same time.

# Last Upstream Rebase

Saturday, January 25, 12:02pm (EST)