### PR TITLE
Improve naming in TA

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -230,7 +230,7 @@ IEnumerable<LinkedEntity> linkedEntities = response.Value;
 Console.WriteLine($"Extracted {linkedEntities.Count()} linked entit{(linkedEntities.Count() > 1 ? "ies" : "y")}:");
 foreach (LinkedEntity linkedEntity in linkedEntities)
 {
-    Console.WriteLine($"Name: {linkedEntity.Name}, Id: {linkedEntity.Id}, Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}");
+    Console.WriteLine($"Name: {linkedEntity.Name}, Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}, Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
     foreach (LinkedEntityMatch match in linkedEntity.Matches)
     {
         Console.WriteLine($"    Match Text: {match.Text}, Score: {match.Score:0.00}, Offset: {match.Offset}, Length: {match.Length}.");

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -153,10 +153,10 @@ string input = "That was the best day of my life!";
 
 DocumentSentiment docSentiment = client.AnalyzeSentiment(input);
 
-Console.WriteLine($"Sentiment was {docSentiment.Sentiment}, with scores: ");
-Console.WriteLine($"    Positive score: {docSentiment.SentimentScores.Positive:0.00}.");
-Console.WriteLine($"    Neutral score: {docSentiment.SentimentScores.Neutral:0.00}.");
-Console.WriteLine($"    Negative score: {docSentiment.SentimentScores.Negative:0.00}.");
+Console.WriteLine($"Sentiment was {docSentiment.Sentiment}, with confidence scores: ");
+Console.WriteLine($"    Positive confidence score: {docSentiment.ConfidenceScores.Positive:0.00}.");
+Console.WriteLine($"    Neutral confidence score: {docSentiment.ConfidenceScores.Neutral:0.00}.");
+Console.WriteLine($"    Negative confidence score: {docSentiment.ConfidenceScores.Negative:0.00}.");
 ```
 For samples on using the production recommended option `AnalyzeSentimentBatch` see [here](#analyze-sentiment-1).
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample2_AnalyzeSentiment.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample2_AnalyzeSentiment.md
@@ -21,10 +21,10 @@ string input = "That was the best day of my life!";
 
 DocumentSentiment docSentiment = client.AnalyzeSentiment(input);
 
-Console.WriteLine($"Sentiment was {docSentiment.Sentiment}, with scores: ");
-Console.WriteLine($"    Positive score: {docSentiment.SentimentScores.Positive:0.00}.");
-Console.WriteLine($"    Neutral score: {docSentiment.SentimentScores.Neutral:0.00}.");
-Console.WriteLine($"    Negative score: {docSentiment.SentimentScores.Negative:0.00}.");
+Console.WriteLine($"Sentiment was {docSentiment.Sentiment}, with confidence scores: ");
+Console.WriteLine($"    Positive confidence score: {docSentiment.ConfidenceScores.Positive:0.00}.");
+Console.WriteLine($"    Neutral confidence score: {docSentiment.ConfidenceScores.Neutral:0.00}.");
+Console.WriteLine($"    Negative confidence score: {docSentiment.ConfidenceScores.Negative:0.00}.");
 ```
 
 ## Analyzing the sentiment of multipile text inputs

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
@@ -24,7 +24,7 @@ IEnumerable<LinkedEntity> linkedEntities = response.Value;
 Console.WriteLine($"Extracted {linkedEntities.Count()} linked entit{(linkedEntities.Count() > 1 ? "ies" : "y")}:");
 foreach (LinkedEntity linkedEntity in linkedEntities)
 {
-    Console.WriteLine($"Name: {linkedEntity.Name}, Id: {linkedEntity.Id}, Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}");
+    Console.WriteLine($"Name: {linkedEntity.Name}, Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}, Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
     foreach (LinkedEntityMatch match in linkedEntity.Matches)
     {
         Console.WriteLine($"    Match Text: {match.Text}, Score: {match.Score:0.00}, Offset: {match.Offset}, Length: {match.Length}.");

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/DocumentSentiment.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/DocumentSentiment.cs
@@ -11,13 +11,15 @@ namespace Azure.AI.TextAnalytics
     /// <summary>
     /// Overall predicted sentiment and confidence scores for the document.
     /// It also includes per-sentence sentiment prediction.
+    /// For more information regarding text sentiment, see
+    /// <a href="https://docs.microsoft.com/en-us/azure/cognitive-services/Text-Analytics/how-tos/text-analytics-how-to-sentiment-analysis"/>.
     /// </summary>
     public class DocumentSentiment
     {
         internal DocumentSentiment(SentimentLabel sentiment, double positiveScore, double neutralScore, double negativeScore, List<SentenceSentiment> sentenceSentiments)
         {
             Sentiment = sentiment;
-            SentimentScores = new SentimentScorePerLabel(positiveScore, neutralScore, negativeScore);
+            ConfidenceScores = new SentimentConfidenceScorePerLabel(positiveScore, neutralScore, negativeScore);
             Sentences = new ReadOnlyCollection<SentenceSentiment>(sentenceSentiments);
         }
 
@@ -28,10 +30,10 @@ namespace Azure.AI.TextAnalytics
         public SentimentLabel Sentiment { get; }
 
         /// <summary>
-        /// Gets the sentiment confidence score between 0 and 1,
-        /// for each sentiment label.
+        /// Gets the sentiment confidence score (Softmax score) between 0 and 1,
+        /// for each sentiment label. Higher values signify higher confidence.
         /// </summary>
-        public SentimentScorePerLabel SentimentScores { get; }
+        public SentimentConfidenceScorePerLabel ConfidenceScores { get; }
 
         /// <summary>
         /// Gets the predicted sentiment for each sentence in the corresponding

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/LinkedEntity.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/LinkedEntity.cs
@@ -14,10 +14,10 @@ namespace Azure.AI.TextAnalytics
     /// </summary>
     public readonly struct LinkedEntity
     {
-        internal LinkedEntity(string name, string id, string language, string dataSource, Uri url, IEnumerable<LinkedEntityMatch> matches)
+        internal LinkedEntity(string name, string dataSourceEntityId, string language, string dataSource, Uri url, IEnumerable<LinkedEntityMatch> matches)
         {
             Name = name;
-            Id = id;
+            DataSourceEntityId = dataSourceEntityId;
             Language = language;
             DataSource = dataSource;
             Url = url;
@@ -32,7 +32,7 @@ namespace Azure.AI.TextAnalytics
         /// <summary>
         /// Gets the unique identifier of the entity in the data source.
         /// </summary>
-        public string Id { get; }
+        public string DataSourceEntityId { get; }
 
         /// <summary>
         /// Gets the language used in the data source.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/SentenceSentiment.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/SentenceSentiment.cs
@@ -4,9 +4,8 @@
 namespace Azure.AI.TextAnalytics
 {
     /// <summary>
-    /// The predicted sentiment for a given span of text.  This may correspond
-    /// to a full text document input or a substring such as a sentence of that
-    /// input.  For more information regarding text sentiment, see
+    /// The predicted sentiment for a given span of text.
+    /// For more information regarding text sentiment, see
     /// <a href="https://docs.microsoft.com/en-us/azure/cognitive-services/Text-Analytics/how-tos/text-analytics-how-to-sentiment-analysis"/>.
     /// </summary>
     public readonly struct SentenceSentiment
@@ -14,7 +13,7 @@ namespace Azure.AI.TextAnalytics
         internal SentenceSentiment(SentimentLabel sentiment, double positiveScore, double neutralScore, double negativeScore, int offset, int length)
         {
             Sentiment = sentiment;
-            SentimentScores = new SentimentScorePerLabel(positiveScore, neutralScore, negativeScore);
+            ConfidenceScores = new SentimentConfidenceScorePerLabel(positiveScore, neutralScore, negativeScore);
             Offset = offset;
             Length = length;
         }
@@ -26,10 +25,10 @@ namespace Azure.AI.TextAnalytics
         public SentimentLabel Sentiment { get; }
 
         /// <summary>
-        /// Gets the sentiment confidence score between 0 and 1,
-        /// for each sentiment label.
+        /// Gets the sentiment confidence score (Softmax score) between 0 and 1,
+        /// for each sentiment label. Higher values signify higher confidence.
         /// </summary>
-        public SentimentScorePerLabel SentimentScores { get; }
+        public SentimentConfidenceScorePerLabel ConfidenceScores { get; }
 
         /// <summary>
         /// Gets the start position for the matching text in the input document.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/SentimentConfidenceScorePerLabel.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/SentimentConfidenceScorePerLabel.cs
@@ -6,9 +6,9 @@ namespace Azure.AI.TextAnalytics
     /// <summary>
     /// The sentiment confidence scores, by sentiment class label.
     /// </summary>
-    public class SentimentScorePerLabel
+    public class SentimentConfidenceScorePerLabel
     {
-        internal SentimentScorePerLabel(double positive, double neutral, double negative)
+        internal SentimentConfidenceScorePerLabel(double positive, double neutral, double negative)
         {
             Positive = positive;
             Neutral = neutral;

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
@@ -847,7 +847,7 @@ namespace Azure.AI.TextAnalytics.Tests
             {
                 Assert.IsTrue(entitiesList.Contains(entity.Name));
                 Assert.IsNotNull(entity.DataSource);
-                Assert.IsNotNull(entity.Id);
+                Assert.IsNotNull(entity.DataSourceEntityId);
                 Assert.IsNotNull(entity.Language);
                 Assert.IsNotNull(entity.Url);
                 Assert.IsNotNull(entity.Matches);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
@@ -202,16 +202,16 @@ namespace Azure.AI.TextAnalytics.Tests
             DocumentSentiment docSentiment = await client.AnalyzeSentimentAsync(input);
 
             Assert.AreEqual("Positive", docSentiment.Sentiment.ToString());
-            Assert.IsNotNull(docSentiment.SentimentScores.Positive);
-            Assert.IsNotNull(docSentiment.SentimentScores.Neutral);
-            Assert.IsNotNull(docSentiment.SentimentScores.Negative);
+            Assert.IsNotNull(docSentiment.ConfidenceScores.Positive);
+            Assert.IsNotNull(docSentiment.ConfidenceScores.Neutral);
+            Assert.IsNotNull(docSentiment.ConfidenceScores.Negative);
 
             foreach (var sentence in docSentiment.Sentences)
             {
                 Assert.AreEqual("Positive", sentence.Sentiment.ToString());
-                Assert.IsNotNull(sentence.SentimentScores.Positive);
-                Assert.IsNotNull(sentence.SentimentScores.Neutral);
-                Assert.IsNotNull(sentence.SentimentScores.Negative);
+                Assert.IsNotNull(sentence.ConfidenceScores.Positive);
+                Assert.IsNotNull(sentence.ConfidenceScores.Neutral);
+                Assert.IsNotNull(sentence.ConfidenceScores.Negative);
                 Assert.IsNotNull(sentence.Offset);
                 Assert.IsNotNull(sentence.Length);
                 Assert.AreEqual(input.Length, sentence.Length);
@@ -247,15 +247,15 @@ namespace Azure.AI.TextAnalytics.Tests
             foreach (AnalyzeSentimentResult docs in results)
             {
                 DocumentSentiment docSentiment = docs.DocumentSentiment;
-                Assert.IsNotNull(docSentiment.SentimentScores.Positive);
-                Assert.IsNotNull(docSentiment.SentimentScores.Neutral);
-                Assert.IsNotNull(docSentiment.SentimentScores.Negative);
+                Assert.IsNotNull(docSentiment.ConfidenceScores.Positive);
+                Assert.IsNotNull(docSentiment.ConfidenceScores.Neutral);
+                Assert.IsNotNull(docSentiment.ConfidenceScores.Negative);
 
                 foreach (var sentence in docSentiment.Sentences)
                 {
-                    Assert.IsNotNull(sentence.SentimentScores.Positive);
-                    Assert.IsNotNull(sentence.SentimentScores.Neutral);
-                    Assert.IsNotNull(sentence.SentimentScores.Negative);
+                    Assert.IsNotNull(sentence.ConfidenceScores.Positive);
+                    Assert.IsNotNull(sentence.ConfidenceScores.Neutral);
+                    Assert.IsNotNull(sentence.ConfidenceScores.Negative);
                     Assert.IsNotNull(sentence.Offset);
                     Assert.IsNotNull(sentence.Length);
                 }
@@ -307,15 +307,15 @@ namespace Azure.AI.TextAnalytics.Tests
             foreach (AnalyzeSentimentResult docs in results)
             {
                 DocumentSentiment docSentiment = docs.DocumentSentiment;
-                Assert.IsNotNull(docSentiment.SentimentScores.Positive);
-                Assert.IsNotNull(docSentiment.SentimentScores.Neutral);
-                Assert.IsNotNull(docSentiment.SentimentScores.Negative);
+                Assert.IsNotNull(docSentiment.ConfidenceScores.Positive);
+                Assert.IsNotNull(docSentiment.ConfidenceScores.Neutral);
+                Assert.IsNotNull(docSentiment.ConfidenceScores.Negative);
 
                 foreach (var sentence in docSentiment.Sentences)
                 {
-                    Assert.IsNotNull(sentence.SentimentScores.Positive);
-                    Assert.IsNotNull(sentence.SentimentScores.Neutral);
-                    Assert.IsNotNull(sentence.SentimentScores.Negative);
+                    Assert.IsNotNull(sentence.ConfidenceScores.Positive);
+                    Assert.IsNotNull(sentence.ConfidenceScores.Neutral);
+                    Assert.IsNotNull(sentence.ConfidenceScores.Negative);
                     Assert.IsNotNull(sentence.Offset);
                     Assert.IsNotNull(sentence.Length);
                 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentiment.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentiment.cs
@@ -25,10 +25,10 @@ namespace Azure.AI.TextAnalytics.Samples
 
             DocumentSentiment docSentiment = client.AnalyzeSentiment(input);
 
-            Console.WriteLine($"Sentiment was {docSentiment.Sentiment}, with scores: ");
-            Console.WriteLine($"    Positive score: {docSentiment.SentimentScores.Positive:0.00}.");
-            Console.WriteLine($"    Neutral score: {docSentiment.SentimentScores.Neutral:0.00}.");
-            Console.WriteLine($"    Negative score: {docSentiment.SentimentScores.Negative:0.00}.");
+            Console.WriteLine($"Sentiment was {docSentiment.Sentiment}, with confidence scores: ");
+            Console.WriteLine($"    Positive confidence score: {docSentiment.ConfidenceScores.Positive:0.00}.");
+            Console.WriteLine($"    Neutral confidence score: {docSentiment.ConfidenceScores.Neutral:0.00}.");
+            Console.WriteLine($"    Negative confidence score: {docSentiment.ConfidenceScores.Negative:0.00}.");
             #endregion
         }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatch.cs
@@ -62,10 +62,10 @@ namespace Azure.AI.TextAnalytics.Samples
                 }
                 else
                 {
-                    Debug.WriteLine($"Document sentiment is {result.DocumentSentiment.Sentiment}, with scores: ");
-                    Debug.WriteLine($"    Positive score: {result.DocumentSentiment.SentimentScores.Positive:0.00}.");
-                    Debug.WriteLine($"    Neutral score: {result.DocumentSentiment.SentimentScores.Neutral:0.00}.");
-                    Debug.WriteLine($"    Negative score: {result.DocumentSentiment.SentimentScores.Negative:0.00}.");
+                    Debug.WriteLine($"Document sentiment is {result.DocumentSentiment.Sentiment}, with confidence scores: ");
+                    Debug.WriteLine($"    Positive confidence score: {result.DocumentSentiment.ConfidenceScores.Positive:0.00}.");
+                    Debug.WriteLine($"    Neutral confidence score: {result.DocumentSentiment.ConfidenceScores.Neutral:0.00}.");
+                    Debug.WriteLine($"    Negative confidence score: {result.DocumentSentiment.ConfidenceScores.Negative:0.00}.");
 
                     Debug.WriteLine($"    Sentence sentiment results:");
 
@@ -73,10 +73,10 @@ namespace Azure.AI.TextAnalytics.Samples
                     {
                         Debug.WriteLine($"    On sentence \"{document.Text.Substring(sentenceSentiment.Offset, sentenceSentiment.Length)}\"");
 
-                        Debug.WriteLine($"    Sentiment is {sentenceSentiment.Sentiment}, with scores: ");
-                        Debug.WriteLine($"        Positive score: {sentenceSentiment.SentimentScores.Positive:0.00}.");
-                        Debug.WriteLine($"        Neutral score: {sentenceSentiment.SentimentScores.Neutral:0.00}.");
-                        Debug.WriteLine($"        Negative score: {sentenceSentiment.SentimentScores.Negative:0.00}.");
+                        Debug.WriteLine($"    Sentiment is {sentenceSentiment.Sentiment}, with confidence scores: ");
+                        Debug.WriteLine($"        Positive confidence score: {sentenceSentiment.ConfidenceScores.Positive:0.00}.");
+                        Debug.WriteLine($"        Neutral confidence score: {sentenceSentiment.ConfidenceScores.Neutral:0.00}.");
+                        Debug.WriteLine($"        Negative confidence score: {sentenceSentiment.ConfidenceScores.Negative:0.00}.");
                     }
 
                     Debug.WriteLine($"    Document statistics:");

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchConvenience.cs
@@ -43,10 +43,10 @@ namespace Azure.AI.TextAnalytics.Samples
             foreach (AnalyzeSentimentResult result in results)
             {
                 DocumentSentiment docSentiment = result.DocumentSentiment;
-                Debug.WriteLine($"Document sentiment is {docSentiment.Sentiment}, with scores: ");
-                Debug.WriteLine($"    Positive score: {docSentiment.SentimentScores.Positive:0.00}.");
-                Debug.WriteLine($"    Neutral score: {docSentiment.SentimentScores.Neutral:0.00}.");
-                Debug.WriteLine($"    Negative score: {docSentiment.SentimentScores.Negative:0.00}.");
+                Debug.WriteLine($"Document sentiment is {docSentiment.Sentiment}, with confidence scores: ");
+                Debug.WriteLine($"    Positive confidence score: {docSentiment.ConfidenceScores.Positive:0.00}.");
+                Debug.WriteLine($"    Neutral confidence score: {docSentiment.ConfidenceScores.Neutral:0.00}.");
+                Debug.WriteLine($"    Negative confidence score: {docSentiment.ConfidenceScores.Negative:0.00}.");
             }
         }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntities.cs
@@ -32,7 +32,7 @@ namespace Azure.AI.TextAnalytics.Samples
             Console.WriteLine($"Extracted {linkedEntities.Count()} linked entit{(linkedEntities.Count() > 1 ? "ies" : "y")}:");
             foreach (LinkedEntity linkedEntity in linkedEntities)
             {
-                Console.WriteLine($"Name: {linkedEntity.Name}, Id: {linkedEntity.Id}, Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}");
+                Console.WriteLine($"Name: {linkedEntity.Name}, Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}, Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
                 foreach (LinkedEntityMatch match in linkedEntity.Matches)
                 {
                     Console.WriteLine($"    Match Text: {match.Text}, Score: {match.Score:0.00}, Offset: {match.Offset}, Length: {match.Length}.");

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatch.cs
@@ -63,7 +63,7 @@ namespace Azure.AI.TextAnalytics.Samples
 
                     foreach (LinkedEntity linkedEntity in result.Entities)
                     {
-                        Debug.WriteLine($"    Name: \"{linkedEntity.Name}\", Id: \"{linkedEntity.Id}\", Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}");
+                        Debug.WriteLine($"    Name: \"{linkedEntity.Name}\", Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}, Entity Id in Data Source: \"{linkedEntity.DataSourceEntityId}\"");
                         foreach (LinkedEntityMatch match in linkedEntity.Matches)
                         {
                             Debug.WriteLine($"        Match Text: \"{match.Text}\", Score: {match.Score:0.00}, Offset: {match.Offset}, Length: {match.Length}.");

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenience.cs
@@ -42,7 +42,7 @@ namespace Azure.AI.TextAnalytics.Samples
 
                 foreach (LinkedEntity linkedEntity in result.Entities)
                 {
-                    Debug.WriteLine($"    Name: \"{linkedEntity.Name}\", Id: \"{linkedEntity.Id}\", Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}");
+                    Debug.WriteLine($"    Name: \"{linkedEntity.Name}\", Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}, Entity Id in Data Source: \"{linkedEntity.DataSourceEntityId}\"");
                     foreach (LinkedEntityMatch match in linkedEntity.Matches)
                     {
                         Debug.WriteLine($"        Match Text: \"{match.Text}\", Score: {match.Score:0.00}, Offset: {match.Offset}, Length: {match.Length}.");


### PR DESCRIPTION
- For `LinkedEntity`, rename Id to `DataSourceEntityId`. Fixes #9989 
- Rename the class `SentimentScorePerLabel` to `SentimentConfidenceScorePerLabel` to reflect swagger naming.
- Rename property `SentimentScores` to `ConfidenceScore`. Fixes: #9794 