### PR TITLE
[Storage][tests] Use "Exists" APIs to improve test reliability

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
@@ -316,7 +316,7 @@ namespace Azure.Storage.Blobs.Test
             // Arrange
             var blobName = GetNewBlobName();
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(blobName));
-            Response<BlobContentInfo> response = await blob.CreateAsync();
+            Response<BlobContentInfo> response = await blob.CreateIfNotExistsAsync();
 
             // Act
             Response<BlobContentInfo> responseExists = await blob.CreateIfNotExistsAsync();
@@ -352,7 +352,7 @@ namespace Azure.Storage.Blobs.Test
             // Arrange
             var blobName = GetNewBlobName();
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(blobName));
-            await blob.CreateAsync();
+            await blob.CreateIfNotExistsAsync();
             const int blobSize = Constants.KB;
             var data = GetRandomBuffer(blobSize);
 
@@ -381,7 +381,7 @@ namespace Azure.Storage.Blobs.Test
             CustomerProvidedKey customerProvidedKey = GetCustomerProvidedKey();
             blob = InstrumentClient(blob.WithCustomerProvidedKey(customerProvidedKey));
             var data = GetRandomBuffer(Constants.KB);
-            await blob.CreateAsync();
+            await blob.CreateIfNotExistsAsync();
 
             // Act
             using var stream = new MemoryStream(data);
@@ -403,7 +403,7 @@ namespace Azure.Storage.Blobs.Test
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(blobName));
             blob = InstrumentClient(blob.WithEncryptionScope(TestConfigDefault.EncryptionScope));
             var data = GetRandomBuffer(Constants.KB);
-            await blob.CreateAsync();
+            await blob.CreateIfNotExistsAsync();
 
             // Act
             using var stream = new MemoryStream(data);
@@ -421,7 +421,7 @@ namespace Azure.Storage.Blobs.Test
 
             // Arrange
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
-            await blob.CreateAsync();
+            await blob.CreateIfNotExistsAsync();
             var data = GetRandomBuffer(Constants.KB);
 
             // Act
@@ -443,7 +443,7 @@ namespace Azure.Storage.Blobs.Test
 
             // Arrange
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
-            await blob.CreateAsync();
+            await blob.CreateIfNotExistsAsync();
             var data = GetRandomBuffer(Constants.KB);
 
             // Act
@@ -496,7 +496,7 @@ namespace Azure.Storage.Blobs.Test
 
                 // Arrange
                 AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
-                await blob.CreateAsync();
+                await blob.CreateIfNotExistsAsync();
                 var data = GetRandomBuffer(7);
                 parameters.Match = await SetupBlobMatchCondition(blob, parameters.Match);
                 parameters.LeaseId = await SetupBlobLeaseCondition(blob, parameters.LeaseId, garbageLeaseId);
@@ -540,7 +540,7 @@ namespace Azure.Storage.Blobs.Test
                 AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
                 var data = GetRandomBuffer(7);
                 // AppendBlob needs to exists for us to test CreateAsync() with access conditions
-                await blob.CreateAsync();
+                await blob.CreateIfNotExistsAsync();
                 parameters.NoneMatch = await SetupBlobMatchCondition(blob, parameters.NoneMatch);
                 AppendBlobRequestConditions accessConditions = BuildDestinationAccessConditions(
                     parameters: parameters,
@@ -578,7 +578,7 @@ namespace Azure.Storage.Blobs.Test
             AppendBlobClient blobFaulty = InstrumentClient(containerFaulty.GetAppendBlobClient(blobName));
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(blobName));
 
-            await blob.CreateAsync();
+            await blob.CreateIfNotExistsAsync();
 
             var data = GetRandomBuffer(blobSize);
             var progressList = new List<long>();
@@ -611,7 +611,7 @@ namespace Azure.Storage.Blobs.Test
             // Arrange
             var blobName = GetNewBlobName();
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(blobName));
-            await blob.CreateAsync();
+            await blob.CreateIfNotExistsAsync();
             const int blobSize = 4 * Constants.MB;
             var data = GetRandomBuffer(blobSize);
             TestProgress progress = new TestProgress();
