### PR TITLE
Retry request timeouts

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.0-preview.1 (Unreleased)
 
 - Block bearer token authentication for non TLS protected endpoints.
+- Add support for retrying on request timeouts.
 
 ## 1.0.1
 

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -328,6 +328,7 @@ namespace Azure.Core
     {
         public ResponseClassifier() { }
         public virtual bool IsErrorResponse(Azure.Core.HttpMessage message) { throw null; }
+        public virtual bool IsRetriableException(Azure.Core.HttpMessage message, System.Exception exception) { throw null; }
         public virtual bool IsRetriableException(System.Exception exception) { throw null; }
         public virtual bool IsRetriableResponse(Azure.Core.HttpMessage message) { throw null; }
     }

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -328,7 +328,7 @@ namespace Azure.Core
     {
         public ResponseClassifier() { }
         public virtual bool IsErrorResponse(Azure.Core.HttpMessage message) { throw null; }
-        public virtual bool IsRetriableException(Azure.Core.HttpMessage message, System.Exception exception) { throw null; }
+        public virtual bool IsRetriable(Azure.Core.HttpMessage message, System.Exception exception) { throw null; }
         public virtual bool IsRetriableException(System.Exception exception) { throw null; }
         public virtual bool IsRetriableResponse(Azure.Core.HttpMessage message) { throw null; }
     }

--- a/sdk/core/Azure.Core/src/Pipeline/Internal/RetryPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/RetryPolicy.cs
@@ -80,7 +80,7 @@ namespace Azure.Core.Pipeline
 
                 if (lastException != null)
                 {
-                    if (shouldRetry && message.ResponseClassifier.IsRetriableException(lastException))
+                    if (shouldRetry && message.ResponseClassifier.IsRetriableException(message, lastException))
                     {
                         GetDelay(attempt, out delay);
                     }

--- a/sdk/core/Azure.Core/src/Pipeline/Internal/RetryPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/RetryPolicy.cs
@@ -80,7 +80,7 @@ namespace Azure.Core.Pipeline
 
                 if (lastException != null)
                 {
-                    if (shouldRetry && message.ResponseClassifier.IsRetriableException(message, lastException))
+                    if (shouldRetry && message.ResponseClassifier.IsRetriable(message, lastException))
                     {
                         GetDelay(attempt, out delay);
                     }

--- a/sdk/core/Azure.Core/src/ResponseClassifier.cs
+++ b/sdk/core/Azure.Core/src/ResponseClassifier.cs
@@ -31,7 +31,7 @@ namespace Azure.Core
         /// <summary>
         /// Specifies if the operation that caused the exception should be retried taking the <see cref="HttpMessage"/> into consideration.
         /// </summary>
-        public virtual bool IsRetriableException(HttpMessage message, Exception exception)
+        public virtual bool IsRetriable(HttpMessage message, Exception exception)
         {
             return IsRetriableException(exception) ||
                    // Retry non-user initiated cancellations

--- a/sdk/core/Azure.Core/src/ResponseClassifier.cs
+++ b/sdk/core/Azure.Core/src/ResponseClassifier.cs
@@ -29,6 +29,16 @@ namespace Azure.Core
         }
 
         /// <summary>
+        /// Specifies if the operation that caused the exception should be retried taking the <see cref="HttpMessage"/> into consideration.
+        /// </summary>
+        public virtual bool IsRetriableException(HttpMessage message, Exception exception)
+        {
+            return IsRetriableException(exception) ||
+                   // Retry non-user initiated cancellations
+                   (exception is OperationCanceledException && !message.CancellationToken.IsCancellationRequested);
+        }
+
+        /// <summary>
         /// Specifies if the response contained in the <paramref name="message"/> is not successful.
         /// </summary>
         public virtual bool IsErrorResponse(HttpMessage message)

--- a/sdk/core/Azure.Core/tests/ResponseClassifierTests.cs
+++ b/sdk/core/Azure.Core/tests/ResponseClassifierTests.cs
@@ -41,7 +41,7 @@ namespace Azure.Core.Tests
         {
             var httpMessage = new HttpMessage(new MockRequest(), new ResponseClassifier());
 
-            Assert.True(httpMessage.ResponseClassifier.IsRetriableException(httpMessage, new OperationCanceledException()));
+            Assert.True(httpMessage.ResponseClassifier.IsRetriable(httpMessage, new OperationCanceledException()));
         }
 
         [Test]

--- a/sdk/core/Azure.Core/tests/ResponseClassifierTests.cs
+++ b/sdk/core/Azure.Core/tests/ResponseClassifierTests.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core.Testing;
+using NUnit.Framework;
+
+namespace Azure.Core.Tests
+{
+    public class ResponseClassifierTests
+    {
+        [Theory]
+        [TestCase(429)]
+        [TestCase(503)]
+        public void RetriesStatusCodes(int code)
+        {
+            var httpMessage = new HttpMessage(new MockRequest(), new ResponseClassifier());
+            httpMessage.Response = new MockResponse(code);
+
+            Assert.True(httpMessage.ResponseClassifier.IsRetriableResponse(httpMessage));
+        }
+
+        [Test]
+        public void RetriesRequestFailedExceptionsWithoutCode()
+        {
+            var classifier = new ResponseClassifier();
+
+            Assert.True(classifier.IsRetriableException(new RequestFailedException(0, "IO Exception")));
+        }
+
+        [Test]
+        public void DoesntRetryRequestFailedExceptionsWithStatusCode()
+        {
+            var classifier = new ResponseClassifier();
+
+            Assert.False(classifier.IsRetriableException(new RequestFailedException(500, "IO Exception")));
+        }
+
+        [Test]
+        public void RetriesNonCustomerOperationCancelledExceptions()
+        {
+            var httpMessage = new HttpMessage(new MockRequest(), new ResponseClassifier());
+
+            Assert.True(httpMessage.ResponseClassifier.IsRetriableException(httpMessage, new OperationCanceledException()));
+        }
+
+        [Test]
+        public void TreatsAll4xAnd5xAsErrors()
+        {
+            var classifier = new ResponseClassifier();
+            var httpMessage = new HttpMessage(new MockRequest(), new ResponseClassifier());
+            for (int i = 400; i < 600; i++)
+            {
+                httpMessage.Response = new MockResponse(i);
+                Assert.True(classifier.IsErrorResponse(httpMessage));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Retry `OperationCancelledException` that are not a result of customers cancellation token being cancelled.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/9031

cc @KrzysztofCwalina for the API addition