### PR TITLE
Error model Text Analytics

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -114,8 +114,7 @@ Run a Text Analytics predictive model to determine the language that the passed-
 ```C# Snippet:DetectLanguage
 string input = "Este documento está en español.";
 
-DetectLanguageResult result = client.DetectLanguage(input);
-DetectedLanguage language = result.PrimaryLanguage;
+DetectedLanguage language = client.DetectLanguage(input);
 
 Console.WriteLine($"Detected language {language.Name} with confidence {language.Score:0.00}.");
 ```
@@ -129,8 +128,7 @@ Run a Text Analytics predictive model to identify the positive, negative, neutra
 ```C# Snippet:AnalyzeSentiment
 string input = "That was the best day of my life!";
 
-AnalyzeSentimentResult result = client.AnalyzeSentiment(input);
-DocumentSentiment docSentiment = result.DocumentSentiment;
+DocumentSentiment docSentiment = client.AnalyzeSentiment(input);
 
 Console.WriteLine($"Sentiment was {docSentiment.Sentiment}, with scores: ");
 Console.WriteLine($"    Positive score: {docSentiment.SentimentScores.Positive:0.00}.");
@@ -147,8 +145,8 @@ Run a model to identify a collection of significant phrases found in the passed-
 ```C# Snippet:ExtractKeyPhrases
 string input = "My cat might need to see a veterinarian.";
 
-ExtractKeyPhrasesResult result = client.ExtractKeyPhrases(input);
-IReadOnlyCollection<string> keyPhrases = result.KeyPhrases;
+Response<IReadOnlyCollection<string>> response = client.ExtractKeyPhrases(input);
+IReadOnlyCollection<string> keyPhrases = response.Value;
 
 Console.WriteLine($"Extracted {keyPhrases.Count()} key phrases:");
 foreach (string keyPhrase in keyPhrases)
@@ -166,8 +164,8 @@ Run a predictive model to identify a collection of named entities in the passed-
 ```C# Snippet:RecognizeEntities
 string input = "Microsoft was founded by Bill Gates and Paul Allen.";
 
-RecognizeEntitiesResult result = client.RecognizeEntities(input);
-IReadOnlyCollection<CategorizedEntity> entities = result.Entities;
+Response<IReadOnlyCollection<CategorizedEntity>> response = client.RecognizeEntities(input);
+IReadOnlyCollection<CategorizedEntity> entities = response.Value;
 
 Console.WriteLine($"Recognized {entities.Count()} entities:");
 foreach (CategorizedEntity entity in entities)
@@ -185,8 +183,8 @@ Run a predictive model to identify a collection of entities containing Personall
 ```C# Snippet:RecognizePiiEntities
 string input = "A developer with SSN 555-55-5555 whose phone number is 555-555-5555 is building tools with our APIs.";
 
-RecognizePiiEntitiesResult result = client.RecognizePiiEntities(input);
-IReadOnlyCollection<PiiEntity> entities = result.Entities;
+Response<IReadOnlyCollection<PiiEntity>> response = client.RecognizePiiEntities(input);
+IReadOnlyCollection<PiiEntity> entities = response.Value;
 
 Console.WriteLine($"Recognized {entities.Count()} PII entit{(entities.Count() > 1 ? "ies" : "y")}:");
 foreach (PiiEntity entity in entities)
@@ -203,10 +201,11 @@ Run a predictive model to identify a collection of entities found in the passed-
 ```C# Snippet:RecognizeLinkedEntities
 string input = "Microsoft was founded by Bill Gates and Paul Allen.";
 
-RecognizeLinkedEntitiesResult result = client.RecognizeLinkedEntities(input);
+Response<IReadOnlyCollection<LinkedEntity>> response = client.RecognizeLinkedEntities(input);
+IReadOnlyCollection<LinkedEntity> linkedEntities = response.Value;
 
-Console.WriteLine($"Extracted {result.LinkedEntities.Count()} linked entit{(result.LinkedEntities.Count() > 1 ? "ies" : "y")}:");
-foreach (LinkedEntity linkedEntity in result.LinkedEntities)
+Console.WriteLine($"Extracted {linkedEntities.Count()} linked entit{(linkedEntities.Count() > 1 ? "ies" : "y")}:");
+foreach (LinkedEntity linkedEntity in linkedEntities)
 {
     Console.WriteLine($"Name: {linkedEntity.Name}, Id: {linkedEntity.Id}, Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}");
     foreach (LinkedEntityMatch match in linkedEntity.Matches)
@@ -225,8 +224,7 @@ Run a Text Analytics predictive model to determine the language that the passed-
 ```C# Snippet:DetectLanguageAsync
 string input = "Este documento está en español.";
 
-DetectLanguageResult result = await client.DetectLanguageAsync(input);
-DetectedLanguage language = result.PrimaryLanguage;
+DetectedLanguage language = await client.DetectLanguageAsync(input);
 
 Console.WriteLine($"Detected language {language.Name} with confidence {language.Score:0.00}.");
 ```
@@ -237,8 +235,8 @@ Run a predictive model to identify a collection of named entities in the passed-
 ```C# Snippet:RecognizeEntitiesAsync
 string input = "Microsoft was founded by Bill Gates and Paul Allen.";
 
-RecognizeEntitiesResult result = await client.RecognizeEntitiesAsync(input);
-IReadOnlyCollection<CategorizedEntity> entities = result.Entities;
+Response<IReadOnlyCollection<CategorizedEntity>> response = await client.RecognizeEntitiesAsync(input);
+IReadOnlyCollection<CategorizedEntity> entities = response.Value;
 
 Console.WriteLine($"Recognized {entities.Count()} entities:");
 foreach (CategorizedEntity entity in entities)
@@ -257,7 +255,7 @@ For example, if you submit a batch of text document inputs containing duplicate 
 ```C# Snippet:BadRequest
 try
 {
-    DetectLanguageResult result = client.DetectLanguage(input);
+    DetectedLanguage result = client.DetectLanguage(input);
 }
 catch (RequestFailedException e)
 {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -146,7 +146,7 @@ Run a model to identify a collection of significant phrases found in the passed-
 string input = "My cat might need to see a veterinarian.";
 
 Response<IReadOnlyCollection<string>> response = client.ExtractKeyPhrases(input);
-IReadOnlyCollection<string> keyPhrases = response.Value;
+IEnumerable<string> keyPhrases = response.Value;
 
 Console.WriteLine($"Extracted {keyPhrases.Count()} key phrases:");
 foreach (string keyPhrase in keyPhrases)
@@ -165,7 +165,7 @@ Run a predictive model to identify a collection of named entities in the passed-
 string input = "Microsoft was founded by Bill Gates and Paul Allen.";
 
 Response<IReadOnlyCollection<CategorizedEntity>> response = client.RecognizeEntities(input);
-IReadOnlyCollection<CategorizedEntity> entities = response.Value;
+IEnumerable<CategorizedEntity> entities = response.Value;
 
 Console.WriteLine($"Recognized {entities.Count()} entities:");
 foreach (CategorizedEntity entity in entities)
@@ -184,7 +184,7 @@ Run a predictive model to identify a collection of entities containing Personall
 string input = "A developer with SSN 555-55-5555 whose phone number is 555-555-5555 is building tools with our APIs.";
 
 Response<IReadOnlyCollection<PiiEntity>> response = client.RecognizePiiEntities(input);
-IReadOnlyCollection<PiiEntity> entities = response.Value;
+IEnumerable<PiiEntity> entities = response.Value;
 
 Console.WriteLine($"Recognized {entities.Count()} PII entit{(entities.Count() > 1 ? "ies" : "y")}:");
 foreach (PiiEntity entity in entities)
@@ -202,7 +202,7 @@ Run a predictive model to identify a collection of entities found in the passed-
 string input = "Microsoft was founded by Bill Gates and Paul Allen.";
 
 Response<IReadOnlyCollection<LinkedEntity>> response = client.RecognizeLinkedEntities(input);
-IReadOnlyCollection<LinkedEntity> linkedEntities = response.Value;
+IEnumerable<LinkedEntity> linkedEntities = response.Value;
 
 Console.WriteLine($"Extracted {linkedEntities.Count()} linked entit{(linkedEntities.Count() > 1 ? "ies" : "y")}:");
 foreach (LinkedEntity linkedEntity in linkedEntities)
@@ -236,7 +236,7 @@ Run a predictive model to identify a collection of named entities in the passed-
 string input = "Microsoft was founded by Bill Gates and Paul Allen.";
 
 Response<IReadOnlyCollection<CategorizedEntity>> response = await client.RecognizeEntitiesAsync(input);
-IReadOnlyCollection<CategorizedEntity> entities = response.Value;
+IEnumerable<CategorizedEntity> entities = response.Value;
 
 Console.WriteLine($"Recognized {entities.Count()} entities:");
 foreach (CategorizedEntity entity in entities)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample1_DetectLanguage.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample1_DetectLanguage.md
@@ -19,8 +19,7 @@ To detect the language of a single text input, pass the input string to the clie
 ```C# Snippet:DetectLanguage
 string input = "Este documento está en español.";
 
-DetectLanguageResult result = client.DetectLanguage(input);
-DetectedLanguage language = result.PrimaryLanguage;
+DetectedLanguage language = client.DetectLanguage(input);
 
 Console.WriteLine($"Detected language {language.Name} with confidence {language.Score:0.00}.");
 ```

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample2_AnalyzeSentiment.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample2_AnalyzeSentiment.md
@@ -19,8 +19,7 @@ To analyze the sentiment of a single text input, pass the input string to the cl
 ```C# Snippet:AnalyzeSentiment
 string input = "That was the best day of my life!";
 
-AnalyzeSentimentResult result = client.AnalyzeSentiment(input);
-DocumentSentiment docSentiment = result.DocumentSentiment;
+DocumentSentiment docSentiment = client.AnalyzeSentiment(input);
 
 Console.WriteLine($"Sentiment was {docSentiment.Sentiment}, with scores: ");
 Console.WriteLine($"    Positive score: {docSentiment.SentimentScores.Positive:0.00}.");

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample3_ExtractKeyPhrases.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample3_ExtractKeyPhrases.md
@@ -19,8 +19,8 @@ To extract key phrases from a single text input, pass the input string to the cl
 ```C# Snippet:ExtractKeyPhrases
 string input = "My cat might need to see a veterinarian.";
 
-ExtractKeyPhrasesResult result = client.ExtractKeyPhrases(input);
-IReadOnlyCollection<string> keyPhrases = result.KeyPhrases;
+Response<IReadOnlyCollection<string>> response = client.ExtractKeyPhrases(input);
+IReadOnlyCollection<string> keyPhrases = response.Value;
 
 Console.WriteLine($"Extracted {keyPhrases.Count()} key phrases:");
 foreach (string keyPhrase in keyPhrases)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample3_ExtractKeyPhrases.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample3_ExtractKeyPhrases.md
@@ -20,7 +20,7 @@ To extract key phrases from a single text input, pass the input string to the cl
 string input = "My cat might need to see a veterinarian.";
 
 Response<IReadOnlyCollection<string>> response = client.ExtractKeyPhrases(input);
-IReadOnlyCollection<string> keyPhrases = response.Value;
+IEnumerable<string> keyPhrases = response.Value;
 
 Console.WriteLine($"Extracted {keyPhrases.Count()} key phrases:");
 foreach (string keyPhrase in keyPhrases)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample4_RecognizeEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample4_RecognizeEntities.md
@@ -19,7 +19,7 @@ To recognize entities in a single text input, pass the input string to the clien
 string input = "Microsoft was founded by Bill Gates and Paul Allen.";
 
 Response<IReadOnlyCollection<CategorizedEntity>> response = client.RecognizeEntities(input);
-IReadOnlyCollection<CategorizedEntity> entities = response.Value;
+IEnumerable<CategorizedEntity> entities = response.Value;
 
 Console.WriteLine($"Recognized {entities.Count()} entities:");
 foreach (CategorizedEntity entity in entities)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample4_RecognizeEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample4_RecognizeEntities.md
@@ -18,8 +18,8 @@ To recognize entities in a single text input, pass the input string to the clien
 ```C# Snippet:RecognizeEntities
 string input = "Microsoft was founded by Bill Gates and Paul Allen.";
 
-RecognizeEntitiesResult result = client.RecognizeEntities(input);
-IReadOnlyCollection<CategorizedEntity> entities = result.Entities;
+Response<IReadOnlyCollection<CategorizedEntity>> response = client.RecognizeEntities(input);
+IReadOnlyCollection<CategorizedEntity> entities = response.Value;
 
 Console.WriteLine($"Recognized {entities.Count()} entities:");
 foreach (CategorizedEntity entity in entities)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample5_RecognizePiiEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample5_RecognizePiiEntities.md
