### PR TITLE
[Event Hubs Client] Test Infrastructure Retry Tweaks (Tracks One and Two)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
@@ -135,9 +135,7 @@ namespace Azure.Messaging.EventHubs.Tests
                                                     double exponentialBackoffSeconds = RetryExponentialBackoffSeconds,
                                                     double baseJitterSeconds = RetryBaseJitterSeconds) =>
            Policy<T>
-               .Handle<ErrorResponseException>(ex => IsRetriableStatus(ex.Response.StatusCode))
-               .Or<CloudException>(ex => IsRetriableStatus(ex.Response.StatusCode))
-               .Or<Exception>(ex => ((IsRetriableExceptionType(ex)) || (IsRetriableExceptionType(ex.InnerException))))
+               .Handle<Exception>(ex => ShouldRetry(ex))
                .WaitAndRetryAsync(maxRetryAttempts, attempt => CalculateRetryDelay(attempt, exponentialBackoffSeconds, baseJitterSeconds));
 
         /// <summary>
@@ -154,9 +152,7 @@ namespace Azure.Messaging.EventHubs.Tests
                                               double exponentialBackoffSeconds = RetryExponentialBackoffSeconds,
                                               double baseJitterSeconds = RetryBaseJitterSeconds) =>
             Policy
-                .Handle<ErrorResponseException>(ex => IsRetriableStatus(ex.Response.StatusCode))
-                .Or<CloudException>(ex => IsRetriableStatus(ex.Response.StatusCode))
-                .Or<Exception>(ex => ((IsRetriableExceptionType(ex)) || (IsRetriableExceptionType(ex.InnerException))))
+                .Handle<Exception>(ex => ShouldRetry(ex))
                 .WaitAndRetryAsync(maxRetryAttempts, attempt => CalculateRetryDelay(attempt, exponentialBackoffSeconds, baseJitterSeconds));
 
         /// <summary>
@@ -178,6 +174,18 @@ namespace Azure.Messaging.EventHubs.Tests
                 || (statusCode == HttpStatusCode.GatewayTimeout));
 
         /// <summary>
+        ///   Determines whether the specified exception is considered eligible to retry the associated
+        ///   operation.
+        /// </summary>
+        ///
+        /// <param name="ex">The exception to consider.</param>
+        ///
+        /// <returns><c>true</c> if the exception is eligible for retries; otherwise, <c>false</c>.</returns>
+        ///
+        private static bool ShouldRetry(Exception ex) =>
+            ((IsRetriableException(ex)) || (IsRetriableException(ex?.InnerException)));
+
+        /// <summary>
         ///   Determines whether the type of the specified exception is considered eligible to retry
         ///   the associated operation.
         /// </summary>
@@ -186,13 +194,34 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         /// <returns><c>true</c> if the exception type is eligible for retries; otherwise, <c>false</c>.</returns>
         ///
-        public static bool IsRetriableExceptionType(Exception ex) =>
-            ((ex is TimeoutException)
-                || (ex is TaskCanceledException)
-                || (ex is OperationCanceledException)
-                || (ex is HttpRequestException)
-                || (ex is SocketException)
-                || (ex is IOException));
+        private static bool IsRetriableException(Exception ex)
+        {
+            if (ex == null)
+            {
+                return false;
+            }
+
+            switch (ex)
+            {
+                case ErrorResponseException erEx:
+                    return IsRetriableStatus(erEx.Response.StatusCode);
+
+                case CloudException clEx:
+                    return IsRetriableStatus(clEx.Response.StatusCode);
+
+                case TimeoutException _:
+                case TaskCanceledException _:
+                case OperationCanceledException _:
+                case HttpRequestException _:
+                case WebException _:
+                case SocketException _:
+                case IOException _:
+                    return true;
+
+                default:
+                    return false;
+            };
+        }
 
         /// <summary>
         ///   Calculates the retry delay to use for management-related operations.

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
@@ -212,21 +212,12 @@ namespace Microsoft.Azure.EventHubs.Tests
 
         private static IAsyncPolicy<T> CreateRetryPolicy<T>(int maxRetryAttempts = RetryMaximumAttempts, double exponentialBackoffSeconds = RetryExponentialBackoffSeconds, double baseJitterSeconds = RetryBaseJitterSeconds) =>
            Policy<T>
