### PR TITLE
[EventHubs] Distributed Tracing: Move message spans outside of Send spans (Track Two)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -422,10 +422,10 @@ namespace Azure.Messaging.EventHubs.Producer
                 activeProducer = PartitionProducers.GetOrAdd(options.PartitionId, id => Connection.CreateTransportProducer(id, RetryPolicy));
             }
 
-            using DiagnosticScope scope = CreateDiagnosticScope();
-
             events = (events as IList<EventData>) ?? events.ToList();
             InstrumentMessages(events);
+
+            using DiagnosticScope scope = CreateDiagnosticScope();
 
             try
             {


### PR DESCRIPTION
Fixes #8760

The issue only applies to sending with `EventData`, which is an `internal` method for the time being. The behavior when sending with a batch had no issues.