### PR TITLE
[Event Hubs Client] Test Stability and Tuning

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Infrastructure/IEventHubsBlobCheckpointSample.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Infrastructure/IEventHubsBlobCheckpointSample.cs
@@ -16,13 +16,13 @@ namespace Azure.Messaging.EventHubs.Processor.Samples.Infrastructure
         ///   The name of the sample.
         /// </summary>
         ///
-        public string Name { get; }
+        string Name { get; }
 
         /// <summary>
         ///   A short description of the associated sample.
         /// </summary>
         ///
-        public string Description { get; }
+        string Description { get; }
 
         /// <summary>
         ///   Allows for executing the sample.
@@ -33,9 +33,9 @@ namespace Azure.Messaging.EventHubs.Processor.Samples.Infrastructure
         /// <param name="blobStorageConnectionString">The connection string for the storage account where checkpoints and state should be persisted.</param>
         /// <param name="blobContainerName">The name of the blob storage container where checkpoints should be persisted.</param>
         ///
-        public Task RunAsync(string eventHubsConnectionString,
-                             string eventHubName,
-                             string blobStorageConnectionString,
-                             string blobContainerName);
+        Task RunAsync(string eventHubsConnectionString,
+                      string eventHubName,
+                      string blobStorageConnectionString,
+                      string blobContainerName);
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Infrastructure/IEventHubsIdentitySample.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Infrastructure/IEventHubsIdentitySample.cs
@@ -23,10 +23,10 @@ namespace Azure.Messaging.EventHubs.Samples.Infrastructure
         /// <param name="clientId">The Azure Active Directory client identifier of the service principal.</param>
         /// <param name="secret">The Azure Active Directory secret of the service principal.</param>
         ///
-        public Task RunAsync(string fullyQualifiedNamespace,
-                             string eventHubName,
-                             string tenantId,
-                             string clientId,
-                             string secret);
+        Task RunAsync(string fullyQualifiedNamespace,
+                      string eventHubName,
+                      string tenantId,
+                      string clientId,
+                      string secret);
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Infrastructure/IEventHubsSample.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Infrastructure/IEventHubsSample.cs
@@ -18,7 +18,7 @@ namespace Azure.Messaging.EventHubs.Samples.Infrastructure
         /// <param name="connectionString">The connection string for the Event Hubs namespace that the sample should target.</param>
         /// <param name="eventHubName">The name of the Event Hub, sometimes known as its path, that the sample should run against.</param>
         ///
-        public Task RunAsync(string connectionString,
-                             string eventHubName);
+        Task RunAsync(string connectionString,
+                      string eventHubName);
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Infrastructure/ISample.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Infrastructure/ISample.cs
@@ -13,13 +13,13 @@ namespace Azure.Messaging.EventHubs.Samples.Infrastructure
         ///   The name of the sample.
         /// </summary>
         ///
-        public string Name { get; }
+        string Name { get; }
 
         /// <summary>
         ///   A short description of the associated sample.
         /// </summary>
         ///
-        public string Description { get; }
+        string Description { get; }
 
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
@@ -128,7 +128,6 @@ namespace Azure.Messaging.EventHubs.Tests
                             if (!wereEventsPublished)
                             {
                                 await producer.SendAsync(eventBatch, new SendEventOptions { PartitionId = partition });
-
                                 wereEventsPublished = true;
                                 continue;
                             }
@@ -147,7 +146,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                                 if (receivedEvents.Count < 1)
                                 {
-                                    await Task.Delay(50);
+                                    await Task.Delay(150);
                                 }
                             }
                         }
@@ -225,7 +224,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                                 if (receivedEvents.Count < 1)
                                 {
-                                    await Task.Delay(50);
+                                    await Task.Delay(150);
                                 }
                             }
                         }
@@ -305,7 +304,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                                 if (receivedEvents.Count < eventSet.Length)
                                 {
-                                    await Task.Delay(50);
+                                    await Task.Delay(150);
                                 }
                             }
                         }
@@ -389,7 +388,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                                 if (receivedEvents.Count < eventBatch.Length)
                                 {
-                                    await Task.Delay(50);
+                                    await Task.Delay(150);
                                 }
                             }
                         }
@@ -476,7 +475,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                                 if (receivedEvents.Count < eventBatch.Length)
                                 {
-                                    await Task.Delay(50);
+                                    await Task.Delay(150);
                                 }
                             }
                         }
@@ -558,7 +557,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                                 if (receivedEvents.Count < expectedEventsCount)
                                 {
-                                    await Task.Delay(50);
+                                    await Task.Delay(150);
                                 }
                             }
                         }
@@ -616,7 +615,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                                 if (receivedEvents.Count < expectedEventsCount)
                                 {
-                                    await Task.Delay(50);
+                                    await Task.Delay(150);
                                 }
                             }
                         }
@@ -688,7 +687,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                                     if (receivedEvents.Count < expectedEventsCount)
                                     {
-                                        await Task.Delay(50);
+                                        await Task.Delay(150);
                                     }
                                 }
                             }
@@ -763,7 +762,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                                     if (receivedEvents.Count < expectedEventsCount)
                                     {
-                                        await Task.Delay(50);
+                                        await Task.Delay(150);
                                     }
                                 }
                             }
