### PR TITLE
Make Storage distributed tracing match the other Track 2 libraries

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs.Batch/src/BatchConstants.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/src/BatchConstants.cs
@@ -25,13 +25,6 @@ namespace Azure.Storage.Blobs.Specialized
         public const string BatchSeparator = "--";
         public const string HttpVersion = "HTTP/1.1";
 
-        public const string BatchOperationName =
-            nameof(Azure) + "." +
-            nameof(Storage) + "." +
-            nameof(Blobs) + "." +
-            nameof(Specialized) + "." +
-            nameof(BlobBatchClient) + "." +
-            nameof(BlobBatchClient.SubmitBatch);
-        public const string DelayedResponsePropertyName = BatchOperationName + ":DelayedResponse";
+        public static readonly string DelayedResponsePropertyName = $"{nameof(BlobBatchClient)}.{nameof(BlobBatchClient.SubmitBatch)}:DelayedResponse";
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs.Batch/src/BlobBatchClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/src/BlobBatchClient.cs
@@ -304,7 +304,7 @@ namespace Azure.Storage.Blobs.Specialized
                     multipartContentType: contentType,
                     version: Version.ToVersionString(),
                     async: async,
-                    operationName: BatchConstants.BatchOperationName,
+                    operationName: $"{nameof(BlobBatchClient)}.{nameof(SubmitBatch)}",
                     cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
 

--- a/sdk/storage/Azure.Storage.Blobs/src/AppendBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/AppendBlobClient.cs
@@ -419,11 +419,11 @@ namespace Azure.Storage.Blobs.Specialized
                     conditions,
                     async,
                     cancellationToken,
-                    Constants.Blob.Append.CreateIfNotExistsOperationName)
+                    $"{nameof(AppendBlobClient)}.{nameof(CreateIfNotExists)}")
                     .ConfigureAwait(false);
             }
             catch (RequestFailedException storageRequestFailedException)
-            when (storageRequestFailedException.ErrorCode == Constants.Blob.AlreadyExists)
+            when (storageRequestFailedException.ErrorCode == BlobErrorCode.BlobAlreadyExists)
             {
                 return default;
             }
@@ -472,7 +472,7 @@ namespace Azure.Storage.Blobs.Specialized
             AppendBlobRequestConditions conditions,
             bool async,
             CancellationToken cancellationToken,
-            string operationName = Constants.Blob.Append.CreateOperationName)
+            string operationName = null)
         {
             using (Pipeline.BeginLoggingScope(nameof(AppendBlobClient)))
             {
@@ -506,7 +506,7 @@ namespace Azure.Storage.Blobs.Specialized
                         ifMatch: conditions?.IfMatch,
                         ifNoneMatch: conditions?.IfNoneMatch,
                         async: async,
-                        operationName: operationName,
+                        operationName: operationName ?? $"{nameof(AppendBlobClient)}.{nameof(Create)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -1843,12 +1843,12 @@ namespace Azure.Storage.Blobs.Specialized
                     conditions,
                     async,
                     cancellationToken,
-                    Constants.Blob.Base.DeleteIfExists)
+                    $"{nameof(BlobBaseClient)}.{nameof(DeleteIfExists)}")
                     .ConfigureAwait(false);
                 return Response.FromValue(true, response);
             }
             catch (RequestFailedException storageRequestFailedException)
-            when (storageRequestFailedException.ErrorCode == Constants.Blob.NotFound)
+            when (storageRequestFailedException.ErrorCode == BlobErrorCode.BlobNotFound)
             {
                 return Response.FromValue(false, default);
             }
@@ -1894,7 +1894,7 @@ namespace Azure.Storage.Blobs.Specialized
             BlobRequestConditions conditions,
             bool async,
             CancellationToken cancellationToken,
-            string operationName = Constants.Blob.Base.Delete)
+            string operationName = null)
         {
             using (Pipeline.BeginLoggingScope(nameof(BlobBaseClient)))
             {
@@ -1918,7 +1918,7 @@ namespace Azure.Storage.Blobs.Specialized
                         ifMatch: conditions?.IfMatch,
                         ifNoneMatch: conditions?.IfNoneMatch,
                         async: async,
-                        operationName: operationName,
+                        operationName: operationName ?? $"{nameof(BlobBaseClient)}.{nameof(Delete)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -2019,14 +2019,14 @@ namespace Azure.Storage.Blobs.Specialized
                         Uri,
                         version: Version.ToVersionString(),
                         async: async,
-                        operationName: Constants.Blob.Base.ExistsOperationName,
+                        operationName: $"{nameof(BlobBaseClient)}.{nameof(Exists)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
                     return Response.FromValue(true, response.GetRawResponse());
                 }
                 catch (RequestFailedException storageRequestFailedException)
-                when (storageRequestFailedException.ErrorCode == Constants.Blob.NotFound)
+                when (storageRequestFailedException.ErrorCode == BlobErrorCode.BlobNotFound)
                 {
                     return Response.FromValue(false, default);
                 }

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClient.cs
@@ -980,7 +980,7 @@ namespace Azure.Storage.Blobs
                 client,
                 transferOptions,
                 singleUploadThreshold,
-                operationName: Constants.Blob.UploadOperationName);
+                operationName: $"{nameof(BlobClient)}.{nameof(Upload)}");
 
             if (async)
             {

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -588,11 +588,11 @@ namespace Azure.Storage.Blobs
                     metadata,
                     async,
                     cancellationToken,
-                    Constants.Blob.Container.CreateIfNotExistsOperationName)
+                    $"{nameof(BlobContainerClient)}.{nameof(CreateIfNotExists)}")
                     .ConfigureAwait(false);
             }
             catch (RequestFailedException storageRequestFailedException)
-            when (storageRequestFailedException.ErrorCode == Constants.Blob.Container.AlreadyExists)
+            when (storageRequestFailedException.ErrorCode == BlobErrorCode.ContainerAlreadyExists)
             {
                 response = default;
             }
@@ -645,7 +645,7 @@ namespace Azure.Storage.Blobs
             Metadata metadata,
             bool async,
             CancellationToken cancellationToken,
-            string operationName = Constants.Blob.Container.CreateOperationName)
+            string operationName = null)
         {
             using (Pipeline.BeginLoggingScope(nameof(BlobContainerClient)))
             {
@@ -664,7 +664,7 @@ namespace Azure.Storage.Blobs
                         version: Version.ToVersionString(),
                         metadata: metadata,
                         async: async,
-                        operationName: operationName,
+                        operationName: operationName ?? $"{nameof(BlobContainerClient)}.{nameof(Create)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -845,12 +845,12 @@ namespace Azure.Storage.Blobs
                     conditions,
                     async,
                     cancellationToken,
-                    Constants.Blob.Container.DeleteIfExistsOperationName)
+                    $"{nameof(BlobContainerClient)}.{nameof(DeleteIfExists)}")
                     .ConfigureAwait(false);
                 return Response.FromValue(true, response);
             }
             catch (RequestFailedException storageRequestFailedException)
