### PR TITLE
Don't block PartitionManager loop on close pump call.

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/PartitionManager.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/PartitionManager.cs
@@ -535,7 +535,7 @@ namespace Microsoft.Azure.EventHubs.Processor
             {
                 if (!capturedPump.IsClosing)
                 {
-                    // Don't block close call more than renew interval if lease is lost.
+                    // Don't block on close call more than renew interval if close reason is lease-lost.
                     // Otherwise we can block indefinetely.
                     var closeTask = capturedPump.CloseAsync(reason);
                     if (reason == CloseReason.LeaseLost)

--- a/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/PartitionManager.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/PartitionManager.cs
@@ -552,8 +552,8 @@ namespace Microsoft.Azure.EventHubs.Processor
         }
 
         /// <summary>
-        /// Awaits givent task for provided wait time.
-        /// Throws OperationCanceledException when wait time exceeded.
+        /// Awaits given task up to provided wait time.
+        /// Throws OperationCanceledException when wait time is exhausted.
         /// </summary>
         async Task WaitTaskTimeoutAsync(Task task, TimeSpan waitTime)
         {

--- a/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/PartitionManager.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/PartitionManager.cs
@@ -535,9 +535,42 @@ namespace Microsoft.Azure.EventHubs.Processor
             {
                 if (!capturedPump.IsClosing)
                 {
-                    await capturedPump.CloseAsync(reason).ConfigureAwait(false);
+                    // Don't block close call more than renew interval if lease is lost.
+                    // Otherwise we can block indefinetely.
+                    var closeTask = capturedPump.CloseAsync(reason);
+                    if (reason == CloseReason.LeaseLost)
+                    {
+                        await this.WaitTaskTimeoutAsync(closeTask, this.host.LeaseManager.LeaseRenewInterval).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        await closeTask.ConfigureAwait(false);
+                    }
                 }
                 // else, pump is already closing/closed, don't need to try to shut it down again
+            }
+        }
+
+        /// <summary>
+        /// Awaits givent task for provided wait time.
+        /// Throws OperationCanceledException when wait time exceeded.
+        /// </summary>
+        async Task WaitTaskTimeoutAsync(Task task, TimeSpan waitTime)
+        {
+            using (var cts = new CancellationTokenSource())
+            {
+                var timeoutTask = Task.Delay(waitTime, cts.Token);
+                var completedTask = await Task.WhenAny(task, timeoutTask).ConfigureAwait(false);
+
+                if (completedTask == task)
+                {
+                    cts.Cancel();
+                }
+                else
+                {
+                    // Throw OperationCanceledException, caller will log the failures appropriately.
+                    throw new OperationCanceledException();
+                }
             }
         }
 


### PR DESCRIPTION
Blocking PartitionManager on pump close causes all leases to expire. Don't block more than renew interval so PM can continue renewing owned leases.