### PR TITLE
Fix SafeName for Eventhub ci

### DIFF
--- a/sdk/eventhub/ci.yml
+++ b/sdk/eventhub/ci.yml
@@ -43,8 +43,8 @@ stages:
     - name: Azure.Messaging.EventHubs.Processor
       safeName: AzureMessagingEventHubsProcessor
     - name: Microsoft.Azure.EventHubs
-      safeName: Microsoft.Azure.EventHubs
+      safeName: MicrosoftAzureEventHubs
     - name: Microsoft.Azure.EventHubs.Processor
-      safeName: Microsoft.Azure.EventHubs.Processor
+      safeName: MicrosoftAzureEventHubsProcessor
     - name: Microsoft.Azure.EventHubs.ServiceFabricProcessor
-      safeName: Microsoft.Azure.EventHubs.ServiceFabricProcessor
+      safeName: MicrosoftAzureEventHubsServiceFabricProcessor


### PR DESCRIPTION
Safe names need to not contain '.' for CI to run