### PR TITLE
[EventHubs] Fixed EventBatch tests and updated batch constructor (Track Two)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
@@ -51,8 +51,7 @@ namespace Azure.Messaging.EventHubs.Producer
 
         /// <summary>
         ///   The fully qualified Event Hubs namespace that the batch is associated with.  To be used
-        ///   during instrumentation.  This is likely to be similar to
-        ///   <c>{yournamespace}.servicebus.windows.net</c>.
+        ///   during instrumentation.
         /// </summary>
         ///
         private string FullyQualifiedNamespace { get; }
@@ -69,7 +68,7 @@ namespace Azure.Messaging.EventHubs.Producer
         /// </summary>
         ///
         /// <param name="transportBatch">The  transport-specific batch responsible for performing the batch operations.</param>
-        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace to use for instrumentation.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace to use for instrumentation.</param>
         /// <param name="eventHubName">The name of the specific Event Hub to associate the events with during instrumentation.</param>
         /// <param name="sendOptions">The set of options that should be used when publishing the batch.</param>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
@@ -50,10 +50,27 @@ namespace Azure.Messaging.EventHubs.Producer
         private TransportEventBatch InnerBatch { get; }
 
         /// <summary>
+        ///   The fully qualified Event Hubs namespace that the batch is associated with.  To be used
+        ///   during instrumentation.  This is likely to be similar to
+        ///   <c>{yournamespace}.servicebus.windows.net</c>.
+        /// </summary>
+        ///
+        private string FullyQualifiedNamespace { get; }
+
+        /// <summary>
+        ///   The name of the Event Hub that the batch is associated with, specific to the
+        ///   Event Hubs namespace that contains it.  To be used during instrumentation.
+        /// </summary>
+        ///
+        private string EventHubName { get; }
+
+        /// <summary>
         ///   Initializes a new instance of the <see cref="EventDataBatch"/> class.
         /// </summary>
         ///
         /// <param name="transportBatch">The  transport-specific batch responsible for performing the batch operations.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace to use for instrumentation.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub to associate the events with during instrumentation.</param>
         /// <param name="sendOptions">The set of options that should be used when publishing the batch.</param>
         ///
         /// <remarks>
@@ -66,12 +83,18 @@ namespace Azure.Messaging.EventHubs.Producer
         /// </remarks>
         ///
         internal EventDataBatch(TransportEventBatch transportBatch,
+                                string fullyQualifiedNamespace,
+                                string eventHubName,
                                 SendEventOptions sendOptions)
         {
             Argument.AssertNotNull(transportBatch, nameof(transportBatch));
+            Argument.AssertNotNullOrEmpty(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace));
+            Argument.AssertNotNullOrEmpty(eventHubName, nameof(eventHubName));
             Argument.AssertNotNull(sendOptions, nameof(sendOptions));
 
             InnerBatch = transportBatch;
+            FullyQualifiedNamespace = fullyQualifiedNamespace;
+            EventHubName = eventHubName;
             SendOptions = sendOptions;
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -189,7 +189,7 @@ namespace Azure.Messaging.EventHubs.Producer
         /// </summary>
         ///
         /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace to connect to.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
-        /// <param name="eventHubName">The name of the specific Event Hub to associated the producer with.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub to associate the producer with.</param>
         /// <param name="credential">The Azure managed identity credential to use for authorization.  Access controls may be specified by the Event Hubs namespace or the requested Event Hub, depending on Azure configuration.</param>
         /// <param name="clientOptions">A set of options to apply when configuring the producer.</param>
         ///
@@ -533,7 +533,7 @@ namespace Azure.Messaging.EventHubs.Producer
             AssertSinglePartitionReference(options.PartitionId, options.PartitionKey);
 
             TransportEventBatch transportBatch = await EventHubProducer.CreateBatchAsync(options, cancellationToken).ConfigureAwait(false);
