### PR TITLE
Adding placeholder to list any third party licenses

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,3 +1,23 @@
+NOTICES AND INFORMATION
+Do Not Translate or Localize
+
+This software incorporates material from third parties. Microsoft makes certain
+open source code available at https://3rdpartysource.microsoft.com, or you may
+send a check or money order for US $5.00, including the product name, the open
+source component name, and version number, to:
+
+Source Code Compliance Team
+Microsoft Corporation
+One Microsoft Way
+Redmond, WA 98052
+USA
+
+Notwithstanding any other terms, you may reverse engineer this software to the
+extent required to debug changes to any libraries licensed under the GNU Lesser
+General Public License.
+
+------------------------------------------------------------------------------
+
 This file list any third-party libraries or other resources that may be
 distributed under licenses different than the Azure SDK for .NET software.
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,7 @@
+This file list any third-party libraries or other resources that may be
+distributed under licenses different than the Azure SDK for .NET software.
+
+In the event that we accidentally failed to list a required notice, please
+bring it to our attention by opening an issue.
+
+The attached notices are provided for information only.


### PR DESCRIPTION
This is a place holder file to list licenses in the event .NET sdk need to redistribute 3rd party source code.