@@ -18,8 +18,8 @@ To recognize Personally Identifiable Information in a single text input, pass th
 ```C# Snippet:RecognizePiiEntities
 string input = "A developer with SSN 555-55-5555 whose phone number is 555-555-5555 is building tools with our APIs.";
 
-RecognizePiiEntitiesResult result = client.RecognizePiiEntities(input);
-IReadOnlyCollection<PiiEntity> entities = result.Entities;
+Response<IReadOnlyCollection<PiiEntity>> response = client.RecognizePiiEntities(input);
+IReadOnlyCollection<PiiEntity> entities = response.Value;
 
 Console.WriteLine($"Recognized {entities.Count()} PII entit{(entities.Count() > 1 ? "ies" : "y")}:");
 foreach (PiiEntity entity in entities)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample5_RecognizePiiEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample5_RecognizePiiEntities.md
@@ -19,7 +19,7 @@ To recognize Personally Identifiable Information in a single text input, pass th
 string input = "A developer with SSN 555-55-5555 whose phone number is 555-555-5555 is building tools with our APIs.";
 
 Response<IReadOnlyCollection<PiiEntity>> response = client.RecognizePiiEntities(input);
-IReadOnlyCollection<PiiEntity> entities = response.Value;
+IEnumerable<PiiEntity> entities = response.Value;
 
 Console.WriteLine($"Recognized {entities.Count()} PII entit{(entities.Count() > 1 ? "ies" : "y")}:");
 foreach (PiiEntity entity in entities)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
@@ -19,7 +19,7 @@ To recognize linked entities in a single text input, pass the input string to th
 string input = "Microsoft was founded by Bill Gates and Paul Allen.";
 
 Response<IReadOnlyCollection<LinkedEntity>> response = client.RecognizeLinkedEntities(input);
-IReadOnlyCollection<LinkedEntity> linkedEntities = response.Value;
+IEnumerable<LinkedEntity> linkedEntities = response.Value;
 
 Console.WriteLine($"Extracted {linkedEntities.Count()} linked entit{(linkedEntities.Count() > 1 ? "ies" : "y")}:");
 foreach (LinkedEntity linkedEntity in linkedEntities)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
@@ -18,10 +18,11 @@ To recognize linked entities in a single text input, pass the input string to th
 ```C# Snippet:RecognizeLinkedEntities
 string input = "Microsoft was founded by Bill Gates and Paul Allen.";
 
-RecognizeLinkedEntitiesResult result = client.RecognizeLinkedEntities(input);
+Response<IReadOnlyCollection<LinkedEntity>> response = client.RecognizeLinkedEntities(input);
+IReadOnlyCollection<LinkedEntity> linkedEntities = response.Value;
 
-Console.WriteLine($"Extracted {result.LinkedEntities.Count()} linked entit{(result.LinkedEntities.Count() > 1 ? "ies" : "y")}:");
-foreach (LinkedEntity linkedEntity in result.LinkedEntities)
+Console.WriteLine($"Extracted {linkedEntities.Count()} linked entit{(linkedEntities.Count() > 1 ? "ies" : "y")}:");
+foreach (LinkedEntity linkedEntity in linkedEntities)
 {
     Console.WriteLine($"Name: {linkedEntity.Name}, Id: {linkedEntity.Id}, Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}");
     foreach (LinkedEntityMatch match in linkedEntity.Matches)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/AnalyzeSentimentResult.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 namespace Azure.AI.TextAnalytics
 {
@@ -14,17 +12,31 @@ namespace Azure.AI.TextAnalytics
     /// </summary>
     public class AnalyzeSentimentResult : TextAnalyticsResult
     {
+        private readonly DocumentSentiment _documentSentiment;
+
         internal AnalyzeSentimentResult(string id, TextDocumentStatistics statistics, DocumentSentiment documentSentiment)
             : base(id, statistics)
         {
-            DocumentSentiment = documentSentiment;
+            _documentSentiment = documentSentiment;
         }
 
-        internal AnalyzeSentimentResult(string id, string errorMessage) : base(id, errorMessage) { }
+        internal AnalyzeSentimentResult(string id, TextAnalyticsError error) : base(id, error) { }
 
         /// <summary>
         /// Gets the predicted sentiment for the full document.
         /// </summary>
-        public DocumentSentiment DocumentSentiment { get; }
+        public DocumentSentiment DocumentSentiment
+        {
+            get
+            {
+                if (HasError)
+                {
+#pragma warning disable CA1065 // Do not raise exceptions in unexpected locations
+                    throw new InvalidOperationException($"Cannot access result for this document, due to error {Error.Code}: {Error.Message}");
+#pragma warning restore CA1065 // Do not raise exceptions in unexpected locations
+                }
+                return _documentSentiment;
+            }
+        }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/DetectLanguageResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/DetectLanguageResult.cs
@@ -2,9 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
 
 namespace Azure.AI.TextAnalytics
 {
@@ -14,17 +11,31 @@ namespace Azure.AI.TextAnalytics
     /// </summary>
     public class DetectLanguageResult : TextAnalyticsResult
     {
+        private readonly DetectedLanguage _primaryLanguage;
+
         internal DetectLanguageResult(string id, TextDocumentStatistics statistics, DetectedLanguage detectedLanguage)
             : base(id, statistics)
         {
-            PrimaryLanguage = detectedLanguage;
+            _primaryLanguage = detectedLanguage;
         }
 
-        internal DetectLanguageResult(string id, string errorMessage) : base(id, errorMessage) { }
+        internal DetectLanguageResult(string id, TextAnalyticsError error) : base(id, error) { }
 
         /// <summary>
         /// The primary language detected in the document.
         /// </summary>
-        public DetectedLanguage PrimaryLanguage { get; }
+        public DetectedLanguage PrimaryLanguage
+        {
+            get
+            {
+                if (HasError)
+                {
+#pragma warning disable CA1065 // Do not raise exceptions in unexpected locations
+                    throw new InvalidOperationException($"Cannot access result for this document, due to error {Error.Code}: {Error.Message}");
+#pragma warning restore CA1065 // Do not raise exceptions in unexpected locations
+                }
+                return _primaryLanguage;
+            }
+        }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractKeyPhrasesResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractKeyPhrasesResult.cs
@@ -13,21 +13,31 @@ namespace Azure.AI.TextAnalytics
     /// </summary>
     public class ExtractKeyPhrasesResult : TextAnalyticsResult
     {
+        private readonly IReadOnlyCollection<string> _keyPhrases;
+
         internal ExtractKeyPhrasesResult(string id, TextDocumentStatistics statistics, IList<string> keyPhrases)
             : base(id, statistics)
         {
-            KeyPhrases = new ReadOnlyCollection<string>(keyPhrases);
+            _keyPhrases = new ReadOnlyCollection<string>(keyPhrases);
         }
 
-        internal ExtractKeyPhrasesResult(string id, string errorMessage)
-            : base(id, errorMessage)
-        {
-            KeyPhrases = Array.Empty<string>();
-        }
+        internal ExtractKeyPhrasesResult(string id, TextAnalyticsError error) : base(id, error) { }
 
         /// <summary>
         /// Gets the collection of key phrases identified in the input document.
         /// </summary>
-        public IReadOnlyCollection<string> KeyPhrases { get; }
+        public IReadOnlyCollection<string> KeyPhrases
+        {
+            get
+            {
+                if (HasError)
+                {
+#pragma warning disable CA1065 // Do not raise exceptions in unexpected locations
+                    throw new InvalidOperationException($"Cannot access result for this document, due to error {Error.Code}: {Error.Message}");
+#pragma warning restore CA1065 // Do not raise exceptions in unexpected locations
+                }
+                return _keyPhrases;
+            }
+        }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeEntitiesResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeEntitiesResult.cs
@@ -14,21 +14,31 @@ namespace Azure.AI.TextAnalytics
     /// </summary>
     public class RecognizeEntitiesResult : TextAnalyticsResult
     {
+        private readonly IReadOnlyCollection<CategorizedEntity> _entities;
+
         internal RecognizeEntitiesResult(string id, TextDocumentStatistics statistics, IList<CategorizedEntity> entities)
             : base(id, statistics)
         {
-            Entities = new ReadOnlyCollection<CategorizedEntity>(entities);
+            _entities = new ReadOnlyCollection<CategorizedEntity>(entities);
         }
 
-        internal RecognizeEntitiesResult(string id, string errorMessage)
-            : base(id, errorMessage)
-        {
-            Entities = Array.Empty<CategorizedEntity>();
-        }
+        internal RecognizeEntitiesResult(string id, TextAnalyticsError error) : base(id, error) { }
 
         /// <summary>
         /// Gets the collection of named entities identified in the input document.
         /// </summary>
-        public IReadOnlyCollection<CategorizedEntity> Entities { get; }
+        public IReadOnlyCollection<CategorizedEntity> Entities
+        {
+            get
+            {
+                if (HasError)
+                {
+#pragma warning disable CA1065 // Do not raise exceptions in unexpected locations
+                    throw new InvalidOperationException($"Cannot access result for this document, due to error {Error.Code}: {Error.Message}");
+#pragma warning restore CA1065 // Do not raise exceptions in unexpected locations
+                }
+                return _entities;
+            }
+        }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeLinkedEntitiesResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeLinkedEntitiesResult.cs
@@ -14,21 +14,31 @@ namespace Azure.AI.TextAnalytics
     /// </summary>
     public class RecognizeLinkedEntitiesResult : TextAnalyticsResult
     {
+        private readonly IReadOnlyCollection<LinkedEntity> _linkedEntities;
+
         internal RecognizeLinkedEntitiesResult(string id, TextDocumentStatistics statistics, IList<LinkedEntity> linkedEntities)
             : base(id, statistics)
         {
-            LinkedEntities = new ReadOnlyCollection<LinkedEntity>(linkedEntities);
+            _linkedEntities = new ReadOnlyCollection<LinkedEntity>(linkedEntities);
         }
 
-        internal RecognizeLinkedEntitiesResult(string id, string errorMessage)
-            : base(id, errorMessage)
-        {
-            LinkedEntities = Array.Empty<LinkedEntity>();
-        }
+        internal RecognizeLinkedEntitiesResult(string id, TextAnalyticsError error) : base(id, error) { }
 
         /// <summary>
         /// Gets the collection of linked entities identified in the input document.
         /// </summary>
-        public IReadOnlyCollection<LinkedEntity> LinkedEntities { get; }
+        public IReadOnlyCollection<LinkedEntity> Entities
+        {
+            get
+            {
+                if (HasError)
+                {
+#pragma warning disable CA1065 // Do not raise exceptions in unexpected locations
+                    throw new InvalidOperationException($"Cannot access result for this document, due to error {Error.Code}: {Error.Message}");
+#pragma warning restore CA1065 // Do not raise exceptions in unexpected locations
+                }
+                return _linkedEntities;
+            }
+        }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizePiiEntitiesResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizePiiEntitiesResult.cs
@@ -15,22 +15,32 @@ namespace Azure.AI.TextAnalytics
     /// </summary>
     public class RecognizePiiEntitiesResult : TextAnalyticsResult
     {
+        private readonly IReadOnlyCollection<PiiEntity> _entities;
+
         internal RecognizePiiEntitiesResult(string id, TextDocumentStatistics statistics, IList<PiiEntity> entities)
             : base(id, statistics)
         {
-            Entities = new ReadOnlyCollection<PiiEntity>(entities);
+            _entities = new ReadOnlyCollection<PiiEntity>(entities);
         }
 
-        internal RecognizePiiEntitiesResult(string id, string errorMessage)
-            : base(id, errorMessage)
-        {
-            Entities = Array.Empty<PiiEntity>();
-        }
+        internal RecognizePiiEntitiesResult(string id, TextAnalyticsError error) : base(id, error) { }
 
         /// <summary>
         /// Gets the collection of PII entities containing Personally
         /// Identifiable Information in the input document.
         /// </summary>
-        public IReadOnlyCollection<PiiEntity> Entities { get; }
+        public IReadOnlyCollection<PiiEntity> Entities
+        {
+            get
+            {
+                if (HasError)
+                {
+#pragma warning disable CA1065 // Do not raise exceptions in unexpected locations
+                    throw new InvalidOperationException($"Cannot access result for this document, due to error {Error.Code}: {Error.Message}");
+#pragma warning restore CA1065 // Do not raise exceptions in unexpected locations
+                }
+                return _entities;
+            }
+        }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
@@ -127,7 +127,7 @@ namespace Azure.AI.TextAnalytics
         /// the model could not analyze the input text.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<DetectLanguageResult>> DetectLanguageAsync(string inputText, string countryHint = default, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<DetectedLanguage>> DetectLanguageAsync(string inputText, string countryHint = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(inputText, nameof(inputText));
 
@@ -146,12 +146,13 @@ namespace Azure.AI.TextAnalytics
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(inputs);
                         DetectLanguageResultCollection result = await CreateDetectLanguageResponseAsync(response, map, cancellationToken).ConfigureAwait(false);
-                        if (result[0].ErrorMessage != default)
+                        if (result[0].HasError)
                         {
                             // only one input, so we can ignore the id and grab the first error message.
-                            throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response, result[0].ErrorMessage).ConfigureAwait(false);
+                            TextAnalyticsError error = result[0].Error;
+                            throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response, error.Message, error.Code, CreateAdditionalInformation(error)).ConfigureAwait(false);
                         }
-                        return Response.FromValue(result[0], response);
+                        return Response.FromValue(result[0].PrimaryLanguage, response);
                     default:
                         throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response).ConfigureAwait(false);
                 }
@@ -184,7 +185,7 @@ namespace Azure.AI.TextAnalytics
         /// the model could not analyze the input text.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<DetectLanguageResult> DetectLanguage(string inputText, string countryHint = default, CancellationToken cancellationToken = default)
+        public virtual Response<DetectedLanguage> DetectLanguage(string inputText, string countryHint = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(inputText, nameof(inputText));
 
@@ -203,12 +204,13 @@ namespace Azure.AI.TextAnalytics
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(inputs);
                         DetectLanguageResultCollection result = CreateDetectLanguageResponse(response, map);
-                        if (result[0].ErrorMessage != default)
+                        if (result[0].HasError)
                         {
                             // only one input, so we can ignore the id and grab the first error message.
-                            throw _clientDiagnostics.CreateRequestFailedException(response, result[0].ErrorMessage);
+                            TextAnalyticsError error = result[0].Error;
+                            throw _clientDiagnostics.CreateRequestFailedException(response, error.Message, error.Code, CreateAdditionalInformation(error));
                         }
-                        return Response.FromValue(result[0], response);
+                        return Response.FromValue(result[0].PrimaryLanguage, response);
                     default:
                         throw _clientDiagnostics.CreateRequestFailedException(response);
                 }
@@ -406,7 +408,7 @@ namespace Azure.AI.TextAnalytics
         /// that the entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<RecognizeEntitiesResult>> RecognizeEntitiesAsync(string inputText, string language = default, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<IReadOnlyCollection<CategorizedEntity>>> RecognizeEntitiesAsync(string inputText, string language = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(inputText, nameof(inputText));
 
@@ -425,12 +427,13 @@ namespace Azure.AI.TextAnalytics
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(inputs);
                         RecognizeEntitiesResultCollection results = await CreateRecognizeEntitiesResponseAsync(response, map, cancellationToken).ConfigureAwait(false);
-                        if (results[0].ErrorMessage != default)
+                        if (results[0].HasError)
                         {
                             // only one input, so we can ignore the id and grab the first error message.
-                            throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response, results[0].ErrorMessage).ConfigureAwait(false);
+                            TextAnalyticsError error = results[0].Error;
+                            throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response, error.Message, error.Code, CreateAdditionalInformation(error)).ConfigureAwait(false);
                         }
-                        return Response.FromValue(results[0], response);
+                        return Response.FromValue((IReadOnlyCollection<CategorizedEntity>)results[0].Entities, response);
                     default:
                         throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response).ConfigureAwait(false);
                 }
@@ -464,7 +467,7 @@ namespace Azure.AI.TextAnalytics
         /// that the entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<RecognizeEntitiesResult> RecognizeEntities(string inputText, string language = default, CancellationToken cancellationToken = default)
+        public virtual Response<IReadOnlyCollection<CategorizedEntity>> RecognizeEntities(string inputText, string language = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(inputText, nameof(inputText));
 
@@ -483,12 +486,13 @@ namespace Azure.AI.TextAnalytics
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(inputs);
                         RecognizeEntitiesResultCollection results = CreateRecognizeEntitiesResponse(response, map);
-                        if (results[0].ErrorMessage != default)
+                        if (results[0].HasError)
                         {
                             // only one input, so we can ignore the id and grab the first error message.
-                            throw _clientDiagnostics.CreateRequestFailedException(response, results[0].ErrorMessage);
+                            TextAnalyticsError error = results[0].Error;
+                            throw _clientDiagnostics.CreateRequestFailedException(response, error.Message, error.Code, CreateAdditionalInformation(error));
                         }
-                        return Response.FromValue(results[0], response);
+                        return Response.FromValue((IReadOnlyCollection<CategorizedEntity>)results[0].Entities, response);
                     default:
                         throw _clientDiagnostics.CreateRequestFailedException(response);
                 }
@@ -689,7 +693,7 @@ namespace Azure.AI.TextAnalytics
         /// and each of the sentences it contains.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<AnalyzeSentimentResult>> AnalyzeSentimentAsync(string inputText, string language = default, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<DocumentSentiment>> AnalyzeSentimentAsync(string inputText, string language = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(inputText, nameof(inputText));
 
@@ -708,12 +712,13 @@ namespace Azure.AI.TextAnalytics
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(inputs);
                         AnalyzeSentimentResultCollection results = await CreateAnalyzeSentimentResponseAsync(response, map, cancellationToken).ConfigureAwait(false);
-                        if (results[0].ErrorMessage != default)
+                        if (results[0].HasError)
                         {
                             // only one input, so we can ignore the id and grab the first error message.
-                            throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response, results[0].ErrorMessage).ConfigureAwait(false);
+                            TextAnalyticsError error = results[0].Error;
+                            throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response, error.Message, error.Code, CreateAdditionalInformation(error)).ConfigureAwait(false);
                         }