-            return new EventDataBatch(transportBatch, options.ToSendOptions());
+            return new EventDataBatch(transportBatch, FullyQualifiedNamespace, EventHubName, options.ToSendOptions());
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
@@ -599,7 +599,7 @@ namespace Azure.Messaging.EventHubs.Tests
             using TransportEventBatch batch = await producer.Object.CreateBatchAsync(options, default);
 
             await producer.Object.CloseAsync(CancellationToken.None);
-            Assert.That(async () => await producer.Object.SendAsync(new EventDataBatch(batch, new SendEventOptions()), CancellationToken.None), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
+            Assert.That(async () => await producer.Object.SendAsync(new EventDataBatch(batch, "ns", "eh", new SendEventOptions()), CancellationToken.None), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
         }
 
         /// <summary>
@@ -639,7 +639,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Verifiable();
 
             using TransportEventBatch batch = await producer.Object.CreateBatchAsync(options, default);
-            await producer.Object.SendAsync(new EventDataBatch(batch, options.ToSendOptions()), CancellationToken.None);
+            await producer.Object.SendAsync(new EventDataBatch(batch, "ns", "eh", options.ToSendOptions()), CancellationToken.None);
 
             producer.VerifyAll();
         }
@@ -685,7 +685,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             using TransportEventBatch transportBatch = await producer.Object.CreateBatchAsync(options, default);
 
-            using var batch = new EventDataBatch(transportBatch, options.ToSendOptions());
+            using var batch = new EventDataBatch(transportBatch, "ns", "eh", options.ToSendOptions());
             batch.TryAdd(new EventData(new byte[] { 0x15 }));
 
             await producer.Object.SendAsync(batch, CancellationToken.None);
@@ -733,7 +733,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             using TransportEventBatch transportBatch = await producer.Object.CreateBatchAsync(options, default);
 
-            using var batch = new EventDataBatch(transportBatch, options.ToSendOptions());
+            using var batch = new EventDataBatch(transportBatch, "ns", "eh", options.ToSendOptions());
             batch.TryAdd(new EventData(new byte[] { 0x15 }));
 
             await producer.Object.SendAsync(batch, CancellationToken.None);
@@ -772,7 +772,7 @@ namespace Azure.Messaging.EventHubs.Tests
             using CancellationTokenSource cancellationSource = new CancellationTokenSource();
 
             cancellationSource.Cancel();