-            when (storageRequestFailedException.ErrorCode == Constants.Blob.Container.NotFound)
+            when (storageRequestFailedException.ErrorCode == BlobErrorCode.ContainerNotFound)
             {
                 return Response.FromValue(false, default);
             }
@@ -888,7 +888,7 @@ namespace Azure.Storage.Blobs
             BlobRequestConditions conditions,
             bool async,
             CancellationToken cancellationToken,
-            string operationName = Constants.Blob.Container.DeleteOperationName)
+            string operationName = null)
         {
             using (Pipeline.BeginLoggingScope(nameof(BlobContainerClient)))
             {
@@ -914,7 +914,7 @@ namespace Azure.Storage.Blobs
                         ifModifiedSince: conditions?.IfModifiedSince,
                         ifUnmodifiedSince: conditions?.IfUnmodifiedSince,
                         async: async,
-                        operationName: operationName,
+                        operationName: operationName ?? $"{nameof(BlobContainerClient)}.{nameof(Delete)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -1016,14 +1016,14 @@ namespace Azure.Storage.Blobs
                         Uri,
                         version: Version.ToVersionString(),
                         async: async,
-                        operationName: Constants.Blob.Container.ExistsOperationName,
+                        operationName: $"{nameof(BlobContainerClient)}.{nameof(Exists)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
                     return Response.FromValue(true, response.GetRawResponse());
                 }
                 catch (RequestFailedException storageRequestFailedException)
-                when (storageRequestFailedException.ErrorCode == Constants.Blob.Container.NotFound)
+                when (storageRequestFailedException.ErrorCode == BlobErrorCode.ContainerNotFound)
                 {
                     return Response.FromValue(false, default);
                 }
@@ -1157,7 +1157,7 @@ namespace Azure.Storage.Blobs
                             version: Version.ToVersionString(),
                             leaseId: conditions?.LeaseId,
                             async: async,
-                            operationName: Constants.Blob.Container.GetPropertiesOperationName,
+                            operationName: $"{nameof(BlobContainerClient)}.{nameof(GetProperties)}",
                             cancellationToken: cancellationToken)
                             .ConfigureAwait(false);
 
@@ -1322,7 +1322,7 @@ namespace Azure.Storage.Blobs
                         leaseId: conditions?.LeaseId,
                         ifModifiedSince: conditions?.IfModifiedSince,
                         async: async,
-                        operationName: Constants.Blob.Container.SetMetaDataOperationName,
+                        operationName: $"{nameof(BlobContainerClient)}.{nameof(SetMetadata)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -1451,7 +1451,7 @@ namespace Azure.Storage.Blobs
                         version: Version.ToVersionString(),
                         leaseId: conditions?.LeaseId,
                         async: async,
-                        operationName: Constants.Blob.Container.GetAccessPolicyOperationName,
+                        operationName: $"{nameof(BlobContainerClient)}.{nameof(GetAccessPolicy)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -1651,7 +1651,7 @@ namespace Azure.Storage.Blobs
                         ifModifiedSince: conditions?.IfModifiedSince,
                         ifUnmodifiedSince: conditions?.IfUnmodifiedSince,
                         async: async,
-                        operationName: Constants.Blob.Container.SetAccessPolicyOperationName,
+                        operationName: $"{nameof(BlobContainerClient)}.{nameof(SetAccessPolicy)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobLeaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobLeaseClient.cs
@@ -293,7 +293,7 @@ namespace Azure.Storage.Blobs.Specialized
                             ifMatch: conditions?.IfMatch,
                             ifNoneMatch: conditions?.IfNoneMatch,
                             async: async,
-                            operationName: Constants.Blob.Lease.AcquireOperationName,
+                            operationName: $"{nameof(BlobLeaseClient)}.{nameof(Acquire)}",
                             cancellationToken: cancellationToken)
                             .ConfigureAwait(false);
                     }
@@ -315,7 +315,7 @@ namespace Azure.Storage.Blobs.Specialized
                             ifModifiedSince: conditions?.IfModifiedSince,
                             ifUnmodifiedSince: conditions?.IfUnmodifiedSince,
                             async: async,
-                            operationName: Constants.Blob.Lease.AcquireOperationName,
+                            operationName: $"{nameof(BlobLeaseClient)}.{nameof(Acquire)}",
                             cancellationToken: cancellationToken)
                             .ConfigureAwait(false);
                     }
@@ -464,7 +464,7 @@ namespace Azure.Storage.Blobs.Specialized
                             ifMatch: conditions?.IfMatch,
                             ifNoneMatch: conditions?.IfNoneMatch,
                             async: async,
-                            operationName: Constants.Blob.Lease.RenewOperationName,
+                            operationName: $"{nameof(BlobLeaseClient)}.{nameof(Renew)}",
                             cancellationToken: cancellationToken)
                             .ConfigureAwait(false);
                     }
@@ -485,7 +485,7 @@ namespace Azure.Storage.Blobs.Specialized
                             ifModifiedSince: conditions?.IfModifiedSince,
                             ifUnmodifiedSince: conditions?.IfUnmodifiedSince,
                             async: async,
-                            operationName: Constants.Blob.Lease.RenewOperationName,
+                            operationName: $"{nameof(BlobLeaseClient)}.{nameof(Renew)}",
                             cancellationToken: cancellationToken)
                             .ConfigureAwait(false);
                     }
@@ -636,7 +636,7 @@ namespace Azure.Storage.Blobs.Specialized
                                 ifMatch: conditions?.IfMatch,
                                 ifNoneMatch: conditions?.IfNoneMatch,
                                 async: async,
-                                operationName: Constants.Blob.Lease.ReleaseOperationName,
+                                operationName: $"{nameof(BlobLeaseClient)}.{nameof(Release)}",
                                 cancellationToken: cancellationToken)
                                 .ConfigureAwait(false);
                         return Response.FromValue(new ReleasedObjectInfo(response.Value), response.GetRawResponse());
@@ -659,7 +659,7 @@ namespace Azure.Storage.Blobs.Specialized
                                 ifModifiedSince: conditions?.IfModifiedSince,
                                 ifUnmodifiedSince: conditions?.IfUnmodifiedSince,
                                 async: async,
-                                operationName: Constants.Blob.Lease.ReleaseOperationName,
+                                operationName: $"{nameof(BlobLeaseClient)}.{nameof(Release)}",
                                 cancellationToken: cancellationToken)
                                 .ConfigureAwait(false);
                         return Response.FromValue(new ReleasedObjectInfo(response.Value), response.GetRawResponse());
@@ -817,7 +817,7 @@ namespace Azure.Storage.Blobs.Specialized
                             ifMatch: conditions?.IfMatch,
                             ifNoneMatch: conditions?.IfNoneMatch,
                             async: async,
