### PR TITLE
[eventhubs] Clarify MaximumWaitTime documentation

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClientOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClientOptions.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel;
 using Azure.Core;
 using Azure.Messaging.EventHubs.Core;
+using Azure.Messaging.EventHubs.Processor;
 
 namespace Azure.Messaging.EventHubs
 {
@@ -49,13 +50,21 @@ namespace Azure.Messaging.EventHubs
 
         /// <summary>
         ///   The maximum amount of time to wait for an event to become available for a given partition before emitting
-        ///   a <c>null</c> event.
+        ///   an empty event.
         /// </summary>
         ///
         /// <value>
         ///   If <c>null</c>, the processor will wait indefinitely for an event to become available; otherwise, a value will
         ///   always be emitted within this interval, whether an event was available or not.
         /// </value>
+        ///
+        /// <remarks>
+        ///   When set, if no events are received before the timeout, <see cref="EventProcessorClient.ProcessEventAsync" />
+        ///   is called with a <see cref="ProcessEventArgs" /> instance that does not contain any event data. The
+        ///   <see cref="ProcessEventArgs.HasEvent" /> property is intended to help detect this.
+        /// </remarks>
+        ///
+        /// <seealso cref="ProcessEventArgs.HasEvent" />
         ///
         public TimeSpan? MaximumWaitTime
         {


### PR DESCRIPTION
When using the `EventProcessorClient` with a `MaximumWaitTime`, if the
timeout is reached, the `ProcessEventAsync` event is raised with an
empty `ProcessEventArgs` structure. The documentation refered to this as
a "null event" which is a little confusing, since `ProcessEventArgs`
itself is not null. Instead, the `HasEvent` property returns `false`.
Try to clarify this is a bit and add some remarks and cross references.