### PR TITLE
[EventHubs] Distributed Tracing: Stamp EventHubs info on processing and message spans (Track Two)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/EventProcessorEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/EventProcessorEventSource.cs
@@ -196,7 +196,7 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// <param name="partitionId">The identifier of the Event Hub partition.</param>
         /// <param name="errorMessage">The message for the exception that occurred.</param>
         ///
-        [Event(10, Level = EventLevel.Error, Message = "An exception occurred while stopping a partition processing task for partition id '{0}' with reason '{1}'. (Error Message: '{2}')")]
+        [Event(10, Level = EventLevel.Error, Message = "An exception occurred while stopping a partition processing task for partition id '{0}'. (Error Message: '{1}')")]
         public virtual void PartitionProcessingError(string partitionId,
                                                      string errorMessage)
         {

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -714,7 +714,9 @@ namespace Azure.Messaging.EventHubs
             await foreach (var partitionEvent in consumer.ReadEventsFromPartitionAsync(partitionId, startingPosition, ProcessingReadEventOptions, cancellationToken).ConfigureAwait(false))
             {
                 using DiagnosticScope diagnosticScope = EventDataInstrumentation.ScopeFactory.CreateScope(DiagnosticProperty.EventProcessorProcessingActivityName);
-                diagnosticScope.AddAttribute("kind", DiagnosticProperty.ConsumerKind);
+                diagnosticScope.AddAttribute(DiagnosticProperty.KindAttribute, DiagnosticProperty.ConsumerKind);
+                diagnosticScope.AddAttribute(DiagnosticProperty.EventHubAttribute, EventHubName);
+                diagnosticScope.AddAttribute(DiagnosticProperty.EndpointAttribute, FullyQualifiedNamespace);
 
                 if (diagnosticScope.IsEnabled
                     && partitionEvent.Data != null

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
@@ -165,7 +165,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             foreach (var scope in listener.Scopes)
             {
-                Assert.That(expectedTags, Is.SubsetOf(scope.Activity.Tags));
+                Assert.That(expectedTags, Is.SubsetOf(scope.Activity.Tags.ToList()));
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
@@ -165,12 +165,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             foreach (var scope in listener.Scopes)
             {
-                var tags = scope.Activity.Tags.ToList();
-
-                foreach (var expectedTag in expectedTags)
-                {
-                    Assert.That(tags, Contains.Item(expectedTag));
-                }
+                CollectionAssert.IsSubsetOf(expectedTags, scope.Activity.Tags);
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
@@ -165,7 +165,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             foreach (var scope in listener.Scopes)
             {
-                CollectionAssert.IsSubsetOf(expectedTags, scope.Activity.Tags);
+                Assert.That(expectedTags, Is.SubsetOf(scope.Activity.Tags));
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Diagnostics/EventDataInstrumentation.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Diagnostics/EventDataInstrumentation.cs
@@ -21,15 +21,21 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// </summary>
         ///
         /// <param name="eventData">The event to instrument.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace to use for instrumentation.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub to associate the event with.</param>
         ///
         /// <returns><c>true</c> if the event was instrumented in response to this request; otherwise, <c>false</c>.</returns>
         ///
-        public static bool InstrumentEvent(EventData eventData)
+        public static bool InstrumentEvent(EventData eventData,
+                                           string fullyQualifiedNamespace,
+                                           string eventHubName)
         {
             if (!eventData.Properties.ContainsKey(DiagnosticProperty.DiagnosticIdAttribute))
             {
                 using DiagnosticScope messageScope = ScopeFactory.CreateScope(DiagnosticProperty.EventActivityName);
                 messageScope.AddAttribute(DiagnosticProperty.KindAttribute, DiagnosticProperty.ProducerKind);
+                messageScope.AddAttribute(DiagnosticProperty.EventHubAttribute, eventHubName);
+                messageScope.AddAttribute(DiagnosticProperty.EndpointAttribute, fullyQualifiedNamespace);
                 messageScope.Start();
 
                 Activity activity = Activity.Current;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -263,7 +263,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         ///
         /// <param name="eventHubName">The name of the Event Hub that properties are being retrieved for.</param>
         ///
-        [Event(12, Level = EventLevel.Informational, Message = "Retrieving properties for Event Hub: {0} (Partition Id: '{1}').")]
+        [Event(12, Level = EventLevel.Informational, Message = "Retrieving properties for Event Hub: {0}.")]
         public void GetPropertiesStart(string eventHubName)
         {
             if (IsEnabled())
@@ -294,7 +294,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="eventHubName">The name of the Event Hub that properties are being retrieved for.</param>
         /// <param name="errorMessage">The message for the exception that occurred.</param>
         ///
-        [Event(14, Level = EventLevel.Error, Message = "An exception occurred while retrieving properties for Event Hub: {0}. Error Message: '{2}'")]
+        [Event(14, Level = EventLevel.Error, Message = "An exception occurred while retrieving properties for Event Hub: {0}. Error Message: '{1}'")]
         public void GetPropertiesError(string eventHubName,
                                        string errorMessage)
         {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
@@ -108,7 +108,7 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         public bool TryAdd(EventData eventData)
         {
-            bool instrumented = EventDataInstrumentation.InstrumentEvent(eventData);
+            bool instrumented = EventDataInstrumentation.InstrumentEvent(eventData, FullyQualifiedNamespace, EventHubName);
             bool added = InnerBatch.TryAdd(eventData);
 
             if (!added && instrumented)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -674,7 +674,7 @@ namespace Azure.Messaging.EventHubs.Producer
         {
             foreach (EventData eventData in events)
             {
-                EventDataInstrumentation.InstrumentEvent(eventData);
+                EventDataInstrumentation.InstrumentEvent(eventData, FullyQualifiedNamespace, EventHubName);
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
@@ -69,7 +69,9 @@ namespace Azure.Messaging.EventHubs.Tests
                 new KeyValuePair<string, string>(DiagnosticProperty.EventHubAttribute, eventHubName),
                 new KeyValuePair<string, string>(DiagnosticProperty.EndpointAttribute, endpoint));
 
-            ClientDiagnosticListener.ProducedDiagnosticScope messageScope = testListener.AssertScope(DiagnosticProperty.EventActivityName);
+            ClientDiagnosticListener.ProducedDiagnosticScope messageScope = testListener.AssertScope(DiagnosticProperty.EventActivityName,
+                new KeyValuePair<string, string>(DiagnosticProperty.EventHubAttribute, eventHubName),
+                new KeyValuePair<string, string>(DiagnosticProperty.EndpointAttribute, endpoint));
 
             Assert.That(eventData.Properties[DiagnosticProperty.DiagnosticIdAttribute], Is.EqualTo(messageScope.Activity.Id), "The diagnostics identifier should match.");
             Assert.That(messageScope.Activity.Tags, Has.One.EqualTo(new KeyValuePair<string, string>(DiagnosticProperty.KindAttribute, DiagnosticProperty.ProducerKind)), "The activities tag should be internal.");
@@ -129,7 +131,9 @@ namespace Azure.Messaging.EventHubs.Tests
                 new KeyValuePair<string, string>(DiagnosticProperty.EventHubAttribute, eventHubName),
                 new KeyValuePair<string, string>(DiagnosticProperty.EndpointAttribute, endpoint));
 
-            ClientDiagnosticListener.ProducedDiagnosticScope messageScope = testListener.AssertScope(DiagnosticProperty.EventActivityName);
+            ClientDiagnosticListener.ProducedDiagnosticScope messageScope = testListener.AssertScope(DiagnosticProperty.EventActivityName,
+                new KeyValuePair<string, string>(DiagnosticProperty.EventHubAttribute, eventHubName),
+                new KeyValuePair<string, string>(DiagnosticProperty.EndpointAttribute, endpoint));
 
             Assert.That(eventData.Properties[DiagnosticProperty.DiagnosticIdAttribute], Is.EqualTo(messageScope.Activity.Id), "The diagnostics identifier should match.");
             Assert.That(messageScope.Activity, Is.Not.SameAs(sendScope.Activity), "The activities should not be the same instance.");


### PR DESCRIPTION
Fixes #9075.

- On message spans, updated the `InstrumentEvent` method to take namespace and Event Hub name as arguments. The values being used are related to the producer client that has created the batch instead of the one that sends it. Even though it's a theoretically possible scenario, using a different producer to send a batch can lead to issues related to batch size limitations, so we expect users to use the same producer. Taking the way less likely scenario into account is not worth the effort given the complexity of the problem we would end up with.

- On processing spans, added the namespace and Event Hub name attributes directly. No issues.

- Updated tests accordingly to reflect the changes. The processor diagnostics test is currently flagged as `Ignored` due to instability during nightly runs, but it ran just fine locally.

- Bonus: updated three `EventSource` strings that were failing due to incoherent indexes.