@@ -641,11 +641,11 @@ namespace Azure.Storage.Blobs.Test
             using (var stream = new MemoryStream(data))
             {
                 AppendBlobClient sourceBlob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
-                await sourceBlob.CreateAsync();
+                await sourceBlob.CreateIfNotExistsAsync();
                 await sourceBlob.AppendBlockAsync(stream);
 
                 AppendBlobClient destBlob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
-                await destBlob.CreateAsync();
+                await destBlob.CreateIfNotExistsAsync();
 
                 // Act
                 await destBlob.AppendBlockFromUriAsync(sourceBlob.Uri, new HttpRange(0, Constants.KB));
@@ -665,13 +665,13 @@ namespace Azure.Storage.Blobs.Test
             using (var stream = new MemoryStream(data))
             {
                 AppendBlobClient sourceBlob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
-                await sourceBlob.CreateAsync();
+                await sourceBlob.CreateIfNotExistsAsync();
                 await sourceBlob.AppendBlockAsync(stream);
 
                 AppendBlobClient destBlob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
                 CustomerProvidedKey customerProvidedKey = GetCustomerProvidedKey();
                 destBlob = InstrumentClient(destBlob.WithCustomerProvidedKey(customerProvidedKey));
-                await destBlob.CreateAsync();
+                await destBlob.CreateIfNotExistsAsync();
 
                 // Act
                 Response<BlobAppendInfo> response = await destBlob.AppendBlockFromUriAsync(
@@ -696,12 +696,12 @@ namespace Azure.Storage.Blobs.Test
             using (var stream = new MemoryStream(data))
             {
                 AppendBlobClient sourceBlob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
-                await sourceBlob.CreateAsync();
+                await sourceBlob.CreateIfNotExistsAsync();
                 await sourceBlob.AppendBlockAsync(stream);
 
                 AppendBlobClient destBlob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
                 destBlob = InstrumentClient(destBlob.WithEncryptionScope(TestConfigDefault.EncryptionScope));
-                await destBlob.CreateAsync();
+                await destBlob.CreateIfNotExistsAsync();
 
                 // Act
                 Response<BlobAppendInfo> response = await destBlob.AppendBlockFromUriAsync(
@@ -725,11 +725,11 @@ namespace Azure.Storage.Blobs.Test
             using (var stream = new MemoryStream(data))
             {
                 AppendBlobClient sourceBlob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
-                await sourceBlob.CreateAsync();
+                await sourceBlob.CreateIfNotExistsAsync();
                 await sourceBlob.AppendBlockAsync(stream);
 
                 AppendBlobClient destBlob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
-                await destBlob.CreateAsync();
+                await destBlob.CreateIfNotExistsAsync();
 
                 // Act
                 await destBlob.AppendBlockFromUriAsync(sourceBlob.Uri, new HttpRange(2 * Constants.KB, 2 * Constants.KB));
@@ -756,11 +756,11 @@ namespace Azure.Storage.Blobs.Test
             using (var stream = new MemoryStream(data))
             {
                 AppendBlobClient sourceBlob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
-                await sourceBlob.CreateAsync();
+                await sourceBlob.CreateIfNotExistsAsync();
                 await sourceBlob.AppendBlockAsync(stream);
 
                 AppendBlobClient destBlob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
-                await destBlob.CreateAsync();
+                await destBlob.CreateIfNotExistsAsync();
 
                 // Act
                 await destBlob.AppendBlockFromUriAsync(
@@ -782,11 +782,11 @@ namespace Azure.Storage.Blobs.Test
             using (var stream = new MemoryStream(data))
             {
                 AppendBlobClient sourceBlob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
-                await sourceBlob.CreateAsync();
+                await sourceBlob.CreateIfNotExistsAsync();
                 await sourceBlob.AppendBlockAsync(stream);
 
                 AppendBlobClient destBlob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
-                await destBlob.CreateAsync();
+                await destBlob.CreateIfNotExistsAsync();
 
                 // Act
                 await TestHelper.AssertExpectedExceptionAsync<RequestFailedException>(
@@ -829,11 +829,11 @@ namespace Azure.Storage.Blobs.Test
                 using (var stream = new MemoryStream(data))
                 {
                     AppendBlobClient sourceBlob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
-                    await sourceBlob.CreateAsync();
+                    await sourceBlob.CreateIfNotExistsAsync();
                     await sourceBlob.AppendBlockAsync(stream);
 
                     AppendBlobClient destBlob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
-                    await destBlob.CreateAsync();
+                    await destBlob.CreateIfNotExistsAsync();
 
                     parameters.Match = await SetupBlobMatchCondition(destBlob, parameters.Match);
                     parameters.SourceIfMatch = await SetupBlobMatchCondition(sourceBlob, parameters.SourceIfMatch);
@@ -884,11 +884,11 @@ namespace Azure.Storage.Blobs.Test
                 using (var stream = new MemoryStream(data))
                 {
                     AppendBlobClient sourceBlob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
-                    await sourceBlob.CreateAsync();
+                    await sourceBlob.CreateIfNotExistsAsync();
                     await sourceBlob.AppendBlockAsync(stream);
 
                     AppendBlobClient destBlob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
-                    await destBlob.CreateAsync();
+                    await destBlob.CreateIfNotExistsAsync();
 
                     parameters.NoneMatch = await SetupBlobMatchCondition(destBlob, parameters.NoneMatch);
                     parameters.SourceIfNoneMatch = await SetupBlobMatchCondition(sourceBlob, parameters.SourceIfNoneMatch);

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -1439,7 +1439,7 @@ namespace Azure.Storage.Blobs.Test
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
             CustomerProvidedKey customerProvidedKey = GetCustomerProvidedKey();
             blob = InstrumentClient(blob.WithCustomerProvidedKey(customerProvidedKey));
-            await blob.CreateAsync();
+            await blob.CreateIfNotExistsAsync();
 
             // Act
             Response<BlobProperties> response = await blob.GetPropertiesAsync();
@@ -1457,7 +1457,7 @@ namespace Azure.Storage.Blobs.Test
             // Arrange
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
             blob = InstrumentClient(blob.WithEncryptionScope(TestConfigDefault.EncryptionScope));
-            await blob.CreateAsync();
+            await blob.CreateIfNotExistsAsync();
 
             // Act
             Response<BlobProperties> response = await blob.GetPropertiesAsync();
@@ -1980,7 +1980,7 @@ namespace Azure.Storage.Blobs.Test
             CustomerProvidedKey customerProvidedKey = GetCustomerProvidedKey();
             blob = InstrumentClient(blob.WithCustomerProvidedKey(customerProvidedKey));
             IDictionary<string, string> metadata = BuildMetadata();
-            await blob.CreateAsync();
+            await blob.CreateIfNotExistsAsync();
 
             // Act
             await blob.SetMetadataAsync(metadata);
@@ -1995,7 +1995,7 @@ namespace Azure.Storage.Blobs.Test
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
             blob = InstrumentClient(blob.WithEncryptionScope(TestConfigDefault.EncryptionScope));
             IDictionary<string, string> metadata = BuildMetadata();
-            await blob.CreateAsync();
+            await blob.CreateIfNotExistsAsync();
 
             // Act
             Response<BlobInfo> response = await blob.SetMetadataAsync(metadata);
@@ -2088,7 +2088,7 @@ namespace Azure.Storage.Blobs.Test
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
             CustomerProvidedKey customerProvidedKey = GetCustomerProvidedKey();
             blob = InstrumentClient(blob.WithCustomerProvidedKey(customerProvidedKey));
-            await blob.CreateAsync();
+            await blob.CreateIfNotExistsAsync();
 
             // Act
             Response<BlobSnapshotInfo> response = await blob.CreateSnapshotAsync();
@@ -2105,7 +2105,7 @@ namespace Azure.Storage.Blobs.Test
             await using DisposingContainer test = await GetTestContainerAsync();
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
             blob = InstrumentClient(blob.WithEncryptionScope(TestConfigDefault.EncryptionScope));
-            await blob.CreateAsync();
+            await blob.CreateIfNotExistsAsync();
 
             // Act
             Response<BlobSnapshotInfo> response = await blob.CreateSnapshotAsync();

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -1334,7 +1334,7 @@ namespace Azure.Storage.Blobs.Test
             try
             {
                 BlobBaseClient blob = await GetNewBlobClient(test.Container);
-                await blob.DeleteAsync();
+                await blob.DeleteIfExistsAsync();
 
                 // Act
                 Response response = await blob.UndeleteAsync();

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -240,7 +240,7 @@ namespace Azure.Storage.Test.Shared
             }
 
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(containerName));
-            await container.CreateAsync(metadata: metadata, publicAccessType: publicAccessType.Value);
+            await container.CreateIfNotExistsAsync(metadata: metadata, publicAccessType: publicAccessType.Value);
             return new DisposingContainer(container);
         }
 
@@ -538,7 +538,7 @@ namespace Azure.Storage.Test.Shared
                 {
                     try
                     {
-                        await Container.DeleteAsync();
+                        await Container.DeleteIfExistsAsync();
                         Container = null;
                     }
                     catch

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -377,7 +377,7 @@ namespace Azure.Storage.Test.Shared
         public async Task<PageBlobClient> CreatePageBlobClientAsync(BlobContainerClient container, long size)
         {
             PageBlobClient blob = InstrumentClient(container.GetPageBlobClient(GetNewBlobName()));
-            await blob.CreateAsync(size, 0).ConfigureAwait(false);
+            await blob.CreateIfNotExistsAsync(size, 0).ConfigureAwait(false);
             return blob;
         }
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
@@ -1580,7 +1580,7 @@ namespace Azure.Storage.Blobs.Test
             // Arrange
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
             IDictionary<string, string> metadata = BuildMetadata();
-            await blob.CreateAsync(metadata: metadata);
+            await blob.CreateIfNotExistsAsync(metadata: metadata);
 
             // Act
             IList<BlobItem> blobs = await test.Container.GetBlobsAsync(traits: BlobTraits.Metadata).ToListAsync();
@@ -1599,7 +1599,7 @@ namespace Azure.Storage.Blobs.Test
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
             blob = InstrumentClient(blob.WithEncryptionScope(TestConfigDefault.EncryptionScope));
 
-            await blob.CreateAsync();
+            await blob.CreateIfNotExistsAsync();
 
             // Act
             IList<BlobItem> blobs = await test.Container.GetBlobsAsync().ToListAsync();
@@ -1620,8 +1620,8 @@ namespace Azure.Storage.Blobs.Test
                 await EnableSoftDelete();
                 var blobName = GetNewBlobName();
                 AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(blobName));
-                await blob.CreateAsync();
-                await blob.DeleteAsync();
+                await blob.CreateIfNotExistsAsync();
+                await blob.DeleteIfExistsAsync();
 
                 // Act
                 IList<BlobItem> blobs = await test.Container.GetBlobsAsync(states: BlobStates.Deleted).ToListAsync();
@@ -1674,7 +1674,7 @@ namespace Azure.Storage.Blobs.Test
 
             // Arrange
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
-            await blob.CreateAsync();
+            await blob.CreateIfNotExistsAsync();
             Response<BlobSnapshotInfo> snapshotResponse = await blob.CreateSnapshotAsync();
 
             // Act
@@ -1800,7 +1800,7 @@ namespace Azure.Storage.Blobs.Test
             // Arrange
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
             IDictionary<string, string> metadata = BuildMetadata();
-            await blob.CreateAsync(metadata: metadata);
+            await blob.CreateIfNotExistsAsync(metadata: metadata);
 
             // Act
             BlobHierarchyItem item = await test.Container.GetBlobsByHierarchyAsync(traits: BlobTraits.Metadata).FirstAsync();
@@ -1818,7 +1818,7 @@ namespace Azure.Storage.Blobs.Test
             // Arrange
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
             blob = InstrumentClient(blob.WithEncryptionScope(TestConfigDefault.EncryptionScope));
-            await blob.CreateAsync();
+            await blob.CreateIfNotExistsAsync();
 
             // Act
             BlobHierarchyItem item = await test.Container.GetBlobsByHierarchyAsync().FirstAsync();
@@ -1839,8 +1839,8 @@ namespace Azure.Storage.Blobs.Test
                 await EnableSoftDelete();
                 var blobName = GetNewBlobName();
                 AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(blobName));
-                await blob.CreateAsync();
-                await blob.DeleteAsync();
+                await blob.CreateIfNotExistsAsync();
+                await blob.DeleteIfExistsAsync();
 
                 // Act
                 IList<BlobHierarchyItem> blobs = await test.Container.GetBlobsByHierarchyAsync(states: BlobStates.Deleted).ToListAsync();
@@ -1893,7 +1893,7 @@ namespace Azure.Storage.Blobs.Test
 
             // Arrange
             AppendBlobClient blob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
-            await blob.CreateAsync();
+            await blob.CreateIfNotExistsAsync();
             Response<BlobSnapshotInfo> snapshotResponse = await blob.CreateSnapshotAsync();
 
             // Act

--- a/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
@@ -80,10 +80,10 @@ namespace Azure.Storage.Blobs.Test
             try
             {
                 // Act
-                await containerClient1.CreateAsync();
+                await containerClient1.CreateIfNotExistsAsync();
                 BlobClient blob1 = InstrumentClient(containerClient1.GetBlobClient(GetNewBlobName()));
 
-                await containerClient2.CreateAsync();
+                await containerClient2.CreateIfNotExistsAsync();
                 BlobClient blob2 = InstrumentClient(containerClient2.GetBlobClient(GetNewBlobName()));
 
                 var data = GetRandomBuffer(Constants.KB);
@@ -104,8 +104,8 @@ namespace Azure.Storage.Blobs.Test
             finally
             {
                 // Clean up
-                await containerClient1.DeleteAsync();
-                await containerClient2.DeleteAsync();
+                await containerClient1.DeleteIfExistsAsync();
+                await containerClient2.DeleteIfExistsAsync();
             }
         }
 
@@ -126,7 +126,7 @@ namespace Azure.Storage.Blobs.Test
             {
                 // Act
                 // This should succeed as we have Container resourceType permission
-                await containerClient.CreateAsync();
+                await containerClient.CreateIfNotExistsAsync();
 
                 BlobClient blob = InstrumentClient(containerClient.GetBlobClient(GetNewBlobName()));
 
@@ -140,7 +140,7 @@ namespace Azure.Storage.Blobs.Test
             finally
             {
                 // Clean up
-                await containerClient.DeleteAsync();
+                await containerClient.DeleteIfExistsAsync();
             }
         }
 
@@ -203,7 +203,7 @@ namespace Azure.Storage.Blobs.Test
             try
             {
                 // Act
-                await containerClient.CreateAsync();
+                await containerClient.CreateIfNotExistsAsync();
 
                 BlobClient blob = InstrumentClient(containerClient.GetBlobClient(GetNewBlobName()));
 
@@ -217,7 +217,7 @@ namespace Azure.Storage.Blobs.Test
             finally
             {
                 // Clean up
-                await containerClient.DeleteAsync();
+                await containerClient.DeleteIfExistsAsync();
             }
         }
         private BlobContainerClient GetBlobContainerClient(string connectionString) =>
@@ -315,7 +315,7 @@ namespace Azure.Storage.Blobs.Test
             }
             finally
             {
-                await container.DeleteAsync();
+                await container.DeleteIfExistsAsync();
             }
         }
 
@@ -348,7 +348,7 @@ namespace Azure.Storage.Blobs.Test
             }
             finally
             {
-                await container.DeleteAsync();
+                await container.DeleteIfExistsAsync();
             }
         }
 
@@ -370,7 +370,7 @@ namespace Azure.Storage.Blobs.Test
             }
             finally
             {
-                await container.DeleteAsync();
+                await container.DeleteIfExistsAsync();
             }
         }
 
@@ -392,7 +392,7 @@ namespace Azure.Storage.Blobs.Test
             }
             finally
             {
-                await container.DeleteAsync();
+                await container.DeleteIfExistsAsync();
             }
         }
 
@@ -420,7 +420,7 @@ namespace Azure.Storage.Blobs.Test
             {
                 if (!pass)
                 {
-                    await container.DeleteAsync();
+                    await container.DeleteIfExistsAsync();
                 }
             }
         }
@@ -441,7 +441,7 @@ namespace Azure.Storage.Blobs.Test
             AssertMetadataEquality(metadata, response.Value.Metadata);
 
             // Cleanup
-            await container.DeleteAsync();
+            await container.DeleteIfExistsAsync();
         }
 
         [Test]
@@ -462,7 +462,7 @@ namespace Azure.Storage.Blobs.Test
             await container.CreateAsync(encryptionScopeOptions: encryptionScopeOptions);
 
             // Cleanup
-            await container.DeleteAsync();
+            await container.DeleteIfExistsAsync();
         }
 
         [Test]
@@ -480,7 +480,7 @@ namespace Azure.Storage.Blobs.Test
             Assert.AreEqual(PublicAccessType.Blob, response.Value.PublicAccess);
 
             // Cleanup
-            await container.DeleteAsync();
+            await container.DeleteIfExistsAsync();
         }
 
         [Test]
@@ -490,7 +490,7 @@ namespace Azure.Storage.Blobs.Test
             BlobServiceClient service = GetServiceClient_SharedKey();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
             // ContainerUri is intentually created twice
-            await container.CreateAsync();
+            await container.CreateIfNotExistsAsync();
 
             // Act
             await TestHelper.AssertExpectedExceptionAsync<RequestFailedException>(
@@ -498,7 +498,7 @@ namespace Azure.Storage.Blobs.Test
                 e => Assert.AreEqual("ContainerAlreadyExists", e.ErrorCode));
 
             // Cleanup
-            await container.DeleteAsync();
+            await container.DeleteIfExistsAsync();
         }
 
         [Test]
@@ -516,7 +516,7 @@ namespace Azure.Storage.Blobs.Test
             Assert.IsNotNull(response.Value.ETag);
 
             // Cleanup
-            await container.DeleteAsync();
+            await container.DeleteIfExistsAsync();
         }
 
         [Test]
@@ -525,7 +525,7 @@ namespace Azure.Storage.Blobs.Test
             // Arrange
             BlobServiceClient service = GetServiceClient_SharedKey();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
-            await container.CreateAsync();
+            await container.CreateIfNotExistsAsync();
 
             // Act
             await container.CreateIfNotExistsAsync();
@@ -535,7 +535,7 @@ namespace Azure.Storage.Blobs.Test
             Assert.IsNotNull(response.Value.ETag);
 
             // Cleanup
-            await container.DeleteAsync();
+            await container.DeleteIfExistsAsync();
         }
 
         [Test]
@@ -558,7 +558,7 @@ namespace Azure.Storage.Blobs.Test
             // Arrange
             BlobServiceClient service = GetServiceClient_SharedKey();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
-            await container.CreateAsync();
+            await container.CreateIfNotExistsAsync();
 
             // Act
             Response response = await container.DeleteAsync();
@@ -589,7 +589,7 @@ namespace Azure.Storage.Blobs.Test
                 // Arrange
                 BlobServiceClient service = GetServiceClient_SharedKey();
                 BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