-                            operationName: Constants.Blob.Lease.ChangeOperationName,
+                            operationName: $"{nameof(BlobLeaseClient)}.{nameof(Change)}",
                             cancellationToken: cancellationToken)
                             .ConfigureAwait(false);
                     }
@@ -839,7 +839,7 @@ namespace Azure.Storage.Blobs.Specialized
                             ifModifiedSince: conditions?.IfModifiedSince,
                             ifUnmodifiedSince: conditions?.IfUnmodifiedSince,
                             async: async,
-                            operationName: Constants.Blob.Lease.ChangeOperationName,
+                            operationName: $"{nameof(BlobLeaseClient)}.{nameof(Change)}",
                             cancellationToken: cancellationToken)
                             .ConfigureAwait(false);
                     }
@@ -1049,7 +1049,7 @@ namespace Azure.Storage.Blobs.Specialized
                             ifMatch: conditions?.IfMatch,
                             ifNoneMatch: conditions?.IfNoneMatch,
                             async: async,
-                            operationName: Constants.Blob.Lease.BreakOperationName,
+                            operationName: $"{nameof(BlobLeaseClient)}.{nameof(Break)}",
                             cancellationToken: cancellationToken)
                             .ConfigureAwait(false))
                             .ToLease();
@@ -1071,7 +1071,7 @@ namespace Azure.Storage.Blobs.Specialized
                             ifModifiedSince: conditions?.IfModifiedSince,
                             ifUnmodifiedSince: conditions?.IfUnmodifiedSince,
                             async: async,
-                            operationName: Constants.Blob.Lease.BreakOperationName,
+                            operationName: $"{nameof(BlobLeaseClient)}.{nameof(Break)}",
                             cancellationToken: cancellationToken)
                             .ConfigureAwait(false))
                             .ToLease();

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
@@ -608,7 +608,7 @@ namespace Azure.Storage.Blobs
                         Uri,
                         version: Version.ToVersionString(),
                         async: async,
-                        operationName: Constants.Blob.Service.GetAccountInfoOperationName,
+                        operationName: $"{nameof(BlobServiceClient)}.{nameof(GetAccountInfo)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -715,7 +715,7 @@ namespace Azure.Storage.Blobs
                         Uri,
                         version: Version.ToVersionString(),
                         async: async,
-                        operationName: Constants.Blob.Service.GetPropertiesOperationName,
+                        operationName: $"{nameof(BlobServiceClient)}.{nameof(GetProperties)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -844,7 +844,7 @@ namespace Azure.Storage.Blobs
                         properties,
                         version: Version.ToVersionString(),
                         async: async,
-                        operationName: Constants.Blob.Service.SetPropertiesOperationName,
+                        operationName: $"{nameof(BlobServiceClient)}.{nameof(SetProperties)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -957,7 +957,7 @@ namespace Azure.Storage.Blobs
                         Uri,
                         version: Version.ToVersionString(),
                         async: async,
-                        operationName: Constants.Blob.Service.GetStatisticsOperationName,
+                        operationName: $"{nameof(BlobServiceClient)}.{nameof(GetStatistics)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -1103,7 +1103,7 @@ namespace Azure.Storage.Blobs
                         keyInfo: keyInfo,
                         version: Version.ToVersionString(),
                         async: async,
-                        operationName: Constants.Blob.Service.GetUserDelegationKeyOperationName,
+                        operationName: $"{nameof(BlobServiceClient)}.{nameof(GetUserDelegationKey)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }

--- a/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
@@ -371,7 +371,7 @@ namespace Azure.Storage.Blobs.Specialized
                 client: this,
                 transferOptions: default,
                 singleUploadThreshold: BlockBlobMaxUploadBlobBytes,
-                operationName: Constants.Blob.Block.UploadOperationName);
+                operationName: $"{nameof(BlockBlobClient)}.{nameof(Upload)}");
 
             return uploader.Upload(
                 content,
@@ -443,7 +443,7 @@ namespace Azure.Storage.Blobs.Specialized
                 client: this,
                 transferOptions: default,
                 singleUploadThreshold: BlockBlobMaxUploadBlobBytes,
-                operationName: Constants.Blob.Block.UploadOperationName);
+                operationName: $"{nameof(BlockBlobClient)}.{nameof(Upload)}");
 
             return await uploader.UploadAsync(
                 content,
@@ -554,7 +554,7 @@ namespace Azure.Storage.Blobs.Specialized
                         ifMatch: conditions?.IfMatch,
                         ifNoneMatch: conditions?.IfNoneMatch,
                         async: async,
-                        operationName: operationName ?? Constants.Blob.Block.UploadOperationName,
+                        operationName: operationName ?? $"{nameof(BlockBlobClient)}.{nameof(Upload)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -787,7 +787,7 @@ namespace Azure.Storage.Blobs.Specialized
                         encryptionKeySha256: CustomerProvidedKey?.EncryptionKeyHash,
                         encryptionAlgorithm: CustomerProvidedKey?.EncryptionAlgorithm,
                         async: async,
-                        operationName: Constants.Blob.Block.StageBlockOperationName,
+                        operationName: $"{nameof(BlockBlobClient)}.{nameof(StageBlock)}",
                         cancellationToken: cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex)
@@ -1059,7 +1059,7 @@ namespace Azure.Storage.Blobs.Specialized
                         sourceIfMatch: sourceConditions?.IfMatch,
                         sourceIfNoneMatch: sourceConditions?.IfNoneMatch,
                         async: async,
-                        operationName: Constants.Blob.Block.StageBlockFromUriOperationName,
+                        operationName: $"{nameof(BlockBlobClient)}.{nameof(StageBlockFromUri)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -1308,7 +1308,7 @@ namespace Azure.Storage.Blobs.Specialized
                         ifMatch: conditions?.IfMatch,
                         ifNoneMatch: conditions?.IfNoneMatch,
                         async: async,
-                        operationName: Constants.Blob.Block.CommitBlockListOperationName,
+                        operationName: $"{nameof(BlockBlobClient)}.{nameof(CommitBlockList)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -1493,7 +1493,7 @@ namespace Azure.Storage.Blobs.Specialized
                         snapshot: snapshot,
                         leaseId: conditions?.LeaseId,
                         async: async,
-                        operationName: Constants.Blob.Block.GetBlockListOperationName,
+                        operationName: $"{nameof(BlockBlobClient)}.{nameof(GetBlockList)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false))
                         .ToBlockList();

--- a/sdk/storage/Azure.Storage.Blobs/src/PageBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/PageBlobClient.cs
@@ -508,11 +508,11 @@ namespace Azure.Storage.Blobs.Specialized
                     conditions,
                     async,
                     cancellationToken,
-                    Constants.Blob.Page.CreateIfNotExistsOperationName)
+                    $"{nameof(PageBlobClient)}.{nameof(CreateIfNotExists)}")
                     .ConfigureAwait(false);
             }
             catch (RequestFailedException storageRequestFailedException)
