### PR TITLE
[Event Hubs] Event Processor Release Preparation (v5.0.1)

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -15,7 +15,7 @@
     <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.0.1" />
     <PackageReference Update="Azure.Security.KeyVault.Certificates" Version="4.0.0" />
     <PackageReference Update="Azure.Security.KeyVault.Keys" Version="4.0.1" />
-    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.0.0-preview.6" />
+    <PackageReference Update="Azure.Messaging.EventHubs" Version="5.0.1" />
     <PackageReference Update="Azure.Storage.Blobs" Version="12.2.0" />
     <PackageReference Update="Azure.Storage.Blobs.Batch" Version="12.1.1" />
     <PackageReference Update="Azure.Storage.Common" Version="12.1.1" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 5.0.0
+## 5.0.1
 
 Thank you to our developer community members who helped to make the Event Hubs client libraries better with their contributions to this release:
 
@@ -32,7 +32,7 @@ Thank you to our developer community members who helped to make the Event Hubs c
 
 ## 5.0.0-preview.6
 
-### Acknowledgments 
+### Acknowledgments
 
 Thank you to our developer community members who helped to make the Event Hubs client libraries better with their contributions to this release:
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/README.md
@@ -6,7 +6,7 @@ The Event Processor client library is a companion to the Azure Event Hubs client
 
 - Reading and processing events across all partitions of an Event Hub at scale with resilience to transient failures and intermittent network issues.
 
-- Procesing events cooperatively, where multiple processors dynamically distribute and share the responsibility in the context of a consumer group, gracefully managing the load as processors are added and removed from the group.
+- Processing events cooperatively, where multiple processors dynamically distribute and share the responsibility in the context of a consumer group, gracefully managing the load as processors are added and removed from the group.
 
 - Managing checkpoints and state for processing in a durable manner using Azure Storage blobs as the underlying data store.
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This library extends its Event Processor with durable storage for checkpoint information using Azure Blob storage.  For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>5.0.0</Version>
+    <Version>5.0.1</Version>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;Event Processor;EventProcessor;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <EnableFxCopAnalyzers>false</EnableFxCopAnalyzers>
@@ -13,11 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Remove the project reference and restore the package reference when Event Hubs preview.7 is published. -->
-    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj" />
-    <!--
     <PackageReference Include="Azure.Messaging.EventHubs" />
-    -->
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Azure.Messaging.EventHubs.Shared.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Azure.Messaging.EventHubs.Shared.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Azure.Messaging.EventHubs.Shared.Tests</AssemblyName>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>5.0.1</VersionPrefix>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <ExcludeRecordingFramework>true</ExcludeRecordingFramework>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 5.1.0-preview.1 (Unreleased)
+
+Release notes will be provided here when the final set of features for the release is available.
+
 ## 5.0.1
 
 ### Acknowledgements

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Azure.Messaging.EventHubs.Samples.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Azure.Messaging.EventHubs.Samples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Azure.Messaging.EventHubs.Samples</AssemblyName>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>5.0.1</VersionPrefix>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This client library allows for both publishing and consuming events using Azure Event Hubs. For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>5.0.1</Version>
+    <Version>5.1.0-preview.1</Version>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;AMQP;IoT;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <EnableFxCopAnalyzers>false</EnableFxCopAnalyzers>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Azure.Messaging.EventHubs.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Azure.Messaging.EventHubs.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Azure.Messaging.EventHubs.Tests</AssemblyName>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>5.0.1</VersionPrefix>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <ExcludeRecordingFramework>true</ExcludeRecordingFramework>


### PR DESCRIPTION
# Summary

The focus of these changes is to ready the Event Processor package for its v5.0.1 release, rebinding references to the most recent release of the core Event Hubs package and to update processor release materials.

# Last Upstream Rebase

Wednesday,, January 29, 11:08am (EST)