-                        return Response.FromValue(results[0], response);
+                        return Response.FromValue(results[0].DocumentSentiment, response);
                     default:
                         throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response).ConfigureAwait(false);
                 }
@@ -744,7 +749,7 @@ namespace Azure.AI.TextAnalytics
         /// and each of the sentences it contains.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<AnalyzeSentimentResult> AnalyzeSentiment(string inputText, string language = default, CancellationToken cancellationToken = default)
+        public virtual Response<DocumentSentiment> AnalyzeSentiment(string inputText, string language = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(inputText, nameof(inputText));
 
@@ -763,12 +768,13 @@ namespace Azure.AI.TextAnalytics
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(inputs);
                         AnalyzeSentimentResultCollection results = CreateAnalyzeSentimentResponse(response, map);
-                        if (results[0].ErrorMessage != default)
+                        if (results[0].HasError)
                         {
                             // only one input, so we can ignore the id and grab the first error message.
-                            throw _clientDiagnostics.CreateRequestFailedException(response, results[0].ErrorMessage);
+                            TextAnalyticsError error = results[0].Error;
+                            throw _clientDiagnostics.CreateRequestFailedException(response, error.Message, error.Code, CreateAdditionalInformation(error));
                         }
-                        return Response.FromValue(results[0], response);
+                        return Response.FromValue(results[0].DocumentSentiment, response);
                     default:
                         throw _clientDiagnostics.CreateRequestFailedException(response);
                 }
@@ -956,7 +962,7 @@ namespace Azure.AI.TextAnalytics
         /// in the input text.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<ExtractKeyPhrasesResult>> ExtractKeyPhrasesAsync(string inputText, string language = default, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<IReadOnlyCollection<string>>> ExtractKeyPhrasesAsync(string inputText, string language = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(inputText, nameof(inputText));
 
@@ -974,13 +980,14 @@ namespace Azure.AI.TextAnalytics
                 {
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(inputs);
-                        ExtractKeyPhrasesResultCollection result = await CreateKeyPhraseResponseAsync(response, map, cancellationToken).ConfigureAwait(false);
-                        if (result[0].ErrorMessage != default)
+                        ExtractKeyPhrasesResultCollection results = await CreateKeyPhraseResponseAsync(response, map, cancellationToken).ConfigureAwait(false);
+                        if (results[0].HasError)
                         {
                             // only one input, so we can ignore the id and grab the first error message.
-                            throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response, result[0].ErrorMessage).ConfigureAwait(false);
+                            TextAnalyticsError error = results[0].Error;
+                            throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response, error.Message, error.Code, CreateAdditionalInformation(error)).ConfigureAwait(false);
                         }
-                        return Response.FromValue(result[0], response);
+                        return Response.FromValue((IReadOnlyCollection<string>)results[0].KeyPhrases, response);
                     default:
                         throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response).ConfigureAwait(false);
                 }
@@ -1010,7 +1017,7 @@ namespace Azure.AI.TextAnalytics
         /// in the input text.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<ExtractKeyPhrasesResult> ExtractKeyPhrases(string inputText, string language = default, CancellationToken cancellationToken = default)
+        public virtual Response<IReadOnlyCollection<string>> ExtractKeyPhrases(string inputText, string language = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(inputText, nameof(inputText));
 
@@ -1028,13 +1035,14 @@ namespace Azure.AI.TextAnalytics
                 {
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(inputs);
-                        ExtractKeyPhrasesResultCollection result = CreateKeyPhraseResponse(response, map);
-                        if (result[0].ErrorMessage != default)
+                        ExtractKeyPhrasesResultCollection results = CreateKeyPhraseResponse(response, map);
+                        if (results[0].HasError)
                         {
                             // only one input, so we can ignore the id and grab the first error message.
-                            throw _clientDiagnostics.CreateRequestFailedException(response, result[0].ErrorMessage);
+                            TextAnalyticsError error = results[0].Error;
+                            throw _clientDiagnostics.CreateRequestFailedException(response, error.Message, error.Code, CreateAdditionalInformation(error));
                         }
-                        return Response.FromValue(result[0], response);
+                        return Response.FromValue((IReadOnlyCollection<string>)results[0].KeyPhrases, response);
                     default:
                         throw _clientDiagnostics.CreateRequestFailedException(response);
                 }
@@ -1221,7 +1229,7 @@ namespace Azure.AI.TextAnalytics
         /// that the entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<RecognizePiiEntitiesResult>> RecognizePiiEntitiesAsync(string inputText, string language = default, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<IReadOnlyCollection<PiiEntity>>> RecognizePiiEntitiesAsync(string inputText, string language = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(inputText, nameof(inputText));
 
@@ -1240,12 +1248,13 @@ namespace Azure.AI.TextAnalytics
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(inputs);
                         RecognizePiiEntitiesResultCollection results = await CreateRecognizePiiEntitiesResponseAsync(response, map, cancellationToken).ConfigureAwait(false);
-                        if (results[0].ErrorMessage != default)
+                        if (results[0].HasError)
                         {
                             // only one input, so we can ignore the id and grab the first error message.
-                            throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response, results[0].ErrorMessage).ConfigureAwait(false);
+                            TextAnalyticsError error = results[0].Error;
+                            throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response, error.Message, error.Code, CreateAdditionalInformation(error)).ConfigureAwait(false);
                         }
-                        return Response.FromValue(results[0], response);
+                        return Response.FromValue((IReadOnlyCollection<PiiEntity>)results[0].Entities, response);
                     default:
                         throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response).ConfigureAwait(false);
                 }
@@ -1278,7 +1287,7 @@ namespace Azure.AI.TextAnalytics
         /// that the entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<RecognizePiiEntitiesResult> RecognizePiiEntities(string inputText, string language = default, CancellationToken cancellationToken = default)
+        public virtual Response<IReadOnlyCollection<PiiEntity>> RecognizePiiEntities(string inputText, string language = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(inputText, nameof(inputText));
 
@@ -1297,12 +1306,13 @@ namespace Azure.AI.TextAnalytics
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(inputs);
                         RecognizePiiEntitiesResultCollection results = CreateRecognizePiiEntitiesResponse(response, map);
-                        if (results[0].ErrorMessage != default)
+                        if (results[0].HasError)
                         {
                             // only one input, so we can ignore the id and grab the first error message.
-                            throw _clientDiagnostics.CreateRequestFailedException(response, results[0].ErrorMessage);
+                            TextAnalyticsError error = results[0].Error;
+                            throw _clientDiagnostics.CreateRequestFailedException(response, error.Message, error.Code, CreateAdditionalInformation(error));
                         }
-                        return Response.FromValue(results[0], response);
+                        return Response.FromValue((IReadOnlyCollection<PiiEntity>)results[0].Entities, response);
                     default:
                         throw _clientDiagnostics.CreateRequestFailedException(response);
                 }
@@ -1500,7 +1510,7 @@ namespace Azure.AI.TextAnalytics
         /// that the entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<RecognizeLinkedEntitiesResult>> RecognizeLinkedEntitiesAsync(string inputText, string language = default, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<IReadOnlyCollection<LinkedEntity>>> RecognizeLinkedEntitiesAsync(string inputText, string language = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(inputText, nameof(inputText));
 
@@ -1518,13 +1528,14 @@ namespace Azure.AI.TextAnalytics
                 {
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(inputs);
-                        RecognizeLinkedEntitiesResultCollection result = await CreateLinkedEntityResponseAsync(response, map, cancellationToken).ConfigureAwait(false);
-                        if (result[0].ErrorMessage != default)
+                        RecognizeLinkedEntitiesResultCollection results = await CreateLinkedEntityResponseAsync(response, map, cancellationToken).ConfigureAwait(false);
+                        if (results[0].HasError)
                         {
                             // only one input, so we can ignore the id and grab the first error message.
-                            throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response, result[0].ErrorMessage).ConfigureAwait(false);
+                            TextAnalyticsError error = results[0].Error;
+                            throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response, error.Message, error.Code, CreateAdditionalInformation(error)).ConfigureAwait(false);
                         }
