### PR TITLE
Don't treat precondition failures as distributed tracing failures

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -919,7 +919,7 @@ namespace Azure.Storage.Blobs
                         Uri,
                         access: publicAccessType,
                         defaultEncryptionScope: encryptionScopeOptions?.DefaultEncryptionScope,
-                        denyEncryptionScopeOverride: encryptionScopeOptions?.PreventEncryptionScopeOverride ,
+                        preventEncryptionScopeOverride: encryptionScopeOptions?.PreventEncryptionScopeOverride,
                         version: Version.ToVersionString(),
                         metadata: metadata,
                         async: async,

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobErrors.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobErrors.cs
@@ -41,5 +41,25 @@ namespace Azure.Storage.Blobs
 
         public static ArgumentException ParsingFullHttpRangeFailed(string range)
             => new ArgumentException("Could not obtain the total length from HTTP range " + range);
+
+        /// <summary>
+        /// Determine if an exception should be treated as a failure for our
+        /// client diagnostics.  This lets us allow list a select few error
+        /// cases - like precondition failures - to avoid cluttering customer
+        /// logs.
+        /// </summary>
+        /// <param name="ex">The exception.</param>
+        /// <returns>Whether the exception should be treated as a failure.</returns>
+        public static bool IsDiagnosticFailure(Exception ex) =>
+            // Any exception other than RequestFailedException is a failure
+            !(ex is RequestFailedException e) ||
+
+            // Any status code other than 412 is a failure
+            e.Status != 412 ||
+
+            // The following 412s are not considered failures
+            (e.ErrorCode != BlobErrorCode.ConditionNotMet &&
+             e.ErrorCode != BlobErrorCode.SourceConditionNotMet &&
+             e.ErrorCode != BlobErrorCode.TargetConditionNotMet);
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
@@ -78,7 +78,7 @@ namespace Azure.Storage.Blobs
                         return SetPropertiesAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -228,7 +228,7 @@ namespace Azure.Storage.Blobs
                         return GetPropertiesAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -374,7 +374,7 @@ namespace Azure.Storage.Blobs
                         return GetStatisticsAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -532,7 +532,7 @@ namespace Azure.Storage.Blobs
                         return ListBlobContainersSegmentAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -692,7 +692,7 @@ namespace Azure.Storage.Blobs
                         return GetUserDelegationKeyAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -841,7 +841,7 @@ namespace Azure.Storage.Blobs
                         return GetAccountInfoAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -1000,7 +1000,7 @@ namespace Azure.Storage.Blobs
                         return SubmitBatchAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -1135,7 +1135,7 @@ namespace Azure.Storage.Blobs
             /// <param name="metadata">Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the operation will copy the metadata from the source blob or file to the destination blob. If one or more name-value pairs are specified, the destination blob is created with the specified metadata, and metadata is not copied from the source blob or file. Note that beginning with version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers, Blobs, and Metadata for more information.</param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="defaultEncryptionScope">Optional.  Version 2019-07-07 and later.  Specifies the default encryption scope to set on the container and use for all future writes.</param>
-            /// <param name="denyEncryptionScopeOverride">Optional.  Version 2019-07-07 and newer.  If true, prevents any request from specifying a different encryption scope than the scope set on the container.</param>
+            /// <param name="preventEncryptionScopeOverride">Optional.  Version 2019-07-07 and newer.  If true, prevents any request from specifying a different encryption scope than the scope set on the container.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="operationName">Operation name.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
@@ -1150,7 +1150,7 @@ namespace Azure.Storage.Blobs
                 System.Collections.Generic.IDictionary<string, string> metadata = default,
                 string requestId = default,
                 string defaultEncryptionScope = default,
-                bool? denyEncryptionScopeOverride = default,
+                bool? preventEncryptionScopeOverride = default,
                 bool async = true,
                 string operationName = "ContainerClient.Create",
                 System.Threading.CancellationToken cancellationToken = default)
@@ -1169,7 +1169,7 @@ namespace Azure.Storage.Blobs
                         metadata,
                         requestId,
                         defaultEncryptionScope,