-                await container.CreateAsync();
+                await container.CreateIfNotExistsAsync();
                 parameters.LeaseId = await SetupContainerLeaseCondition(container, parameters.LeaseId, garbageLeaseId);
                 BlobRequestConditions accessConditions = BuildContainerAccessConditions(
                     parameters: parameters,
@@ -611,7 +611,7 @@ namespace Azure.Storage.Blobs.Test
             // Arrange
             BlobServiceClient service = GetServiceClient_SharedKey();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
-            await container.CreateAsync();
+            await container.CreateIfNotExistsAsync();
             var conditions = new BlobRequestConditions()
             {
                 IfMatch = new ETag("etag")
@@ -629,7 +629,7 @@ namespace Azure.Storage.Blobs.Test
             // Arrange
             BlobServiceClient service = GetServiceClient_SharedKey();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
-            await container.CreateAsync();
+            await container.CreateIfNotExistsAsync();
             var conditions = new BlobRequestConditions()
             {
                 IfNoneMatch = new ETag("etag")
@@ -667,7 +667,7 @@ namespace Azure.Storage.Blobs.Test
             // Arrange
             BlobServiceClient service = GetServiceClient_SharedKey();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
-            await container.CreateAsync();
+            await container.CreateIfNotExistsAsync();
 
             // Act
             Response<bool> response = await container.DeleteIfExistsAsync();
@@ -699,7 +699,7 @@ namespace Azure.Storage.Blobs.Test
             // Arrange
             BlobServiceClient service = GetServiceClient_SharedKey();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
-            await container.CreateAsync();
+            await container.CreateIfNotExistsAsync();
 
             // Act
             Response<bool> response = await container.ExistsAsync();
@@ -707,7 +707,7 @@ namespace Azure.Storage.Blobs.Test
             // Assert
             Assert.IsTrue(response.Value);
 
-            await container.DeleteAsync();
+            await container.DeleteIfExistsAsync();
         }
 
         [Test]
@@ -823,7 +823,7 @@ namespace Azure.Storage.Blobs.Test
             {
                 BlobServiceClient service = GetServiceClient_SharedKey();
                 BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
-                await container.CreateAsync();
+                await container.CreateIfNotExistsAsync();
                 parameters.LeaseId = await SetupContainerLeaseCondition(container, parameters.LeaseId, garbageLeaseId);
                 IDictionary<string, string> metadata = BuildMetadata();
                 BlobRequestConditions accessConditions = BuildContainerAccessConditions(
@@ -840,7 +840,7 @@ namespace Azure.Storage.Blobs.Test
                 Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
 
                 // Cleanup
-                await container.DeleteAsync(new BlobRequestConditions { LeaseId = parameters.LeaseId });
+                await container.DeleteIfExistsAsync(new BlobRequestConditions { LeaseId = parameters.LeaseId });
             }
         }
 
@@ -891,7 +891,7 @@ namespace Azure.Storage.Blobs.Test
             // Arrange
             BlobServiceClient service = GetServiceClient_SharedKey();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
-            await container.CreateAsync();
+            await container.CreateIfNotExistsAsync();
             var garbageLeaseId = GetGarbageLeaseId();
             var leaseId = await SetupContainerLeaseCondition(container, ReceivedLeaseId, garbageLeaseId);
             var leaseAccessConditions = new BlobRequestConditions
@@ -906,7 +906,7 @@ namespace Azure.Storage.Blobs.Test
             Assert.IsNotNull(response);
 
             // Cleanup
-            await container.DeleteAsync(conditions: leaseAccessConditions);
+            await container.DeleteIfExistsAsync(conditions: leaseAccessConditions);
         }
 
         [Test]
@@ -992,7 +992,7 @@ namespace Azure.Storage.Blobs.Test
                 // Arrange
                 BlobServiceClient service = GetServiceClient_SharedKey();
                 BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
-                await container.CreateAsync();
+                await container.CreateIfNotExistsAsync();
                 PublicAccessType publicAccessType = PublicAccessType.BlobContainer;
                 BlobSignedIdentifier[] signedIdentifiers = BuildSignedIdentifiers();
                 parameters.LeaseId = await SetupContainerLeaseCondition(container, parameters.LeaseId, garbageLeaseId);
@@ -1012,7 +1012,7 @@ namespace Azure.Storage.Blobs.Test
                 Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
 
                 // Cleanup
-                await container.DeleteAsync(conditions: new BlobRequestConditions { LeaseId = parameters.LeaseId });
+                await container.DeleteIfExistsAsync(conditions: new BlobRequestConditions { LeaseId = parameters.LeaseId });
             }
         }
 
@@ -1047,7 +1047,7 @@ namespace Azure.Storage.Blobs.Test
             // Arrange
             BlobServiceClient service = GetServiceClient_SharedKey();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
-            await container.CreateAsync();
+            await container.CreateIfNotExistsAsync();
             var id = Recording.Random.NewGuid().ToString();
             var duration = TimeSpan.FromSeconds(15);
 
@@ -1058,7 +1058,7 @@ namespace Azure.Storage.Blobs.Test
             Assert.AreEqual(id, response.Value.LeaseId);
 
             // Cleanup
-            await container.DeleteAsync(conditions: new BlobRequestConditions { LeaseId = response.Value.LeaseId });
+            await container.DeleteIfExistsAsync(conditions: new BlobRequestConditions { LeaseId = response.Value.LeaseId });
         }
 
         [Test]
@@ -1099,7 +1099,7 @@ namespace Azure.Storage.Blobs.Test
                 // Arrange
                 BlobServiceClient service = GetServiceClient_SharedKey();
                 BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
-                await container.CreateAsync();
+                await container.CreateIfNotExistsAsync();
                 BlobRequestConditions accessConditions = BuildContainerAccessConditions(
                     parameters: parameters,
                     ifUnmodifiedSince: true,
@@ -1117,7 +1117,7 @@ namespace Azure.Storage.Blobs.Test
                 Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
 
                 // cleanup
-                await container.DeleteAsync(conditions: new BlobRequestConditions { LeaseId = response.Value.LeaseId });
+                await container.DeleteIfExistsAsync(conditions: new BlobRequestConditions { LeaseId = response.Value.LeaseId });
             }
         }
 
@@ -1152,7 +1152,7 @@ namespace Azure.Storage.Blobs.Test
             // Arrange
             BlobServiceClient service = GetServiceClient_SharedKey();
             BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
-            await container.CreateAsync();
+            await container.CreateIfNotExistsAsync();
 
             var id = Recording.Random.NewGuid().ToString();
             var duration = TimeSpan.FromSeconds(15);
@@ -1167,7 +1167,7 @@ namespace Azure.Storage.Blobs.Test
             Assert.IsNotNull(renewResponse.GetRawResponse().Headers.RequestId);
 
             // Cleanup
-            await container.DeleteAsync(conditions: new BlobRequestConditions { LeaseId = renewResponse.Value.LeaseId });
+            await container.DeleteIfExistsAsync(conditions: new BlobRequestConditions { LeaseId = renewResponse.Value.LeaseId });
         }
 
         [Test]
@@ -1192,7 +1192,7 @@ namespace Azure.Storage.Blobs.Test
                 // Arrange
                 BlobServiceClient service = GetServiceClient_SharedKey();
                 BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
-                await container.CreateAsync();
+                await container.CreateIfNotExistsAsync();
                 BlobRequestConditions accessConditions = BuildContainerAccessConditions(
                     parameters: parameters,
                     ifUnmodifiedSince: true,
@@ -1210,7 +1210,7 @@ namespace Azure.Storage.Blobs.Test
                 Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
 
                 // cleanup
-                await container.DeleteAsync(conditions: new BlobRequestConditions { LeaseId = response.Value.LeaseId });
+                await container.DeleteIfExistsAsync(conditions: new BlobRequestConditions { LeaseId = response.Value.LeaseId });
             }
         }
 
@@ -1222,7 +1222,7 @@ namespace Azure.Storage.Blobs.Test
                 // Arrange
                 BlobServiceClient service = GetServiceClient_SharedKey();
                 BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
-                await container.CreateAsync();
+                await container.CreateIfNotExistsAsync();
                 BlobRequestConditions accessConditions = BuildContainerAccessConditions(
                     parameters: parameters,
                     ifUnmodifiedSince: true,
@@ -1240,7 +1240,7 @@ namespace Azure.Storage.Blobs.Test
                     e => { });
 
                 // cleanup
-                await container.DeleteAsync(conditions: new BlobRequestConditions { LeaseId = aquireLeaseResponse.Value.LeaseId });
+                await container.DeleteIfExistsAsync(conditions: new BlobRequestConditions { LeaseId = aquireLeaseResponse.Value.LeaseId });
             }
         }
 
@@ -1313,7 +1313,7 @@ namespace Azure.Storage.Blobs.Test
                 // Arrange
                 BlobServiceClient service = GetServiceClient_SharedKey();
                 BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
-                await container.CreateAsync();
+                await container.CreateIfNotExistsAsync();
                 BlobRequestConditions accessConditions = BuildContainerAccessConditions(
                     parameters: parameters,
                     ifUnmodifiedSince: true,
@@ -1331,7 +1331,7 @@ namespace Azure.Storage.Blobs.Test
                     e => { });
 
                 // cleanup
-                await container.DeleteAsync(conditions: new BlobRequestConditions { LeaseId = aquireLeaseResponse.Value.LeaseId });
+                await container.DeleteIfExistsAsync(conditions: new BlobRequestConditions { LeaseId = aquireLeaseResponse.Value.LeaseId });
             }
         }
 
@@ -1377,7 +1377,7 @@ namespace Azure.Storage.Blobs.Test
                 // Arrange
                 BlobServiceClient service = GetServiceClient_SharedKey();
                 BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
-                await container.CreateAsync();
+                await container.CreateIfNotExistsAsync();
 
                 BlobRequestConditions accessConditions = BuildContainerAccessConditions(
                     parameters: parameters,
@@ -1397,7 +1397,7 @@ namespace Azure.Storage.Blobs.Test
                 Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
 
                 // Cleanup
-                await container.DeleteAsync(conditions: new BlobRequestConditions { LeaseId = aquireLeaseResponse.Value.LeaseId });
+                await container.DeleteIfExistsAsync(conditions: new BlobRequestConditions { LeaseId = aquireLeaseResponse.Value.LeaseId });
             }
         }
 
@@ -1409,7 +1409,7 @@ namespace Azure.Storage.Blobs.Test
                 // Arrange
                 BlobServiceClient service = GetServiceClient_SharedKey();
                 BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
-                await container.CreateAsync();
+                await container.CreateIfNotExistsAsync();
                 BlobRequestConditions accessConditions = BuildContainerAccessConditions(
                     parameters: parameters,
                     ifUnmodifiedSince: true,
@@ -1427,7 +1427,7 @@ namespace Azure.Storage.Blobs.Test
                     e => { });
 
                 // cleanup
-                await container.DeleteAsync(conditions: new BlobRequestConditions { LeaseId = aquireLeaseResponse.Value.LeaseId });
+                await container.DeleteIfExistsAsync(conditions: new BlobRequestConditions { LeaseId = aquireLeaseResponse.Value.LeaseId });
             }
         }
 
@@ -1474,7 +1474,7 @@ namespace Azure.Storage.Blobs.Test
                 // Arrange
                 BlobServiceClient service = GetServiceClient_SharedKey();
                 BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
-                await container.CreateAsync();
+                await container.CreateIfNotExistsAsync();
 
                 BlobRequestConditions accessConditions = BuildContainerAccessConditions(
                     parameters: parameters,
@@ -1496,7 +1496,7 @@ namespace Azure.Storage.Blobs.Test
                 Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
 
                 // Cleanup
-                await container.DeleteAsync(conditions: new BlobRequestConditions { LeaseId = response.Value.LeaseId });
+                await container.DeleteIfExistsAsync(conditions: new BlobRequestConditions { LeaseId = response.Value.LeaseId });
             }
         }
 
