### PR TITLE
Resolve wonky spacing in textanalytics "examples" header

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -93,8 +93,8 @@ For each supported operation, `TextAnalyticsClient` provides a method that accep
 
 **Note:** It is recommended to use the batch methods when working on production environments as they allow you to send one request with multiple text inputs. This is more performant than sending a request per each text input.
 
- ## Examples
- The following section provides several code snippets using the `client` [created above](#create-textanalyticsclient), and covers the main functions of Text Analytics.
+## Examples
+The following section provides several code snippets using the `client` [created above](#create-textanalyticsclient), and covers the main functions of Text Analytics.
 
 ### Sync examples
 * [Detect Language](#detect-language)


### PR DESCRIPTION
It's causing weirdness when doc-warden translates the markdown to html. 

@maririos 