@@ -839,7 +838,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                                     if (receivedEvents.Count < expectedEventsCount)
                                     {
-                                        await Task.Delay(50);
+                                        await Task.Delay(150);
                                     }
                                 }
                             }
@@ -919,7 +918,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                             if (receivedEvents.Count < expectedCount)
                             {
-                                await Task.Delay(50);
+                                await Task.Delay(150);
                             }
                         }
                     }
@@ -980,6 +979,7 @@ namespace Azure.Messaging.EventHubs.Tests
                             }
 
                             await producer.SendAsync(batch, cancellationSource.Token);
+                            await Task.Delay(TimeSpan.FromSeconds(1));
                         }
                     }
 
@@ -1008,7 +1008,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                             if (receivedEvents.Count < expectedCount)
                             {
-                                await Task.Delay(50);
+                                await Task.Delay(150);
                             }
                         }
                     }
@@ -1050,7 +1050,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                             if (receivedEvents.Count < expectedCount)
                             {
-                                await Task.Delay(50);
+                                await Task.Delay(150);
                             }
                         }
                     }
@@ -1274,7 +1274,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                             if (receivedEvents.Count < expectedEventsCount)
                             {
-                                await Task.Delay(50);
+                                await Task.Delay(150);
                             }
                         }
                     }
@@ -2112,6 +2112,7 @@ namespace Azure.Messaging.EventHubs.Tests
                                 await producer.SendAsync(eventBatch, new SendEventOptions { PartitionId = partitionIds[0] });
                             }
 
+                            await Task.Delay(TimeSpan.FromSeconds(1));
                             wereEventsPublished = true;
                             continue;
                         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
@@ -1748,14 +1748,14 @@ namespace Azure.Messaging.EventHubs.Tests
             var maxWaitTime = TimeSpan.FromMilliseconds(50);
             var publishDelay = maxWaitTime.Add(TimeSpan.FromMilliseconds(15));
             var options = new ReadEventOptions { MaximumWaitTime = maxWaitTime };
-            var transportConsumer = new PublishingTransportConsumerMock(events, () => publishDelay);
-            var mockConnection = new MockConnection(() => transportConsumer);
+            var mockConnection = new MockConnection(() => new PublishingTransportConsumerMock(events, () => publishDelay));
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
             var receivedEvents = new List<EventData>();
             var consecutiveEmptyCount = 0;
 
             var partitions = await mockConnection.GetPartitionIdsAsync(Mock.Of<EventHubsRetryPolicy>());
             var thresholdModifier = 2 * partitions.Length;
+            var expectedEventCount = (events.Count * partitions.Length);
 
             using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(100));
 
@@ -1775,21 +1775,20 @@ namespace Azure.Messaging.EventHubs.Tests
 
             Assert.That(cancellation.IsCancellationRequested, Is.False, "The iteration should have completed normally.");
             Assert.That(receivedEvents.Count, Is.AtLeast(events.Count + 1).And.LessThanOrEqualTo(events.Count * thresholdModifier), "There should be empty events present due to the wait time.");
-            Assert.That(receivedEvents.Where(item => item != null).Count(), Is.EqualTo(events.Count), "The received event count should match the published events when empty events are removed.");
+            Assert.That(receivedEvents.Where(item => item != null).Count(), Is.EqualTo(expectedEventCount), "The received event count should match the published events when empty events are removed.");
 
             // Validate that each message received appeared in the source set once.
 
-            var sourceEventMessages = new HashSet<string>();
+            var receivedEventMessages = new HashSet<string>();
 
-            foreach (var message in events.Select(item => Encoding.UTF8.GetString(item.Body.ToArray())))
+            foreach (var message in receivedEvents.Where(item => item != null).Select(item => Encoding.UTF8.GetString(item.Body.ToArray())))
             {
-                sourceEventMessages.Add(message);
+                receivedEventMessages.Add(message);
             }
 
-            foreach (var receivedMessage in receivedEvents.Where(item => item != null).Select(item => Encoding.UTF8.GetString(item.Body.ToArray())))
+            foreach (var sourceMessage in events.Select(item => Encoding.UTF8.GetString(item.Body.ToArray())))
             {
-                Assert.That(sourceEventMessages.Contains(receivedMessage), $"The message: { receivedEvents } was not in the source set or has appeared more than once.");
-                sourceEventMessages.Remove(receivedMessage);
+                Assert.That(receivedEventMessages.Contains(sourceMessage), $"The message: { sourceMessage } was not received.");
             }
         }
 


### PR DESCRIPTION
# Summary

The focus of these changes is to continue to iterate on test configuration and resolve intermittent issues that appear.  The following changes were
applied:

- The retry configuration for management operations was tweaked; additional  HTTP status codes were added to the retry-eligible list and a new approach  to test exception types for eligibility have been applied to the live infrastructure for tracks one and two.

- A race condition causing infrequent intermittent failures with a consumer test has been resolved.

- The backoff for consumer tests that must wait for published events to be visible has been increased, allowing additional time for events to become available in the partition.

- A short delay has been added for two tests with the need for newly published events which were more consistently experiencing issues with timing for availability in the partition.

- _(unrelated to tests)_  Removed unnecessary visibility modifiers from the  sample interface definitions to better conform to C# norms.

# Last Upstream Rebase

Wednesday, January 29, 4:17pm (EST)