-            when (storageRequestFailedException.ErrorCode == Constants.Blob.AlreadyExists)
+            when (storageRequestFailedException.ErrorCode == BlobErrorCode.BlobAlreadyExists)
             {
                 return default;
             }
@@ -573,7 +573,7 @@ namespace Azure.Storage.Blobs.Specialized
             PageBlobRequestConditions conditions,
             bool async,
             CancellationToken cancellationToken,
-            string operationName = Constants.Blob.Page.CreateOperationName)
+            string operationName = null)
         {
             using (Pipeline.BeginLoggingScope(nameof(PageBlobClient)))
             {
@@ -610,7 +610,7 @@ namespace Azure.Storage.Blobs.Specialized
                         blobContentLength: size,
                         blobSequenceNumber: sequenceNumber,
                         async: async,
-                        operationName: operationName,
+                        operationName: operationName ?? $"{nameof(PageBlobClient)}.{nameof(Create)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -841,7 +841,7 @@ namespace Azure.Storage.Blobs.Specialized
                         ifMatch: conditions?.IfMatch,
                         ifNoneMatch: conditions?.IfNoneMatch,
                         async: async,
-                        operationName: Constants.Blob.Page.UploadOperationName,
+                        operationName: $"{nameof(PageBlobClient)}.{nameof(UploadPages)}",
                         cancellationToken: cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex)
@@ -1010,7 +1010,7 @@ namespace Azure.Storage.Blobs.Specialized
                         ifMatch: conditions?.IfMatch,
                         ifNoneMatch: conditions?.IfNoneMatch,
                         async: async,
-                        operationName: Constants.Blob.Page.ClearOperationName,
+                        operationName: $"{nameof(PageBlobClient)}.{nameof(ClearPages)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -1180,7 +1180,7 @@ namespace Azure.Storage.Blobs.Specialized
                         ifMatch: conditions?.IfMatch,
                         ifNoneMatch: conditions?.IfNoneMatch,
                         async: async,
-                        operationName: Constants.Blob.Page.GetPageRangesOperationName,
+                        operationName: $"{nameof(PageBlobClient)}.{nameof(GetPageRanges)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
@@ -1389,7 +1389,7 @@ namespace Azure.Storage.Blobs.Specialized
                         ifMatch: conditions?.IfMatch,
                         ifNoneMatch: conditions?.IfNoneMatch,
                         async: async,
-                        operationName: Constants.Blob.Page.GetPageRangesDiffOperationName,
+                        operationName: $"{nameof(PageBlobClient)}.{nameof(GetPageRangesDiff)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
@@ -1558,7 +1558,7 @@ namespace Azure.Storage.Blobs.Specialized
                         ifMatch: conditions?.IfMatch,
                         ifNoneMatch: conditions?.IfNoneMatch,
                         async: async,
-                        operationName: Constants.Blob.Page.ResizeOperationName,
+                        operationName: $"{nameof(PageBlobClient)}.{nameof(Resize)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -1767,7 +1767,7 @@ namespace Azure.Storage.Blobs.Specialized
                         ifUnmodifiedSince: conditions?.IfUnmodifiedSince,
                         ifMatch: conditions?.IfMatch,
                         ifNoneMatch: conditions?.IfNoneMatch,
-                        operationName: Constants.Blob.Page.UpdateSequenceNumberOperationName,
+                        operationName: $"{nameof(PageBlobClient)}.{nameof(UpdateSequenceNumber)}",
                         async: async,
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
@@ -2117,7 +2117,7 @@ namespace Azure.Storage.Blobs.Specialized
                         ifMatch: conditions?.IfMatch,
                         ifNoneMatch: conditions?.IfNoneMatch,
                         async: async,
-                        operationName: Constants.Blob.Page.StartCopyIncrementalOperationName,
+                        operationName: $"{nameof(PageBlobClient)}.{nameof(StartCopyIncremental)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -2390,7 +2390,7 @@ namespace Azure.Storage.Blobs.Specialized
                         sourceIfMatch: sourceConditions?.IfMatch,
                         sourceIfNoneMatch: sourceConditions?.IfNoneMatch,
                         async: async,
-                        operationName: Constants.Blob.Page.UploadPagesFromUriOperationName,
+                        operationName: $"{nameof(PageBlobClient)}.{nameof(UploadPagesFromUri)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs
@@ -70,7 +70,7 @@ namespace Azure.Storage
         public const string Http = "http";
 
         /// <summary>
-        /// Storage Connection Strings
+        /// Storage Connection String constant values.
         /// </summary>
         internal static class ConnectionStrings
         {
@@ -109,7 +109,7 @@ namespace Azure.Storage
         }
 
         /// <summary>
-        /// Header Request Names
+        /// Header Name constant values.
         /// </summary>
         internal static class HeaderNames
         {
@@ -142,42 +142,17 @@ namespace Azure.Storage
         }
 
         /// <summary>
-        /// Blob constant values
+        /// Blob constant values.
         /// </summary>
         internal static class Blob
         {
             public const int HttpsPort = 443;
             public const string UriSubDomain = "blob";
 
-            /// <summary>
-            ///  Error code for blobs
-            /// </summary>
-            public const string AlreadyExists = "BlobAlreadyExists";
-            public const string NotFound = "BlobNotFound";
-
-            public const string UploadOperationName =
-                "BlobClient.Upload";
-
             internal static class Append
             {
                 public const int MaxAppendBlockBytes = 4 * Constants.MB; // 4MB
                 public const int MaxBlocks = 50000;
-                public const string CreateOperationName =
-                    "AppendBlobClient.Create";
-                public const string CreateIfNotExistsOperationName =
-                    "AppendBlobClient.CreateIfNotExists";
-            }
-
-            internal static class Base
-            {
-                public const string Delete =
-                    "BlobBaseClient.Delete";
-                public const string DeleteIfExists =
-                    "BlobBaseClient.DeleteIfExists";
-                public const string SetTierOperationName =
-                    "BlobBaseClient.SetTier";
-                public const string ExistsOperationName =
-                    "BlobBaseClient.Exists";
             }
 
             internal static class Block
@@ -187,20 +162,6 @@ namespace Azure.Storage
                 public const int MaxDownloadBytes = 256 * Constants.MB; // 256MB
                 public const int MaxStageBytes = 100 * Constants.MB; // 100MB
                 public const int MaxBlocks = 50000;
-
-                /// <summary>
-                /// The Azure Storage Operation Names for Block Blob Client.
-                /// </summary>
-                public const string UploadOperationName =
-                    "BlockBlobClient.Upload";
-                public const string StageBlockOperationName =
-                    "BlockBlobClient.StageBlock";
-                public const string StageBlockFromUriOperationName =
-                    "BlockBlobClient.StageBlockFromUri";
-                public const string CommitBlockListOperationName =
-                    "BlockBlobClient.CommitBlockList";
-                public const string GetBlockListOperationName =
-                    "BlockBlobClient.GetBlockList";
             }
 
             internal static class Container
@@ -219,34 +180,6 @@ namespace Azure.Storage
                 /// The Azure Storage name used to identify a storage account's web content container.
                 /// </summary>
                 public const string WebName = "$web";
-
-                /// <summary>
-                /// The Azure Storage error codes for Blob Container Client.
-                /// </summary>
-                public const string AlreadyExists = "ContainerAlreadyExists";
-                public const string NotFound = "ContainerNotFound";
-
-                /// <summary>
-                /// The Azure Storage Operation Names for Blob Container Client.
-                /// </summary>
-                public const string CreateOperationName =
-                    "BlobContainerClient.Create";
-                public const string CreateIfNotExistsOperationName =
-                    "BlobContainerClient.CreateIfNotExists";
-                public const string DeleteOperationName =
-                    "BlobContainerClient.Delete";
-                public const string DeleteIfExistsOperationName =
-                    "BlobContainerClient.DeleteIfExists";
-                public const string ExistsOperationName =
-                    "BlobContainerClient.Exists";
-                public const string GetPropertiesOperationName =
-                    "BlobContainerClient.GetProperties";
-                public const string SetMetaDataOperationName =
-                    "BlobContainerClient.SetMetadata";
-                public const string GetAccessPolicyOperationName =
-                    "BlobContainerClient.GetAccessPolicy";
-                public const string SetAccessPolicyOperationName =
-                    "BlobContainerClient.SetAccessPolicy";
             }
 
             internal static class Lease