-                        return Response.FromValue(result[0], response);
+                        return Response.FromValue((IReadOnlyCollection<LinkedEntity>)results[0].Entities, response);
                     default:
                         throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response).ConfigureAwait(false);
                 }
@@ -1556,7 +1567,7 @@ namespace Azure.AI.TextAnalytics
         /// that the entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<RecognizeLinkedEntitiesResult> RecognizeLinkedEntities(string inputText, string language = default, CancellationToken cancellationToken = default)
+        public virtual Response<IReadOnlyCollection<LinkedEntity>> RecognizeLinkedEntities(string inputText, string language = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(inputText, nameof(inputText));
 
@@ -1575,12 +1586,13 @@ namespace Azure.AI.TextAnalytics
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(inputs);
                         RecognizeLinkedEntitiesResultCollection results = CreateLinkedEntityResponse(response, map);
-                        if (results[0].ErrorMessage != default)
+                        if (results[0].HasError)
                         {
                             // only one input, so we can ignore the id and grab the first error message.
-                            throw _clientDiagnostics.CreateRequestFailedException(response, results[0].ErrorMessage);
+                            TextAnalyticsError error = results[0].Error;
+                            throw _clientDiagnostics.CreateRequestFailedException(response, error.Message, error.Code, CreateAdditionalInformation(error));
                         }
-                        return Response.FromValue(results[0], response);
+                        return Response.FromValue((IReadOnlyCollection<LinkedEntity>)results[0].Entities, response);
                     default:
                         throw _clientDiagnostics.CreateRequestFailedException(response);
                 }
@@ -1814,6 +1826,13 @@ namespace Azure.AI.TextAnalytics
             request.Content = RequestContent.Create(content);
 
             return request;