@@ -1508,7 +1508,7 @@ namespace Azure.Storage.Blobs.Test
                 // Arrange
                 BlobServiceClient service = GetServiceClient_SharedKey();
                 BlobContainerClient container = InstrumentClient(service.GetBlobContainerClient(GetNewContainerName()));
-                await container.CreateAsync();
+                await container.CreateIfNotExistsAsync();
                 BlobRequestConditions accessConditions = BuildContainerAccessConditions(
                     parameters: parameters,
                     ifUnmodifiedSince: true,
@@ -1528,7 +1528,7 @@ namespace Azure.Storage.Blobs.Test
                     e => { });
 
                 // cleanup
-                await container.DeleteAsync(conditions: new BlobRequestConditions { LeaseId = aquireLeaseResponse.Value.LeaseId });
+                await container.DeleteIfExistsAsync(conditions: new BlobRequestConditions { LeaseId = aquireLeaseResponse.Value.LeaseId });
             }
         }
 
@@ -2033,7 +2033,7 @@ namespace Azure.Storage.Blobs.Test
         private async Task<TestExceptionPolicy> PerformSecondaryStorageTest(int numberOfReadFailuresToSimulate, bool retryOn404 = false)
         {
             BlobContainerClient containerClient = GetBlobContainerClient_SecondaryAccount_ReadEnabledOnRetry(numberOfReadFailuresToSimulate, out TestExceptionPolicy testExceptionPolicy, retryOn404);
-            await containerClient.CreateAsync();
+            await containerClient.CreateIfNotExistsAsync();
 
             Response<BlobContainerProperties> properties = await EnsurePropagatedAsync(
                 async () => await containerClient.GetPropertiesAsync(),
@@ -2042,7 +2042,7 @@ namespace Azure.Storage.Blobs.Test
             Assert.IsNotNull(properties);
             Assert.AreEqual(200, properties.GetRawResponse().Status);
 
-            await containerClient.DeleteAsync();
+            await containerClient.DeleteIfExistsAsync();
             return testExceptionPolicy;
         }
         #endregion

--- a/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/PageBlobClientTests.cs
@@ -347,7 +347,7 @@ namespace Azure.Storage.Blobs.Test
             CustomerProvidedKey customerProvidedKey = GetCustomerProvidedKey();
             blob = InstrumentClient(blob.WithCustomerProvidedKey(customerProvidedKey));
             var data = GetRandomBuffer(Constants.KB);
-            await blob.CreateAsync(Constants.KB);
+            await blob.CreateIfNotExistsAsync(Constants.KB);
 
             using var stream = new MemoryStream(data);
 
@@ -371,7 +371,7 @@ namespace Azure.Storage.Blobs.Test
             PageBlobClient blob = InstrumentClient(test.Container.GetPageBlobClient(blobName));
             blob = InstrumentClient(blob.WithEncryptionScope(TestConfigDefault.EncryptionScope));
             var data = GetRandomBuffer(Constants.KB);
-            await blob.CreateAsync(Constants.KB);
+            await blob.CreateIfNotExistsAsync(Constants.KB);
 
             using var stream = new MemoryStream(data);
 
@@ -536,7 +536,7 @@ namespace Azure.Storage.Blobs.Test
             PageBlobClient blobFaulty = InstrumentClient(containerClientFaulty.GetPageBlobClient(pageBlobName));
             PageBlobClient blob = InstrumentClient(test.Container.GetPageBlobClient(pageBlobName));
 
-            await blob.CreateAsync(blobSize)
+            await blob.CreateIfNotExistsAsync(blobSize)
                 .ConfigureAwait(false);
 
             var offset = 0 * Constants.KB;
@@ -627,7 +627,7 @@ namespace Azure.Storage.Blobs.Test
             PageBlobClient blob = InstrumentClient(test.Container.GetPageBlobClient(GetNewBlobName()));
             CustomerProvidedKey customerProvidedKey = GetCustomerProvidedKey();
             blob = InstrumentClient(blob.WithCustomerProvidedKey(customerProvidedKey));
-            await blob.CreateAsync(4 * Constants.KB);
+            await blob.CreateIfNotExistsAsync(4 * Constants.KB);
             var data = GetRandomBuffer(4 * Constants.KB);
             using (var stream = new MemoryStream(data))
             {
@@ -651,7 +651,7 @@ namespace Azure.Storage.Blobs.Test
             // Arrange
             PageBlobClient blob = InstrumentClient(test.Container.GetPageBlobClient(GetNewBlobName()));
             blob = InstrumentClient(blob.WithEncryptionScope(TestConfigDefault.EncryptionScope));
-            await blob.CreateAsync(4 * Constants.KB);
+            await blob.CreateIfNotExistsAsync(4 * Constants.KB);
             var data = GetRandomBuffer(4 * Constants.KB);
             using (var stream = new MemoryStream(data))
             {
@@ -1250,7 +1250,7 @@ namespace Azure.Storage.Blobs.Test
             PageBlobClient blob = InstrumentClient(test.Container.GetPageBlobClient(GetNewBlobName()));
             CustomerProvidedKey customerProvidedKey = GetCustomerProvidedKey();
             blob = InstrumentClient(blob.WithCustomerProvidedKey(customerProvidedKey));
-            await blob.CreateAsync(Constants.KB);
+            await blob.CreateIfNotExistsAsync(Constants.KB);
             var newSize = 8 * Constants.KB;
 
             // Act
@@ -1269,7 +1269,7 @@ namespace Azure.Storage.Blobs.Test
             // Arrange
             PageBlobClient blob = InstrumentClient(test.Container.GetPageBlobClient(GetNewBlobName()));
             blob = InstrumentClient(blob.WithEncryptionScope(TestConfigDefault.EncryptionScope));
-            await blob.CreateAsync(Constants.KB);
+            await blob.CreateIfNotExistsAsync(Constants.KB);
             var newSize = 8 * Constants.KB;
 
             // Act
@@ -1774,11 +1774,11 @@ namespace Azure.Storage.Blobs.Test
             using (var stream = new MemoryStream(data))
             {
                 PageBlobClient sourceBlob = InstrumentClient(test.Container.GetPageBlobClient(GetNewBlobName()));
-                await sourceBlob.CreateAsync(Constants.KB);
+                await sourceBlob.CreateIfNotExistsAsync(Constants.KB);
                 await sourceBlob.UploadPagesAsync(stream, 0);
 
                 PageBlobClient destBlob = InstrumentClient(test.Container.GetPageBlobClient(GetNewBlobName()));
-                await destBlob.CreateAsync(Constants.KB);
+                await destBlob.CreateIfNotExistsAsync(Constants.KB);
                 var range = new HttpRange(0, Constants.KB);
 
                 // Act
@@ -1801,13 +1801,13 @@ namespace Azure.Storage.Blobs.Test
 
             using var stream = new MemoryStream(data);
             PageBlobClient sourceBlob = InstrumentClient(test.Container.GetPageBlobClient(GetNewBlobName()));
-            await sourceBlob.CreateAsync(Constants.KB);
+            await sourceBlob.CreateIfNotExistsAsync(Constants.KB);
             await sourceBlob.UploadPagesAsync(stream, 0);
 
             PageBlobClient destBlob = InstrumentClient(test.Container.GetPageBlobClient(GetNewBlobName()));
             CustomerProvidedKey customerProvidedKey = GetCustomerProvidedKey();
             destBlob = InstrumentClient(destBlob.WithCustomerProvidedKey(customerProvidedKey));
-            await destBlob.CreateAsync(Constants.KB);
+            await destBlob.CreateIfNotExistsAsync(Constants.KB);
             var range = new HttpRange(0, Constants.KB);
 
             // Act
@@ -1833,12 +1833,12 @@ namespace Azure.Storage.Blobs.Test
 
             using var stream = new MemoryStream(data);
             PageBlobClient sourceBlob = InstrumentClient(test.Container.GetPageBlobClient(GetNewBlobName()));
-            await sourceBlob.CreateAsync(Constants.KB);
+            await sourceBlob.CreateIfNotExistsAsync(Constants.KB);
             await sourceBlob.UploadPagesAsync(stream, 0);
 
             PageBlobClient destBlob = InstrumentClient(test.Container.GetPageBlobClient(GetNewBlobName()));
             destBlob = InstrumentClient(destBlob.WithEncryptionScope(TestConfigDefault.EncryptionScope));
-            await destBlob.CreateAsync(Constants.KB);
+            await destBlob.CreateIfNotExistsAsync(Constants.KB);
             var range = new HttpRange(0, Constants.KB);
 
             // Act
@@ -1864,11 +1864,11 @@ namespace Azure.Storage.Blobs.Test
             using (var stream = new MemoryStream(data))
             {
                 PageBlobClient sourceBlob = InstrumentClient(test.Container.GetPageBlobClient(GetNewBlobName()));
-                await sourceBlob.CreateAsync(4 * Constants.KB);
+                await sourceBlob.CreateIfNotExistsAsync(4 * Constants.KB);
                 await sourceBlob.UploadPagesAsync(stream, 0);
 
                 PageBlobClient destBlob = InstrumentClient(test.Container.GetPageBlobClient(GetNewBlobName()));
-                await destBlob.CreateAsync(2 * Constants.KB);
+                await destBlob.CreateIfNotExistsAsync(2 * Constants.KB);
                 var range = new HttpRange(0, 2 * Constants.KB);
 
                 // Act
@@ -1899,11 +1899,11 @@ namespace Azure.Storage.Blobs.Test
             using (var stream = new MemoryStream(data))
             {
                 PageBlobClient sourceBlob = InstrumentClient(test.Container.GetPageBlobClient(GetNewBlobName()));
-                await sourceBlob.CreateAsync(Constants.KB);
+                await sourceBlob.CreateIfNotExistsAsync(Constants.KB);
                 await sourceBlob.UploadPagesAsync(stream, 0);
 
                 PageBlobClient destBlob = InstrumentClient(test.Container.GetPageBlobClient(GetNewBlobName()));
-                await destBlob.CreateAsync(Constants.KB);
+                await destBlob.CreateIfNotExistsAsync(Constants.KB);
                 var range = new HttpRange(0, Constants.KB);
 
                 // Act
@@ -1928,11 +1928,11 @@ namespace Azure.Storage.Blobs.Test
             using (var stream = new MemoryStream(data))
             {
                 PageBlobClient sourceBlob = InstrumentClient(test.Container.GetPageBlobClient(GetNewBlobName()));
-                await sourceBlob.CreateAsync(Constants.KB);
+                await sourceBlob.CreateIfNotExistsAsync(Constants.KB);
                 await sourceBlob.UploadPagesAsync(stream, 0);
 
                 PageBlobClient destBlob = InstrumentClient(test.Container.GetPageBlobClient(GetNewBlobName()));
-                await destBlob.CreateAsync(Constants.KB);
+                await destBlob.CreateIfNotExistsAsync(Constants.KB);
                 var range = new HttpRange(0, Constants.KB);
 
                 // Act
@@ -1981,11 +1981,11 @@ namespace Azure.Storage.Blobs.Test
                 using (var stream = new MemoryStream(data))
                 {
                     PageBlobClient sourceBlob = InstrumentClient(test.Container.GetPageBlobClient(GetNewBlobName()));
-                    await sourceBlob.CreateAsync(Constants.KB);
+                    await sourceBlob.CreateIfNotExistsAsync(Constants.KB);
                     await sourceBlob.UploadPagesAsync(stream, 0);
 
                     PageBlobClient destBlob = InstrumentClient(test.Container.GetPageBlobClient(GetNewBlobName()));
-                    await destBlob.CreateAsync(Constants.KB);
+                    await destBlob.CreateIfNotExistsAsync(Constants.KB);
 
                     parameters.Match = await SetupBlobMatchCondition(destBlob, parameters.Match);
                     parameters.SourceIfMatch = await SetupBlobMatchCondition(sourceBlob, parameters.SourceIfMatch);
@@ -2043,11 +2043,11 @@ namespace Azure.Storage.Blobs.Test
                 using (var stream = new MemoryStream(data))
                 {
                     PageBlobClient sourceBlob = InstrumentClient(test.Container.GetPageBlobClient(GetNewBlobName()));
-                    await sourceBlob.CreateAsync(Constants.KB);
+                    await sourceBlob.CreateIfNotExistsAsync(Constants.KB);
                     await sourceBlob.UploadPagesAsync(stream, 0);
 
                     PageBlobClient destBlob = InstrumentClient(test.Container.GetPageBlobClient(GetNewBlobName()));
-                    await destBlob.CreateAsync(Constants.KB);
+                    await destBlob.CreateIfNotExistsAsync(Constants.KB);
 
                     parameters.NoneMatch = await SetupBlobMatchCondition(destBlob, parameters.NoneMatch);
                     parameters.SourceIfNoneMatch = await SetupBlobMatchCondition(sourceBlob, parameters.SourceIfNoneMatch);

--- a/sdk/storage/Azure.Storage.Common/tests/StorageSharedKeyCredentialsTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/StorageSharedKeyCredentialsTests.cs
@@ -67,7 +67,8 @@ namespace Azure.Storage.Test
                         GetBlobOptions()));
 
             // Create a child container
-            BlobContainerClient container = await service.CreateBlobContainerAsync(GetNewContainerName());
+            BlobContainerClient container = service.GetBlobContainerClient(GetNewContainerName());
+            await container.CreateIfNotExistsAsync();
             try
             {
                 // Verify the credential works (i.e., doesn't throw)
@@ -89,7 +90,7 @@ namespace Azure.Storage.Test
             finally
             {
                 // Clean up the child container
-                await container.DeleteAsync();
+                await container.DeleteIfExistsAsync();
             }
         }
     }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
@@ -385,7 +385,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 {
                     try
                     {
-                        await FileSystem.DeleteAsync();
+                        await FileSystem.DeleteIfExistsAsync();
                         FileSystem = null;
                     }
                     catch

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
@@ -1584,7 +1584,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             // Arrange
             string fileName = GetNewFileName();
             DataLakeFileClient fileClient = directory.GetFileClient(fileName);
-            await fileClient.CreateAsync();
+            await fileClient.CreateIfNotExistsAsync();
 
             // Assert
             await directory.DeleteFileAsync(fileName);

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
@@ -292,7 +292,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             // Arrange
             await using DisposingFileSystem test = await GetNewFileSystem();
             DataLakeDirectoryClient directory = InstrumentClient(test.FileSystem.GetDirectoryClient(GetNewDirectoryName()));
-            await directory.CreateAsync();
+            await directory.CreateIfNotExistsAsync();
 
             // Act
             Response<PathInfo> response = await directory.CreateIfNotExistsAsync();
@@ -321,7 +321,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             // Arrange
             await using DisposingFileSystem test = await GetNewFileSystem();
             DataLakeDirectoryClient directory = InstrumentClient(test.FileSystem.GetDirectoryClient(GetNewDirectoryName()));
-            await directory.CreateAsync();
+            await directory.CreateIfNotExistsAsync();
 
             // Act
             Response<bool> response = await directory.ExistsAsync();
@@ -364,7 +364,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             // Arrange
             await using DisposingFileSystem test = await GetNewFileSystem();
             DataLakeDirectoryClient directory = InstrumentClient(test.FileSystem.GetDirectoryClient(GetNewDirectoryName()));
-            await directory.CreateAsync();
+            await directory.CreateIfNotExistsAsync();
 
             // Act
             Response<bool> response = await directory.DeleteIfExistsAsync();
@@ -412,7 +412,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             // Arrange
             var name = GetNewDirectoryName();
             DataLakeDirectoryClient directory = InstrumentClient(test.FileSystem.GetDirectoryClient(name));
-            await directory.CreateAsync();
+            await directory.CreateIfNotExistsAsync();
 
             // Act
             Response response = await directory.DeleteAsync();
@@ -1144,7 +1144,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             await using DisposingFileSystem test = await GetNewFileSystem(fileSystemName: fileSystemName);
             DataLakeDirectoryClient directoryClient = InstrumentClient(test.FileSystem.GetDirectoryClient(directoryName));
-            await directoryClient.CreateAsync();
+            await directoryClient.CreateIfNotExistsAsync();
 
             DataLakeSignedIdentifier signedIdentifier = new DataLakeSignedIdentifier
             {
@@ -1767,7 +1767,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             // Arrange
             string directoryName = GetNewDirectoryName();
             DataLakeDirectoryClient directoryClient = directory.GetSubDirectoryClient(directoryName);
-            await directoryClient.CreateAsync();
+            await directoryClient.CreateIfNotExistsAsync();
 
             // Assert
             await directory.DeleteFileAsync(directoryName);

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/FileClientTests.cs
@@ -300,7 +300,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             await using DisposingFileSystem test = await GetNewFileSystem();
             DataLakeDirectoryClient directory = await test.FileSystem.CreateDirectoryAsync(GetNewDirectoryName());
             DataLakeFileClient file = InstrumentClient(directory.GetFileClient(GetNewFileName()));
-            await file.CreateAsync();
+            await file.CreateIfNotExistsAsync();
 
             // Act
             Response<PathInfo> response = await file.CreateIfNotExistsAsync();
@@ -331,7 +331,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             await using DisposingFileSystem test = await GetNewFileSystem();
             DataLakeDirectoryClient directory = await test.FileSystem.CreateDirectoryAsync(GetNewDirectoryName());
             DataLakeFileClient file = InstrumentClient(directory.GetFileClient(GetNewFileName()));
-            await file.CreateAsync();
+            await file.CreateIfNotExistsAsync();
 
             // Act
             Response<bool> response = await file.ExistsAsync();
@@ -377,7 +377,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             await using DisposingFileSystem test = await GetNewFileSystem();
             DataLakeDirectoryClient directory = await test.FileSystem.CreateDirectoryAsync(GetNewDirectoryName());
             DataLakeFileClient file = InstrumentClient(directory.GetFileClient(GetNewFileName()));
-            await file.CreateAsync();
+            await file.CreateIfNotExistsAsync();
 
             // Act
             Response<bool> response = await file.DeleteIfExistsAsync();
@@ -1481,7 +1481,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             // Arrange
             DataLakeFileClient file = InstrumentClient(test.FileSystem.GetFileClient(GetNewFileName()));
-            await file.CreateAsync();
+            await file.CreateIfNotExistsAsync();
             var data = GetRandomBuffer(Size);
 
             // Act
@@ -1522,7 +1522,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             // Arrange
             DataLakeFileClient file = InstrumentClient(test.FileSystem.GetFileClient(GetNewFileName()));
-            await file.CreateAsync();
+            await file.CreateIfNotExistsAsync();
             var data = GetRandomBuffer(Size);
             TestProgress progress = new TestProgress();
 
@@ -1546,7 +1546,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             // Arrange
             DataLakeFileClient file = InstrumentClient(test.FileSystem.GetFileClient(GetNewFileName()));
-            await file.CreateAsync();
+            await file.CreateIfNotExistsAsync();
             var data = GetRandomBuffer(Size);
             byte[] contentHash = MD5.Create().ComputeHash(data);
 
@@ -1582,7 +1582,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             // Arrange
             DataLakeFileClient file = InstrumentClient(test.FileSystem.GetFileClient(GetNewFileName()));
-            await file.CreateAsync();
+            await file.CreateIfNotExistsAsync();
             var data0 = GetRandomBuffer(Constants.KB);
             var data1 = GetRandomBuffer(Constants.KB);
 
@@ -1612,7 +1612,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             // Arrange
             DataLakeFileClient file = InstrumentClient(test.FileSystem.GetFileClient(GetNewFileName()));
-            await file.CreateAsync();
+            await file.CreateIfNotExistsAsync();
             var data = GetRandomBuffer(Size);
             var leaseId = Recording.Random.NewGuid().ToString();
             var duration = TimeSpan.FromSeconds(15);
@@ -1632,7 +1632,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             // Arrange
             DataLakeFileClient file = InstrumentClient(test.FileSystem.GetFileClient(GetNewFileName()));
-            await file.CreateAsync();
+            await file.CreateIfNotExistsAsync();
             var data = GetRandomBuffer(Size);
 
             // Act
@@ -1651,7 +1651,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             // Arrange
             DataLakeFileClient file = InstrumentClient(test.FileSystem.GetFileClient(GetNewFileName()));
-            await file.CreateAsync();
+            await file.CreateIfNotExistsAsync();
 
             // Act
             using (var stream = (MemoryStream)null)
@@ -1673,7 +1673,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             // Arrange
             DataLakeFileClient file = InstrumentClient(test.FileSystem.GetFileClient(GetNewFileName()));
-            await file.CreateAsync();
+            await file.CreateIfNotExistsAsync();
             var data = GetRandomBuffer(Constants.KB);
 
             using (var stream = new MemoryStream(data))
@@ -1695,7 +1695,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             // Arrange
             DataLakeFileClient file = InstrumentClient(test.FileSystem.GetFileClient(GetNewFileName()));
-            await file.CreateAsync();
+            await file.CreateIfNotExistsAsync();
             byte[] data = GetRandomBuffer(Constants.KB);
             byte[] contentHash = MD5.Create().ComputeHash(data);
             PathHttpHeaders headers = new PathHttpHeaders
@@ -1733,7 +1733,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             // Arrange
             DataLakeFileClient file = InstrumentClient(test.FileSystem.GetFileClient(GetNewFileName()));
-            await file.CreateAsync();
+            await file.CreateIfNotExistsAsync();
             var data = GetRandomBuffer(Constants.KB);
 
             using (var stream = new MemoryStream(data))
@@ -1755,7 +1755,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             // Arrange
             DataLakeFileClient file = InstrumentClient(test.FileSystem.GetFileClient(GetNewFileName()));
-            await file.CreateAsync();
+            await file.CreateIfNotExistsAsync();
             var data = GetRandomBuffer(Constants.KB);
 
             using (var stream = new MemoryStream(data))
@@ -1777,7 +1777,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
             // Arrange
             DataLakeFileClient file = InstrumentClient(test.FileSystem.GetFileClient(GetNewFileName()));
-            await file.CreateAsync();
+            await file.CreateIfNotExistsAsync();
             var data = GetRandomBuffer(Constants.KB);
 
             using (var stream = new MemoryStream(data))
@@ -1802,7 +1802,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
                 // Arrange
                 DataLakeFileClient file = InstrumentClient(test.FileSystem.GetFileClient(GetNewFileName()));
-                await file.CreateAsync();
+                await file.CreateIfNotExistsAsync();
                 var data = GetRandomBuffer(Constants.KB);
 
                 using (var stream = new MemoryStream(data))
@@ -1831,7 +1831,7 @@ namespace Azure.Storage.Files.DataLake.Tests
 
                 // Arrange
                 DataLakeFileClient file = InstrumentClient(test.FileSystem.GetFileClient(GetNewFileName()));
-                await file.CreateAsync();
+                await file.CreateIfNotExistsAsync();
                 var data = GetRandomBuffer(Size);
 
                 using (var stream = new MemoryStream(data))

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/FileSystemClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/FileSystemClientTests.cs
@@ -1759,7 +1759,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             {
                 DataLakeDirectoryClient directory = InstrumentClient(fileSystem.GetDirectoryClient(pathNames[i]));
                 directories[i] = directory;
-                await directory.CreateAsync();
+                await directory.CreateIfNotExistsAsync();
             }
         }
 

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/FileSystemClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/FileSystemClientTests.cs
@@ -172,7 +172,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             }
             finally
             {
-                await fileSystem.DeleteAsync();
+                await fileSystem.DeleteIfExistsAsync();
             }
         }
 
@@ -194,7 +194,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             }
             finally
             {
-                await fileSystem.DeleteAsync();
+                await fileSystem.DeleteIfExistsAsync();
             }
         }
 
@@ -222,7 +222,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             {
                 if (!pass)
                 {
-                    await fileSystem.DeleteAsync();
+                    await fileSystem.DeleteIfExistsAsync();
                 }
             }
         }
@@ -249,7 +249,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             }
             finally
             {
-                await fileSystem.DeleteAsync();
+                await fileSystem.DeleteIfExistsAsync();
             }
         }
 