-                        denyEncryptionScopeOverride))
+                        preventEncryptionScopeOverride))
                     {
                         if (async)
                         {
@@ -1187,7 +1187,7 @@ namespace Azure.Storage.Blobs
                         return CreateAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -1209,7 +1209,7 @@ namespace Azure.Storage.Blobs
             /// <param name="metadata">Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the operation will copy the metadata from the source blob or file to the destination blob. If one or more name-value pairs are specified, the destination blob is created with the specified metadata, and metadata is not copied from the source blob or file. Note that beginning with version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers, Blobs, and Metadata for more information.</param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="defaultEncryptionScope">Optional.  Version 2019-07-07 and later.  Specifies the default encryption scope to set on the container and use for all future writes.</param>
-            /// <param name="denyEncryptionScopeOverride">Optional.  Version 2019-07-07 and newer.  If true, prevents any request from specifying a different encryption scope than the scope set on the container.</param>
+            /// <param name="preventEncryptionScopeOverride">Optional.  Version 2019-07-07 and newer.  If true, prevents any request from specifying a different encryption scope than the scope set on the container.</param>
             /// <returns>The Container.CreateAsync Message.</returns>
             internal static Azure.Core.HttpMessage CreateAsync_CreateMessage(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
@@ -1220,7 +1220,7 @@ namespace Azure.Storage.Blobs
                 System.Collections.Generic.IDictionary<string, string> metadata = default,
                 string requestId = default,
                 string defaultEncryptionScope = default,
-                bool? denyEncryptionScopeOverride = default)
+                bool? preventEncryptionScopeOverride = default)
             {
                 // Validation
                 if (resourceUri == null)
@@ -1253,9 +1253,9 @@ namespace Azure.Storage.Blobs
                 }
                 if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
                 if (defaultEncryptionScope != null) { _request.Headers.SetValue("x-ms-default-encryption-scope", defaultEncryptionScope); }
-                if (denyEncryptionScopeOverride != null) {
+                if (preventEncryptionScopeOverride != null) {
                 #pragma warning disable CA1308 // Normalize strings to uppercase
-                _request.Headers.SetValue("x-ms-deny-encryption-scope-override", denyEncryptionScopeOverride.Value.ToString(System.Globalization.CultureInfo.InvariantCulture).ToLowerInvariant());
+                _request.Headers.SetValue("x-ms-deny-encryption-scope-override", preventEncryptionScopeOverride.Value.ToString(System.Globalization.CultureInfo.InvariantCulture).ToLowerInvariant());
                 #pragma warning restore CA1308 // Normalize strings to uppercase
                 }
 
@@ -1362,7 +1362,7 @@ namespace Azure.Storage.Blobs
                         return GetPropertiesAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -1569,7 +1569,7 @@ namespace Azure.Storage.Blobs
                         return DeleteAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -1723,7 +1723,7 @@ namespace Azure.Storage.Blobs
                         return SetMetadataAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -1892,7 +1892,7 @@ namespace Azure.Storage.Blobs
                         return GetAccessPolicyAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -2076,7 +2076,7 @@ namespace Azure.Storage.Blobs
                         return SetAccessPolicyAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -2268,7 +2268,7 @@ namespace Azure.Storage.Blobs
                         return AcquireLeaseAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -2446,7 +2446,7 @@ namespace Azure.Storage.Blobs
                         return ReleaseLeaseAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -2621,7 +2621,7 @@ namespace Azure.Storage.Blobs
                         return RenewLeaseAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -2800,7 +2800,7 @@ namespace Azure.Storage.Blobs
                         return BreakLeaseAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -2978,7 +2978,7 @@ namespace Azure.Storage.Blobs
                         return ChangeLeaseAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -3167,7 +3167,7 @@ namespace Azure.Storage.Blobs
                         return ListBlobsFlatSegmentAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -3340,7 +3340,7 @@ namespace Azure.Storage.Blobs
                         return ListBlobsHierarchySegmentAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -3547,7 +3547,7 @@ namespace Azure.Storage.Blobs
                         return (DownloadAsync_CreateResponse(clientDiagnostics, _response), _message.ExtractResponseContent());
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -4013,7 +4013,7 @@ namespace Azure.Storage.Blobs
                         return GetPropertiesAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -4349,7 +4349,7 @@ namespace Azure.Storage.Blobs
                         return DeleteAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -4532,7 +4532,7 @@ namespace Azure.Storage.Blobs
                         return SetAccessControlAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -4728,7 +4728,7 @@ namespace Azure.Storage.Blobs
                         return GetAccessControlAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -4981,7 +4981,7 @@ namespace Azure.Storage.Blobs
                         return RenameAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -5199,7 +5199,7 @@ namespace Azure.Storage.Blobs
                         return UndeleteAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -5368,7 +5368,7 @@ namespace Azure.Storage.Blobs
                         return SetHttpHeadersAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -5586,7 +5586,7 @@ namespace Azure.Storage.Blobs
                         return SetMetadataAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -5802,7 +5802,7 @@ namespace Azure.Storage.Blobs
                         return AcquireLeaseAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -5991,7 +5991,7 @@ namespace Azure.Storage.Blobs
                         return ReleaseLeaseAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -6177,7 +6177,7 @@ namespace Azure.Storage.Blobs
                         return RenewLeaseAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -6370,7 +6370,7 @@ namespace Azure.Storage.Blobs
                         return ChangeLeaseAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -6567,7 +6567,7 @@ namespace Azure.Storage.Blobs
                         return BreakLeaseAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -6768,7 +6768,7 @@ namespace Azure.Storage.Blobs
                         return CreateSnapshotAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -7001,7 +7001,7 @@ namespace Azure.Storage.Blobs
                         return StartCopyFromUriAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -7246,7 +7246,7 @@ namespace Azure.Storage.Blobs
                         return CopyFromUriAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -7459,7 +7459,7 @@ namespace Azure.Storage.Blobs
                         return AbortCopyFromUriAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -7615,7 +7615,7 @@ namespace Azure.Storage.Blobs
                         return SetAccessTierAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -7832,7 +7832,7 @@ namespace Azure.Storage.Blobs
                         return CreateAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -8115,7 +8115,7 @@ namespace Azure.Storage.Blobs
                         return UploadPagesAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -8386,7 +8386,7 @@ namespace Azure.Storage.Blobs
                         return ClearPagesAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -8662,7 +8662,7 @@ namespace Azure.Storage.Blobs
                         return UploadPagesFromUriAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -8947,7 +8947,7 @@ namespace Azure.Storage.Blobs
                         return GetPageRangesAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -9156,7 +9156,7 @@ namespace Azure.Storage.Blobs
                         return GetPageRangesDiffAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -9374,7 +9374,7 @@ namespace Azure.Storage.Blobs
                         return ResizeAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -9580,7 +9580,7 @@ namespace Azure.Storage.Blobs
                         return UpdateSequenceNumberAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -9771,7 +9771,7 @@ namespace Azure.Storage.Blobs
                         return CopyIncrementalAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -10008,7 +10008,7 @@ namespace Azure.Storage.Blobs
                         return CreateAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -10276,7 +10276,7 @@ namespace Azure.Storage.Blobs
                         return AppendBlockAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -10569,7 +10569,7 @@ namespace Azure.Storage.Blobs
                         return AppendBlockFromUriAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -10897,7 +10897,7 @@ namespace Azure.Storage.Blobs
                         return UploadAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -11165,7 +11165,7 @@ namespace Azure.Storage.Blobs
                         return StageBlockAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -11409,7 +11409,7 @@ namespace Azure.Storage.Blobs
                         return StageBlockFromUriAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -11695,7 +11695,7 @@ namespace Azure.Storage.Blobs
                         return CommitBlockListAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -11946,7 +11946,7 @@ namespace Azure.Storage.Blobs
                         return GetBlockListAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -12167,7 +12167,7 @@ namespace Azure.Storage.Blobs
                         return CreateAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -12424,7 +12424,7 @@ namespace Azure.Storage.Blobs
                         return RenameAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -12670,7 +12670,7 @@ namespace Azure.Storage.Blobs
                         return DeleteAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -12868,7 +12868,7 @@ namespace Azure.Storage.Blobs
                         return SetAccessControlAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;
@@ -13064,7 +13064,7 @@ namespace Azure.Storage.Blobs
                         return GetAccessControlAsync_CreateResponse(clientDiagnostics, _response);
                     }
                 }
