### PR TITLE
[Event Hubs Client] Test Infrastructure Retry Tweak (Tracks One and Two)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using System.Net.Http;
 using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Threading;
@@ -189,7 +190,7 @@ namespace Azure.Messaging.EventHubs.Tests
             ((ex is TimeoutException)
                 || (ex is TaskCanceledException)
                 || (ex is OperationCanceledException)
-                || (ex is TimeoutException)
+                || (ex is HttpRequestException)
                 || (ex is SocketException)
                 || (ex is IOException));
 

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Security.Authentication;
@@ -241,7 +242,7 @@ namespace Microsoft.Azure.EventHubs.Tests
             ((ex is TimeoutException)
                 || (ex is TaskCanceledException)
                 || (ex is OperationCanceledException)
-                || (ex is TimeoutException)
+                || (ex is HttpRequestException)
                 || (ex is SocketException)
                 || (ex is IOException));
 


### PR DESCRIPTION
# Summary

The focus of these changes is to continue the game of whack-a-mole to properly detect and retry transient failures coming from the management plane when dynamically creating resources for test runs.  In this episode, support is added directly for the `HttpRequestException`, as peeking at the inner exception did not match the existing clauses.

# Last Upstream Rebase

Friday, January 31, 9:18am (EST)