@@ -269,7 +269,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             AssertMetadataEquality(metadata, response.Value.Metadata);
 
             // Cleanup
-            await fileSystem.DeleteAsync();
+            await fileSystem.DeleteIfExistsAsync();
         }
 
         [Test]
@@ -287,7 +287,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             Assert.AreEqual(Models.PublicAccessType.Path, response.Value.PublicAccess);
 
             // Cleanup
-            await fileSystem.DeleteAsync();
+            await fileSystem.DeleteIfExistsAsync();
         }
 
         [Test]
@@ -305,7 +305,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 e => Assert.AreEqual("ContainerAlreadyExists", e.ErrorCode));
 
             // Cleanup
-            await fileSystemClient.DeleteAsync();
+            await fileSystemClient.DeleteIfExistsAsync();
         }
 
         [Test]
@@ -326,7 +326,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             finally
             {
                 // Cleanup
-                await fileSystemClient.DeleteAsync();
+                await fileSystemClient.DeleteIfExistsAsync();
             }
         }
 
@@ -338,7 +338,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeFileSystemClient fileSystemClient = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
             try
             {
-                await fileSystemClient.CreateAsync();
+                await fileSystemClient.CreateIfNotExistsAsync();
 
                 // Act
                 Response<FileSystemInfo> response = await fileSystemClient.CreateIfNotExistsAsync();
@@ -349,7 +349,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             finally
             {
                 // Cleanup
-                await fileSystemClient.DeleteAsync();
+                await fileSystemClient.DeleteIfExistsAsync();
             }
         }
 
