### PR TITLE
[Identity] [Fix] UsernamePasswordCredential call with correct parameter order

### DIFF
--- a/sdk/identity/Azure.Identity/src/EnvironmentCredential.cs
+++ b/sdk/identity/Azure.Identity/src/EnvironmentCredential.cs
@@ -66,9 +66,9 @@ namespace Azure.Identity
                 {
                     _credential = new ClientSecretCredential(tenantId, clientId, clientSecret, _pipeline);
                 }
-                else if (username != null && password != null && tenantId != null && clientId != null)
+                else if (username != null && password != null)
                 {
-                    _credential = new UsernamePasswordCredential(username, password, clientId, tenantId, _pipeline);
+                    _credential = new UsernamePasswordCredential(username, password,  tenantId, clientId,_pipeline);
                 }
             }
 

--- a/sdk/identity/Azure.Identity/src/EnvironmentCredential.cs
+++ b/sdk/identity/Azure.Identity/src/EnvironmentCredential.cs
@@ -68,7 +68,7 @@ namespace Azure.Identity
                 }
                 else if (username != null && password != null)
                 {
-                    _credential = new UsernamePasswordCredential(username, password,  tenantId, clientId,_pipeline);
+                    _credential = new UsernamePasswordCredential(username, password, tenantId, clientId,_pipeline);
                 }
             }
 

--- a/sdk/identity/Azure.Identity/src/EnvironmentCredential.cs
+++ b/sdk/identity/Azure.Identity/src/EnvironmentCredential.cs
@@ -68,7 +68,7 @@ namespace Azure.Identity
                 }
                 else if (username != null && password != null)
                 {
-                    _credential = new UsernamePasswordCredential(username, password, tenantId, clientId,_pipeline);
+                    _credential = new UsernamePasswordCredential(username, password, tenantId, clientId, _pipeline);
                 }
             }
 


### PR DESCRIPTION
This PR fixes the parameter order for the call to the `UsernamePasswordCredential` constructor as the `tenantid` and the `clientId` parameters are currently reversed.

This also removes the redundant null checks for the `tenantId` and the `clientId` already made in the surrounding `if` clause.