### PR TITLE
[EventHubs] Distributed Tracing: Do not populate schema in peer.address attribute (Track Two)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -658,7 +658,7 @@ namespace Azure.Messaging.EventHubs.Producer
             scope.AddAttribute(DiagnosticProperty.KindAttribute, DiagnosticProperty.ClientKind);
             scope.AddAttribute(DiagnosticProperty.ServiceContextAttribute, DiagnosticProperty.EventHubsServiceContext);
             scope.AddAttribute(DiagnosticProperty.EventHubAttribute, EventHubName);
-            scope.AddAttribute(DiagnosticProperty.EndpointAttribute, Connection.ServiceEndpoint);
+            scope.AddAttribute(DiagnosticProperty.EndpointAttribute, FullyQualifiedNamespace);
             scope.Start();
 
             return scope;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
@@ -240,7 +240,7 @@ namespace Azure.Messaging.EventHubs.Tests
             private const string MockConnectionStringFormat = "Endpoint={0};SharedAccessKeyName=[value];SharedAccessKey=[value];";
 
             public MockConnection(string serviceEndpoint,
-                                  string eventHubName) : base(String.Format(MockConnectionStringFormat, serviceEndpoint), eventHubName)
+                                  string eventHubName) : base(string.Format(MockConnectionStringFormat, serviceEndpoint), eventHubName)
             {
             }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
@@ -47,7 +47,7 @@ namespace Azure.Messaging.EventHubs.Tests
             using var testListener = new ClientDiagnosticListener(DiagnosticSourceName);
 
             var eventHubName = "SomeName";
-            var endpoint = new Uri("amqp://endpoint");
+            var endpoint = "endpoint";
             var fakeConnection = new MockConnection(endpoint, eventHubName);
             var transportMock = new Mock<TransportProducer>();
 
@@ -64,7 +64,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 new KeyValuePair<string, string>(DiagnosticProperty.KindAttribute, DiagnosticProperty.ClientKind),
                 new KeyValuePair<string, string>(DiagnosticProperty.ServiceContextAttribute, DiagnosticProperty.EventHubsServiceContext),
                 new KeyValuePair<string, string>(DiagnosticProperty.EventHubAttribute, eventHubName),
-                new KeyValuePair<string, string>(DiagnosticProperty.EndpointAttribute, endpoint.ToString()));
+                new KeyValuePair<string, string>(DiagnosticProperty.EndpointAttribute, endpoint));
 
             ClientDiagnosticListener.ProducedDiagnosticScope messageScope = testListener.AssertScope(DiagnosticProperty.EventActivityName);
 
@@ -84,7 +84,7 @@ namespace Azure.Messaging.EventHubs.Tests
             using var testListener = new ClientDiagnosticListener(DiagnosticSourceName);
 
             var eventHubName = "SomeName";
-            var endpoint = new Uri("amqp://endpoint");
+            var endpoint = "endpoint";
             var fakeConnection = new MockConnection(endpoint, eventHubName);
             var eventCount = 0;
             var batchTransportMock = new Mock<TransportEventBatch>();
@@ -119,7 +119,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 new KeyValuePair<string, string>(DiagnosticProperty.KindAttribute, DiagnosticProperty.ClientKind),
                 new KeyValuePair<string, string>(DiagnosticProperty.ServiceContextAttribute, DiagnosticProperty.EventHubsServiceContext),
                 new KeyValuePair<string, string>(DiagnosticProperty.EventHubAttribute, eventHubName),
-                new KeyValuePair<string, string>(DiagnosticProperty.EndpointAttribute, endpoint.ToString()));
+                new KeyValuePair<string, string>(DiagnosticProperty.EndpointAttribute, endpoint));
 
             ClientDiagnosticListener.ProducedDiagnosticScope messageScope = testListener.AssertScope(DiagnosticProperty.EventActivityName);
 
@@ -138,7 +138,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Activity activity = new Activity("SomeActivity").Start();
 
             var eventHubName = "SomeName";
-            var endpoint = new Uri("amqp://some.endpoint.com/path");
+            var endpoint = "some.endpoint.com";
             var fakeConnection = new MockConnection(endpoint, eventHubName);
             var transportMock = new Mock<TransportProducer>();
 
@@ -178,7 +178,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Activity activity = new Activity("SomeActivity").Start();
 
             var eventHubName = "SomeName";
-            var endpoint = new Uri("amqp://some.endpoint.com/path");
+            var endpoint = "some.endpoint.com";
             var writtenEventsData = new List<EventData>();
             var batchTransportMock = new Mock<TransportEventBatch>();
             var fakeConnection = new MockConnection(endpoint, eventHubName);
@@ -237,28 +237,17 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         private class MockConnection : EventHubConnection
         {
-            private const string MockConnectionString = "Endpoint=value.com;SharedAccessKeyName=[value];SharedAccessKey=[value];";
-            private Uri _serviceEndpoint;
+            private const string MockConnectionStringFormat = "Endpoint={0};SharedAccessKeyName=[value];SharedAccessKey=[value];";
 
-            public MockConnection(Uri serviceEndpoint,
-                                  string eventHubName) : base(MockConnectionString, eventHubName)
+            public MockConnection(string serviceEndpoint,
+                                  string eventHubName) : base(String.Format(MockConnectionStringFormat, serviceEndpoint), eventHubName)
             {
-                _serviceEndpoint = serviceEndpoint;
             }
 
             internal override TransportClient CreateTransportClient(string fullyQualifiedNamespace,
                                                                     string eventHubName,
                                                                     EventHubTokenCredential credential,
-                                                                    EventHubConnectionOptions options)
-            {
-                var mockTransport = new Mock<TransportClient>();
-
-                mockTransport
-                    .Setup(t => t.ServiceEndpoint)
-                    .Returns(() => _serviceEndpoint);
-
-                return mockTransport.Object;
-            }
+                                                                    EventHubConnectionOptions options) => Mock.Of<TransportClient>();
         }
     }
 }


### PR DESCRIPTION
Fixes #9631.

Simplified the diagnostics test file a bit because we don't need a `Uri` anymore.