@@ -413,7 +413,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             // Arrange
             DataLakeServiceClient service = GetServiceClient_SharedKey();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
-            await fileSystem.CreateAsync();
+            await fileSystem.CreateIfNotExistsAsync();
 
             // Act
             Response response = await fileSystem.DeleteAsync();
@@ -444,7 +444,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 // Arrange
                 DataLakeServiceClient service = GetServiceClient_SharedKey();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
-                await fileSystem.CreateAsync();
+                await fileSystem.CreateIfNotExistsAsync();
                 parameters.LeaseId = await SetupFileSystemLeaseCondition(fileSystem, parameters.LeaseId, garbageLeaseId);
                 DataLakeRequestConditions conditions = BuildFileSystemConditions(
                     parameters: parameters,
@@ -487,7 +487,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             // Arrange
             DataLakeServiceClient service = GetServiceClient_SharedKey();
             DataLakeFileSystemClient fileSystemClient = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
-            await fileSystemClient.CreateAsync();
+            await fileSystemClient.CreateIfNotExistsAsync();
 
             // Act
             Response<bool> response = await fileSystemClient.DeleteIfExistsAsync();
@@ -684,7 +684,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 // Arrange
                 DataLakeServiceClient service = GetServiceClient_SharedKey();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
-                await fileSystem.CreateAsync();
+                await fileSystem.CreateIfNotExistsAsync();
                 parameters.LeaseId = await SetupFileSystemLeaseCondition(fileSystem, parameters.LeaseId, garbageLeaseId);
                 IDictionary<string, string> metadata = BuildMetadata();
                 DataLakeRequestConditions conditions = BuildFileSystemConditions(
@@ -701,7 +701,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
 
                 // Cleanup
-                await fileSystem.DeleteAsync(new DataLakeRequestConditions
+                await fileSystem.DeleteIfExistsAsync(new DataLakeRequestConditions
                 {
                     LeaseId = parameters.LeaseId
                 });
@@ -973,7 +973,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             // Arrange
             DataLakeServiceClient service = GetServiceClient_SharedKey();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
-            await fileSystem.CreateAsync();
+            await fileSystem.CreateIfNotExistsAsync();
             var id = Recording.Random.NewGuid().ToString();
             var duration = TimeSpan.FromSeconds(15);
 
@@ -984,7 +984,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             Assert.AreEqual(id, response.Value.LeaseId);
 
             // Cleanup
-            await fileSystem.DeleteAsync(conditions: new DataLakeRequestConditions
+            await fileSystem.DeleteIfExistsAsync(conditions: new DataLakeRequestConditions
             {
                 LeaseId = response.Value.LeaseId
             });
@@ -1013,7 +1013,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 // Arrange
                 DataLakeServiceClient service = GetServiceClient_SharedKey();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
-                await fileSystem.CreateAsync();
+                await fileSystem.CreateIfNotExistsAsync();
                 DataLakeRequestConditions conditions = BuildFileSystemConditions(
                     parameters: parameters,
                     ifUnmodifiedSince: true,
@@ -1031,7 +1031,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
 
                 // cleanup
-                await fileSystem.DeleteAsync(conditions: new DataLakeRequestConditions
+                await fileSystem.DeleteIfExistsAsync(conditions: new DataLakeRequestConditions
                 {
                     LeaseId = response.Value.LeaseId
                 });
@@ -1069,7 +1069,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             // Arrange
             DataLakeServiceClient service = GetServiceClient_SharedKey();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
-            await fileSystem.CreateAsync();
+            await fileSystem.CreateIfNotExistsAsync();
 
             var id = Recording.Random.NewGuid().ToString();
             var duration = TimeSpan.FromSeconds(15);
@@ -1084,7 +1084,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             Assert.IsNotNull(renewResponse.GetRawResponse().Headers.RequestId);
 
             // Cleanup
-            await fileSystem.DeleteAsync(conditions: new DataLakeRequestConditions
+            await fileSystem.DeleteIfExistsAsync(conditions: new DataLakeRequestConditions
             {
                 LeaseId = renewResponse.Value.LeaseId
             });
@@ -1112,7 +1112,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 // Arrange
                 DataLakeServiceClient service = GetServiceClient_SharedKey();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
-                await fileSystem.CreateAsync();
+                await fileSystem.CreateIfNotExistsAsync();
                 DataLakeRequestConditions conditions = BuildFileSystemConditions(
                     parameters: parameters,
                     ifUnmodifiedSince: true,
@@ -1130,7 +1130,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
 
                 // cleanup
-                await fileSystem.DeleteAsync(conditions: new DataLakeRequestConditions
+                await fileSystem.DeleteIfExistsAsync(conditions: new DataLakeRequestConditions
                 {
                     LeaseId = response.Value.LeaseId
                 });
@@ -1145,7 +1145,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 // Arrange
                 DataLakeServiceClient service = GetServiceClient_SharedKey();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
-                await fileSystem.CreateAsync();
+                await fileSystem.CreateIfNotExistsAsync();
                 DataLakeRequestConditions conditions = BuildFileSystemConditions(
                     parameters: parameters,
                     ifUnmodifiedSince: true,
@@ -1163,7 +1163,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                     e => { });
 
                 // cleanup
-                await fileSystem.DeleteAsync(conditions: new DataLakeRequestConditions
+                await fileSystem.DeleteIfExistsAsync(conditions: new DataLakeRequestConditions
                 {
                     LeaseId = aquireLeaseResponse.Value.LeaseId
                 });
@@ -1239,7 +1239,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 // Arrange
                 DataLakeServiceClient service = GetServiceClient_SharedKey();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
-                await fileSystem.CreateAsync();
+                await fileSystem.CreateIfNotExistsAsync();
                 DataLakeRequestConditions conditions = BuildFileSystemConditions(
                     parameters: parameters,
                     ifUnmodifiedSince: true,
@@ -1257,7 +1257,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                     e => { });
 
                 // cleanup
-                await fileSystem.DeleteAsync(conditions: new DataLakeRequestConditions
+                await fileSystem.DeleteIfExistsAsync(conditions: new DataLakeRequestConditions
                 {
                     LeaseId = aquireLeaseResponse.Value.LeaseId
                 });
@@ -1307,7 +1307,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 // Arrange
                 DataLakeServiceClient service = GetServiceClient_SharedKey();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
-                await fileSystem.CreateAsync();
+                await fileSystem.CreateIfNotExistsAsync();
 
                 DataLakeRequestConditions conditions = BuildFileSystemConditions(
                     parameters: parameters,
@@ -1329,7 +1329,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
 
                 // Cleanup
-                await fileSystem.DeleteAsync(conditions: new DataLakeRequestConditions
+                await fileSystem.DeleteIfExistsAsync(conditions: new DataLakeRequestConditions
                 {
                     LeaseId = response.Value.LeaseId
                 });
@@ -1344,7 +1344,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 // Arrange
                 DataLakeServiceClient service = GetServiceClient_SharedKey();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
-                await fileSystem.CreateAsync();
+                await fileSystem.CreateIfNotExistsAsync();
                 DataLakeRequestConditions conditions = BuildFileSystemConditions(
                     parameters: parameters,
                     ifUnmodifiedSince: true,
@@ -1364,7 +1364,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                     e => { });
 
                 // cleanup
-                await fileSystem.DeleteAsync(conditions: new DataLakeRequestConditions
+                await fileSystem.DeleteIfExistsAsync(conditions: new DataLakeRequestConditions
                 {
                     LeaseId = aquireLeaseResponse.Value.LeaseId
                 });
@@ -1413,7 +1413,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 // Arrange
                 DataLakeServiceClient service = GetServiceClient_SharedKey();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
-                await fileSystem.CreateAsync();
+                await fileSystem.CreateIfNotExistsAsync();
 
                 DataLakeRequestConditions conditions = BuildFileSystemConditions(
                     parameters: parameters,
@@ -1433,7 +1433,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
 
                 // Cleanup
-                await fileSystem.DeleteAsync(conditions: new DataLakeRequestConditions
+                await fileSystem.DeleteIfExistsAsync(conditions: new DataLakeRequestConditions
                 {
                     LeaseId = aquireLeaseResponse.Value.LeaseId
                 });
@@ -1448,7 +1448,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 // Arrange
                 DataLakeServiceClient service = GetServiceClient_SharedKey();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
-                await fileSystem.CreateAsync();
+                await fileSystem.CreateIfNotExistsAsync();
                 DataLakeRequestConditions conditions = BuildFileSystemConditions(
                     parameters: parameters,
                     ifUnmodifiedSince: true,
@@ -1466,7 +1466,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                     e => { });
 
                 // cleanup
-                await fileSystem.DeleteAsync(conditions: new DataLakeRequestConditions
+                await fileSystem.DeleteIfExistsAsync(conditions: new DataLakeRequestConditions
                 {
                     LeaseId = aquireLeaseResponse.Value.LeaseId
                 });
@@ -1504,7 +1504,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             // Arrange
             DataLakeServiceClient service = GetServiceClient_SharedKey();
             DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
-            await fileSystem.CreateAsync();
+            await fileSystem.CreateIfNotExistsAsync();
             string garbageLeaseId = GetGarbageLeaseId();
             string leaseId = await SetupFileSystemLeaseCondition(fileSystem, ReceivedLeaseId, garbageLeaseId);
             DataLakeRequestConditions leaseAccessConditions = new DataLakeRequestConditions
@@ -1520,7 +1520,7 @@ namespace Azure.Storage.Files.DataLake.Tests
             Assert.AreEqual(0, response.Value.SignedIdentifiers.Count());
 
             // Cleanup
-            await fileSystem.DeleteAsync(conditions: leaseAccessConditions);
+            await fileSystem.DeleteIfExistsAsync(conditions: leaseAccessConditions);
         }
 
         [Test]
@@ -1641,7 +1641,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                 DataLakeSignedIdentifier[] signedIdentifiers = BuildSignedIdentifiers();
                 DataLakeServiceClient service = GetServiceClient_SharedKey();
                 DataLakeFileSystemClient fileSystem = InstrumentClient(service.GetFileSystemClient(GetNewFileSystemName()));
-                await fileSystem.CreateAsync();
+                await fileSystem.CreateIfNotExistsAsync();
 
                 DataLakeRequestConditions conditions = BuildFileSystemConditions(
                     parameters: parameters,

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
@@ -198,7 +198,7 @@ namespace Azure.Storage.Files.Shares.Test
             // Arrange
             ShareDirectoryClient directory = InstrumentClient(share.GetDirectoryClient(GetNewDirectoryName()));
             // Directory is intentionally created twice
-            await directory.CreateAsync();
+            await directory.CreateIfNotExistsAsync();
 
             // Act
             await TestHelper.AssertExpectedExceptionAsync<RequestFailedException>(
@@ -248,7 +248,7 @@ namespace Azure.Storage.Files.Shares.Test
             ShareClient share = test.Share;
             string name = GetNewDirectoryName();
             ShareDirectoryClient directory = InstrumentClient(share.GetDirectoryClient(name));
-            await directory.CreateAsync();
+            await directory.CreateIfNotExistsAsync();
 
             // Act
             Response<ShareDirectoryInfo> response = await directory.CreateIfNotExistsAsync();
@@ -297,7 +297,7 @@ namespace Azure.Storage.Files.Shares.Test
             ShareClient share = test.Share;
             string name = GetNewDirectoryName();
             ShareDirectoryClient directory = InstrumentClient(share.GetDirectoryClient(name));
-            await directory.CreateAsync();
+            await directory.CreateIfNotExistsAsync();
 
             // Act
             Response<bool> response = await directory.ExistsAsync();
@@ -329,7 +329,7 @@ namespace Azure.Storage.Files.Shares.Test
             ShareClient share = test.Share;
             string name = GetNewDirectoryName();
             ShareDirectoryClient directory = InstrumentClient(share.GetDirectoryClient(name));
-            await directory.CreateAsync();
+            await directory.CreateIfNotExistsAsync();
 
             // Act
             Response<bool> response = await directory.DeleteIfExistsAsync();
@@ -362,7 +362,7 @@ namespace Azure.Storage.Files.Shares.Test
             ShareClient share = test.Share;
             string name = GetNewDirectoryName();
             ShareDirectoryClient directory = InstrumentClient(share.GetDirectoryClient(name));
-            await directory.CreateAsync();
+            await directory.CreateIfNotExistsAsync();
             await directory.CreateFileAsync(GetNewFileName(), Constants.KB);
 
             // Act
@@ -409,7 +409,7 @@ namespace Azure.Storage.Files.Shares.Test
             ShareDirectoryClient directory = InstrumentClient(share.GetDirectoryClient(GetNewDirectoryName()));
 
             // Act
-            Response<ShareDirectoryInfo> createResponse = await directory.CreateAsync();
+            Response<ShareDirectoryInfo> createResponse = await directory.CreateIfNotExistsAsync();
             Response<ShareDirectoryProperties> getPropertiesResponse = await directory.GetPropertiesAsync();
 
             // Assert
@@ -442,7 +442,7 @@ namespace Azure.Storage.Files.Shares.Test
             // Arrange
             ShareDirectoryClient directory = InstrumentClient(share.GetDirectoryClient(GetNewDirectoryName()));
             var filePermission = "O:S-1-5-21-2127521184-1604012920-1887927527-21560751G:S-1-5-21-2127521184-1604012920-1887927527-513D:AI(A;;FA;;;SY)(A;;FA;;;BA)(A;;0x1200a9;;;S-1-5-21-397955417-626881126-188441444-3053964)";
-            await directory.CreateAsync();
+            await directory.CreateIfNotExistsAsync();
 
             // Act
             Response<ShareDirectoryInfo> response = await directory.SetHttpHeadersAsync(filePermission: filePermission);
@@ -471,7 +471,7 @@ namespace Azure.Storage.Files.Shares.Test
             };
 
 
-            await directory.CreateAsync();
+            await directory.CreateIfNotExistsAsync();
 
             // Act
             Response<ShareDirectoryInfo> response = await directory.SetHttpHeadersAsync(smbProperties: smbProperties);
@@ -492,7 +492,7 @@ namespace Azure.Storage.Files.Shares.Test
             // Arrange
             ShareDirectoryClient directory = InstrumentClient(share.GetDirectoryClient(GetNewDirectoryName()));
             var filePermission = new string('*', 9 * Constants.KB);
-            await directory.CreateAsync();
+            await directory.CreateIfNotExistsAsync();
 
             // Act
             await TestHelper.AssertExpectedExceptionAsync<ArgumentOutOfRangeException>(
@@ -516,7 +516,7 @@ namespace Azure.Storage.Files.Shares.Test
             {
                 FilePermissionKey = "filePermissionKey"
             };
-            await directory.CreateAsync();
+            await directory.CreateIfNotExistsAsync();
 
             // Act
             await TestHelper.AssertExpectedExceptionAsync<ArgumentException>(
@@ -573,7 +573,7 @@ namespace Azure.Storage.Files.Shares.Test
             ShareClient share = test.Share;
 
             ShareDirectoryClient directory = InstrumentClient(share.GetDirectoryClient(GetNewDirectoryName()));
-            await directory.CreateAsync();
+            await directory.CreateIfNotExistsAsync();
 
             foreach (var fileName in fileNames)
             {
@@ -586,7 +586,7 @@ namespace Azure.Storage.Files.Shares.Test
             {
                 ShareDirectoryClient subDir = InstrumentClient(directory.GetSubdirectoryClient(subDirName));
 
-                await subDir.CreateAsync();
+                await subDir.CreateIfNotExistsAsync();
             }
 
             var directories = new List<ShareFileItem>();

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
@@ -233,7 +233,7 @@ namespace Azure.Storage.Files.Shares.Test
             Response<PermissionInfo> createPermissionResponse = await share.CreatePermissionAsync(permission);
 
             ShareDirectoryClient directory = InstrumentClient(share.GetDirectoryClient(GetNewDirectoryName()));
-            await directory.CreateAsync();
+            await directory.CreateIfNotExistsAsync();
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewFileName()));
             var smbProperties = new FileSmbProperties
@@ -819,7 +819,7 @@ namespace Azure.Storage.Files.Shares.Test
             Response<PermissionInfo> createPermissionResponse = await share.CreatePermissionAsync(permission);
 
             ShareDirectoryClient directory = InstrumentClient(share.GetDirectoryClient(GetNewDirectoryName()));
-            await directory.CreateAsync();
+            await directory.CreateIfNotExistsAsync();
 
             ShareFileClient file = InstrumentClient(directory.GetFileClient(GetNewFileName()));
             var smbProperties = new FileSmbProperties
@@ -1559,7 +1559,7 @@ namespace Azure.Storage.Files.Shares.Test
                     new StorageSharedKeyCredential(TestConfigDefault.AccountName, TestConfigDefault.AccountKey),
                     GetFaultyFileConnectionOptions(raiseAt: 256 * Constants.KB)));
 
-            await directory.CreateAsync();
+            await directory.CreateIfNotExistsAsync();
 
             // Arrange
             var fileName = GetNewFileName();
@@ -1975,7 +1975,7 @@ namespace Azure.Storage.Files.Shares.Test
                         TestConfigDefault.AccountKey),
                     GetFaultyFileConnectionOptions()));
 
-            await directory.CreateAsync();
+            await directory.CreateIfNotExistsAsync();
 
             // Arrange
             var fileName = GetNewFileName();
@@ -2025,7 +2025,7 @@ namespace Azure.Storage.Files.Shares.Test
             // Arrange
             var directoryName = this.GetNewDirectoryName();
             var directory = this.InstrumentClient(share.GetDirectoryClient(directoryName));
-            await directory.CreateAsync();
+            await directory.CreateIfNotExistsAsync();
 
             var fileName = this.GetNewFileName();
             var data = this.GetRandomBuffer(Constants.KB);
@@ -2078,7 +2078,7 @@ namespace Azure.Storage.Files.Shares.Test
             // Arrange
             var directoryName = this.GetNewDirectoryName();
             var directory = this.InstrumentClient(share.GetDirectoryClient(directoryName));
-            await directory.CreateAsync();
+            await directory.CreateIfNotExistsAsync();
 
             var fileName = this.GetNewFileName();
             var data = this.GetRandomBuffer(Constants.KB);
@@ -2127,7 +2127,7 @@ namespace Azure.Storage.Files.Shares.Test
             // Arrange
             var directoryName = this.GetNewDirectoryName();
             var directory = this.InstrumentClient(share.GetDirectoryClient(directoryName));
-            await directory.CreateAsync();
+            await directory.CreateIfNotExistsAsync();
 
             var fileName = this.GetNewFileName();
             var data = this.GetRandomBuffer(Constants.KB);
@@ -2175,7 +2175,7 @@ namespace Azure.Storage.Files.Shares.Test
             // Arrange
             var directoryName = this.GetNewDirectoryName();
             var directory = this.InstrumentClient(share.GetDirectoryClient(directoryName));
-            await directory.CreateAsync();
+            await directory.CreateIfNotExistsAsync();
 
             var fileName = this.GetNewFileName();
             var sourceFile = this.InstrumentClient(directory.GetFileClient(fileName));

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
@@ -296,7 +296,7 @@ namespace Azure.Storage.Files.Shares.Tests
 
             public static async Task<DisposingDirectory> CreateAsync(DisposingShare test, ShareDirectoryClient directory)
             {
-                await directory.CreateAsync();
+                await directory.CreateIfNotExistsAsync();
                 return new DisposingDirectory(test, directory);
             }
 

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
@@ -261,7 +261,7 @@ namespace Azure.Storage.Files.Shares.Tests
 
             public static async Task<DisposingShare> CreateAsync(ShareClient share, IDictionary<string, string> metadata)
             {
-                await share.CreateAsync(metadata: metadata);
+                await share.CreateIfNotExistsAsync(metadata: metadata);
                 return new DisposingShare(share);
             }
 

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
@@ -276,7 +276,7 @@ namespace Azure.Storage.Files.Shares.Tests
                 {
                     try
                     {
-                        await Share.DeleteAsync(true);
+                        await Share.DeleteIfExistsAsync(true);
                         Share = null;
                     }
                     catch

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
@@ -753,7 +753,7 @@ namespace Azure.Storage.Files.Shares.Test
             ShareClient share = test.Share;
             string directoryName = GetNewDirectoryName();
             ShareDirectoryClient directory = InstrumentClient(share.GetDirectoryClient(directoryName));
-            await directory.CreateAsync();
+            await directory.CreateIfNotExistsAsync();
 
             // Act
             await share.DeleteDirectoryAsync(directoryName);

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
@@ -85,7 +85,7 @@ namespace Azure.Storage.Files.Shares.Test
 
             async Task<ShareFileClient> GetFileClient(ShareClient share)
             {
-                await share.CreateAsync();
+                await share.CreateIfNotExistsAsync();
                 string dirName = GetNewDirectoryName();
                 await share.CreateDirectoryAsync(dirName);
                 return InstrumentClient(share.GetDirectoryClient(dirName).GetFileClient(GetNewFileName()));
@@ -194,7 +194,7 @@ namespace Azure.Storage.Files.Shares.Test
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
 
             // Share is intentionally created twice
-            await share.CreateAsync();
+            await share.CreateIfNotExistsAsync();
 
             // Act
             await TestHelper.AssertExpectedExceptionAsync<RequestFailedException>(
@@ -325,7 +325,7 @@ namespace Azure.Storage.Files.Shares.Test
             var shareName = GetNewShareName();
             ShareServiceClient service = GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
-            await share.CreateAsync();
+            await share.CreateIfNotExistsAsync();
 
             // Act
             Response<ShareInfo> response = await share.CreateIfNotExistsAsync();
@@ -374,7 +374,7 @@ namespace Azure.Storage.Files.Shares.Test
             var shareName = GetNewShareName();
             ShareServiceClient service = GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
-            await share.CreateAsync();
+            await share.CreateIfNotExistsAsync();
 
             // Act
             Response<bool> response = await share.ExistsAsync();
@@ -408,7 +408,7 @@ namespace Azure.Storage.Files.Shares.Test
             var shareName = GetNewShareName();
             ShareServiceClient service = GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
-            await share.CreateAsync();
+            await share.CreateIfNotExistsAsync();
 
             // Act
             Response<bool> response = await share.DeleteIfExistsAsync();
@@ -710,7 +710,7 @@ namespace Azure.Storage.Files.Shares.Test
             var shareName = GetNewShareName();
             ShareServiceClient service = GetServiceClient_SharedKey();
             ShareClient share = InstrumentClient(service.GetShareClient(shareName));
-            await share.CreateAsync(quotaInGB: 1);
+            await share.CreateIfNotExistsAsync(quotaInGB: 1);
 
             // Act
             Response response = await share.DeleteAsync(false);

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
@@ -113,8 +113,8 @@ namespace Azure.Storage.Files.Shares.Test
             finally
             {
                 // Clean up
-                await shareClient1.DeleteAsync();
-                await shareClient2.DeleteAsync();
+                await shareClient1.DeleteIfExistsAsync();
+                await shareClient2.DeleteIfExistsAsync();
             }
         }
 
@@ -161,7 +161,7 @@ namespace Azure.Storage.Files.Shares.Test
             }
             finally
             {
-                await share.DeleteAsync(false);
+                await share.DeleteIfExistsAsync(false);
             }
         }
 
@@ -182,7 +182,7 @@ namespace Azure.Storage.Files.Shares.Test
             AssertMetadataEquality(metadata, response.Value.Metadata);
 
             // Cleanup
-            await share.DeleteAsync(false);
+            await share.DeleteIfExistsAsync(false);
         }
 
         [Test]
@@ -202,7 +202,7 @@ namespace Azure.Storage.Files.Shares.Test
                 e => Assert.AreEqual("ShareAlreadyExists", e.ErrorCode));
 
             // Cleanup
-            await share.DeleteAsync(false);
+            await share.DeleteIfExistsAsync(false);
         }
 
         [Test]
@@ -220,7 +220,7 @@ namespace Azure.Storage.Files.Shares.Test
             }
             finally
             {
-                await share.DeleteAsync(false);
+                await share.DeleteIfExistsAsync(false);
             }
         }
 
@@ -248,7 +248,7 @@ namespace Azure.Storage.Files.Shares.Test
             {
                 if (!pass)
                 {
-                    await share.DeleteAsync();
+                    await share.DeleteIfExistsAsync();
                 }
             }
         }
@@ -315,7 +315,7 @@ namespace Azure.Storage.Files.Shares.Test
             Assert.IsNotNull(response);
 
             // Cleanup
-            await share.DeleteAsync();
+            await share.DeleteIfExistsAsync();
         }
 
         [Test]
@@ -334,7 +334,7 @@ namespace Azure.Storage.Files.Shares.Test
             Assert.IsNull(response);
 
             // Cleanup
-            await share.DeleteAsync();
+            await share.DeleteIfExistsAsync();
         }
 
         [Test]
@@ -383,7 +383,7 @@ namespace Azure.Storage.Files.Shares.Test
             Assert.IsTrue(response.Value);
 
             // Cleanup
-            await share.DeleteAsync();
+            await share.DeleteIfExistsAsync();
         }
 
         [Test]

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueClientTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueClientTests.cs
@@ -82,8 +82,8 @@ namespace Azure.Storage.Queues.Test
             try
             {
                 // Act
-                await queueClient1.CreateAsync();
-                await queueClient2.CreateAsync();
+                await queueClient1.CreateIfNotExistsAsync();
+                await queueClient2.CreateIfNotExistsAsync();
 
                 var data = GetRandomBuffer(Constants.KB);
 
@@ -97,8 +97,8 @@ namespace Azure.Storage.Queues.Test
             finally
             {
                 // Clean up
-                await queueClient1.DeleteAsync();
-                await queueClient2.DeleteAsync();
+                await queueClient1.DeleteIfExistsAsync();
+                await queueClient2.DeleteIfExistsAsync();
             }
         }
 
@@ -147,7 +147,7 @@ namespace Azure.Storage.Queues.Test
             }
             finally
             {
-                await queue.DeleteAsync();
+                await queue.DeleteIfExistsAsync();
             }
         }
 
@@ -190,7 +190,7 @@ namespace Azure.Storage.Queues.Test
             }
             finally
             {
-                await queue.DeleteAsync();
+                await queue.DeleteIfExistsAsync();
             }
         }
 
