### PR TITLE
[Service Bus Client] Test Resources Tweaks

### DIFF
--- a/sdk/servicebus/test-resources.json
+++ b/sdk/servicebus/test-resources.json
@@ -9,10 +9,24 @@
                 "description": "The base resource name."
             }
         },
+        "subscriptionId": {
+            "type": "string",
+            "defaultValue": "[subscription().subscriptionId]",
+            "metadata": {
+                "description": "The subscription ID to which the application and resources belong."
+            }
+        },
         "tenantId": {
             "type": "string",
+            "defaultValue": "[subscription().tenantId]",
             "metadata": {
                 "description": "The tenant ID to which the application and resources belong."
+            }
+        },
+        "testApplicationOid": {
+            "type": "string",
+            "metadata": {
+                "description": "The client OID to grant access to test resources."
             }
         },
         "testApplicationId": {
@@ -27,12 +41,6 @@
                 "description": "The application client secret used to run tests."
             }
         },
-        "testApplicationOid": {
-            "type": "string",
-            "metadata": {
-                "description": "The client OID to grant access to test resources."
-            }
-        },
         "location": {
             "type": "string",
             "defaultValue": "[resourceGroup().location]",
@@ -42,16 +50,26 @@
         }
     },
     "variables": {
-        "serviceBusDataOwnerRoleId": "090c5cfd-751d-490a-894a-3ce6f1109419",
-        "subscriptionId": "[subscription().id]"
+        "contributorRoleId": "b24988ac-6180-42a0-ab88-20f7382dd24c",
+        "serviceBusDataOwnerRoleId": "090c5cfd-751d-490a-894a-3ce6f1109419"
     },
     "resources": [
       {
         "type": "Microsoft.Authorization/roleAssignments",
         "apiVersion": "2019-04-01-preview",
-        "name": "[guid(resourceGroup().id)]",
+        "name": "[guid(resourceGroup().id, deployment().name, variables('serviceBusDataOwnerRoleId'))]",
         "properties": {
           "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('serviceBusDataOwnerRoleId'))]",
+          "principalId": "[parameters('testApplicationOid')]",
+          "scope": "[resourceGroup().id]"
+        }
+      },
+      {
+        "type": "Microsoft.Authorization/roleAssignments",
+        "apiVersion": "2019-04-01-preview",
+        "name": "[guid(resourceGroup().id, deployment().name, variables('contributorRoleId'))]",
+        "properties": {
+          "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('contributorRoleId'))]",
           "principalId": "[parameters('testApplicationOid')]",
           "scope": "[resourceGroup().id]"
         }
@@ -60,7 +78,7 @@
     "outputs": {
         "SERVICE_BUS_SUBSCRIPTION": {
             "type": "string",
-            "value": "[guid(variables('subscriptionId'))]"
+            "value": "[parameters('subscriptionId')]"
         },
         "SERVICE_BUS_TENANT": {
             "type": "string",


### PR DESCRIPTION
# Summary

The focus of these changes is to correct an issue with the test resources ARM template selecting an incorrect subscription for output, ensure the service principal has the contributor role, to allow make some small adjustments to template parameters.

# Last Upstream Rebase

Monday, February 17, 10:47am (EST)