-                catch (System.Exception ex)
+                catch (System.Exception ex) when (Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure(ex))
                 {
                     _scope.Failed(ex);
                     throw;

--- a/sdk/storage/Azure.Storage.Blobs/src/PartitionedDownloader.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/PartitionedDownloader.cs
@@ -159,7 +159,7 @@ namespace Azure.Storage.Blobs
                         .ConfigureAwait(false);
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (BlobErrors.IsDiagnosticFailure(ex))
             {
                 scope.Failed(ex);
                 throw;
@@ -233,7 +233,7 @@ namespace Azure.Storage.Blobs
 
                 return initialResponse.GetRawResponse();
             }
-            catch (Exception ex)
+            catch (Exception ex) when (BlobErrors.IsDiagnosticFailure(ex))
             {
                 scope.Failed(ex);
                 throw;

--- a/sdk/storage/Azure.Storage.Blobs/src/PartitionedUploader.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/PartitionedUploader.cs
@@ -227,7 +227,7 @@ namespace Azure.Storage.Blobs
                     accessTier,
                     cancellationToken);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (BlobErrors.IsDiagnosticFailure(ex))
             {
                 scope.Failed(ex);
                 throw;
@@ -320,7 +320,7 @@ namespace Azure.Storage.Blobs
                     cancellationToken)
                     .ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (BlobErrors.IsDiagnosticFailure(ex))
             {
                 scope.Failed(ex);
                 throw;

--- a/sdk/storage/Azure.Storage.Blobs/swagger/readme.md
+++ b/sdk/storage/Azure.Storage.Blobs/swagger/readme.md
@@ -31,6 +31,7 @@ directive:
     $["x-az-skip-path-components"] = true;
     $["x-az-include-sync-methods"] = true;
     $["x-az-public"] = false;
+    $["x-az-trace-failure-check"] = "Azure.Storage.Blobs.BlobErrors.IsDiagnosticFailure";
 ```
 
 ### Move directory operations last

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTests/ExceptionsAreDistributedTracingFailures.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTests/ExceptionsAreDistributedTracingFailures.json
@@ -1,0 +1,107 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://storageteglazatesting.blob.core.windows.net/test-container-92b1ac99-8096-ec50-0098-0274db7abc74?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-42051efd7355a147bc98a388855047d2-89f8d5fc639a2042-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.3.0-dev.20200212.1\u002B2001fe133680d4ec3a4a5409fab25948e4e93325",
+          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "09644ce2-3990-a037-a788-90a0cb2a3dea",
+        "x-ms-date": "Thu, 13 Feb 2020 01:02:09 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 13 Feb 2020 01:02:09 GMT",
+        "ETag": "\u00220x8D7B0205AA09F4F\u0022",
+        "Last-Modified": "Thu, 13 Feb 2020 01:02:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "09644ce2-3990-a037-a788-90a0cb2a3dea",
+        "x-ms-request-id": "1104abb5-401e-0099-5b09-e232b3000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storageteglazatesting.blob.core.windows.net/test-container-92b1ac99-8096-ec50-0098-0274db7abc74/test-blob-a785c3b2-2844-bddf-b92b-d77190f2afc3?comp=metadata",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-12c324ca9e234746927e66c047fc1bba-c2493cfc5fe63d4f-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.3.0-dev.20200212.1\u002B2001fe133680d4ec3a4a5409fab25948e4e93325",
+          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "7aaa04e7-a6b7-baa8-6da6-506461c50fb4",
+        "x-ms-date": "Thu, 13 Feb 2020 01:02:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "215",
+        "Content-Type": "application/xml",
+        "Date": "Thu, 13 Feb 2020 01:02:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7aaa04e7-a6b7-baa8-6da6-506461c50fb4",
+        "x-ms-error-code": "BlobNotFound",
+        "x-ms-request-id": "1104abd4-401e-0099-7109-e232b3000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": [
+        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EBlobNotFound\u003C/Code\u003E\u003CMessage\u003EThe specified blob does not exist.\n",
+        "RequestId:1104abd4-401e-0099-7109-e232b3000000\n",
+        "Time:2020-02-13T01:02:10.2713115Z\u003C/Message\u003E\u003C/Error\u003E"
+      ]
+    },
+    {
+      "RequestUri": "https://storageteglazatesting.blob.core.windows.net/test-container-92b1ac99-8096-ec50-0098-0274db7abc74?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-3a103b5352720b48beab5c6b571284eb-dd7828955a949441-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.3.0-dev.20200212.1\u002B2001fe133680d4ec3a4a5409fab25948e4e93325",
+          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "8b894772-3448-a50c-6cd7-216f62809e86",
+        "x-ms-date": "Thu, 13 Feb 2020 01:02:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 13 Feb 2020 01:02:09 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8b894772-3448-a50c-6cd7-216f62809e86",
+        "x-ms-request-id": "1104abe8-401e-0099-0109-e232b3000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1829513170",
+    "Storage_TestConfigDefault": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttps://storageteglazatesting.blob.core.windows.net\nhttps://storageteglazatesting.file.core.windows.net\nhttps://storageteglazatesting.queue.core.windows.net\nhttps://storageteglazatesting.table.core.windows.net\n\n\n\n\nhttps://storageteglazatesting-secondary.blob.core.windows.net\n\nhttps://storageteglazatesting-secondary.queue.core.windows.net\nhttps://storageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://storageteglazatesting.blob.core.windows.net/;QueueEndpoint=https://storageteglazatesting.queue.core.windows.net/;FileEndpoint=https://storageteglazatesting.file.core.windows.net/;BlobSecondaryEndpoint=https://storageteglazatesting-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://storageteglazatesting-secondary.queue.core.windows.net/;AccountName=storageteglazatesting;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTests/ExceptionsAreDistributedTracingFailuresAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTests/ExceptionsAreDistributedTracingFailuresAsync.json
@@ -1,0 +1,107 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://storageteglazatesting.blob.core.windows.net/test-container-f66c4d7a-0f24-8e54-374c-fd4d22263527?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-6448dc6ba2a8d34ea93d9a038e5954f0-46ae42f6124f0845-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.3.0-dev.20200212.1\u002B2001fe133680d4ec3a4a5409fab25948e4e93325",
+          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "d5da12d4-469e-30fc-e855-26ee476a8aa7",
+        "x-ms-date": "Thu, 13 Feb 2020 01:02:19 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 13 Feb 2020 01:02:19 GMT",
+        "ETag": "\u00220x8D7B020600D6043\u0022",
+        "Last-Modified": "Thu, 13 Feb 2020 01:02:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d5da12d4-469e-30fc-e855-26ee476a8aa7",
+        "x-ms-request-id": "001c08ec-101e-004f-0b09-e23c5a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storageteglazatesting.blob.core.windows.net/test-container-f66c4d7a-0f24-8e54-374c-fd4d22263527/test-blob-962b5310-9b2f-1ff0-f41c-00a94d551d3b?comp=metadata",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-de790dd4667e6741bb4c74dc53071f8b-6e1b6dff3f163e4e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.3.0-dev.20200212.1\u002B2001fe133680d4ec3a4a5409fab25948e4e93325",
+          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "1ced19f0-29d0-3891-22ba-e1824553e293",
+        "x-ms-date": "Thu, 13 Feb 2020 01:02:19 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "215",
+        "Content-Type": "application/xml",
+        "Date": "Thu, 13 Feb 2020 01:02:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1ced19f0-29d0-3891-22ba-e1824553e293",
+        "x-ms-error-code": "BlobNotFound",
+        "x-ms-request-id": "001c08fd-101e-004f-1909-e23c5a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": [
+        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EBlobNotFound\u003C/Code\u003E\u003CMessage\u003EThe specified blob does not exist.\n",
+        "RequestId:001c08fd-101e-004f-1909-e23c5a000000\n",
+        "Time:2020-02-13T01:02:19.3336100Z\u003C/Message\u003E\u003C/Error\u003E"
+      ]
+    },
+    {
+      "RequestUri": "https://storageteglazatesting.blob.core.windows.net/test-container-f66c4d7a-0f24-8e54-374c-fd4d22263527?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-851314f659122d46b258a5f42a6bb3c7-790234a4bf0e2d4c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.3.0-dev.20200212.1\u002B2001fe133680d4ec3a4a5409fab25948e4e93325",
+          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "34b87513-0168-636a-ab40-ed907f07e556",
+        "x-ms-date": "Thu, 13 Feb 2020 01:02:19 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 13 Feb 2020 01:02:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "34b87513-0168-636a-ab40-ed907f07e556",
+        "x-ms-request-id": "001c0906-101e-004f-2009-e23c5a000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1172282990",
+    "Storage_TestConfigDefault": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttps://storageteglazatesting.blob.core.windows.net\nhttps://storageteglazatesting.file.core.windows.net\nhttps://storageteglazatesting.queue.core.windows.net\nhttps://storageteglazatesting.table.core.windows.net\n\n\n\n\nhttps://storageteglazatesting-secondary.blob.core.windows.net\n\nhttps://storageteglazatesting-secondary.queue.core.windows.net\nhttps://storageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://storageteglazatesting.blob.core.windows.net/;QueueEndpoint=https://storageteglazatesting.queue.core.windows.net/;FileEndpoint=https://storageteglazatesting.file.core.windows.net/;BlobSecondaryEndpoint=https://storageteglazatesting-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://storageteglazatesting-secondary.queue.core.windows.net/;AccountName=storageteglazatesting;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTests/PreconditionsAreNotDistributedTracingFailures.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTests/PreconditionsAreNotDistributedTracingFailures.json
@@ -1,0 +1,143 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://storageteglazatesting.blob.core.windows.net/test-container-53ece79f-d814-e2b9-17aa-0df91c4581e0?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-1b26628ea00c1d42810e310d3e1df858-a3c2f64716bb9545-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.3.0-dev.20200212.1\u002B2001fe133680d4ec3a4a5409fab25948e4e93325",
+          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "ddb80309-3623-a273-8a3b-a4b3272cdb5a",
+        "x-ms-date": "Thu, 13 Feb 2020 01:02:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 13 Feb 2020 01:02:10 GMT",
+        "ETag": "\u00220x8D7B0205ABC344E\u0022",
+        "Last-Modified": "Thu, 13 Feb 2020 01:02:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ddb80309-3623-a273-8a3b-a4b3272cdb5a",
+        "x-ms-request-id": "df07c68f-201e-0026-0109-e20516000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storageteglazatesting.blob.core.windows.net/test-container-53ece79f-d814-e2b9-17aa-0df91c4581e0/test-blob-9173b1a5-91ae-ee59-2492-bdc3a926a0e4",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "If-None-Match": "*",
+        "traceparent": "00-36ff21cb7ec7c94d8981472c2d376f28-dae045a9c758d041-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.3.0-dev.20200212.1\u002B2001fe133680d4ec3a4a5409fab25948e4e93325",
+          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "3f6cf3b4-ac6c-643f-a03d-8f407c19e0a8",
+        "x-ms-date": "Thu, 13 Feb 2020 01:02:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": "ezTvGI2kvYPLIKPUDQ4zaXXU7Y\u002B/nSl4qsm4kXmw\u002BWSavzjyPMLNAfTwxo7uhOEWXlNN1DgQJd0Ld27D6ywKGic/OU3WQS2zB\u002BybztabiSXoojIlYiQripla5sRTCRXI5qtmr0uUPx0mms1LdVYGb\u002B5I20n55LcDE6\u002Bze1poX/3X0ugqNdraU2IU/shW3xVDU3fWCy7MzgHzY5uc4MTDvjrQdKNu2zoTbYfm5eXvrTSZcCfjkVTOCwPnNtE/PnOeUUCOhmty1Xc8wp2m5ekbBLVnAnCc4CzlAWmfhqRo1C8UR5OlYCfIJ5uvps62JyUZyzIc1zwDAnEUqIQC0k7S1O5ukp1VdqSOntrU7DldLtlDhbtyTPzyEUUikbeixlVN3NLgSJWIw1WNjTliLhU3tnmrvk2TYIfxe4FXM\u002BTs7NeEhxBnfOZDusFl5L/DkOMw6to99gcIuXxK780TMJBwoaBi3aYF0DqTZwSLLXvILuqeJ0kKrvXPfM2THIwZMIox9EMeYLM8Kxqgqo8DfIwBgsHidQlHZvKrkmDYcbStejd5Wjg3qs03YfsvagRly/9BkpnLNrqA6o5Qcs5SZLll8i9YiSJTydj0qxQNF/zuRcZglt8a4kR9\u002BHCq5zf/5P1CyXfUDUHd7sjB1oqlc9KSYS0H8s3ZSxDr25GyqeKh9McXy06EGTeFg6gXWQu514WdF4UJ\u002BPEvaH1m6TKwK0XmIOLDjqeDDUj1gm8lwvIFMQMLFJFcl/zV52LRHi8F1FdiMDgp9kjeGgk9FHaCCaWKYbgupRa0iYjl7adEsu8Y8K0Xw5G53Dq7LPqHH4OGUt28Rr131i5BrqawQwihmWcaJCPIa0YU0YR9c3gcLGoFXpvJh2wyoBp/1hTqCZgyGpOSbPpfveeXqHQ4\u002BmK1JIE8quVt2BH76IMJSZUxKcjsS1nlisBvpqC0Mt73\u002Baa3ybGTrl6zxEGBl4R3VXRSZX\u002BsS64J0JrBzQREuaUzA\u002B7cUX/jnnppOYYXZPI7\u002BFAsYcxfS674rvkX0uFZbwucTpOVmgP0bsYEQhIn8WunhdS0F1fY07hA5KOGy8yZD8p7exZfpl5MN/IFWgic0L2Nb0wMpVezw3raVbVgbqP6azNHrHZVSN92Z\u002BBk03mwoxPm\u002BVx/jGpzyLibhFCo68lPC\u002B7VVCRHNydtlj12Tu8AKrGhenRGe97I1OO9ucOOzXwWFMeK20/vn8E0EvYs/HnImlqfBnFUCZAQDIBAiX5k3sjBXzkodk5istuzEmjom9hp9R5o78cLwgs3es/PrhVDzzQta5w/oCQMPVSVoPYnJ3Co1pRf/O8Btp0u8Pt/kwPFcEI0uzA7KlT6XLFydSEVD1JeJg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "S1Ewr5KLNv3h\u002BoiSGvWSZw==",
+        "Date": "Thu, 13 Feb 2020 01:02:10 GMT",
+        "ETag": "\u00220x8D7B0205AC25BFD\u0022",
+        "Last-Modified": "Thu, 13 Feb 2020 01:02:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3f6cf3b4-ac6c-643f-a03d-8f407c19e0a8",
+        "x-ms-content-crc64": "Mpitl8BIl/Y=",
+        "x-ms-request-id": "df07c6bd-201e-0026-2c09-e20516000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storageteglazatesting.blob.core.windows.net/test-container-53ece79f-d814-e2b9-17aa-0df91c4581e0/test-blob-9173b1a5-91ae-ee59-2492-bdc3a926a0e4?comp=metadata",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "If-None-Match": "*",
+        "traceparent": "00-5af3b5d765491841aaf5a7bb703f6821-e3be472da8ac124f-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.3.0-dev.20200212.1\u002B2001fe133680d4ec3a4a5409fab25948e4e93325",
+          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "1c60f1a5-1ee6-2bba-417f-33079c7482f8",
+        "x-ms-date": "Thu, 13 Feb 2020 01:02:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 13 Feb 2020 01:02:10 GMT",
+        "ETag": "\u00220x8D7B0205AC569FA\u0022",
+        "Last-Modified": "Thu, 13 Feb 2020 01:02:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1c60f1a5-1ee6-2bba-417f-33079c7482f8",
+        "x-ms-request-id": "df07c6d0-201e-0026-3d09-e20516000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storageteglazatesting.blob.core.windows.net/test-container-53ece79f-d814-e2b9-17aa-0df91c4581e0?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-568cfe0f83bca046aa9b0cf28b090b42-93592b2d1c519542-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.3.0-dev.20200212.1\u002B2001fe133680d4ec3a4a5409fab25948e4e93325",
+          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "8a9a6d35-c3b8-02c1-b1ff-020d3ae7f307",
+        "x-ms-date": "Thu, 13 Feb 2020 01:02:10 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 13 Feb 2020 01:02:10 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8a9a6d35-c3b8-02c1-b1ff-020d3ae7f307",
+        "x-ms-request-id": "df07c6e0-201e-0026-4b09-e20516000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1419267015",
+    "Storage_TestConfigDefault": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttps://storageteglazatesting.blob.core.windows.net\nhttps://storageteglazatesting.file.core.windows.net\nhttps://storageteglazatesting.queue.core.windows.net\nhttps://storageteglazatesting.table.core.windows.net\n\n\n\n\nhttps://storageteglazatesting-secondary.blob.core.windows.net\n\nhttps://storageteglazatesting-secondary.queue.core.windows.net\nhttps://storageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://storageteglazatesting.blob.core.windows.net/;QueueEndpoint=https://storageteglazatesting.queue.core.windows.net/;FileEndpoint=https://storageteglazatesting.file.core.windows.net/;BlobSecondaryEndpoint=https://storageteglazatesting-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://storageteglazatesting-secondary.queue.core.windows.net/;AccountName=storageteglazatesting;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTests/PreconditionsAreNotDistributedTracingFailuresAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobClientTests/PreconditionsAreNotDistributedTracingFailuresAsync.json
@@ -1,0 +1,143 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://storageteglazatesting.blob.core.windows.net/test-container-3de0cf2b-cd03-7a18-1819-85ce8ff2de6e?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-954a0a5a6d4ef845b1d3bfc0232ae137-b569c543af2b8f42-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.3.0-dev.20200212.1\u002B2001fe133680d4ec3a4a5409fab25948e4e93325",
+          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "476b5d12-3f50-2adb-20f5-2681b5b685a4",
+        "x-ms-date": "Thu, 13 Feb 2020 01:02:19 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 13 Feb 2020 01:02:19 GMT",
+        "ETag": "\u00220x8D7B020601AC3F8\u0022",
+        "Last-Modified": "Thu, 13 Feb 2020 01:02:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "476b5d12-3f50-2adb-20f5-2681b5b685a4",
+        "x-ms-request-id": "778072cc-001e-006c-1009-e2a699000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storageteglazatesting.blob.core.windows.net/test-container-3de0cf2b-cd03-7a18-1819-85ce8ff2de6e/test-blob-d5c95fca-18d1-5552-58fd-25d6efaa0703",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "If-None-Match": "*",
+        "traceparent": "00-a75fe371128a9344ad714176b1cb8a48-7e89f9f860de8049-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.3.0-dev.20200212.1\u002B2001fe133680d4ec3a4a5409fab25948e4e93325",
+          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "139e2939-fe76-703f-8024-1167b6970c4b",
+        "x-ms-date": "Thu, 13 Feb 2020 01:02:19 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": "6/K7MYeWHcy4RyiRr/UuYqg4oxRLV8H5CxXvUxkFOnXuIpXC\u002BlMdM0H9HYrwwKZizsMutgfzt5MwwSZyp8mysgyyo41fa2dUG2/STjo2CUtvjIRW14Ru\u002B2oCkTktqox3S2p\u002BPRwYA2Nb2ZuXIGlY\u002BrfaAhpFW9uIRKgiXdkuJ3DjWgPQuMwuVokh\u002Bv7o19oBqZeBUqhyMu\u002BP9vh09qWKLbEqs8ZliELrrKyQI2Ddn23OIbNBrNXIcScUQcHTuWDjl81MviMUnCBVlqb84Q\u002BOsVeLptXxSIDcYkKeUUeAF/JLrYyTkOBKuYST7BYuzI8YhY9qRxOL8k5Mb1zgdUrY1X6zsDSC\u002ByF2QexQXltqrZWyhcu4FdDfwLs9RiGEaUQ5uheYextblopu9AYmOpPz4sHGLfB/H7\u002Bt1O95RLT/8deoFqNE0TJ6V\u002B9BSiDKuYUnSmNfvjxTuppX6qcr4lHVbgIufSTvrhCPTNYBPtWe4xpqUflRoDObVFsI7OeLTnSda9wenDtgN5xT0HJlUnzFuAaMwZBXhM7PkijI5sIpA/5hY9L4gEffCRld/s/BNQLfQzPh/ozjRecOTwkSmFDZKcxzBO6pzTi\u002Brbh3\u002Bob\u002BDVwm6aOOSARxfR7q6jE\u002BzHHJg9QCTTETNXX7IlHUbEthEEGt666tS\u002BHHAobQv\u002BMHgOBHrnax\u002B78qErMtkyWynRDTiNnvkODCGzjyOkuqQ3aS86FxjL7UsBSBgtn7f7e7FWR1/TYJF/D/hZI9vsB0gM89m5\u002BEQRBS/tjFbQ4HxpyBNyXnNEY/idyxcgcsl/FUDQIJveQXN9NTI/9eRKnh9771vIeajEuJ/hHD0s4JJWbncWAL/gi4aQBSlBFG4UUyz3pJN9tquYC2gL/SVGQFSv2YdtJJ1fm1PFKHSPg6QhzMkAJTv\u002B6LfLjfVH5J5hWbTEkTrmpy6fmBlPqI43CHfD2jBsNisYoPDPoaaYF7bFY86/uuJpSyWacI0ivzAplHV9hApeBSOZu/A6FwV394BiekTPd02Fap8awcWd9eGwpg0xKoOsZ16rJg7yLyQQEnkMsDT7ah0n6Cl7QzNt\u002B8YOeXD4Rtz8xhLmJFFOkztq\u002Bq9MkTW8xUvwCTJqIRQrTSo446WzJ8usD/oSBTXL2VTuEFiUEWqAUbQ1CE2akqUOyucnFb\u002BFp9LToJFLmrAGJC/tjADLhyu/qIHxji\u002BOAW1FE0pelMOlaGiFsHDZRMb0PtQdvRaUQzO7d20thCmjRZ8j9nd1p59cSBOoNda65mPLDV9LcERWsNAWoy1md9RO0mrRtU5fjoc0sXTy/A1dAJEJYobaV9VKzUWnbwRh9cBPaWN72SEVe37IFr7fY8TSuZKQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "4IY/Yx0fCd78V36uk3CqMg==",
+        "Date": "Thu, 13 Feb 2020 01:02:19 GMT",
+        "ETag": "\u00220x8D7B020601E5B12\u0022",
+        "Last-Modified": "Thu, 13 Feb 2020 01:02:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "139e2939-fe76-703f-8024-1167b6970c4b",
+        "x-ms-content-crc64": "IpdbiYKmBR8=",
+        "x-ms-request-id": "778072df-001e-006c-2209-e2a699000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storageteglazatesting.blob.core.windows.net/test-container-3de0cf2b-cd03-7a18-1819-85ce8ff2de6e/test-blob-d5c95fca-18d1-5552-58fd-25d6efaa0703?comp=metadata",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "If-None-Match": "*",
+        "traceparent": "00-df6bd0a04e62a142b4d517393d842268-c16bdb424f17b342-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.3.0-dev.20200212.1\u002B2001fe133680d4ec3a4a5409fab25948e4e93325",
+          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "2303ab32-868c-c7b3-92e4-552396f2b8e8",
+        "x-ms-date": "Thu, 13 Feb 2020 01:02:19 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 13 Feb 2020 01:02:19 GMT",
+        "ETag": "\u00220x8D7B0206020CCAB\u0022",
+        "Last-Modified": "Thu, 13 Feb 2020 01:02:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2303ab32-868c-c7b3-92e4-552396f2b8e8",
+        "x-ms-request-id": "778072eb-001e-006c-2e09-e2a699000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://storageteglazatesting.blob.core.windows.net/test-container-3de0cf2b-cd03-7a18-1819-85ce8ff2de6e?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-63ec571a4fe1c84ea2fe58dc0e1d7029-fcafc0f9d9eed249-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.3.0-dev.20200212.1\u002B2001fe133680d4ec3a4a5409fab25948e4e93325",
+          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "0a34d1d0-e994-d0be-6a92-f9cbc92bf771",
+        "x-ms-date": "Thu, 13 Feb 2020 01:02:19 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Thu, 13 Feb 2020 01:02:19 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0a34d1d0-e994-d0be-6a92-f9cbc92bf771",
+        "x-ms-request-id": "778072f1-001e-006c-3409-e2a699000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "752242273",
+    "Storage_TestConfigDefault": "ProductionTenant\nstorageteglazatesting\nU2FuaXRpemVk\nhttps://storageteglazatesting.blob.core.windows.net\nhttps://storageteglazatesting.file.core.windows.net\nhttps://storageteglazatesting.queue.core.windows.net\nhttps://storageteglazatesting.table.core.windows.net\n\n\n\n\nhttps://storageteglazatesting-secondary.blob.core.windows.net\n\nhttps://storageteglazatesting-secondary.queue.core.windows.net\nhttps://storageteglazatesting-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=https://storageteglazatesting.blob.core.windows.net/;QueueEndpoint=https://storageteglazatesting.queue.core.windows.net/;FileEndpoint=https://storageteglazatesting.file.core.windows.net/;BlobSecondaryEndpoint=https://storageteglazatesting-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=https://storageteglazatesting-secondary.queue.core.windows.net/;AccountName=storageteglazatesting;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Common/swagger/Generator/readme.md
+++ b/sdk/storage/Azure.Storage.Common/swagger/Generator/readme.md
@@ -8,6 +8,7 @@ We support a number of extensions including using the vendor prefix `x-az-`:
 - `x-az-response-schema-name`: If we combine headers and a schema into a response type, this allows you to provide the name of the scehma property.  The default value is `Body`.
 - `x-az-create-exception`: `true` denotes that this partial type will provide an implementation of the method `Exception CreateException()` to turn an error object into something that can be thrown.  The default value is `false`.
 - `x-az-trace`: Indicates whether a parameter will be logged as part of our distributed tracing.  The default value is `false`.
+- `x-az-trace-failure-check`: The name of a static method to determine whether exceptions should be ignored as failures for distributed tracing.  This is set on x-ms-code-generation-settings.
 - `x-az-enum-skip-value`: The name of a default value to skip while serializing.
 - `x-az-disable-warnings`: Wraps a declaration in a `#pragma disable` when specified.
 - `x-az-skip-path-components`: Whether to skip any path components and always assume a fully formed URL to the resource (this currently must be set to `true`).

--- a/sdk/storage/Azure.Storage.Common/swagger/Generator/src/generator.ts
+++ b/sdk/storage/Azure.Storage.Common/swagger/Generator/src/generator.ts
@@ -244,7 +244,11 @@ function generateOperation(w: IndentWriter, serviceModel: IServiceModel, group: 
                 }
             });
         });
