### PR TITLE
Minor speed increase for CI

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Processor/PartitionLoadBalancer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Processor/PartitionLoadBalancer.cs
@@ -79,7 +79,7 @@ namespace Azure.Messaging.EventHubs.Processor
         ///   The partitionIds currently owned by the associated event processor.
         /// </summary>
         ///
-        public IEnumerable<string> OwnedPartitionIds => InstanceOwnership.Keys;
+        public virtual IEnumerable<string> OwnedPartitionIds => InstanceOwnership.Keys;
 
         /// <summary>
         ///   The instance of <see cref="PartitionLoadBalancerEventSource" /> which can be mocked for testing.


### PR DESCRIPTION
This PR makes a minor tweak to `PartitionInitializingAsyncIsTriggeredWhenPartitionProcessingIsStarting` which trims nearly 10 seconds of run time per iteration.

![image](https://user-images.githubusercontent.com/1279263/75211200-e0437300-5748-11ea-9f08-d660468a463f.png)