+        }
+
+        private IDictionary<string,string> CreateAdditionalInformation(TextAnalyticsError error)
+        {
+            if (string.IsNullOrEmpty(error.Target))
+                return null;
+            return new Dictionary<string, string> { { "Target", error.Target } };
         }
         #endregion
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsError.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsError.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.AI.TextAnalytics
+{
+    /// <summary>
+    /// Text Analitics Error.
+    /// </summary>
+    public struct TextAnalyticsError
+    {
+        internal TextAnalyticsError(string code, string message, string target = null)
+        {
+            Code = code;
+            Message = message;
+            Target = target;
+        }
+
+        /// <summary>
+        /// Error code that serves as an indicator of the HTTP error code.
+        /// </summary>
+        public string Code { get; }
+
+        /// <summary>
+        /// Message that contains more information about the reason of the error.
+        /// </summary>
+        public string Message { get; }
+
+        /// <summary>
+        /// Target of the particular error (e.g. the name of
+        /// the property in error).
+        /// </summary>
+        public string Target { get; }
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsResult.cs
@@ -6,7 +6,7 @@ namespace Azure.AI.TextAnalytics
     /// <summary>
     /// Base type for results of text analytics operations corresponding to a
     /// single input document.  If the operation is unsuccessful, the Id and
-    /// ErrorMessage fields will be populated, but not others.
+    /// Error properties will be populated, but not others.
     /// </summary>
     public class TextAnalyticsResult
     {
@@ -16,10 +16,10 @@ namespace Azure.AI.TextAnalytics
             Statistics = statistics;
         }
 
-        internal TextAnalyticsResult(string id, string errorMessage)
+        internal TextAnalyticsResult(string id, TextAnalyticsError error)
         {
             Id = id;
-            ErrorMessage = errorMessage;
+            Error = error;
         }
 
         /// <summary>
@@ -36,10 +36,15 @@ namespace Azure.AI.TextAnalytics
         public TextDocumentStatistics Statistics { get; }
 
         /// <summary>
-        /// Gets the error message explaining why the operation failed on this
-        /// document.  This property will have a value only when the document
+        /// Gets the error explaining why the operation failed on this
+        /// input text. This property will have a value only when the input text
         /// cannot be processed.
         /// </summary>
-        public string ErrorMessage { get; }
+        public TextAnalyticsError Error { get; }
+
+        /// <summary>
+        /// Indicates that the input text was not successfully processed and an error was returned for this document.
+        /// </summary>
+        public bool HasError => Error.Code != default;
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/AnalyzeSentimentBatchWithErrorTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/AnalyzeSentimentBatchWithErrorTest.json
@@ -1,0 +1,115 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://westus2.api.cognitive.microsoft.com/text/analytics/v3.0-preview.1/sentiment",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "207",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3c088f34cad9aa479cbb8cdaf3065e43-91e060011a6f9b42-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200205.1\u002Bf8d73daa11c41f2bc0e09182d73b8ba9b5a9b924",
+          "(.NET Core 4.6.28207.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "1b52db9847c2d4b48a2b88ff8bb0f502",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "language": "en",
+            "id": "0",
+            "text": "That was the best day of my life!"
+          },
+          {
+            "language": "en",
+            "id": "1",
+            "text": ""
+          },
+          {
+            "language": "en",
+            "id": "2",
+            "text": "I\u0027m not sure how I feel about this product."
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1f2fecd7-60bf-406b-9ff3-1b86243a8d22",
+        "Content-Type": "application/json; charset=utf-8",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2",
+        "Date": "Thu, 06 Feb 2020 04:36:04 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "70"
+      },
+      "ResponseBody": {
+        "documents": [
+          {
+            "id": "0",
+            "sentiment": "positive",
+            "documentScores": {
+              "positive": 1.0,
+              "neutral": 0.0,
+              "negative": 0.0
+            },
+            "sentences": [
+              {
+                "sentiment": "positive",
+                "sentenceScores": {
+                  "positive": 1.0,
+                  "neutral": 0.0,
+                  "negative": 0.0
+                },
+                "offset": 0,
+                "length": 33
+              }
+            ]
+          },
+          {
+            "id": "2",
+            "sentiment": "neutral",
+            "documentScores": {
+              "positive": 0.02,
+              "neutral": 0.85,
+              "negative": 0.13
+            },
+            "sentences": [
+              {
+                "sentiment": "neutral",
+                "sentenceScores": {
+                  "positive": 0.02,
+                  "neutral": 0.85,
+                  "negative": 0.13
+                },
+                "offset": 0,
+                "length": 43
+              }
+            ]
+          }
+        ],
+        "errors": [
+          {
+            "id": "1",
+            "error": {
+              "code": "InvalidArgument",
+              "innerError": {
+                "code": "InvalidDocument",
+                "message": "Document text is empty."
+              },
+              "message": "Invalid document in request."
+            }
+          }
+        ],
+        "modelVersion": "2019-10-01"
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1415988774",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://westus2.api.cognitive.microsoft.com/"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/AnalyzeSentimentBatchWithErrorTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/AnalyzeSentimentBatchWithErrorTestAsync.json
@@ -1,0 +1,115 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://westus2.api.cognitive.microsoft.com/text/analytics/v3.0-preview.1/sentiment",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "207",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-8601ee8914e12849bb5220163f4bad78-319cf49bbfd15144-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200205.1\u002Bf8d73daa11c41f2bc0e09182d73b8ba9b5a9b924",
+          "(.NET Core 4.6.28207.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "d5e2753fdde06b0a3d579c4aa1b24257",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "language": "en",
+            "id": "0",
+            "text": "That was the best day of my life!"
+          },
+          {
+            "language": "en",
+            "id": "1",
+            "text": ""
+          },
+          {
+            "language": "en",
+            "id": "2",
+            "text": "I\u0027m not sure how I feel about this product."
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "647edc67-3268-4400-97e5-85474406f2fc",
+        "Content-Type": "application/json; charset=utf-8",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2",
+        "Date": "Thu, 06 Feb 2020 04:36:05 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "78"
+      },
+      "ResponseBody": {
+        "documents": [
+          {
+            "id": "0",
+            "sentiment": "positive",
+            "documentScores": {
+              "positive": 1.0,
+              "neutral": 0.0,
+              "negative": 0.0
+            },
+            "sentences": [
+              {
+                "sentiment": "positive",
+                "sentenceScores": {
+                  "positive": 1.0,
+                  "neutral": 0.0,
+                  "negative": 0.0
+                },
+                "offset": 0,
+                "length": 33
+              }
+            ]
+          },
+          {
+            "id": "2",
+            "sentiment": "neutral",
+            "documentScores": {
+              "positive": 0.02,
+              "neutral": 0.85,
+              "negative": 0.13
+            },
+            "sentences": [
+              {
+                "sentiment": "neutral",
+                "sentenceScores": {
+                  "positive": 0.02,
+                  "neutral": 0.85,
+                  "negative": 0.13
+                },
+                "offset": 0,
+                "length": 43
+              }
+            ]
+          }
+        ],
+        "errors": [
+          {
+            "id": "1",
+            "error": {
+              "code": "InvalidArgument",
+              "innerError": {
+                "code": "InvalidDocument",
+                "message": "Document text is empty."
+              },
+              "message": "Invalid document in request."
+            }
+          }
+        ],
+        "modelVersion": "2019-10-01"
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "902220833",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://westus2.api.cognitive.microsoft.com/"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/DetectLanguageBatchWithErrorTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/DetectLanguageBatchWithErrorTest.json
@@ -1,0 +1,93 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://westus2.api.cognitive.microsoft.com/text/analytics/v3.0-preview.1/languages",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "156",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-dd3eb880cc443543a8de6d8bfebaaef7-7649100633584d4a-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200205.1\u002Bf8d73daa11c41f2bc0e09182d73b8ba9b5a9b924",
+          "(.NET Core 4.6.28207.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "73f5cc77e5862fe0fbea5cc07aeb9cc6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "countryHint": "us",
+            "id": "0",
+            "text": "Hello world"
+          },
+          {
+            "countryHint": "us",
+            "id": "1",
+            "text": ""
+          },
+          {
+            "countryHint": "us",
+            "id": "2",
+            "text": "Hola mundo"
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6a4c9464-c92e-4102-82bb-d1772339982d",
+        "Content-Type": "application/json; charset=utf-8",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2",
+        "Date": "Thu, 06 Feb 2020 04:36:04 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "5"
+      },
+      "ResponseBody": {
+        "documents": [
+          {
+            "id": "0",
+            "detectedLanguages": [
+              {
+                "name": "English",
+                "iso6391Name": "en",
+                "score": 1.0
+              }
+            ]
+          },
+          {
+            "id": "2",
+            "detectedLanguages": [
+              {
+                "name": "Spanish",
+                "iso6391Name": "es",
+                "score": 1.0
+              }
+            ]
+          }
+        ],
+        "errors": [
+          {
+            "id": "1",
+            "error": {
+              "code": "InvalidArgument",
+              "innerError": {
+                "code": "InvalidDocument",
+                "message": "Document text is empty."
+              },
+              "message": "Invalid document in request."
+            }
+          }
+        ],
+        "modelVersion": "2019-10-01"
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1680733337",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://westus2.api.cognitive.microsoft.com/"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/DetectLanguageBatchWithErrorTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/DetectLanguageBatchWithErrorTestAsync.json
@@ -1,0 +1,93 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://westus2.api.cognitive.microsoft.com/text/analytics/v3.0-preview.1/languages",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "156",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-081065231fffca40bae4fc1461457f2e-050ea6cd877bdf49-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200205.1\u002Bf8d73daa11c41f2bc0e09182d73b8ba9b5a9b924",
+          "(.NET Core 4.6.28207.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "657bba06d655a68e54d2efc01e358958",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "countryHint": "us",
+            "id": "0",
+            "text": "Hello world"
+          },
+          {
+            "countryHint": "us",
+            "id": "1",
+            "text": ""
+          },
+          {
+            "countryHint": "us",
+            "id": "2",
+            "text": "Hola mundo"
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3da54340-3ec5-4d53-a5a8-9b55e1c55846",
+        "Content-Type": "application/json; charset=utf-8",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2",
+        "Date": "Thu, 06 Feb 2020 04:36:05 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "4"
+      },
+      "ResponseBody": {
+        "documents": [
+          {
+            "id": "0",
+            "detectedLanguages": [
+              {
+                "name": "English",
+                "iso6391Name": "en",
+                "score": 1.0
+              }
+            ]
+          },
+          {
+            "id": "2",
+            "detectedLanguages": [
+              {
+                "name": "Spanish",
+                "iso6391Name": "es",
+                "score": 1.0
+              }
+            ]
+          }
+        ],
+        "errors": [
+          {
+            "id": "1",
+            "error": {
+              "code": "InvalidArgument",
+              "innerError": {
+                "code": "InvalidDocument",
+                "message": "Document text is empty."
+              },
+              "message": "Invalid document in request."
+            }
+          }
+        ],
+        "modelVersion": "2019-10-01"
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1638255384",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://westus2.api.cognitive.microsoft.com/"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/ExtractKeyPhrasesBatchWithErrorTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/ExtractKeyPhrasesBatchWithErrorTest.json
@@ -1,0 +1,88 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://westus2.api.cognitive.microsoft.com/text/analytics/v3.0-preview.1/keyPhrases",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "217",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-497cff09f418f244a82888e468e60777-368f264f400c354c-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200205.1\u002Bf8d73daa11c41f2bc0e09182d73b8ba9b5a9b924",
+          "(.NET Core 4.6.28207.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "1f94a0d5a668d181a6dbd88650ec9cd6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "language": "en",
+            "id": "0",
+            "text": "Microsoft was founded by Bill Gates and Paul Allen."
+          },
+          {
+            "language": "en",
+            "id": "1",
+            "text": ""
+          },
+          {
+            "language": "en",
+            "id": "2",
+            "text": "My cat might need to see a veterinarian."
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "06deb33d-9bee-4464-83f2-54a8dc595424",
+        "Content-Type": "application/json; charset=utf-8",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2",
+        "Date": "Thu, 06 Feb 2020 04:36:04 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "5"
+      },
+      "ResponseBody": {
+        "documents": [
+          {
+            "id": "0",
+            "keyPhrases": [
+              "Bill Gates",
+              "Paul Allen",
+              "Microsoft"
+            ]
+          },
+          {
+            "id": "2",
+            "keyPhrases": [
+              "cat",
+              "veterinarian"
+            ]
+          }
+        ],
+        "errors": [
+          {
+            "id": "1",
+            "error": {
+              "code": "InvalidArgument",
+              "innerError": {
+                "code": "InvalidDocument",
+                "message": "Document text is empty."
+              },
+              "message": "Invalid document in request."
+            }
+          }
+        ],
+        "modelVersion": "2019-10-01"
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1391992895",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://westus2.api.cognitive.microsoft.com/"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/ExtractKeyPhrasesBatchWithErrorTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/ExtractKeyPhrasesBatchWithErrorTestAsync.json
@@ -1,0 +1,88 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://westus2.api.cognitive.microsoft.com/text/analytics/v3.0-preview.1/keyPhrases",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "217",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-7bfd5dba8a1ac7449602f9506f524dbd-3574fc65d0b2cd45-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200205.1\u002Bf8d73daa11c41f2bc0e09182d73b8ba9b5a9b924",
+          "(.NET Core 4.6.28207.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "fa792cb9b402586aaed41cf340711303",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "language": "en",
+            "id": "0",
+            "text": "Microsoft was founded by Bill Gates and Paul Allen."
+          },
+          {
+            "language": "en",
+            "id": "1",
+            "text": ""
+          },
+          {
+            "language": "en",
+            "id": "2",
+            "text": "My cat might need to see a veterinarian."
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6e0bb14c-8145-4458-baec-12a6ba5d49e4",
+        "Content-Type": "application/json; charset=utf-8",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2",
+        "Date": "Thu, 06 Feb 2020 04:36:05 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "5"
+      },
+      "ResponseBody": {
+        "documents": [
+          {
+            "id": "0",
+            "keyPhrases": [
+              "Bill Gates",
+              "Paul Allen",
+              "Microsoft"
+            ]
+          },
+          {
+            "id": "2",
+            "keyPhrases": [
+              "cat",
+              "veterinarian"
+            ]
+          }
+        ],
+        "errors": [
+          {
+            "id": "1",
+            "error": {
+              "code": "InvalidArgument",
+              "innerError": {
+                "code": "InvalidDocument",
+                "message": "Document text is empty."
+              },
+              "message": "Invalid document in request."
+            }
+          }
+        ],
+        "modelVersion": "2019-10-01"
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1752379634",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://westus2.api.cognitive.microsoft.com/"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizeEntitiesBatchWithErrorTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizeEntitiesBatchWithErrorTest.json
@@ -1,0 +1,103 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://westus2.api.cognitive.microsoft.com/text/analytics/v3.0-preview.1/entities/recognition/general",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "217",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-a767a99e56b0ee459a59b3e81b21e880-3de36f1bc57d1740-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200205.1\u002Bf8d73daa11c41f2bc0e09182d73b8ba9b5a9b924",
+          "(.NET Core 4.6.28207.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "3ff95858c19275f33d23070f9ab76ce8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "language": "en",
+            "id": "0",
+            "text": "Microsoft was founded by Bill Gates and Paul Allen."
+          },
+          {
+            "language": "en",
+            "id": "1",
+            "text": ""
+          },
+          {
+            "language": "en",
+            "id": "2",
+            "text": "My cat might need to see a veterinarian."
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "fc0483ff-ff49-47ce-b871-391ce0cfd377",
+        "Content-Type": "application/json; charset=utf-8",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2",
+        "Date": "Thu, 06 Feb 2020 04:36:04 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "18"
+      },
+      "ResponseBody": {
+        "documents": [
+          {
+            "id": "0",
+            "entities": [
+              {
+                "text": "Microsoft",
+                "type": "Organization",
+                "offset": 0,
+                "length": 9,
+                "score": 0.99993896484375
+              },
+              {
+                "text": "Bill Gates",
+                "type": "Person",
+                "offset": 25,
+                "length": 10,
+                "score": 0.99974066019058228
+              },
+              {
+                "text": "Paul Allen",
+                "type": "Person",
+                "offset": 40,
+                "length": 10,
+                "score": 0.99951183795928955
+              }
+            ]
+          },
+          {
+            "id": "2",
+            "entities": []
+          }
+        ],
+        "errors": [
+          {
+            "id": "1",
+            "error": {
+              "code": "InvalidArgument",
+              "innerError": {
+                "code": "InvalidDocument",
+                "message": "Document text is empty."
+              },
+              "message": "Invalid document in request."
+            }
+          }
+        ],
+        "modelVersion": "2019-10-01"
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1784295012",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://westus2.api.cognitive.microsoft.com/"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizeEntitiesBatchWithErrorTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizeEntitiesBatchWithErrorTestAsync.json
@@ -1,0 +1,103 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://westus2.api.cognitive.microsoft.com/text/analytics/v3.0-preview.1/entities/recognition/general",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "217",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-f2df7df4a44c78439c721e35f8a447d6-05c790afc960ff44-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200205.1\u002Bf8d73daa11c41f2bc0e09182d73b8ba9b5a9b924",
+          "(.NET Core 4.6.28207.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "e3f1ecf4efc6a209650b9e605228fe76",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "language": "en",
+            "id": "0",
+            "text": "Microsoft was founded by Bill Gates and Paul Allen."
+          },
+          {
+            "language": "en",
+            "id": "1",
+            "text": ""
+          },
+          {
+            "language": "en",
+            "id": "2",
+            "text": "My cat might need to see a veterinarian."
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "25ff1417-749d-4325-8349-7c625fdc8eb9",
+        "Content-Type": "application/json; charset=utf-8",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2",
+        "Date": "Thu, 06 Feb 2020 04:36:05 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "12"
+      },
+      "ResponseBody": {
+        "documents": [
+          {
+            "id": "0",
+            "entities": [
+              {
+                "text": "Microsoft",
+                "type": "Organization",
+                "offset": 0,
+                "length": 9,
+                "score": 0.99993896484375
+              },
+              {
+                "text": "Bill Gates",
+                "type": "Person",
+                "offset": 25,
+                "length": 10,
+                "score": 0.99974066019058228
+              },
+              {
+                "text": "Paul Allen",
+                "type": "Person",
+                "offset": 40,
+                "length": 10,
+                "score": 0.99951183795928955
+              }
+            ]
+          },
+          {
+            "id": "2",
+            "entities": []
+          }
+        ],
+        "errors": [
+          {
+            "id": "1",
+            "error": {
+              "code": "InvalidArgument",
+              "innerError": {
+                "code": "InvalidDocument",
+                "message": "Document text is empty."
+              },
+              "message": "Invalid document in request."
+            }
+          }
+        ],
+        "modelVersion": "2019-10-01"
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "118852258",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://westus2.api.cognitive.microsoft.com/"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizeLinkedEntitiesBatchWithErrorTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizeLinkedEntitiesBatchWithErrorTest.json
@@ -1,0 +1,158 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://westus2.api.cognitive.microsoft.com/text/analytics/v3.0-preview.1/entities/linking",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "229",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-fb0152d958748241bb701290c8bd9ffe-8660a7b0f5102546-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200205.1\u002Bf8d73daa11c41f2bc0e09182d73b8ba9b5a9b924",
+          "(.NET Core 4.6.28207.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "6a5575a529785c2c520d773fd2c105b9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "language": "en",
+            "id": "0",
+            "text": "Microsoft was founded by Bill Gates and Paul Allen."
+          },
+          {
+            "language": "en",
+            "id": "1",
+            "text": ""
+          },
+          {
+            "language": "en",
+            "id": "2",
+            "text": "Pike place market is my favorite Seattle attraction."
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "36c202d9-66e1-4faf-ba6c-f10a5ecf71b0",
+        "Content-Type": "application/json; charset=utf-8",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2",
+        "Date": "Thu, 06 Feb 2020 04:36:04 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "10"
+      },
+      "ResponseBody": {
+        "documents": [
+          {
+            "id": "0",
+            "entities": [
+              {
+                "name": "Bill Gates",
+                "matches": [
+                  {
+                    "text": "Bill Gates",
+                    "offset": 25,
+                    "length": 10,
+                    "score": 0.45485126470303006
+                  }
+                ],
+                "language": "en",
+                "id": "Bill Gates",
+                "url": "https://en.wikipedia.org/wiki/Bill_Gates",
+                "dataSource": "Wikipedia"
+              },
+              {
+                "name": "Paul Allen",
+                "matches": [
+                  {
+                    "text": "Paul Allen",
+                    "offset": 40,
+                    "length": 10,
+                    "score": 0.82665495321760041
+                  }
+                ],
+                "language": "en",
+                "id": "Paul Allen",
+                "url": "https://en.wikipedia.org/wiki/Paul_Allen",
+                "dataSource": "Wikipedia"
+              },
+              {
+                "name": "Microsoft",
+                "matches": [
+                  {
+                    "text": "Microsoft",
+                    "offset": 0,
+                    "length": 9,
+                    "score": 0.4029093227589069
+                  }
+                ],
+                "language": "en",
+                "id": "Microsoft",
+                "url": "https://en.wikipedia.org/wiki/Microsoft",
+                "dataSource": "Wikipedia"
+              }
+            ]
+          },
+          {
+            "id": "2",
+            "entities": [
+              {
+                "name": "Pike Place Market",
+                "matches": [
+                  {
+                    "text": "Pike place market",
+                    "offset": 0,
+                    "length": 17,
+                    "score": 0.76924872758183072
+                  }
+                ],
+                "language": "en",
+                "id": "Pike Place Market",
+                "url": "https://en.wikipedia.org/wiki/Pike_Place_Market",
+                "dataSource": "Wikipedia"
+              },
+              {
+                "name": "Seattle",
+                "matches": [
+                  {
+                    "text": "Seattle",
+                    "offset": 33,
+                    "length": 7,
+                    "score": 0.2361670688278743
+                  }
+                ],
+                "language": "en",
+                "id": "Seattle",
+                "url": "https://en.wikipedia.org/wiki/Seattle",
+                "dataSource": "Wikipedia"
+              }
+            ]
+          }
+        ],
+        "errors": [
+          {
+            "id": "1",
+            "error": {
+              "code": "InvalidArgument",
+              "innerError": {
+                "code": "InvalidDocument",
+                "message": "Document text is empty."
+              },
+              "message": "Invalid document in request."
+            }
+          }
+        ],
+        "modelVersion": "2019-10-01"
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1922483248",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://westus2.api.cognitive.microsoft.com/"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizeLinkedEntitiesBatchWithErrorTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizeLinkedEntitiesBatchWithErrorTestAsync.json
@@ -1,0 +1,158 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://westus2.api.cognitive.microsoft.com/text/analytics/v3.0-preview.1/entities/linking",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "229",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-5ca4bd6ea4bb8a43b267c162329ace90-1b44158d97259945-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200205.1\u002Bf8d73daa11c41f2bc0e09182d73b8ba9b5a9b924",
+          "(.NET Core 4.6.28207.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "a31c6139014927c10b81c58c3423ed27",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "language": "en",
+            "id": "0",
+            "text": "Microsoft was founded by Bill Gates and Paul Allen."
+          },
+          {
+            "language": "en",
+            "id": "1",
+            "text": ""
+          },
+          {
+            "language": "en",
+            "id": "2",
+            "text": "Pike place market is my favorite Seattle attraction."
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "13b51adf-6ec1-4643-b05e-43677a63d901",
+        "Content-Type": "application/json; charset=utf-8",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2",
+        "Date": "Thu, 06 Feb 2020 04:36:05 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "12"
+      },
+      "ResponseBody": {
+        "documents": [
+          {
+            "id": "0",
+            "entities": [
+              {
+                "name": "Bill Gates",
+                "matches": [
+                  {
+                    "text": "Bill Gates",
+                    "offset": 25,
+                    "length": 10,
+                    "score": 0.45485126470303006
+                  }
+                ],
+                "language": "en",
+                "id": "Bill Gates",
+                "url": "https://en.wikipedia.org/wiki/Bill_Gates",
+                "dataSource": "Wikipedia"
+              },
+              {
+                "name": "Paul Allen",
+                "matches": [
+                  {
+                    "text": "Paul Allen",
+                    "offset": 40,
+                    "length": 10,
+                    "score": 0.82665495321760041
+                  }
+                ],
+                "language": "en",
+                "id": "Paul Allen",
+                "url": "https://en.wikipedia.org/wiki/Paul_Allen",
+                "dataSource": "Wikipedia"
+              },
+              {
+                "name": "Microsoft",
+                "matches": [
+                  {
+                    "text": "Microsoft",
+                    "offset": 0,
+                    "length": 9,
+                    "score": 0.4029093227589069
+                  }
+                ],
+                "language": "en",
+                "id": "Microsoft",
+                "url": "https://en.wikipedia.org/wiki/Microsoft",
+                "dataSource": "Wikipedia"
+              }
+            ]
+          },
+          {
+            "id": "2",
+            "entities": [
+              {
+                "name": "Pike Place Market",
+                "matches": [
+                  {
+                    "text": "Pike place market",
+                    "offset": 0,
+                    "length": 17,
+                    "score": 0.76924872758183072
+                  }
+                ],
+                "language": "en",
+                "id": "Pike Place Market",
+                "url": "https://en.wikipedia.org/wiki/Pike_Place_Market",
+                "dataSource": "Wikipedia"
+              },
+              {
+                "name": "Seattle",
+                "matches": [
+                  {
+                    "text": "Seattle",
+                    "offset": 33,
+                    "length": 7,
+                    "score": 0.2361670688278743
+                  }
+                ],
+                "language": "en",
+                "id": "Seattle",
+                "url": "https://en.wikipedia.org/wiki/Seattle",
+                "dataSource": "Wikipedia"
+              }
+            ]
+          }
+        ],
+        "errors": [
+          {
+            "id": "1",
+            "error": {
+              "code": "InvalidArgument",
+              "innerError": {
+                "code": "InvalidDocument",
+                "message": "Document text is empty."
+              },
+              "message": "Invalid document in request."
+            }
+          }
+        ],
+        "modelVersion": "2019-10-01"
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "35415180",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://westus2.api.cognitive.microsoft.com/"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizePiiEntitiesBatchWithErrorTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizePiiEntitiesBatchWithErrorTest.json
@@ -1,0 +1,107 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://westus2.api.cognitive.microsoft.com/text/analytics/v3.0-preview.1/entities/recognition/pii",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "331",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e901fca0c6aa3f4fb0aa0b92b1cce31e-41855a15d3f4974d-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200205.1\u002Bf8d73daa11c41f2bc0e09182d73b8ba9b5a9b924",
+          "(.NET Core 4.6.28207.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "03024d16a8fe05bfd80888914124dbf6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "language": "en",
+            "id": "0",
+            "text": "A developer with SSN 555-55-5555 whose phone number is 555-555-5555 is building tools with our APIs."
+          },
+          {
+            "language": "en",
+            "id": "1",
+            "text": ""
+          },
+          {
+            "language": "en",
+            "id": "2",
+            "text": "Your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check."
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c163c3b2-3239-4634-8223-bf7e015efc33",
+        "Content-Type": "application/json; charset=utf-8",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2",
+        "Date": "Thu, 06 Feb 2020 04:36:05 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "17"
+      },
+      "ResponseBody": {
+        "documents": [
+          {
+            "id": "0",
+            "entities": [
+              {
+                "text": "555-55-5555",
+                "type": "U.S. Social Security Number (SSN)",
+                "subtype": "",
+                "offset": 21,
+                "length": 11,
+                "score": 0.85
+              },
+              {
+                "text": " 555-555-5555 ",
+                "type": "EU Phone Number",
+                "subtype": "",
+                "offset": 54,
+                "length": 14,
+                "score": 0.75
+              }
+            ]
+          },
+          {
+            "id": "2",
+            "entities": [
+              {
+                "text": "111000025",
+                "type": "ABA Routing Number",
+                "subtype": "",
+                "offset": 18,
+                "length": 9,
+                "score": 0.75
+              }
+            ]
+          }
+        ],
+        "errors": [
+          {
+            "id": "1",
+            "error": {
+              "code": "InvalidArgument",
+              "innerError": {
+                "code": "InvalidDocument",
+                "message": "Document text is empty."
+              },
+              "message": "Invalid document in request."
+            }
+          }
+        ],
+        "modelVersion": "2019-10-01"
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "983540859",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://westus2.api.cognitive.microsoft.com/"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizePiiEntitiesBatchWithErrorTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizePiiEntitiesBatchWithErrorTestAsync.json
@@ -1,0 +1,107 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://westus2.api.cognitive.microsoft.com/text/analytics/v3.0-preview.1/entities/recognition/pii",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "331",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-4afce94c1f42bd47b4820189474ffaa7-a915e749fc316141-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200205.1\u002Bf8d73daa11c41f2bc0e09182d73b8ba9b5a9b924",
+          "(.NET Core 4.6.28207.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "d5f4c0ad8b55427f79b64f75dca696eb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "language": "en",
+            "id": "0",
+            "text": "A developer with SSN 555-55-5555 whose phone number is 555-555-5555 is building tools with our APIs."
+          },
+          {
+            "language": "en",
+            "id": "1",
+            "text": ""
+          },
+          {
+            "language": "en",
+            "id": "2",
+            "text": "Your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check."
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c2b9a756-ed81-40e4-bd9b-2432fa5a1d59",
+        "Content-Type": "application/json; charset=utf-8",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=2",
+        "Date": "Thu, 06 Feb 2020 04:36:05 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "15"
+      },
+      "ResponseBody": {
+        "documents": [
+          {
+            "id": "0",
+            "entities": [
+              {
+                "text": "555-55-5555",
+                "type": "U.S. Social Security Number (SSN)",
+                "subtype": "",
+                "offset": 21,
+                "length": 11,
+                "score": 0.85
+              },
+              {
+                "text": " 555-555-5555 ",
+                "type": "EU Phone Number",
+                "subtype": "",
+                "offset": 54,
+                "length": 14,
+                "score": 0.75
+              }
+            ]
+          },
+          {
+            "id": "2",
+            "entities": [
+              {
+                "text": "111000025",
+                "type": "ABA Routing Number",
+                "subtype": "",
+                "offset": 18,
+                "length": 9,
+                "score": 0.75
+              }
+            ]
+          }
+        ],
+        "errors": [
+          {
+            "id": "1",
+            "error": {
+              "code": "InvalidArgument",
+              "innerError": {
+                "code": "InvalidDocument",
+                "message": "Document text is empty."
+              },
+              "message": "Invalid document in request."
+            }
+          }
+        ],
+        "modelVersion": "2019-10-01"
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1106582482",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://westus2.api.cognitive.microsoft.com/"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/ThrowExceptionTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/ThrowExceptionTest.json
@@ -1,0 +1,48 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://westus2.api.cognitive.microsoft.com/text/analytics/v3.0-preview.1/languages",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "16",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-7b48975da76f534c875d6109a52333ce-1cec560c993ee245-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200206.1\u002B60a8ad8ae9abc1b72ebc58e76e36c2da32bf20d5",
+          "(.NET Core 4.6.28207.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "b46a7fc4c693afe0072f7a9e93de40e9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": []
+      },
+      "StatusCode": 400,
+      "ResponseHeaders": {
+        "apim-request-id": "3c93f58e-acfe-4541-91bb-2024c40bae6e",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 07 Feb 2020 04:28:48 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "3"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "InvalidRequest",
+          "message": "Invalid Request.",
+          "innerError": {
+            "code": "MissingInputRecords",
+            "message": "Missing input records."
+          }
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "15839780",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://westus2.api.cognitive.microsoft.com/"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/ThrowExceptionTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/ThrowExceptionTestAsync.json
@@ -1,0 +1,48 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://westus2.api.cognitive.microsoft.com/text/analytics/v3.0-preview.1/languages",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "16",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-a10b079a43bb854388f01cfec429e88b-0776e824bb99c949-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200206.1\u002B60a8ad8ae9abc1b72ebc58e76e36c2da32bf20d5",
+          "(.NET Core 4.6.28207.04; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "1c329710ac91ccc2b10d09198e1659d8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": []
+      },
+      "StatusCode": 400,
+      "ResponseHeaders": {
+        "apim-request-id": "95ad9b91-a13a-41e1-83bc-1176c90f6764",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 07 Feb 2020 04:28:49 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "4"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "InvalidRequest",
+          "message": "Invalid Request.",
+          "innerError": {
+            "code": "MissingInputRecords",
+            "message": "Missing input records."
+          }
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "311407816",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://westus2.api.cognitive.microsoft.com/"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
@@ -39,8 +39,7 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             string input = "This is written in English.";
 
-            DetectLanguageResult result = await client.DetectLanguageAsync(input);
-            DetectedLanguage language = result.PrimaryLanguage;
+            DetectedLanguage language = await client.DetectLanguageAsync(input);
 
             Assert.AreEqual("English", language.Name);
             Assert.AreEqual("en", language.Iso6391Name);
@@ -53,10 +52,29 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             string input = "Este documento está en español";
 
-            DetectLanguageResult result = await client.DetectLanguageAsync(input, "CO");
-            DetectedLanguage language = result.PrimaryLanguage;
+            DetectedLanguage language = await client.DetectLanguageAsync(input, "CO");
 
             Assert.AreEqual("Spanish", language.Name);
+        }
+
+        [Test]
+        public async Task DetectLanguageBatchWithErrorTest()
+        {
+            TextAnalyticsClient client = GetClient();
+            var inputs = new List<string>
+            {
+                "Hello world",
+                "",
+                "Hola mundo"
+            };
+
+            DetectLanguageResultCollection results = await client.DetectLanguageBatchAsync(inputs);
+
+            Assert.IsTrue(!results[0].HasError);
+            Assert.IsTrue(!results[2].HasError);
+
+            Assert.IsTrue(results[1].HasError);
+            Assert.Throws<InvalidOperationException>(() => results[1].PrimaryLanguage.GetType());
         }
 
         [Test]
@@ -65,8 +83,7 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             string input = "That was the best day of my life!";
 
-            AnalyzeSentimentResult result = await client.AnalyzeSentimentAsync(input);
-            DocumentSentiment docSentiment = result.DocumentSentiment;
+            DocumentSentiment docSentiment = await client.AnalyzeSentimentAsync(input);
 
             Assert.AreEqual("Positive", docSentiment.Sentiment.ToString());
             Assert.IsNotNull(docSentiment.SentimentScores.Positive);
@@ -91,10 +108,29 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             string input = "El mejor test del mundo!";
 
-            AnalyzeSentimentResult result = await client.AnalyzeSentimentAsync(input, "es");
-            DocumentSentiment docSentiment = result.DocumentSentiment;
+            DocumentSentiment docSentiment = await client.AnalyzeSentimentAsync(input, "es");
 
             Assert.AreEqual("Positive", docSentiment.Sentiment.ToString());
+        }
+
+        [Test]
+        public async Task AnalyzeSentimentBatchWithErrorTest()
+        {
+            TextAnalyticsClient client = GetClient();
+            var inputs = new List<string>
+            {
+                "That was the best day of my life!",
+                "",
+                "I'm not sure how I feel about this product."
+            };
+
+            AnalyzeSentimentResultCollection results = await client.AnalyzeSentimentBatchAsync(inputs);
+
+            Assert.IsTrue(!results[0].HasError);
+            Assert.IsTrue(!results[2].HasError);
+
+            Assert.IsTrue(results[1].HasError);
+            Assert.Throws<InvalidOperationException>(() => results[1].DocumentSentiment.GetType());
         }
 
         [Test]
