### PR TITLE
[Event Hubs Client] Project File Tweaks

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Azure.Messaging.EventHubs.Processor.Samples.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Azure.Messaging.EventHubs.Processor.Samples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Azure.Messaging.EventHubs.Processor.Samples</AssemblyName>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <Version>1.0.0</Version>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Azure.Messaging.EventHubs.Processor.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Azure.Messaging.EventHubs.Processor.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Azure.Messaging.EventHubs.Processor.Tests</AssemblyName>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <Version>1.0.0</Version>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <ExcludeRecordingFramework>true</ExcludeRecordingFramework>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Azure.Messaging.EventHubs.Shared.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Azure.Messaging.EventHubs.Shared.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Azure.Messaging.EventHubs.Shared.Tests</AssemblyName>
-    <VersionPrefix>5.0.1</VersionPrefix>
+    <Version>1.0.0</Version>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <ExcludeRecordingFramework>true</ExcludeRecordingFramework>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Azure.Messaging.EventHubs.Samples.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Azure.Messaging.EventHubs.Samples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Azure.Messaging.EventHubs.Samples</AssemblyName>
-    <VersionPrefix>5.0.1</VersionPrefix>
+    <Version>1.0.0</Version>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Azure.Messaging.EventHubs.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Azure.Messaging.EventHubs.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Azure.Messaging.EventHubs.Tests</AssemblyName>
-    <VersionPrefix>5.0.1</VersionPrefix>
+    <Version>1.0.0</Version>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <ExcludeRecordingFramework>true</ExcludeRecordingFramework>


### PR DESCRIPTION
# Summary

The focus of these changes is to reset the version for non-product supporting libraries and pin them at 1.0.0, since there is little value in managing them to keep aligned with the accompanying product.   Also updating the attribute used for version tracking, as the prefix use was made obsolete a while back and I forgot to update these.

# Last Upstream Rebase

Thursday, January 30, 2:16pm (EST)