@@ -212,7 +212,7 @@ namespace Azure.Storage.Queues.Test
             }
             finally
             {
-                await queue.DeleteAsync();
+                await queue.DeleteIfExistsAsync();
             }
         }
 
@@ -242,7 +242,7 @@ namespace Azure.Storage.Queues.Test
             {
                 if (!pass)
                 {
-                    await queue.DeleteAsync();
+                    await queue.DeleteIfExistsAsync();
                 }
             }
         }
@@ -254,7 +254,7 @@ namespace Azure.Storage.Queues.Test
             var queueName = GetNewQueueName();
             QueueServiceClient service = GetServiceClient_SharedKey();
             QueueClient queue = InstrumentClient(service.GetQueueClient(queueName));
-            await queue.CreateAsync();
+            await queue.CreateIfNotExistsAsync();
 
             // Act
             await TestHelper.AssertExpectedExceptionAsync<RequestFailedException>(
@@ -277,7 +277,7 @@ namespace Azure.Storage.Queues.Test
             Assert.IsNotNull(response);
 
             // Cleanup
-            await queue.DeleteAsync();
+            await queue.DeleteIfExistsAsync();
         }
 
         [Test]
@@ -287,7 +287,7 @@ namespace Azure.Storage.Queues.Test
             var queueName = GetNewQueueName();
             QueueServiceClient service = GetServiceClient_SharedKey();
             QueueClient queue = InstrumentClient(service.GetQueueClient(queueName));