-            Assert.That(async () => await producer.Object.SendAsync(new EventDataBatch(batch, options.ToSendOptions()), cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
+            Assert.That(async () => await producer.Object.SendAsync(new EventDataBatch(batch, "ns", "eh", options.ToSendOptions()), cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
         }
 
         /// <summary>
@@ -788,7 +788,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new CreateBatchOptions { PartitionKey = partitionKey };
             var retriableException = new EventHubsException(true, "Test");
             var retryPolicy = new BasicRetryPolicy(retryOptions);
-            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), options.ToSendOptions());
+            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options.ToSendOptions());
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
             {
@@ -827,7 +827,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new CreateBatchOptions { PartitionKey = partitionKey };
             var retriableException = new OperationCanceledException();
             var retryPolicy = new BasicRetryPolicy(retryOptions);
-            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), options.ToSendOptions());
+            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options.ToSendOptions());
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
             {
@@ -866,7 +866,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new CreateBatchOptions { PartitionKey = partitionKey };
             var retriableException = AmqpError.CreateExceptionForError(new Error { Value = AmqpError.ServerBusyError }, "dummy");
             var retryPolicy = new BasicRetryPolicy(retryOptions);
-            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), options.ToSendOptions());
+            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options.ToSendOptions());
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
             {
@@ -904,7 +904,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new CreateBatchOptions { PartitionKey = partitionKey };
             var embeddedException = new OperationCanceledException("", new ArgumentNullException());
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
-            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), options.ToSendOptions());
+            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options.ToSendOptions());
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
             {
@@ -942,7 +942,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new CreateBatchOptions { PartitionKey = partitionKey };
             var embeddedException = new OperationCanceledException("", new AmqpException(new Error { Condition = AmqpError.ArgumentError }));
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
-            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), options.ToSendOptions());
+            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options.ToSendOptions());
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Connection/EventHubConnectionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Connection/EventHubConnectionTests.cs
@@ -94,13 +94,12 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorRequiresConnectionString(string connectionString)
         {
-            // Seems ExactTypeConstraints is not re-entrant.
-            ExactTypeConstraint TypeConstraint() => connectionString is null ? Throws.ArgumentNullException : Throws.ArgumentException;
+            var expectedType = connectionString is null ? typeof(ArgumentNullException) : typeof(ArgumentException);
 
-            Assert.That(() => new EventHubConnection(connectionString), TypeConstraint(), "The constructor without options should perform validation.");
-            Assert.That(() => new EventHubConnection(connectionString, "eventHub"), TypeConstraint(), "The constructor with the event hub without options should perform validation.");
-            Assert.That(() => new EventHubConnection(connectionString, "eventHub", new EventHubConnectionOptions()), TypeConstraint(), "The constructor with the event hub and options should perform validation.");
-            Assert.That(() => new EventHubConnection(connectionString, new EventHubConnectionOptions()), TypeConstraint(), "The constructor with options and no event hub should perform validation.");
+            Assert.That(() => new EventHubConnection(connectionString), Throws.TypeOf(expectedType), "The constructor without options should perform validation.");
+            Assert.That(() => new EventHubConnection(connectionString, "eventHub"), Throws.TypeOf(expectedType), "The constructor with the event hub without options should perform validation.");
+            Assert.That(() => new EventHubConnection(connectionString, "eventHub", new EventHubConnectionOptions()), Throws.TypeOf(expectedType), "The constructor with the event hub and options should perform validation.");
+            Assert.That(() => new EventHubConnection(connectionString, new EventHubConnectionOptions()), Throws.TypeOf(expectedType), "The constructor with options and no event hub should perform validation.");
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventDataBatchTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventDataBatchTests.cs
@@ -40,10 +40,8 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorVerifiesTheFullyQualifiedNamespace(string fullyQualifiedNamespace)
         {
-            // Seems ExactTypeConstraints is not re-entrant.
-            ExactTypeConstraint TypeConstraint() => fullyQualifiedNamespace is null ? Throws.ArgumentNullException : Throws.ArgumentException;
-
-            Assert.That(() => new EventDataBatch(new MockTransportBatch(), fullyQualifiedNamespace, "eh", new SendEventOptions()), TypeConstraint());
+            var expectedType = fullyQualifiedNamespace is null ? typeof(ArgumentNullException) : typeof(ArgumentException);
+            Assert.That(() => new EventDataBatch(new MockTransportBatch(), fullyQualifiedNamespace, "eh", new SendEventOptions()), Throws.TypeOf(expectedType));
         }
 
         /// <summary>
@@ -56,10 +54,8 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorVerifiesTheEventHubName(string eventHubName)
         {
-            // Seems ExactTypeConstraints is not re-entrant.
-            ExactTypeConstraint TypeConstraint() => eventHubName is null ? Throws.ArgumentNullException : Throws.ArgumentException;
-
-            Assert.That(() => new EventDataBatch(new MockTransportBatch(), "ns", eventHubName, new SendEventOptions()), TypeConstraint());
+            var expectedType = eventHubName is null ? typeof(ArgumentNullException) : typeof(ArgumentException);
+            Assert.That(() => new EventDataBatch(new MockTransportBatch(), "ns", eventHubName, new SendEventOptions()), Throws.TypeOf(expectedType));
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventDataBatchTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventDataBatchTests.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Producer;
 using NUnit.Framework;
+using NUnit.Framework.Constraints;
 
 namespace Azure.Messaging.EventHubs.Tests
 {
@@ -22,9 +24,10 @@ namespace Azure.Messaging.EventHubs.Tests
         ///   constructor.
         /// </summary>
         ///
+        [Test]
         public void ConstructorVerifiesTheTransportBatch()
         {
-            Assert.That(() => new EventDataBatch(null, new SendEventOptions()), Throws.ArgumentNullException);
+            Assert.That(() => new EventDataBatch(null, "ns", "eh", new SendEventOptions()), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -32,9 +35,42 @@ namespace Azure.Messaging.EventHubs.Tests
         ///   constructor.
         /// </summary>
         ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void ConstructorVerifiesTheFullyQualifiedNamespace(string fullyQualifiedNamespace)
+        {
+            // Seems ExactTypeConstraints is not re-entrant.
+            ExactTypeConstraint TypeConstraint() => fullyQualifiedNamespace is null ? Throws.ArgumentNullException : Throws.ArgumentException;
+
+            Assert.That(() => new EventDataBatch(new MockTransportBatch(), fullyQualifiedNamespace, "eh", new SendEventOptions()), TypeConstraint());
+        }
+
+        /// <summary>
+        ///   Verifies property accessors for the <see cref="EventDataBatch" />
+        ///   constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void ConstructorVerifiesTheEventHubName(string eventHubName)
+        {
+            // Seems ExactTypeConstraints is not re-entrant.
+            ExactTypeConstraint TypeConstraint() => eventHubName is null ? Throws.ArgumentNullException : Throws.ArgumentException;
+
+            Assert.That(() => new EventDataBatch(new MockTransportBatch(), "ns", eventHubName, new SendEventOptions()), TypeConstraint());
+        }
+
+        /// <summary>
+        ///   Verifies property accessors for the <see cref="EventDataBatch" />
+        ///   constructor.
+        /// </summary>
+        ///
+        [Test]
         public void ConstructorVerifiesTheSendOptions()
         {
-            Assert.That(() => new EventDataBatch(new MockTransportBatch(), null), Throws.ArgumentNullException);
+            Assert.That(() => new EventDataBatch(new MockTransportBatch(), "ns", "eh", null), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -42,11 +78,12 @@ namespace Azure.Messaging.EventHubs.Tests
         ///   constructor.
         /// </summary>
         ///
+        [Test]
         public void ConstructorUpdatesState()
         {
             var sendOptions = new SendEventOptions();
             var mockBatch = new MockTransportBatch();
-            var batch = new EventDataBatch(new MockTransportBatch(), null);
+            var batch = new EventDataBatch(mockBatch, "ns", "eh", sendOptions);
 
             Assert.That(batch.SendOptions, Is.SameAs(sendOptions), "The send options should have been set.");
             Assert.That(GetInnerBatch(batch), Is.SameAs(mockBatch), "The inner transport batch should have been set.");
@@ -57,10 +94,11 @@ namespace Azure.Messaging.EventHubs.Tests
         ///   class.
         /// </summary>
         ///
+        [Test]
         public void PropertyAccessIsDelegatedToTheTransportClient()
         {
             var mockBatch = new MockTransportBatch();
-            var batch = new EventDataBatch(mockBatch, new SendEventOptions());
+            var batch = new EventDataBatch(mockBatch, "ns", "eh", new SendEventOptions());
 
             Assert.That(batch.MaximumSizeInBytes, Is.EqualTo(mockBatch.MaximumSizeInBytes), "The maximum size should have been delegated.");
             Assert.That(batch.SizeInBytes, Is.EqualTo(mockBatch.SizeInBytes), "The size should have been delegated.");
@@ -72,10 +110,11 @@ namespace Azure.Messaging.EventHubs.Tests
         ///   method.
         /// </summary>
         ///
+        [Test]
         public void TryAddIsDelegatedToTheTransportClient()
         {
             var mockBatch = new MockTransportBatch();
-            var batch = new EventDataBatch(mockBatch, new SendEventOptions());
+            var batch = new EventDataBatch(mockBatch, "ns", "eh", new SendEventOptions());
             var eventData = new EventData(new byte[] { 0x21 });
 
             Assert.That(batch.TryAdd(eventData), Is.True, "The event should have been accepted.");
@@ -87,10 +126,11 @@ namespace Azure.Messaging.EventHubs.Tests
         ///   method.
         /// </summary>
         ///
+        [Test]
         public void AsEnumerableIsDelegatedToTheTransportClient()
         {
             var mockBatch = new MockTransportBatch();
-            var batch = new EventDataBatch(mockBatch, new SendEventOptions());
+            var batch = new EventDataBatch(mockBatch, "ns", "eh", new SendEventOptions());
 
             batch.AsEnumerable<string>();
             Assert.That(mockBatch.AsEnumerableCalledWith, Is.EqualTo(typeof(string)), "The enumerable should delegated the requested type parameter.");
@@ -101,10 +141,11 @@ namespace Azure.Messaging.EventHubs.Tests
         ///   method.
         /// </summary>
         ///
+        [Test]
         public void DisposeIsDelegatedToTheTransportClient()
         {
             var mockBatch = new MockTransportBatch();
-            var batch = new EventDataBatch(mockBatch, new SendEventOptions());
+            var batch = new EventDataBatch(mockBatch, "ns", "eh", new SendEventOptions());
 
             batch.Dispose();
             Assert.That(mockBatch.DisposeInvoked, Is.True);
@@ -122,7 +163,7 @@ namespace Azure.Messaging.EventHubs.Tests
         private static TransportEventBatch GetInnerBatch(EventDataBatch batch) =>
             (TransportEventBatch)
                 typeof(EventDataBatch)
-                    .GetProperty("InnerBatch")
+                    .GetProperty("InnerBatch", BindingFlags.Instance | BindingFlags.NonPublic)
                     .GetValue(batch);
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
@@ -393,7 +393,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SendAllowsAPartitionHashKeyWithABatch()
         {
             var batchOptions = new CreateBatchOptions { PartitionKey = "testKey" };
-            var batch = new EventDataBatch(new MockTransportBatch(), batchOptions.ToSendOptions());
+            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions.ToSendOptions());
             var transportProducer = new ObservableTransportProducerMock();
             var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
@@ -425,7 +425,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SendForASpecificPartitionDoesNotAllowAPartitionHashKeyWithABatch()
         {
             var batchOptions = new CreateBatchOptions { PartitionKey = "testKey", PartitionId = "1" };
-            var batch = new EventDataBatch(new MockTransportBatch(), batchOptions.ToSendOptions());
+            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions.ToSendOptions());
             var transportProducer = new ObservableTransportProducerMock();
             var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
@@ -482,7 +482,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task SendInvokesTheTransportProducerWithABatch()
         {
             var batchOptions = new CreateBatchOptions { PartitionKey = "testKey" };
-            var batch = new EventDataBatch(new MockTransportBatch(), batchOptions.ToSendOptions());
+            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions.ToSendOptions());
             var transportProducer = new ObservableTransportProducerMock();
             var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
@@ -571,8 +571,8 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task CloseAsyncClosesTheTransportProducers()
         {
             var transportProducer = new ObservableTransportProducerMock();
-            var mockFirstBatch = new EventDataBatch(new MockTransportBatch(), new SendEventOptions { PartitionId = "1" });
-            var mockSecondBatch = new EventDataBatch(new MockTransportBatch(), new SendEventOptions { PartitionId = "2" });
+            var mockFirstBatch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", new SendEventOptions { PartitionId = "1" });
+            var mockSecondBatch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", new SendEventOptions { PartitionId = "2" });
             var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
             try
@@ -598,7 +598,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var mockTransportProducer = new Mock<TransportProducer>();
             var mockConnection = new MockConnection(() => mockTransportProducer.Object);
-            var mockBatch = new EventDataBatch(new MockTransportBatch(), new SendEventOptions { PartitionId = "1" });
+            var mockBatch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", new SendEventOptions { PartitionId = "1" });
             var producer = new EventHubProducerClient(mockConnection);
 
             mockTransportProducer


### PR DESCRIPTION
This PR contains the first set of changes needed for issue #9075 (including `FullyQualifiedNamespace` and `EventHubName` in the `EventDataBatch` constructor).

`EventDataBatch` tests were updated accordingly. The `Test` attribute was missing from all of them, but this matter has been dealt with.