@@ -103,8 +139,8 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             string input = "My cat might need to see a veterinarian.";
 
-            ExtractKeyPhrasesResult result = await client.ExtractKeyPhrasesAsync(input);
-            IReadOnlyCollection<string> keyPhrases = result.KeyPhrases;
+            Response<IReadOnlyCollection<string>> response = await client.ExtractKeyPhrasesAsync(input);
+            IReadOnlyCollection<string> keyPhrases = response.Value;
 
             Assert.AreEqual(2, keyPhrases.Count);
             Assert.IsTrue(keyPhrases.Contains("cat"));
@@ -117,10 +153,30 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             string input = "Mi perro está en el veterinario";
 
-            ExtractKeyPhrasesResult result = await client.ExtractKeyPhrasesAsync(input, "es");
-            IReadOnlyCollection<string> keyPhrases = result.KeyPhrases;
+            Response<IReadOnlyCollection<string>> response = await client.ExtractKeyPhrasesAsync(input, "es");
+            IReadOnlyCollection<string> keyPhrases = response.Value;
 
             Assert.AreEqual(2, keyPhrases.Count);
+        }
+
+        [Test]
+        public async Task ExtractKeyPhrasesBatchWithErrorTest()
+        {
+            TextAnalyticsClient client = GetClient();
+            var inputs = new List<string>
+            {
+                "Microsoft was founded by Bill Gates and Paul Allen.",
+                 "",
+                "My cat might need to see a veterinarian."
+            };
+
+            ExtractKeyPhrasesResultCollection results = await client.ExtractKeyPhrasesBatchAsync(inputs);
+
+            Assert.IsTrue(!results[0].HasError);
+            Assert.IsTrue(!results[2].HasError);
+
+            Assert.IsTrue(results[1].HasError);
+            Assert.Throws<InvalidOperationException>(() => results[1].KeyPhrases.GetType());
         }
 
         [Test]