-            await queue.CreateAsync();
+            await queue.CreateIfNotExistsAsync();
 
             // Act
             Response response = await queue.CreateIfNotExistsAsync();
@@ -296,7 +296,7 @@ namespace Azure.Storage.Queues.Test
             Assert.IsNull(response);
 
             // Cleanup
-            await queue.DeleteAsync();
+            await queue.DeleteIfExistsAsync();
         }
 
         [Test]
@@ -307,7 +307,7 @@ namespace Azure.Storage.Queues.Test
             QueueServiceClient service = GetServiceClient_SharedKey();
             QueueClient queue = InstrumentClient(service.GetQueueClient(queueName));
 
-            await queue.CreateAsync(BuildMetadata());
+            await queue.CreateIfNotExistsAsync(BuildMetadata());
 
             // Act
             Response response = await queue.CreateIfNotExistsAsync();
@@ -316,7 +316,7 @@ namespace Azure.Storage.Queues.Test
             Assert.IsNull(response);
 
             // Cleanup
-            await queue.DeleteAsync();
+            await queue.DeleteIfExistsAsync();
         }
 
         [Test]
@@ -341,7 +341,7 @@ namespace Azure.Storage.Queues.Test
             var queueName = GetNewQueueName();
             QueueServiceClient service = GetServiceClient_SharedKey();
             QueueClient queue = InstrumentClient(service.GetQueueClient(queueName));
-            await queue.CreateAsync();
+            await queue.CreateIfNotExistsAsync();
 
             // Act
             Response<bool> response = await queue.ExistsAsync();
@@ -350,7 +350,7 @@ namespace Azure.Storage.Queues.Test
             Assert.IsTrue(response.Value);
 
             // Cleanup
-            await queue.DeleteAsync();
+            await queue.DeleteIfExistsAsync();
         }
 
         [Test]
@@ -390,7 +390,7 @@ namespace Azure.Storage.Queues.Test
             var queueName = GetNewQueueName();
             QueueServiceClient service = GetServiceClient_SharedKey();
             QueueClient queue = InstrumentClient(service.GetQueueClient(queueName));
-            await queue.CreateAsync();
+            await queue.CreateIfNotExistsAsync();
 
             // Act
             Response<bool> response = await queue.DeleteIfExistsAsync();
@@ -462,7 +462,7 @@ namespace Azure.Storage.Queues.Test
         public async Task GetPropertiesAsync_SecondaryStorage()
         {
             QueueClient queueClient = GetQueueClient_SecondaryAccount_ReadEnabledOnRetry(1, out TestExceptionPolicy testExceptionPolicy);
-            await queueClient.CreateAsync();
+            await queueClient.CreateIfNotExistsAsync();
             Response<QueueProperties> properties = await EnsurePropagatedAsync(
                 async () => await queueClient.GetPropertiesAsync(),
                 properties => properties.GetRawResponse().Status != 404);
@@ -470,7 +470,7 @@ namespace Azure.Storage.Queues.Test
             Assert.IsNotNull(properties);
             Assert.AreEqual(200, properties.GetRawResponse().Status);
 
-            await queueClient.DeleteAsync();
+            await queueClient.DeleteIfExistsAsync();
             AssertSecondaryStorageFirstRetrySuccessful(SecondaryStorageTenantPrimaryHost(), SecondaryStorageTenantSecondaryHost(), testExceptionPolicy);
         }
         #endregion
@@ -590,7 +590,7 @@ namespace Azure.Storage.Queues.Test
             var queueName = GetNewQueueName();
             QueueServiceClient service = GetServiceClient_SharedKey();
             QueueClient queue = InstrumentClient(service.GetQueueClient(queueName));
-            await queue.CreateAsync();
+            await queue.CreateIfNotExistsAsync();
 
             // Act
             Response result = await queue.DeleteAsync();

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueTestBase.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueTestBase.cs
@@ -202,7 +202,7 @@ namespace Azure.Storage.Queues.Tests
 
             public static async Task<DisposingQueue> CreateAsync(QueueClient queue, IDictionary<string, string> metadata)
             {
-                await queue.CreateAsync(metadata: metadata);
+                await queue.CreateIfNotExistsAsync(metadata: metadata);
                 return new DisposingQueue(queue);
             }
 
@@ -217,7 +217,7 @@ namespace Azure.Storage.Queues.Tests
                 {
                     try
                     {
-                        await Queue.DeleteAsync();
+                        await Queue.DeleteIfExistsAsync();
                         Queue = null;
                     }
                     catch


### PR DESCRIPTION
- In test code, all calls to Create() or Delete() were replaced by CreateIfNotExists() and DeleteIfExists(), with the exception of calls explicitly testing Create() or Delete(), and calls which require the response (since the "Exists" APIs may return a null response).

- The non-"Exists" APIs may fail at any time if the server failed to respond to the first HTTP request and it was retried

## PRs which added "Exists" APIs to product code
* Blob: #7881
* Files.Shares: #10074
* Files.DataLake: #9996
* Queues: #10050