@@ -255,66 +188,11 @@ namespace Azure.Storage
                 /// Lease Duration is set as infinite when passed -1
                 /// </summary>
                 public const int InfiniteLeaseDuration = -1;
-                /// <summary>
-                /// The Azure Storage Operation Names for Blob Lease Client.
-                /// </summary>
-                public const string AcquireOperationName =
-                    "BlobLeaseClient.Acquire";
-                public const string RenewOperationName =
-                    "BlobLeaseClient.Renew";
-                public const string ReleaseOperationName =
-                    "BlobLeaseClient.Release";
-                public const string ChangeOperationName =
-                    "BlobLeaseClient.Change";
-                public const string BreakOperationName =
-                    "BlobLeaseClient.Break";
             }
-
-            internal static class Page
-            {
-                public const string CreateOperationName =
-                    "PageBlobClient.Create";
-                public const string CreateIfNotExistsOperationName =
-                    "PageBlobClient.CreateIfNotExists";
-                public const string UploadOperationName =
-                    "PageBlobClient.UploadPages";
-                public const string ClearOperationName =
-                    "PageBlobClient.ClearPages";
-                public const string GetPageRangesOperationName =
-                    "PageBlobClient.GetPageRanges";
-                public const string GetPageRangesDiffOperationName =
-                    "PageBlobClient.GetPageRangesDiff";
-                public const string ResizeOperationName =
-                    "PageBlobClient.Resize";
-                public const string UpdateSequenceNumberOperationName =
-                    "PageBlobClient.UpdateSequenceNumber";
-                public const string StartCopyIncrementalOperationName =
-                    "PageBlobClient.StartCopyIncremental";
-                public const string UploadPagesFromUriOperationName =
-                    "PageBlobClient.UploadPagesFromUri";
-            }
-
-            internal static class Service
-            {
-                /// <summary>
-                /// The Azure Storage Operation Names for Blob Service Client.
-                /// </summary>
-                public const string GetAccountInfoOperationName =
-                    "BlobServiceClient.GetAccountInfo";
-                public const string GetPropertiesOperationName =
-                    "BlobServiceClient.GetProperties";
-                public const string SetPropertiesOperationName =
-                    "BlobServiceClient.SetProperties";
-                public const string GetStatisticsOperationName =
-                    "BlobServiceClient.GetStatistics";
-                public const string GetUserDelegationKeyOperationName =
-                    "BlobServiceClient.GetUserDelegationKey";
-            }
-
         }
 
         /// <summary>
