### PR TITLE
Fix readme and enable it

### DIFF
--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -135,7 +135,6 @@ known_content_issues:
   - ['sdk/cognitiveservices/Personalizer/src/README.md','#5499']
   - ['sdk/batch/Microsoft.Azure.Batch/README.md','#5499']
   - ['sdk/batch/Microsoft.Azure.Batch.Conventions.Files/README.md','#5499']
-  - ['sdk/textanalytics/Azure.AI.TextAnalytics/README.md','#5499']
 
 # .net climbs upwards. placing these to prevent assigning readmes to the wrong project
 package_indexing_exclusion_list:

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -286,7 +286,8 @@ Headers:
     Content-Type: application/json; charset=utf-8
 ```
 
-## Next Steps
+## Next steps
+
 Samples showing how to use the Cognitive Services Text Analytics library are available in this GitHub repository.
 Samples are provided for each main functional area, and for each area, samples are provided for analyzing a single text input, a collection of text input strings, and a collection of text document inputs.
 


### PR DESCRIPTION
Fix for readme template:
```
\sdk\textanalytics\Azure.AI.TextAnalytics\README.md is missing headers with patterns:
 * ^Next steps$
```