@@ -129,8 +185,8 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             string input = "Microsoft was founded by Bill Gates and Paul Allen.";
 
-            RecognizeEntitiesResult result = await client.RecognizeEntitiesAsync(input);
-            IReadOnlyCollection<CategorizedEntity> entities = result.Entities;
+            Response<IReadOnlyCollection<CategorizedEntity>> response = await client.RecognizeEntitiesAsync(input);
+            IReadOnlyCollection<CategorizedEntity> entities = response.Value;
 
             Assert.AreEqual(3, entities.Count);
 
@@ -151,8 +207,8 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             string input = "Microsoft fue fundado por Bill Gates y Paul Allen.";
 
-            RecognizeEntitiesResult result = await client.RecognizeEntitiesAsync(input, "es");
-            IReadOnlyCollection<CategorizedEntity> entities = result.Entities;
+            Response<IReadOnlyCollection<CategorizedEntity>> response = await client.RecognizeEntitiesAsync(input, "es");
+            IReadOnlyCollection<CategorizedEntity> entities = response.Value;
 
             Assert.AreEqual(3, entities.Count);
         }
@@ -163,8 +219,8 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             string input = "I had a wonderful trip to Seattle last week.";
 
-            RecognizeEntitiesResult result = await client.RecognizeEntitiesAsync(input);
-            IReadOnlyCollection<CategorizedEntity> entities = result.Entities;
+            Response<IReadOnlyCollection<CategorizedEntity>> response = await client.RecognizeEntitiesAsync(input);
+            IReadOnlyCollection<CategorizedEntity> entities = response.Value;
 
             Assert.AreEqual(2, entities.Count);
 
@@ -176,13 +232,33 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [Test]
+        public async Task RecognizeEntitiesBatchWithErrorTest()
+        {
+            TextAnalyticsClient client = GetClient();
+            var inputs = new List<string>
+            {
+                "Microsoft was founded by Bill Gates and Paul Allen.",
+                 "",
+                "My cat might need to see a veterinarian."
+            };
+
+            RecognizeEntitiesResultCollection results = await client.RecognizeEntitiesBatchAsync(inputs);
+
+            Assert.IsTrue(!results[0].HasError);
+            Assert.IsTrue(!results[2].HasError);
+
+            Assert.IsTrue(results[1].HasError);
+            Assert.Throws<InvalidOperationException>(() => results[1].Entities.GetType());
+        }
+
+        [Test]
         public async Task RecognizePiiEntitiesTest()
         {
             TextAnalyticsClient client = GetClient();
             string input = "A developer with SSN 555-55-5555 whose phone number is 800-102-1100 is building tools with our APIs.";
 
-            RecognizePiiEntitiesResult result = await client.RecognizePiiEntitiesAsync(input);
-            IReadOnlyCollection<PiiEntity> entities = result.Entities;
+            Response<IReadOnlyCollection<PiiEntity>> response = await client.RecognizePiiEntitiesAsync(input);
+            IReadOnlyCollection<PiiEntity> entities = response.Value;
 
             Assert.AreEqual(2, entities.Count);
 
@@ -203,10 +279,30 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             string input = "A developer with SSN 555-55-5555 whose phone number is 800-102-1100 is building tools with our APIs.";
 
-            RecognizePiiEntitiesResult result = await client.RecognizePiiEntitiesAsync(input, "en");
-            IReadOnlyCollection<PiiEntity> entities = result.Entities;
+            Response<IReadOnlyCollection<PiiEntity>> response = await client.RecognizePiiEntitiesAsync(input, "en");
+            IReadOnlyCollection<PiiEntity> entities = response.Value;
 
             Assert.AreEqual(2, entities.Count);
+        }
+
+        [Test]
+        public async Task RecognizePiiEntitiesBatchWithErrorTest()
+        {
+            TextAnalyticsClient client = GetClient();
+            var inputs = new List<string>
+            {
+                "A developer with SSN 555-55-5555 whose phone number is 555-555-5555 is building tools with our APIs.",
+                "",
+                "Your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check.",
+            };
+
+            RecognizePiiEntitiesResultCollection results = await client.RecognizePiiEntitiesBatchAsync(inputs);
+
+            Assert.IsTrue(!results[0].HasError);
+            Assert.IsTrue(!results[2].HasError);
+
+            Assert.IsTrue(results[1].HasError);
+            Assert.Throws<InvalidOperationException>(() => results[1].Entities.GetType());
         }
 
         [Test]
@@ -215,15 +311,13 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             string input = "Microsoft was founded by Bill Gates and Paul Allen.";
 
-            RecognizeLinkedEntitiesResult result = await client.RecognizeLinkedEntitiesAsync(input);
+            Response<IReadOnlyCollection<LinkedEntity>> response = await client.RecognizeLinkedEntitiesAsync(input);
+            IReadOnlyCollection<LinkedEntity> linkedEntities = response.Value;
 
-            Assert.IsNotNull(result.Id);
-            Assert.AreEqual(3, result.LinkedEntities.Count);
-            Assert.IsNotNull(result.Statistics.CharacterCount);
-            Assert.IsNotNull(result.Statistics.TransactionCount);
+            Assert.AreEqual(3, linkedEntities.Count);
 
             var entitiesList = new List<string> { "Bill Gates", "Microsoft", "Paul Allen" };
-            foreach (LinkedEntity entity in result.LinkedEntities)
+            foreach (LinkedEntity entity in linkedEntities)
             {
                 Assert.IsTrue(entitiesList.Contains(entity.Name));
                 Assert.IsNotNull(entity.DataSource);
@@ -244,10 +338,30 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             string input = "Microsoft fue fundado por Bill Gates y Paul Allen.";
 
-            RecognizeLinkedEntitiesResult result = await client.RecognizeLinkedEntitiesAsync(input, "es");
+            Response<IReadOnlyCollection<LinkedEntity>> response = await client.RecognizeLinkedEntitiesAsync(input, "es");
+            IReadOnlyCollection<LinkedEntity> linkedEntities = response.Value;
 
-            Assert.IsNotNull(result.Id);
-            Assert.AreEqual(3, result.LinkedEntities.Count);
+            Assert.AreEqual(3, linkedEntities.Count);
+        }
+
+        [Test]
+        public async Task RecognizeLinkedEntitiesBatchWithErrorTest()
+        {
+            TextAnalyticsClient client = GetClient();
+            var inputs = new List<string>
+            {
+                "Microsoft was founded by Bill Gates and Paul Allen.",
+                "",
+                "Pike place market is my favorite Seattle attraction.",
+            };
+
+            RecognizeLinkedEntitiesResultCollection results = await client.RecognizeLinkedEntitiesBatchAsync(inputs);
+
+            Assert.IsTrue(!results[0].HasError);
+            Assert.IsTrue(!results[2].HasError);
+
+            Assert.IsTrue(results[1].HasError);
+            Assert.Throws<InvalidOperationException>(() => results[1].Entities.GetType());
         }
 
         [Test]
@@ -256,8 +370,8 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             const string input = "Bill Gates | Microsoft | New Mexico | 800-102-1100 | help@microsoft.com | April 4, 1975 12:34 | April 4, 1975 | 12:34 | five seconds | 9 | third | 120% | €30 | 11m | 22 °C";
 
-            RecognizeEntitiesResult result = await client.RecognizeEntitiesAsync(input);
-            List<CategorizedEntity> entities = result.Entities.ToList();
+            Response<IReadOnlyCollection<CategorizedEntity>> response = await client.RecognizeEntitiesAsync(input);
+            List<CategorizedEntity> entities = response.Value.ToList();
 
             Assert.AreEqual(15, entities.Count);
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
@@ -443,5 +443,14 @@ namespace Azure.AI.TextAnalytics.Tests
             credential.UpdateCredential(apiKey);
             await client.DetectLanguageAsync(input);
         }
+
+        [Test]
+        public void ThrowExceptionTest()
+        {
+            TextAnalyticsClient client = GetClient();
+            var input = new List<string>();
+
+            Assert.ThrowsAsync<RequestFailedException>(() => client.DetectLanguageBatchAsync(input));
+        }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientMockTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientMockTests.cs
@@ -87,8 +87,8 @@ namespace Azure.AI.TextAnalytics.Tests
                     new CategorizedEntity("EntityText0", "EntityCategory0", "EntitySubCategory0", 0, 1, 0.5),
                     new CategorizedEntity("EntityText1", "EntityCategory1", "EntitySubCategory1", 0, 1, 0.5),
                 }),
