### PR TITLE
ServiceBus ManagedIdentityTokenProvider with AzureServiceTokenProvider.

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ManagedIdentityTokenProvider.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ManagedIdentityTokenProvider.cs
@@ -12,7 +12,17 @@ namespace Microsoft.Azure.ServiceBus.Primitives
     /// </summary>
     public class ManagedIdentityTokenProvider : TokenProvider
     {
-        static AzureServiceTokenProvider azureServiceTokenProvider = new AzureServiceTokenProvider();
+        private readonly AzureServiceTokenProvider azureServiceTokenProvider;
+
+        /// <summary>Initializes new instance of <see cref="ManagedIdentityTokenProvider"/> class with default <see cref="AzureServiceTokenProvider"/> configuration.
+        public ManagedIdentityTokenProvider() : this(new AzureServiceTokenProvider()){}
+
+        /// <summary>Initializes new instance of <see cref="ManagedIdentityTokenProvider"/> class with <see cref="AzureServiceTokenProvider"/>.
+        /// <remarks>Call that constructore to set <see cref="AzureServiceTokenProvider"/> with required Managed Identity connection string.</remarks>
+        public ManagedIdentityTokenProvider(AzureServiceTokenProvider azureServiceTokenProvider)
+        {
+            this.azureServiceTokenProvider = azureServiceTokenProvider;
+        }
 
         /// <summary>
         /// Gets a <see cref="SecurityToken"/> for the given audience and duration.


### PR DESCRIPTION
Allows to set customized AzureServiceTokenProvider to ManagedIdentityTokenProvider constructor.
AzureServiceTokenProvider may be constructed using different Managed Identity connectionStrings.