-        /// File constant values
+        /// File constant values.
         /// </summary>
         internal static class File
         {
@@ -327,86 +205,6 @@ namespace Azure.Storage
             public const int MaxFileUpdateRange = 4 * MB;
             public const string FileTimeFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff'Z'";
 
-            public const string SetHttpHeadersOperationName =
-                "ShareFileClient.SetHttpHeaders";
-            public const string ForceCloseAllHandlesOperationName =
-                "ShareFileClient.ForceCloseAllHandles";
-            public const string ForceCloseHandleOperationName =
-                "ShareFileClient.ForceCloseHandle";
-            public const string CreateOperationName =
-                "ShareFileClient.Create";
-            public const string UploadRangeOperationName =
-                "ShareFileClient.UploadRange";
-            public const string StartCopyOperationName =
-                "ShareFileClient.StartCopy";
-            public const string AbortCopyOperationName =
-                "ShareFileClient.AbortCopy";
-            public const string DownloadOperationName =
-                "ShareFileClient.Download";
-            public const string GetPropertiesOperationName =
-                "ShareFileClient.GetProperties";
-            public const string DeleteOperationName =
-                "ShareFileClient.Delete";
-            public const string SetMetadataOperationName =
-                "ShareFileClient.SetMetadata";
-            public const string GetRangeListOperationName =
-                "ShareFileClient.GetRangeList";
-            internal static class Directory
-            {
-                public const string CreateOperationName =
-                    "ShareDirectoryClient.Create";
-                public const string DeleteOperationName =
-                    "ShareDirectoryClient.Delete";
-                public const string GetPropertiesOperationName =
-                    "ShareDirectoryClient.GetProperties";
-                public const string SetHttpHeadersOperationName =
-                    "ShareDirectoryClient.SetHttpHeaders";
-                public const string SetMetadataOperationName =
-                    "ShareDirectoryClient.SetMetadata";
-                public const string ListFilesAndDirectoriesSegmentOperationName =
-                    "ShareDirectoryClient.ListFilesAndDirectoriesSegment";
-                public const string GetHandlesOperationName =
-                    "ShareDirectoryClient.ListHandles";
-                public const string ForceCloseAllHandlesOperationName =
-                    "ShareDirectoryClient.ForceCloseAllHandles";
-                public const string ForceCloseHandleOperationName =
-                    "ShareDirectoryClient.ForceCloseHandle";
-            }
-
-            internal static class Service
-            {
-                public const string GetPropertiesOperationName =
-                    "ShareServiceClient.GetProperties";
-                public const string SetPropertiesOperationName =
-                    "ShareServiceClient.SetProperties";
-            }
-
-            internal static class Share
-            {
-                public const string CreateOperationName =
-                    "ShareClient.Create";
-                public const string CreateSnapshotOperationName =
-                    "ShareClient.CreateSnapshot";
-                public const string DeleteOperationName =
-                    "ShareClient.Delete";
-                public const string GetPropertiesOperationName =
-                    "ShareClient.GetProperties";
-                public const string SetQuotaOperationName =
-                    "ShareClient.SetQuota";
-                public const string SetMetadataOperationName =
-                    "ShareClient.SetMetadata";
-                public const string GetAccessPolicyOperationName =
-                    "ShareClient.GetAccessPolicy";
-                public const string SetAccessPolicyOperationName =
-                    "ShareClient.SetAccessPolicy";
-                public const string GetStatisticsOperationName =
-                    "ShareClient.GetStatistics";
-                public const string GetPermissionOperationName =
-                    "ShareClient.GetPermission";
-                public const string CreatePermissionOperationName =
-                    "ShareClient.CreatePermission";
-            }
-
             internal static class Errors
             {
                 public const string ShareUsageBytesOverflow =
@@ -415,11 +213,10 @@ namespace Azure.Storage
         }
 
         /// <summary>
-        /// Data Lake constant values;
+        /// Data Lake constant values.
         /// </summary>
         internal static class DataLake
         {
-
             /// <summary>
             /// The blob URI suffix.
             /// </summary>
@@ -444,15 +241,10 @@ namespace Azure.Storage
             /// The key of the error message returned for errors.
             /// </summary>
             public const string ErrorMessageKey = "message";
-
-            /// <summary>
-            /// The Azure Storage error codes for Datalake Client.
-            /// </summary>
-            public const string AlreadyExists = "ContainerAlreadyExists";
         }
 
         /// <summary>
-        /// Queue constant values
+        /// Queue constant values.
         /// </summary>
         internal static class Queue
         {
@@ -470,23 +262,10 @@ namespace Azure.Storage
             public const string MessagesUri = "messages";
 
             public const string UriSubDomain = "queue";
-
-            public const string ClearMessagesOperationName =
-                "QueueClient.ClearMessages";
-            public const string SendMessageOperationName =
-                "QueueClient.SendMessage";
-            public const string ReceiveMessagesOperationName =
-                "QueueClient.ReceiveMessages";
-            public const string PeekMessagesOperationName =
-                "QueueClient.PeekMessages";
-            public const string DeleteMessageOperationName =
-                "QueueClient.DeleteMessage";
-            public const string UpdateMessageOperationName =
-                 "QueueClient.UpdateMessage";
         }
 
         /// <summary>
-        /// Sas constant values
+        /// Sas constant values.
         /// </summary>
         internal static class Sas
         {
@@ -576,7 +355,7 @@ namespace Azure.Storage
         }
 
         /// <summary>
-        /// XML strings to parse for elements
+        /// XML Element Name constant values.
         /// </summary>
         internal static class Xml
         {

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
@@ -117,12 +117,12 @@ namespace Azure.Storage.Files.DataLake.Tests
             {
                 await RetryAsync(
                     async () => await fileSystem.CreateAsync(metadata: metadata, publicAccessType: publicAccessType),
-                    ex => ex.ErrorCode == Constants.Blob.Container.AlreadyExists,
+                    ex => ex.ErrorCode == Blobs.Models.BlobErrorCode.ContainerAlreadyExists,
                     retryDelay: TestConstants.DataLakeRetryDelay,
                     retryAttempts: 1);
             }
             catch (RequestFailedException storageRequestFailedException)
-            when (storageRequestFailedException.ErrorCode == Constants.Blob.Container.AlreadyExists)
+            when (storageRequestFailedException.ErrorCode == Blobs.Models.BlobErrorCode.ContainerAlreadyExists)
             {
                 // if we still get this error after retrying, mark the test as inconclusive
                 TestContext.Out.WriteLine(

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
@@ -427,7 +427,7 @@ namespace Azure.Storage.Files.Shares
                         metadata: metadata,
                         quotaInGB: quotaInGB,
                         async: async,
-                        operationName: Constants.File.Share.CreateOperationName,
+                        operationName: $"{nameof(ShareClient)}.{nameof(Create)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -545,7 +545,7 @@ namespace Azure.Storage.Files.Shares
                         version: Version.ToVersionString(),
                         metadata: metadata,
                         async: async,
-                        operationName: Constants.File.Share.CreateSnapshotOperationName,
+                        operationName: $"{nameof(ShareClient)}.{nameof(CreateSnapshot)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -667,7 +667,7 @@ namespace Azure.Storage.Files.Shares
                         version: Version.ToVersionString(),
                         deleteSnapshots: includeSnapshots ? DeleteSnapshotsOptionType.Include : (DeleteSnapshotsOptionType?)null,
                         async: async,
-                        operationName: Constants.File.Share.DeleteOperationName,
+                        operationName: $"{nameof(ShareClient)}.{nameof(Delete)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -777,7 +777,7 @@ namespace Azure.Storage.Files.Shares
                         Uri,
                         version: Version.ToVersionString(),
                         async: async,
-                        operationName: Constants.File.Share.GetPropertiesOperationName,
+                        operationName: $"{nameof(ShareClient)}.{nameof(GetProperties)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -891,7 +891,7 @@ namespace Azure.Storage.Files.Shares
                         version: Version.ToVersionString(),
                         quotaInGB: quotaInGB,
                         async: async,
-                        operationName: Constants.File.Share.SetQuotaOperationName,
+                        operationName: $"{nameof(ShareClient)}.{nameof(SetQuota)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -1012,7 +1012,7 @@ namespace Azure.Storage.Files.Shares
                         version: Version.ToVersionString(),
                         metadata: metadata,
                         async: async,
-                        operationName: Constants.File.Share.SetMetadataOperationName,
+                        operationName: $"{nameof(ShareClient)}.{nameof(SetMetadata)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -1121,7 +1121,7 @@ namespace Azure.Storage.Files.Shares
                         Uri,
                         version: Version.ToVersionString(),
                         async: async,
-                        operationName: Constants.File.Share.GetAccessPolicyOperationName,
+                        operationName: $"{nameof(ShareClient)}.{nameof(GetAccessPolicy)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -1248,7 +1248,7 @@ namespace Azure.Storage.Files.Shares
                         version: Version.ToVersionString(),
                         permissions: permissions,
                         async: async,
-                        operationName: Constants.File.Share.SetAccessPolicyOperationName,
+                        operationName: $"{nameof(ShareClient)}.{nameof(SetAccessPolicy)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -1351,7 +1351,7 @@ namespace Azure.Storage.Files.Shares
                         Uri,
                         version: Version.ToVersionString(),
                         async: async,
-                        operationName: Constants.File.Share.GetStatisticsOperationName,
+                        operationName: $"{nameof(ShareClient)}.{nameof(GetStatistics)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -1434,7 +1434,7 @@ namespace Azure.Storage.Files.Shares
                             filePermissionKey: filePermissionKey,
                             version: Version.ToVersionString(),
                             async: async,
-                            operationName: Constants.File.Share.GetPermissionOperationName,
+                            operationName: $"{nameof(ShareClient)}.{nameof(GetPermission)}",
                             cancellationToken: cancellationToken)
                             .ConfigureAwait(false);
 
@@ -1556,7 +1556,7 @@ namespace Azure.Storage.Files.Shares
                         version: Version.ToVersionString(),
                         sharePermissionJson: json,
                         async: async,
-                        operationName: Constants.File.Share.CreatePermissionOperationName,
+                        operationName: $"{nameof(ShareClient)}.{nameof(CreatePermission)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareDirectoryClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareDirectoryClient.cs
@@ -495,7 +495,7 @@ namespace Azure.Storage.Files.Shares
                         fileLastWriteTime: smbProps.FileLastWriteTimeToString() ?? Constants.File.FileTimeNow,
                         filePermissionKey: smbProps.FilePermissionKey,
                         async: async,
-                        operationName: Constants.File.Directory.CreateOperationName,
+                        operationName: $"{nameof(ShareDirectoryClient)}.{nameof(Create)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
@@ -595,7 +595,7 @@ namespace Azure.Storage.Files.Shares
                         Uri,
                         version: Version.ToVersionString(),
                         async: async,
-                        operationName: Constants.File.Directory.DeleteOperationName,
+                        operationName: $"{nameof(ShareDirectoryClient)}.{nameof(Delete)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -708,7 +708,7 @@ namespace Azure.Storage.Files.Shares
                         Uri,
                         version: Version.ToVersionString(),
                         async: async,
-                        operationName: Constants.File.Directory.GetPropertiesOperationName,
+                        operationName: $"{nameof(ShareDirectoryClient)}.{nameof(GetProperties)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
@@ -861,7 +861,7 @@ namespace Azure.Storage.Files.Shares
                         fileLastWriteTime: smbProps.FileLastWriteTimeToString() ?? Constants.File.Preserve,
                         filePermissionKey: smbProps.FilePermissionKey,
                         async: async,
-                        operationName: Constants.File.Directory.SetHttpHeadersOperationName,
+                        operationName: $"{nameof(ShareDirectoryClient)}.{nameof(SetHttpHeaders)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
@@ -981,7 +981,7 @@ namespace Azure.Storage.Files.Shares
                         version: Version.ToVersionString(),
                         metadata: metadata,
                         async: async,
-                        operationName: Constants.File.Directory.SetMetadataOperationName,
+                        operationName: $"{nameof(ShareDirectoryClient)}.{nameof(SetMetadata)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
@@ -1124,7 +1124,7 @@ namespace Azure.Storage.Files.Shares
                         prefix: prefix,
                         maxresults: pageSizeHint,
                         async: async,
-                        operationName: Constants.File.Directory.ListFilesAndDirectoriesSegmentOperationName,
+                        operationName: $"{nameof(ShareDirectoryClient)}.{nameof(GetFilesAndDirectories)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -1261,7 +1261,7 @@ namespace Azure.Storage.Files.Shares
                         maxresults: maxResults,
                         recursive: recursive,
                         async: async,
-                        operationName: Constants.File.Directory.GetHandlesOperationName,
+                        operationName: $"{nameof(ShareDirectoryClient)}.{nameof(GetHandles)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -1316,7 +1316,7 @@ namespace Azure.Storage.Files.Shares
                 null,
                 false, // async
                 cancellationToken,
-                Constants.File.Directory.ForceCloseHandleOperationName)
+                $"{nameof(ShareDirectoryClient)}.{nameof(ForceCloseHandle)}")
                 .EnsureCompleted();
 
             return Response.FromValue(
@@ -1364,7 +1364,7 @@ namespace Azure.Storage.Files.Shares
                 null,
                 true, // async
                 cancellationToken,
-                Constants.File.Directory.ForceCloseHandleOperationName)
+                $"{nameof(ShareDirectoryClient)}.{nameof(ForceCloseHandle)}")
                 .ConfigureAwait(false);
 
             return Response.FromValue(
@@ -1561,7 +1561,7 @@ namespace Azure.Storage.Files.Shares
             bool? recursive,
             bool async,
             CancellationToken cancellationToken,
-            string operationName = Constants.File.Directory.ForceCloseAllHandlesOperationName)
+            string operationName = null)
         {
             using (Pipeline.BeginLoggingScope(nameof(ShareDirectoryClient)))
             {
@@ -1583,7 +1583,7 @@ namespace Azure.Storage.Files.Shares
                         version: Version.ToVersionString(),
                         recursive: recursive,
                         async: async,
-                        operationName: operationName,
+                        operationName: operationName ?? $"{nameof(ShareDirectoryClient)}.{nameof(ForceCloseAllHandles)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
@@ -531,7 +531,7 @@ namespace Azure.Storage.Files.Shares
                         filePermissionKey: smbProps.FilePermissionKey,
                         async: async,
                         cancellationToken: cancellationToken,
-                        operationName: Constants.File.CreateOperationName)
+                        operationName: $"{nameof(ShareFileClient)}.{nameof(Create)}")
                         .ConfigureAwait(false);
 
                     return Response.FromValue(new ShareFileInfo(response.Value), response.GetRawResponse());
