### PR TITLE
[Event Hubs Client] Clean Nightly Test Configuration

### DIFF
--- a/sdk/eventhub/test-resources.json
+++ b/sdk/eventhub/test-resources.json
@@ -57,7 +57,7 @@
       {
         "type": "Microsoft.Authorization/roleAssignments",
         "apiVersion": "2019-04-01-preview",
-        "name": "[guid(resourceGroup().id, deployment().name, variables('eventHubsDataOwnerRoleId'))]",
+        "name": "[guid(resourceGroup().id, deployment().name, parameters('baseName'), variables('eventHubsDataOwnerRoleId'))]",
         "properties": {
           "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('eventHubsDataOwnerRoleId'))]",
           "principalId": "[parameters('testApplicationOid')]",
@@ -67,7 +67,7 @@
       {
         "type": "Microsoft.Authorization/roleAssignments",
         "apiVersion": "2019-04-01-preview",
-        "name": "[guid(resourceGroup().id, deployment().name, variables('contributorRoleId'))]",
+        "name": "[guid(resourceGroup().id, deployment().name, parameters('baseName'), variables('contributorRoleId'))]",
         "properties": {
           "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('contributorRoleId'))]",
           "principalId": "[parameters('testApplicationOid')]",

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -13,9 +13,3 @@ jobs:
     MaxParallel: 4
     ServiceDirectory: eventhub
     TimeoutInMinutes: 120
-    EnvVars:
-      EVENT_HUBS_CLIENT: $(aad-azure-sdk-test-client-id)
-      EVENT_HUBS_SECRET: $(aad-azure-sdk-test-client-secret)
-      EVENT_HUBS_TENANT: $(aad-azure-sdk-test-tenant-id)
-      EVENT_HUBS_SUBSCRIPTION: $(test-subscription-id)
-      EVENT_HUBS_RESOURCEGROUP: $(net-eventhubs-internal-group)


### PR DESCRIPTION
# Summary

With the Event Hubs nightly tests making use of the test resources  template, the previous approach of setting environment variables from the pipeline test configuration is no longer needed.  The focus of these changes is to remove them.

# Last Upstream Rebase

Sunday, February 23, 12:12pm (EST)