-                new RecognizeEntitiesResult("4", "Document is invalid."),
-                new RecognizeEntitiesResult("5", "Document is invalid."),
+                new RecognizeEntitiesResult("4", new TextAnalyticsError("InvalidDocument", "Document is invalid.")),
+                new RecognizeEntitiesResult("5", new TextAnalyticsError("InvalidDocument", "Document is invalid.")),
             };
             var mockResultCollection = new RecognizeEntitiesResultCollection(mockResults,
                 new TextDocumentBatchStatistics(2, 2, 2, 2),
@@ -125,7 +125,7 @@ namespace Azure.AI.TextAnalytics.Tests
             {
                 foreach (var result in resultCollection)
                 {
-                    if (result.Entities.Count > 0)
+                    if (!result.HasError)
                     {
                         json.WriteStartObject();
                         json.WriteString("id", result.Id);
@@ -149,17 +149,17 @@ namespace Azure.AI.TextAnalytics.Tests
             json.WriteEndArray();
 
             json.WriteStartArray("errors");
-            if (resultCollection.FirstOrDefault(r => r.ErrorMessage != default) != default)
+            if (resultCollection.FirstOrDefault(r => r.HasError) != default)
             {
                 foreach (var result in resultCollection)
                 {
-                    if (result.ErrorMessage != null)
+                    if (result.HasError)
                     {
                         json.WriteStartObject();
                         json.WriteString("id", result.Id);
                         json.WriteStartObject("error");
                         json.WriteStartObject("innerError");
-                        json.WriteString("message", result.ErrorMessage);
+                        json.WriteString("message", result.Error.Message);
                         json.WriteEndObject();
                         json.WriteEndObject();
                         json.WriteEndObject();

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsErrorTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsErrorTests.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core.Testing;
+using NUnit.Framework;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Azure.AI.TextAnalytics.Tests
+{
+    public class TextAnalyticsErrorTests : SyncAsyncPolicyTestBase
+    {
+        public TextAnalyticsErrorTests(bool isAsync) : base(isAsync) { }
+
+        [Test]
+        public void DeserializeTextAnalyticsError()
+        {
+            var errors = @"
+                {
+                ""errors"": [
+                    {
+                      ""id"": ""2"",
+                      ""error"": {
+                        ""code"": ""InvalidArgument"",
+                        ""innerError"": {
+                            ""code"": ""InvalidDocument"",
+                            ""message"": ""Document text is empty.""
+                            },
+                        ""message"": ""Invalid document in request.""
+                        }
+                    }
+                ]
+                }
+                ";
+
+            using JsonDocument json = JsonDocument.Parse(errors);
+            TextAnalyticsResult result = TextAnalyticsServiceSerializer.ReadDocumentErrors(json.RootElement).FirstOrDefault();
+
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.Error);
+            Assert.AreEqual(result.Error.Code, "InvalidDocument");
+            Assert.AreEqual(result.Error.Message, "Document text is empty.");
+        }
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguage.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguage.cs
@@ -23,8 +23,7 @@ namespace Azure.AI.TextAnalytics.Samples
             #region Snippet:DetectLanguage
             string input = "Este documento está en español.";
 
-            DetectLanguageResult result = client.DetectLanguage(input);
-            DetectedLanguage language = result.PrimaryLanguage;
+            DetectedLanguage language = client.DetectLanguage(input);
 
             Console.WriteLine($"Detected language {language.Name} with confidence {language.Score:0.00}.");
             #endregion

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageAsync.cs
@@ -23,8 +23,7 @@ namespace Azure.AI.TextAnalytics.Samples
             #region Snippet:DetectLanguageAsync
             string input = "Este documento está en español.";
 
-            DetectLanguageResult result = await client.DetectLanguageAsync(input);
-            DetectedLanguage language = result.PrimaryLanguage;
+            DetectedLanguage language = await client.DetectLanguageAsync(input);
 
             Console.WriteLine($"Detected language {language.Name} with confidence {language.Score:0.00}.");
             #endregion

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatch.cs
@@ -55,9 +55,10 @@ namespace Azure.AI.TextAnalytics.Samples
 
                 Debug.WriteLine($"On document (Id={document.Id}, CountryHint=\"{document.CountryHint}\", Text=\"{document.Text}\"):");
 
-                if (result.ErrorMessage != default)
+                if (result.HasError)
                 {
-                    Debug.WriteLine($"    Document error: {result.ErrorMessage}.");
+                    Debug.WriteLine($"    Document error code: {result.Error.Code}.");
+                    Debug.WriteLine($"    Message: {result.Error.Message}.");
                 }
                 else
                 {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentiment.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentiment.cs
@@ -23,8 +23,7 @@ namespace Azure.AI.TextAnalytics.Samples
             #region Snippet:AnalyzeSentiment
             string input = "That was the best day of my life!";
 
-            AnalyzeSentimentResult result = client.AnalyzeSentiment(input);
-            DocumentSentiment docSentiment = result.DocumentSentiment;
+            DocumentSentiment docSentiment = client.AnalyzeSentiment(input);
 
             Console.WriteLine($"Sentiment was {docSentiment.Sentiment}, with scores: ");
             Console.WriteLine($"    Positive score: {docSentiment.SentimentScores.Positive:0.00}.");

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatch.cs
@@ -55,9 +55,10 @@ namespace Azure.AI.TextAnalytics.Samples
 
                 Debug.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\", Text=\"{document.Text}\"):");
 
-                if (result.ErrorMessage != default)
+                if (result.HasError)
                 {
-                    Debug.WriteLine($"Document error: {result.ErrorMessage}.");
+                    Debug.WriteLine($"    Document error: {result.Error.Code}.");
+                    Debug.WriteLine($"    Message: {result.Error.Message}.");
                 }
                 else
                 {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrases.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrases.cs
@@ -25,8 +25,8 @@ namespace Azure.AI.TextAnalytics.Samples
             #region Snippet:ExtractKeyPhrases
             string input = "My cat might need to see a veterinarian.";
 
-            ExtractKeyPhrasesResult result = client.ExtractKeyPhrases(input);
-            IReadOnlyCollection<string> keyPhrases = result.KeyPhrases;
+            Response<IReadOnlyCollection<string>> response = client.ExtractKeyPhrases(input);
+            IReadOnlyCollection<string> keyPhrases = response.Value;
 
             Console.WriteLine($"Extracted {keyPhrases.Count()} key phrases:");
             foreach (string keyPhrase in keyPhrases)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrases.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrases.cs
@@ -26,7 +26,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string input = "My cat might need to see a veterinarian.";
 
             Response<IReadOnlyCollection<string>> response = client.ExtractKeyPhrases(input);
-            IReadOnlyCollection<string> keyPhrases = response.Value;
+            IEnumerable<string> keyPhrases = response.Value;
 
             Console.WriteLine($"Extracted {keyPhrases.Count()} key phrases:");
             foreach (string keyPhrase in keyPhrases)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatch.cs
@@ -52,9 +52,10 @@ namespace Azure.AI.TextAnalytics.Samples
 
                 Debug.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\", Text=\"{document.Text}\"):");
 
-                if (result.ErrorMessage != default)
+                if (result.HasError)
                 {
-                    Debug.WriteLine($"Document error: {result.ErrorMessage}.");
+                    Debug.WriteLine($"    Document error: {result.Error.Code}.");
+                    Debug.WriteLine($"    Message: {result.Error.Message}.");
                 }
                 else
                 {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntities.cs
@@ -25,8 +25,8 @@ namespace Azure.AI.TextAnalytics.Samples
             #region Snippet:RecognizeEntities
             string input = "Microsoft was founded by Bill Gates and Paul Allen.";
 
-            RecognizeEntitiesResult result = client.RecognizeEntities(input);
-            IReadOnlyCollection<CategorizedEntity> entities = result.Entities;
+            Response<IReadOnlyCollection<CategorizedEntity>> response = client.RecognizeEntities(input);
+            IReadOnlyCollection<CategorizedEntity> entities = response.Value;
 
             Console.WriteLine($"Recognized {entities.Count()} entities:");
             foreach (CategorizedEntity entity in entities)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntities.cs
@@ -26,7 +26,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string input = "Microsoft was founded by Bill Gates and Paul Allen.";
 
             Response<IReadOnlyCollection<CategorizedEntity>> response = client.RecognizeEntities(input);
-            IReadOnlyCollection<CategorizedEntity> entities = response.Value;
+            IEnumerable<CategorizedEntity> entities = response.Value;
 
             Console.WriteLine($"Recognized {entities.Count()} entities:");
             foreach (CategorizedEntity entity in entities)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesAsync.cs
@@ -26,8 +26,8 @@ namespace Azure.AI.TextAnalytics.Samples
             #region Snippet:RecognizeEntitiesAsync
             string input = "Microsoft was founded by Bill Gates and Paul Allen.";
 
-            RecognizeEntitiesResult result = await client.RecognizeEntitiesAsync(input);
-            IReadOnlyCollection<CategorizedEntity> entities = result.Entities;
+            Response<IReadOnlyCollection<CategorizedEntity>> response = await client.RecognizeEntitiesAsync(input);
+            IReadOnlyCollection<CategorizedEntity> entities = response.Value;
 
             Console.WriteLine($"Recognized {entities.Count()} entities:");
             foreach (CategorizedEntity entity in entities)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesAsync.cs
@@ -27,7 +27,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string input = "Microsoft was founded by Bill Gates and Paul Allen.";
 
             Response<IReadOnlyCollection<CategorizedEntity>> response = await client.RecognizeEntitiesAsync(input);
-            IReadOnlyCollection<CategorizedEntity> entities = response.Value;
+            IEnumerable<CategorizedEntity> entities = response.Value;
 
             Console.WriteLine($"Recognized {entities.Count()} entities:");
             foreach (CategorizedEntity entity in entities)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatch.cs
@@ -52,9 +52,10 @@ namespace Azure.AI.TextAnalytics.Samples
 
                 Debug.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\", Text=\"{document.Text}\"):");
 
-                if (result.ErrorMessage != default)
+                if (result.HasError)
                 {
-                    Debug.WriteLine($"    Document error: {result.ErrorMessage}.");
+                    Debug.WriteLine($"    Document error code: {result.Error.Code}.");
+                    Debug.WriteLine($"    Message: {result.Error.Message}.");
                 }
                 else
                 {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntities.cs
@@ -25,8 +25,8 @@ namespace Azure.AI.TextAnalytics.Samples
             #region Snippet:RecognizePiiEntities
             string input = "A developer with SSN 555-55-5555 whose phone number is 555-555-5555 is building tools with our APIs.";
 
-            RecognizePiiEntitiesResult result = client.RecognizePiiEntities(input);
-            IReadOnlyCollection<PiiEntity> entities = result.Entities;
+            Response<IReadOnlyCollection<PiiEntity>> response = client.RecognizePiiEntities(input);
+            IReadOnlyCollection<PiiEntity> entities = response.Value;
 
             Console.WriteLine($"Recognized {entities.Count()} PII entit{(entities.Count() > 1 ? "ies" : "y")}:");
             foreach (PiiEntity entity in entities)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntities.cs
@@ -26,7 +26,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string input = "A developer with SSN 555-55-5555 whose phone number is 555-555-5555 is building tools with our APIs.";
 
             Response<IReadOnlyCollection<PiiEntity>> response = client.RecognizePiiEntities(input);
-            IReadOnlyCollection<PiiEntity> entities = response.Value;
+            IEnumerable<PiiEntity> entities = response.Value;
 
             Console.WriteLine($"Recognized {entities.Count()} PII entit{(entities.Count() > 1 ? "ies" : "y")}:");
             foreach (PiiEntity entity in entities)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatch.cs
@@ -48,9 +48,10 @@ namespace Azure.AI.TextAnalytics.Samples
 
                 Debug.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\", Text=\"{document.Text}\"):");
 
-                if (result.ErrorMessage != default)
+                if (result.HasError)
                 {
-                    Debug.WriteLine($"Document error: {result.ErrorMessage}.");
+                    Debug.WriteLine($"    Document error code: {result.Error.Code}.");
+                    Debug.WriteLine($"    Message: {result.Error.Message}.");
                 }
                 else
                 {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntities.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using Azure.Core.Testing;
 using NUnit.Framework;
@@ -24,10 +26,11 @@ namespace Azure.AI.TextAnalytics.Samples
             #region Snippet:RecognizeLinkedEntities
             string input = "Microsoft was founded by Bill Gates and Paul Allen.";
 
-            RecognizeLinkedEntitiesResult result = client.RecognizeLinkedEntities(input);
+            Response<IReadOnlyCollection<LinkedEntity>> response = client.RecognizeLinkedEntities(input);
+            IReadOnlyCollection<LinkedEntity> linkedEntities = response.Value;
 
-            Console.WriteLine($"Extracted {result.LinkedEntities.Count()} linked entit{(result.LinkedEntities.Count() > 1 ? "ies" : "y")}:");
-            foreach (LinkedEntity linkedEntity in result.LinkedEntities)
+            Console.WriteLine($"Extracted {linkedEntities.Count()} linked entit{(linkedEntities.Count() > 1 ? "ies" : "y")}:");
+            foreach (LinkedEntity linkedEntity in linkedEntities)
             {
                 Console.WriteLine($"Name: {linkedEntity.Name}, Id: {linkedEntity.Id}, Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}");
                 foreach (LinkedEntityMatch match in linkedEntity.Matches)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntities.cs
@@ -27,7 +27,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string input = "Microsoft was founded by Bill Gates and Paul Allen.";
 
             Response<IReadOnlyCollection<LinkedEntity>> response = client.RecognizeLinkedEntities(input);
-            IReadOnlyCollection<LinkedEntity> linkedEntities = response.Value;
+            IEnumerable<LinkedEntity> linkedEntities = response.Value;
 
             Console.WriteLine($"Extracted {linkedEntities.Count()} linked entit{(linkedEntities.Count() > 1 ? "ies" : "y")}:");
             foreach (LinkedEntity linkedEntity in linkedEntities)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatch.cs
@@ -52,15 +52,16 @@ namespace Azure.AI.TextAnalytics.Samples
 
                 Debug.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\", Text=\"{document.Text}\"):");
 
-                if (result.ErrorMessage != default)
+                if (result.HasError)
                 {
-                    Debug.WriteLine($"Document error: {result.ErrorMessage}.");
+                    Debug.WriteLine($"    Document error code: {result.Error.Code}.");
+                    Debug.WriteLine($"    Message: {result.Error.Message}.");
                 }
                 else
                 {
-                    Debug.WriteLine($"    Extracted the following {result.LinkedEntities.Count()} linked entities:");
+                    Debug.WriteLine($"    Extracted the following {result.Entities.Count()} linked entities:");
 
-                    foreach (LinkedEntity linkedEntity in result.LinkedEntities)
+                    foreach (LinkedEntity linkedEntity in result.Entities)
                     {
                         Debug.WriteLine($"    Name: \"{linkedEntity.Name}\", Id: \"{linkedEntity.Id}\", Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}");
                         foreach (LinkedEntityMatch match in linkedEntity.Matches)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenience.cs
@@ -38,9 +38,9 @@ namespace Azure.AI.TextAnalytics.Samples
             foreach (RecognizeLinkedEntitiesResult result in results)
             {
                 Debug.Write($"For input: \"{inputs[i++]}\", ");
-                Debug.WriteLine($"extracted {result.LinkedEntities.Count()} linked entit{(result.LinkedEntities.Count() > 1 ? "ies" : "y")}:");
+                Debug.WriteLine($"extracted {result.Entities.Count()} linked entit{(result.Entities.Count() > 1 ? "ies" : "y")}:");
 
-                foreach (LinkedEntity linkedEntity in result.LinkedEntities)
+                foreach (LinkedEntity linkedEntity in result.Entities)
                 {
                     Debug.WriteLine($"    Name: \"{linkedEntity.Name}\", Id: \"{linkedEntity.Id}\", Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}");
                     foreach (LinkedEntityMatch match in linkedEntity.Matches)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/SampleSnippets.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/SampleSnippets.cs
@@ -52,7 +52,7 @@ namespace Azure.AI.TextAnalytics.Samples
             #region Snippet:BadRequest
             try
             {
-                DetectLanguageResult result = client.DetectLanguage(input);
+                DetectedLanguage result = client.DetectLanguage(input);
             }
             catch (RequestFailedException e)
             {


### PR DESCRIPTION
This PR includes:
- Error model for Text analytics => #8864 
- Making the return types for single methods atomic
- Renaming of `RecognizeLinkedEntitiesResult.LinkedEntities` to `RecognizeLinkedEntitiesResult.LinkedEntities.Entities`