@@ -668,7 +668,7 @@ namespace Azure.Storage.Files.Shares
                         metadata: metadata,
                         async: async,
                         cancellationToken: cancellationToken,
-                        operationName: Constants.File.StartCopyOperationName)
+                        operationName: $"{nameof(ShareFileClient)}.{nameof(StartCopy)}")
                         .ConfigureAwait(false);
                 }
                 catch (Exception ex)
@@ -787,7 +787,7 @@ namespace Azure.Storage.Files.Shares
                         version: Version.ToVersionString(),
                         async: async,
                         cancellationToken: cancellationToken,
-                        operationName: Constants.File.AbortCopyOperationName)
+                        operationName: $"{nameof(ShareFileClient)}.{nameof(AbortCopy)}")
                         .ConfigureAwait(false);
                 }
                 catch (Exception ex)
@@ -1039,7 +1039,7 @@ namespace Azure.Storage.Files.Shares
                     rangeGetContentHash: rangeGetContentHash ? (bool?)true : null,
                     async: async,
                     cancellationToken: cancellationToken,
-                    operationName: Constants.File.DownloadOperationName)
+                    operationName: $"{nameof(ShareFileClient)}.{nameof(Download)}")
                     .ConfigureAwait(false);
             Pipeline.LogTrace($"Response: {response.GetRawResponse().Status}, ContentLength: {response.Value.ContentLength}");
             return (response, stream);
@@ -1130,7 +1130,7 @@ namespace Azure.Storage.Files.Shares
                         version: Version.ToVersionString(),
                         async: async,
                         cancellationToken: cancellationToken,
-                        operationName: Constants.File.DeleteOperationName)
+                        operationName: $"{nameof(ShareFileClient)}.{nameof(Delete)}")
                         .ConfigureAwait(false);
                 }
                 catch (Exception ex)