-               .Handle<ErrorResponseException>(ex => IsRetriableStatus(ex.Response.StatusCode))
-               .Or<CloudException>(ex => IsRetriableStatus(ex.Response.StatusCode))
-               .Or<TaskCanceledException>()
-               .Or<OperationCanceledException>()
-               .Or<SocketException>()
-               .Or<IOException>()
+               .Handle<Exception>(ex => ShouldRetry(ex))
                .WaitAndRetryAsync(maxRetryAttempts, attempt => CalculateRetryDelay(attempt, exponentialBackoffSeconds, baseJitterSeconds));
 
         private static IAsyncPolicy CreateRetryPolicy(int maxRetryAttempts = RetryMaximumAttempts, double exponentialBackoffSeconds = RetryExponentialBackoffSeconds, double baseJitterSeconds = RetryBaseJitterSeconds) =>
             Policy
-                .Handle<ErrorResponseException>(ex => IsRetriableStatus(ex.Response.StatusCode))
-                .Or<CloudException>(ex => IsRetriableStatus(ex.Response.StatusCode))
-                .Or<StorageException>(ex => IsRetriableStatus((HttpStatusCode)ex.RequestInformation.HttpStatusCode))
-                .Or<StorageException>(ex => IsRetriableExceptionType(ex.InnerException))
-                .Or<Exception>(ex => ((IsRetriableExceptionType(ex)) || (IsRetriableExceptionType(ex.InnerException))))
+                .Handle<Exception>(ex => ShouldRetry(ex))
                 .WaitAndRetryAsync(maxRetryAttempts, attempt => CalculateRetryDelay(attempt, exponentialBackoffSeconds, baseJitterSeconds));
 
         private static bool IsRetriableStatus(HttpStatusCode statusCode) =>
@@ -238,13 +229,40 @@ namespace Microsoft.Azure.EventHubs.Tests
                 || (statusCode == HttpStatusCode.ServiceUnavailable)
                 || (statusCode == HttpStatusCode.GatewayTimeout));
 
-        public static bool IsRetriableExceptionType(Exception ex) =>
-            ((ex is TimeoutException)
-                || (ex is TaskCanceledException)
-                || (ex is OperationCanceledException)
-                || (ex is HttpRequestException)
-                || (ex is SocketException)
-                || (ex is IOException));
+         private static bool ShouldRetry(Exception ex) =>
+            ((IsRetriableException(ex)) || (IsRetriableException(ex?.InnerException)));
+
+        private static bool IsRetriableException(Exception ex)
+        {
+            if (ex == null)
+            {
+                return false;
+            }
+
+            switch (ex)
+            {
+                case ErrorResponseException erEx:
+                    return IsRetriableStatus(erEx.Response.StatusCode);
+
+                case CloudException clEx:
+                    return IsRetriableStatus(clEx.Response.StatusCode);
+
+                case StorageException stEx:
+                    return IsRetriableStatus((HttpStatusCode)stEx.RequestInformation.HttpStatusCode);
+
+                case TimeoutException _:
+                case TaskCanceledException _:
+                case OperationCanceledException _:
+                case HttpRequestException _:
+                case WebException _:
+                case SocketException _:
+                case IOException _:
+                    return true;
+
+                default:
+                    return false;
+            };
+        }
 
         private static TimeSpan CalculateRetryDelay(int attempt, double exponentialBackoffSeconds, double baseJitterSeconds) =>
             TimeSpan.FromSeconds((Math.Pow(2, attempt) * exponentialBackoffSeconds) + (RandomNumberGenerator.Value.NextDouble() * baseJitterSeconds));


### PR DESCRIPTION
# Summary

The focus of these changes is to tweak the conditions for retries when creation of dynamic test infrastructure fails, based on observations of the failure details.   This pass also does some light code clean-up, in an attempt to improve quality and readability.

# Last Upstream Rebase

Monday, February 3, 8:51am (EST)
