### PR TITLE
Don't run ApiCompat for design time build

### DIFF
--- a/eng/Directory.Build.Data.targets
+++ b/eng/Directory.Build.Data.targets
@@ -126,7 +126,7 @@
            Text="When UseProjectReferenceToAzureClients=true all Azure.* references should be Project References, but the following are not [@(ShouldBeProjectReference)]" />
   </Target>
 
-   <Target Name="RunApiCompat" AfterTargets="CoreBuild" Condition="'$(EnableApiCompat)' == 'true'">
+   <Target Name="RunApiCompat" AfterTargets="CoreBuild" Condition="'$(EnableApiCompat)' == 'true' and '$(DesignTimeBuild)' != 'true'">
     <MSBuild
       Projects="$(MSBuildThisFileDirectory)/ApiCompat/ApiCompat.csproj"
       Properties="TargetPackageName=$(PackageId);TargetOutputPath=$(IntermediateOutputPath)"


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/9773