@@ -1243,7 +1243,7 @@ namespace Azure.Storage.Files.Shares
                         version: Version.ToVersionString(),
                         async: async,
                         cancellationToken: cancellationToken,
-                        operationName: Constants.File.GetPropertiesOperationName)
+                        operationName: $"{nameof(ShareFileClient)}.{nameof(GetProperties)}")
                         .ConfigureAwait(false);
 
                     // Return an exploding Response on 304
@@ -1441,7 +1441,7 @@ namespace Azure.Storage.Files.Shares
                         fileLastWriteTime: smbProps.FileLastWriteTimeToString() ?? Constants.File.Preserve,
                         filePermissionKey: smbProps.FilePermissionKey,
                         async: async,
-                        operationName: Constants.File.SetHttpHeadersOperationName,
+                        operationName: $"{nameof(ShareFileClient)}.{nameof(SetHttpHeaders)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
@@ -1565,7 +1565,7 @@ namespace Azure.Storage.Files.Shares
                         metadata: metadata,
                         async: async,
                         cancellationToken: cancellationToken,
-                        operationName: Constants.File.SetMetadataOperationName)
+                        operationName: $"{nameof(ShareFileClient)}.{nameof(SetMetadata)}")
                         .ConfigureAwait(false);
 
                     return Response.FromValue(new ShareFileInfo(response.Value), response.GetRawResponse());
@@ -1771,7 +1771,7 @@ namespace Azure.Storage.Files.Shares
                         contentHash: transactionalContentHash,
                         async: async,
                         cancellationToken: cancellationToken,
-                        operationName: Constants.File.UploadRangeOperationName).ConfigureAwait(false);
+                        operationName: $"{nameof(ShareFileClient)}.{nameof(UploadRange)}").ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -2243,7 +2243,7 @@ namespace Azure.Storage.Files.Shares
                         range: range.ToString(),
                         async: async,
                         cancellationToken: cancellationToken,
-                        operationName: Constants.File.GetRangeListOperationName)
+                        operationName: $"{nameof(ShareFileClient)}.{nameof(GetRangeList)}")
                         .ConfigureAwait(false);
                     return Response.FromValue(new ShareFileRangeInfo(response.Value), response.GetRawResponse());
                 }
@@ -2421,7 +2421,7 @@ namespace Azure.Storage.Files.Shares
                 null,
                 false, // async,
                 cancellationToken,
-                Constants.File.ForceCloseHandleOperationName)
+                $"{nameof(ShareFileClient)}.{nameof(ForceCloseHandle)}")
                 .EnsureCompleted();
 
             return Response.FromValue(
@@ -2468,7 +2468,7 @@ namespace Azure.Storage.Files.Shares
                 null,
                 true, // async,
                 cancellationToken,
-                Constants.File.ForceCloseHandleOperationName)
+                $"{nameof(ShareFileClient)}.{nameof(ForceCloseHandle)}")
                 .ConfigureAwait(false);
 
             return Response.FromValue(
@@ -2637,7 +2637,7 @@ namespace Azure.Storage.Files.Shares
             string marker,
             bool async,
             CancellationToken cancellationToken,
-            string operationName = Constants.File.ForceCloseAllHandlesOperationName)
+            string operationName = null)
         {
             using (Pipeline.BeginLoggingScope(nameof(ShareFileClient)))
             {
@@ -2658,7 +2658,7 @@ namespace Azure.Storage.Files.Shares
                         version: Version.ToVersionString(),
                         async: async,
                         cancellationToken: cancellationToken,
-                        operationName: operationName)
+                        operationName: operationName ?? $"{nameof(ShareFileClient)}.{nameof(ForceCloseAllHandles)}")
                         .ConfigureAwait(false);
                 }
                 catch (Exception ex)

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareServiceClient.cs
@@ -480,7 +480,7 @@ namespace Azure.Storage.Files.Shares
                         Uri,
                         version: Version.ToVersionString(),
                         async: async,
-                        operationName: Constants.File.Service.GetPropertiesOperationName,
+                        operationName: $"{nameof(ShareServiceClient)}.{nameof(GetProperties)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -604,7 +604,7 @@ namespace Azure.Storage.Files.Shares
                         version: Version.ToVersionString(),
                         properties: properties,
                         async: async,
-                        operationName: Constants.File.Service.SetPropertiesOperationName,
+                        operationName: $"{nameof(ShareServiceClient)}.{nameof(SetProperties)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }

--- a/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
@@ -917,7 +917,7 @@ namespace Azure.Storage.Queues
                         MessagesUri,
                         version: Version.ToVersionString(),
                         async: async,
-                        operationName: Constants.Queue.ClearMessagesOperationName,
+                        operationName: $"{nameof(QueueClient)}.{nameof(ClearMessages)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -1126,7 +1126,7 @@ namespace Azure.Storage.Queues
                             visibilitytimeout: (int?)visibilityTimeout?.TotalSeconds,
                             messageTimeToLive: (int?)timeToLive?.TotalSeconds,
                             async: async,
-                            operationName: Constants.Queue.SendMessageOperationName,
+                            operationName: $"{nameof(QueueClient)}.{nameof(SendMessage)}",
                             cancellationToken: cancellationToken)
                             .ConfigureAwait(false);
                     // The service returns a sequence of messages, but the
@@ -1300,7 +1300,7 @@ namespace Azure.Storage.Queues
                         numberOfMessages: maxMessages,
                         visibilitytimeout: (int?)visibilityTimeout?.TotalSeconds,
                         async: async,
-                        operationName: Constants.Queue.ReceiveMessagesOperationName,
+                        operationName: $"{nameof(QueueClient)}.{nameof(ReceiveMessages)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
@@ -1407,7 +1407,7 @@ namespace Azure.Storage.Queues
                         version: Version.ToVersionString(),
                         numberOfMessages: maxMessages,
                         async: async,
-                        operationName: Constants.Queue.PeekMessagesOperationName,
+                        operationName: $"{nameof(QueueClient)}.{nameof(PeekMessages)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
@@ -1528,7 +1528,7 @@ namespace Azure.Storage.Queues
                         popReceipt: popReceipt,
                         version: Version.ToVersionString(),
                         async: async,
-                        operationName: Constants.Queue.DeleteMessageOperationName,
+                        operationName: $"{nameof(QueueClient)}.{nameof(DeleteMessage)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -1673,7 +1673,7 @@ namespace Azure.Storage.Queues
                         visibilitytimeout: (int)visibilityTimeout.TotalSeconds,
                         version: Version.ToVersionString(),
                         async: async,
-                        operationName: Constants.Queue.UpdateMessageOperationName,
+                        operationName: $"{nameof(QueueClient)}.{nameof(UpdateMessage)}",
                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
                 }


### PR DESCRIPTION
Follow up to https://github.com/Azure/azure-sdk-for-net/pull/9651.  Switching from values in Constants.cs to `$"{nameof(Client)}.{nameof(Operation)}"` inline constants.  This actually fixed a couple of scope names that were incorrect.