-        w.line(`catch (System.Exception ex)`);
+        w.write(`catch (System.Exception ex)`);
+        if (serviceModel.info.traceFailureCheck) {
+            w.write(` when (${serviceModel.info.traceFailureCheck}(ex))`);
+        }
+        w.line();
         w.scope('{', '}', () => {
             w.line(`${scopeName}.Failed(ex);`);
             w.line(`throw;`);

--- a/sdk/storage/Azure.Storage.Common/swagger/Generator/src/models.ts
+++ b/sdk/storage/Azure.Storage.Common/swagger/Generator/src/models.ts
@@ -92,7 +92,8 @@ export interface IServiceInfo {
         parameters: IParameters,
         useSchemePrefix: boolean,
         position: string
-    }
+    },
+    traceFailureCheck?: string
 }
 
 export interface IService {

--- a/sdk/storage/Azure.Storage.Common/swagger/Generator/src/serviceModel.ts
+++ b/sdk/storage/Azure.Storage.Common/swagger/Generator/src/serviceModel.ts
@@ -286,7 +286,8 @@ function createServiceInfo(project: IProject): IServiceInfo {
             name: 'MIT',
             header: `Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.`
-        }
+        },
+        traceFailureCheck: project.swagger.info[`x-ms-code-generation-settings`][`x-az-trace-failure-check`]
     };
 }
 


### PR DESCRIPTION
We're allow listing a few select error codes for precondition failures that are typically considered expected behavior and we'd prefer they not show up as errors in Azure Monitor.

This (obviously) breaks a bunch of the Access Conditions tests.  I'm not going to patch those up unless we decide we want to move forward with this approach.