### PR TITLE
[Event Hubs Client] Event Processor<TPartition> Skeleton

### DIFF
--- a/sdk/core/Azure.Core/tests/TestFramework/ClientDiagnosticListener.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/ClientDiagnosticListener.cs
@@ -85,7 +85,7 @@ namespace Azure.Core.Tests
                                 throw new InvalidOperationException("Scope should not be stopped when calling Failed");
                             }
 
-                            producedDiagnosticScope.Exception = (Exception) value.Value;
+                            producedDiagnosticScope.Exception = (Exception)value.Value;
                         }
                     }
                 }

--- a/sdk/core/Azure.Core/tests/TestFramework/ClientTestFixtureAttribute.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/ClientTestFixtureAttribute.cs
@@ -128,6 +128,6 @@ namespace Azure.Core.Testing
 
         bool IPreFilter.IsMatch(Type type) => true;
 
-        bool IPreFilter.IsMatch(Type type, MethodInfo method)  => true;
+        bool IPreFilter.IsMatch(Type type, MethodInfo method) => true;
     }
 }

--- a/sdk/core/Azure.Core/tests/TestFramework/DiagnosticScopeValidatingInterceptor.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/DiagnosticScopeValidatingInterceptor.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;

--- a/sdk/core/Azure.Core/tests/TestFramework/EnumValuesAttribute.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/EnumValuesAttribute.cs
@@ -6,7 +6,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using NUnit.Framework;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 

--- a/sdk/core/Azure.Core/tests/TestFramework/TestDiagnosticListener.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/TestDiagnosticListener.cs
@@ -18,7 +18,7 @@ namespace Azure.Core.Tests
 
         public Queue<(string, object, object)> IsEnabledCalls { get; } = new Queue<(string, object, object)>();
 
-        public TestDiagnosticListener(string name): this(source => source.Name == name)
+        public TestDiagnosticListener(string name) : this(source => source.Name == name)
         {
         }
 
@@ -82,7 +82,7 @@ namespace Azure.Core.Tests
             }
         }
 
-        private class InternalListener: IObserver<KeyValuePair<string, object>>
+        private class InternalListener : IObserver<KeyValuePair<string, object>>
         {
             private readonly Queue<(string, object, DiagnosticListener)> _queue;
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
@@ -35,7 +35,7 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         ///   outside the scope of this library.  Exposed for testing purposes only.
         /// </summary>
         ///
-        internal BlobEventStoreEventSource()  : base(EventSourceName, EventSourceSettings.Default, AzureEventSourceListener.TraitName, AzureEventSourceListener.TraitValue)
+        internal BlobEventStoreEventSource() : base(EventSourceName, EventSourceSettings.Default, AzureEventSourceListener.TraitName, AzureEventSourceListener.TraitValue)
         {
         }
 
@@ -222,6 +222,27 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
             if (IsEnabled())
             {
                 WriteEvent(10, partitionId ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that invalid checkpoint data was found during an attempt to retrieve a list of checkpoints.
+        /// </summary>
+        ///
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the data is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the data is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the data is associated with.</param>
+        /// <param name="partitionId">The identifier of the partition the data is associated with.</param>
+        ///
+        [Event(11, Level = EventLevel.Error, Message = "Invalid checkpoint data found when listing checkpoints; this checkpoint is not valid and will be ignored.  FullyQualifiedNamespace: '{0}'; EventHubName: '{1}'; ConsumerGroup: '{2}'; PartitionId: '{3}'.")]
+        public virtual void InvalidCheckpointFound(string fullyQualifiedNamespace,
+                                                   string eventHubName,
+                                                   string consumerGroup,
+                                                   string partitionId)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(11, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, partitionId ?? string.Empty);
             }
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -324,6 +324,8 @@ namespace Azure.Messaging.EventHubs
         ///   Event Hub will result in a connection string that contains the name.
         /// </remarks>
         ///
+        /// <seealso href="https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string"/>
+        ///
         public EventProcessorClient(BlobContainerClient checkpointStore,
                                     string consumerGroup,
                                     string connectionString) : this(checkpointStore, consumerGroup, connectionString, null, null)
@@ -348,6 +350,8 @@ namespace Azure.Messaging.EventHubs
         ///   Event Hub will result in a connection string that contains the name.
         /// </remarks>
         ///
+        /// <seealso href="https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string"/>
+        ///
         public EventProcessorClient(BlobContainerClient checkpointStore,
                                     string consumerGroup,
                                     string connectionString,
@@ -369,6 +373,8 @@ namespace Azure.Messaging.EventHubs
         ///   and can be used directly without passing the <paramref name="eventHubName" />.  The name of the Event Hub should be
         ///   passed only once, either as part of the connection string or separately.
         /// </remarks>
+        ///
+        /// <seealso href="https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string"/>
         ///
         public EventProcessorClient(BlobContainerClient checkpointStore,
                                     string consumerGroup,
@@ -392,6 +398,8 @@ namespace Azure.Messaging.EventHubs
         ///   and can be used directly without passing the <paramref name="eventHubName" />.  The name of the Event Hub should be
         ///   passed only once, either as part of the connection string or separately.
         /// </remarks>
+        ///
+        /// <seealso href="https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string"/>
         ///
         public EventProcessorClient(BlobContainerClient checkpointStore,
                                     string consumerGroup,
@@ -544,11 +552,10 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the start operation.  This won't affect the <see cref="EventProcessorClient" /> once it starts running.</param>
         ///
-        /// <exception cref="EventHubsException">Occurs when this <see cref="EventProcessorClient" /> instance is already closed.</exception>
         /// <exception cref="InvalidOperationException">Occurs when this method is invoked without <see cref="ProcessEventAsync" /> or <see cref="ProcessErrorAsync" /> set.</exception>
         ///
-        public virtual async Task StartProcessingAsync(CancellationToken cancellationToken = default)
-            => await StartProcessingInternalAsync(true, cancellationToken).ConfigureAwait(false);
+        public virtual async Task StartProcessingAsync(CancellationToken cancellationToken = default) =>
+            await StartProcessingInternalAsync(true, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         ///   Signals the <see cref="EventProcessorClient" /> to begin processing events.  Should this method be called while the processor
@@ -557,7 +564,6 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the start operation.  This won't affect the <see cref="EventProcessorClient" /> once it starts running.</param>
         ///
-        /// <exception cref="EventHubsException">Occurs when this <see cref="EventProcessorClient" /> instance is already closed.</exception>
         /// <exception cref="InvalidOperationException">Occurs when this method is invoked without <see cref="ProcessEventAsync" /> or <see cref="ProcessErrorAsync" /> set.</exception>
         ///
         public virtual void StartProcessing(CancellationToken cancellationToken = default) =>
@@ -580,8 +586,8 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the stop operation.  If the operation is successfully canceled, the <see cref="EventProcessorClient" /> will keep running.</param>
         ///
-        public virtual void StopProcessing(CancellationToken cancellationToken = default)
-            => StopProcessingInternalAsync(false, cancellationToken).EnsureCompleted();
+        public virtual void StopProcessing(CancellationToken cancellationToken = default) =>
+            StopProcessingInternalAsync(false, cancellationToken).EnsureCompleted();
 
         /// <summary>
         ///   Determines whether the specified <see cref="System.Object" /> is equal to this instance.
@@ -639,9 +645,7 @@ namespace Azure.Messaging.EventHubs
                 FullyQualifiedNamespace = FullyQualifiedNamespace,
                 EventHubName = EventHubName,
                 ConsumerGroup = ConsumerGroup,
-                PartitionId = context.PartitionId,
-                Offset = eventData.Offset,
-                SequenceNumber = eventData.SequenceNumber
+                PartitionId = context.PartitionId
             };
 
             using DiagnosticScope scope =
@@ -650,7 +654,7 @@ namespace Azure.Messaging.EventHubs
 
             try
             {
-                return StorageManager.UpdateCheckpointAsync(checkpoint, cancellationToken);
+                return StorageManager.UpdateCheckpointAsync(checkpoint, eventData, cancellationToken);
             }
             catch (Exception e)
             {
@@ -953,18 +957,7 @@ namespace Azure.Messaging.EventHubs
             {
                 if (checkpoint.PartitionId == partitionId)
                 {
-                    // When resuming from a checkpoint, the intent to process the next available event in the stream which
-                    // follows the one that was used to create the checkpoint.  Create the position using an exclusive offset, if available.
-                    // If there was no offset, fall back to the sequence number and then the default starting position.
-
-                    startingPosition = checkpoint switch
-                    {
-                        EventProcessorCheckpoint cp when (cp.Offset.HasValue) => EventPosition.FromOffset(cp.Offset.Value, false),
-                        EventProcessorCheckpoint cp when (cp.SequenceNumber.HasValue) => EventPosition.FromSequenceNumber(cp.SequenceNumber.Value, false),
-                        _ => startingPosition
-                    };
-
-                    break;
+                    startingPosition = checkpoint.StartingPosition;
                 }
             }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClientOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClientOptions.cs
@@ -10,7 +10,7 @@ using Azure.Messaging.EventHubs.Processor;
 namespace Azure.Messaging.EventHubs
 {
     /// <summary>
-    ///   The baseline set of options that can be specified when creating an <see cref="EventProcessorClient" />
+    ///   The set of options that can be specified when creating an <see cref="EventProcessorClient" />
     ///   to configure its behavior.
     /// </summary>
     ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/CheckpointStore/BlobsCheckpointStoreLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/CheckpointStore/BlobsCheckpointStoreLiveTests.cs
@@ -10,6 +10,7 @@ using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Primitives;
 using Azure.Messaging.EventHubs.Tests;
 using Azure.Storage.Blobs;
+using Moq;
 using NUnit.Framework;
 
 namespace Azure.Messaging.EventHubs.Processor.Tests
@@ -141,12 +142,15 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                     FullyQualifiedNamespace = "namespace",
                     EventHubName = "eventHubName",
                     ConsumerGroup = "consumerGroup",
-                    PartitionId = "partitionId",
-                    Offset = 10,
-                    SequenceNumber = 20
+                    PartitionId = "partitionId"
                 };
 
-                Assert.That(async () => await checkpointStore.UpdateCheckpointAsync(checkpoint, default), Throws.Nothing);
+                var mockEvent = new MockEventData(
+                    eventBody: Array.Empty<byte>(),
+                    offset: 10,
+                    sequenceNumber: 20);
+
+                Assert.That(async () => await checkpointStore.UpdateCheckpointAsync(checkpoint, mockEvent, default), Throws.Nothing);
             }
         }
 
@@ -806,12 +810,15 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                     FullyQualifiedNamespace = "namespace",
                     EventHubName = "eventHubName",
                     ConsumerGroup = "consumerGroup",
-                    PartitionId = "partitionId",
-                    Offset = 10,
-                    SequenceNumber = 20
+                    PartitionId = "partitionId"
                 };
 
-                Assert.That(async () => await checkpointStore.UpdateCheckpointAsync(checkpoint, default), Throws.InstanceOf<RequestFailedException>());
+                var mockEvent = new MockEventData(
+                    eventBody: Array.Empty<byte>(),
+                    offset: 10,
+                    sequenceNumber: 20);
+
+                Assert.That(async () => await checkpointStore.UpdateCheckpointAsync(checkpoint, mockEvent, default), Throws.InstanceOf<RequestFailedException>());
             }
         }
 
@@ -827,28 +834,28 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             {
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
-
                 var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
+
+                var mockEvent = new MockEventData(
+                    eventBody: Array.Empty<byte>(),
+                    offset: 10,
+                    sequenceNumber: 20);
 
                 await checkpointStore.UpdateCheckpointAsync(new EventProcessorCheckpoint
                 {
                     FullyQualifiedNamespace = "namespace",
                     EventHubName = "eventHubName",
                     ConsumerGroup = "consumerGroup1",
-                    PartitionId = "partitionId",
-                    Offset = 10,
-                    SequenceNumber = 20
-                }, default);
+                    PartitionId = "partitionId"
+                }, mockEvent, default);
 
                 await checkpointStore.UpdateCheckpointAsync(new EventProcessorCheckpoint
                 {
                     FullyQualifiedNamespace = "namespace",
                     EventHubName = "eventHubName",
                     ConsumerGroup = "consumerGroup2",
-                    PartitionId = "partitionId",
-                    Offset = 10,
-                    SequenceNumber = 20
-                }, default);
+                    PartitionId = "partitionId"
+                }, mockEvent, default);
 
                 IEnumerable<EventProcessorCheckpoint> storedCheckpointsList1 = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup1", default);
                 IEnumerable<EventProcessorCheckpoint> storedCheckpointsList2 = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup2", default);
@@ -873,28 +880,28 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             {
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
-
                 var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
+
+                var mockEvent = new MockEventData(
+                    eventBody: Array.Empty<byte>(),
+                    offset: 10,
+                    sequenceNumber: 20);
 
                 await checkpointStore.UpdateCheckpointAsync(new EventProcessorCheckpoint
                 {
                     FullyQualifiedNamespace = "namespace",
                     EventHubName = "eventHubName1",
                     ConsumerGroup = "consumerGroup",
-                    PartitionId = "partitionId",
-                    Offset = 10,
-                    SequenceNumber = 20
-                }, default);
+                    PartitionId = "partitionId"
+                }, mockEvent, default);
 
                 await checkpointStore.UpdateCheckpointAsync(new EventProcessorCheckpoint
                 {
                     FullyQualifiedNamespace = "namespace",
                     EventHubName = "eventHubName2",
                     ConsumerGroup = "consumerGroup",
-                    PartitionId = "partitionId",
-                    Offset = 10,
-                    SequenceNumber = 20
-                }, default);
+                    PartitionId = "partitionId"
+                }, mockEvent, default);
 
                 IEnumerable<EventProcessorCheckpoint> storedCheckpointsList1 = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName1", "consumerGroup", default);
                 IEnumerable<EventProcessorCheckpoint> storedCheckpointsList2 = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName2", "consumerGroup", default);
@@ -919,28 +926,28 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             {
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
-
                 var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
+
+                var mockEvent = new MockEventData(
+                    eventBody: Array.Empty<byte>(),
+                    offset: 10,
+                    sequenceNumber: 20);
 
                 await checkpointStore.UpdateCheckpointAsync(new EventProcessorCheckpoint
                 {
                     FullyQualifiedNamespace = "namespace1",
                     EventHubName = "eventHubName",
                     ConsumerGroup = "consumerGroup",
-                    PartitionId = "partitionId",
-                    Offset = 10,
-                    SequenceNumber = 20
-                }, default);
+                    PartitionId = "partitionId"
+                }, mockEvent, default);
 
                 await checkpointStore.UpdateCheckpointAsync(new EventProcessorCheckpoint
                 {
                     FullyQualifiedNamespace = "namespace2",
                     EventHubName = "eventHubName",
                     ConsumerGroup = "consumerGroup",
-                    PartitionId = "partitionId",
-                    Offset = 10,
-                    SequenceNumber = 20
-                }, default);
+                    PartitionId = "partitionId"
+                }, mockEvent, default);
 
                 IEnumerable<EventProcessorCheckpoint> storedCheckpointsList1 = await checkpointStore.ListCheckpointsAsync("namespace1", "eventHubName", "consumerGroup", default);
                 IEnumerable<EventProcessorCheckpoint> storedCheckpointsList2 = await checkpointStore.ListCheckpointsAsync("namespace2", "eventHubName", "consumerGroup", default);
@@ -965,28 +972,28 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             {
                 var storageConnectionString = StorageTestEnvironment.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
-
                 var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
 
-                await checkpointStore.UpdateCheckpointAsync(new EventProcessorCheckpoint
-                {
-                    FullyQualifiedNamespace = "namespace",
-                    EventHubName = "eventHubName",
-                    ConsumerGroup = "consumerGroup",
-                    PartitionId = "partitionId1",
-                    Offset = 10,
-                    SequenceNumber = 20
-                }, default);
+                var mockEvent = new MockEventData(
+                    eventBody: Array.Empty<byte>(),
+                    offset: 10,
+                    sequenceNumber: 20);
 
                 await checkpointStore.UpdateCheckpointAsync(new EventProcessorCheckpoint
                 {
                     FullyQualifiedNamespace = "namespace",
                     EventHubName = "eventHubName",
                     ConsumerGroup = "consumerGroup",
-                    PartitionId = "partitionId2",
-                    Offset = 10,
-                    SequenceNumber = 20
-                }, default);
+                    PartitionId = "partitionId1"
+                }, mockEvent, default);
+
+                await checkpointStore.UpdateCheckpointAsync(new EventProcessorCheckpoint
+                {
+                    FullyQualifiedNamespace = "namespace",
+                    EventHubName = "eventHubName",
+                    ConsumerGroup = "consumerGroup",
+                    PartitionId = "partitionId2"
+                }, mockEvent, default);
 
                 IEnumerable<EventProcessorCheckpoint> storedCheckpointsList = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup", default);
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
@@ -183,19 +183,6 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             }
         }
 
-        private class MockEventData : EventData
-        {
-            public MockEventData(ReadOnlyMemory<byte> eventBody,
-                                 IDictionary<string, object> properties = null,
-                                 IReadOnlyDictionary<string, object> systemProperties = null,
-                                 long sequenceNumber = long.MinValue,
-                                 long offset = long.MinValue,
-                                 DateTimeOffset enqueuedTime = default,
-                                 string partitionKey = null) : base(eventBody, properties, systemProperties, sequenceNumber, offset, enqueuedTime, partitionKey)
-            {
-            }
-        }
-
         private class MockPartitionContext : PartitionContext
         {
             public MockPartitionContext(string partitionId) : base(partitionId)

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
@@ -2723,6 +2723,7 @@ namespace Azure.Messaging.EventHubs.Tests
             mockStorage
                 .Setup(storage => storage.UpdateCheckpointAsync(
                     It.IsAny<EventProcessorCheckpoint>(),
+                    It.IsAny<EventData>(),
                     It.IsAny<CancellationToken>()))
                 .Throws(expectedExceptionReference);
 
@@ -3031,18 +3032,17 @@ namespace Azure.Messaging.EventHubs.Tests
                 FullyQualifiedNamespace = fqNamespace,
                 EventHubName = eventHub,
                 ConsumerGroup = consumerGroup,
-                PartitionId = partitionId,
-                Offset = checkpointOffset,
-                SequenceNumber = 0
+                PartitionId = partitionId
             };
 
             var mockStorage = new MockCheckPointStorage();
+            var mockEvent = new MockEventData(Array.Empty<byte>(), offset: checkpointOffset);
             var mockConsumer = new Mock<EventHubConsumerClient>(consumerGroup, Mock.Of<EventHubConnection>(), default);
             var mockProcessor = new InjectableEventSourceProcessorMock(mockStorage, consumerGroup, fqNamespace, eventHub, Mock.Of<Func<EventHubConnection>>(), default, mockConsumer.Object);
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             mockStorage
-                .Checkpoints.Add((fqNamespace, eventHub, consumerGroup, partitionId), checkpoint);
+                .Checkpoints.Add((fqNamespace, eventHub, consumerGroup, partitionId), new MockCheckPointStorage.CheckpointData(checkpoint, mockEvent));
 
             mockConsumer
                 .Setup(consumer => consumer.GetPartitionIdsAsync(It.IsAny<CancellationToken>()))

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Processor/StorageManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Processor/StorageManager.cs
@@ -64,9 +64,11 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// </summary>
         ///
         /// <param name="checkpoint">The checkpoint containing the information to be stored.</param>
+        /// <param name="eventData">The event to use as the basis for the checkpoint's starting position.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         public abstract Task UpdateCheckpointAsync(EventProcessorCheckpoint checkpoint,
+                                                   EventData eventData,
                                                    CancellationToken cancellationToken);
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/MockEventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/MockEventData.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   A mock version of <see cref="EventData" />, allowing tests to manipulate the
+    ///   set of properties owned by the service when an event is consumed.
+    /// </summary>
+    ///
+    internal class MockEventData : EventData
+    {
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="MockEventData"/> class.
+        /// </summary>
+        ///
+        /// <param name="eventBody">The raw data to use as the body of the event.</param>
+        /// <param name="properties">The set of free-form event properties to send with the event.</param>
+        /// <param name="systemProperties">The set of system properties received from the Event Hubs service.</param>
+        /// <param name="sequenceNumber">The sequence number assigned to the event when it was enqueued in the associated Event Hub partition.</param>
+        /// <param name="offset">The offset of the event when it was received from the associated Event Hub partition.</param>
+        /// <param name="enqueuedTime">The date and time, in UTC, of when the event was enqueued in the Event Hub partition.</param>
+        /// <param name="partitionKey">The partition hashing key applied to the batch that the associated <see cref="EventData"/>, was sent with.</param>
+        ///
+        public MockEventData(ReadOnlyMemory<byte> eventBody,
+                             IDictionary<string, object> properties = null,
+                             IReadOnlyDictionary<string, object> systemProperties = null,
+                             long sequenceNumber = long.MinValue,
+                             long offset = long.MinValue,
+                             DateTimeOffset enqueuedTime = default,
+                             string partitionKey = null) : base(eventBody, properties, systemProperties, sequenceNumber, offset, enqueuedTime, partitionKey)
+        {
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Azure.Messaging.EventHubs.Shared.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Azure.Messaging.EventHubs.Shared.Tests.csproj
@@ -36,6 +36,7 @@
   <ItemGroup>
     <Compile Include="..\src\Testing\EventDataExtensions.cs" Link="SharedSource\Testing\EventDataExtensions.cs" />
     <Compile Include="..\src\Testing\MockCheckPointStorage.cs" Link="SharedSource\Testing\MockCheckPointStorage.cs" />
+    <Compile Include="..\src\Testing\MockEventData.cs" Link="SharedSource\Testing\MockEventData.cs" />
   </ItemGroup>
 
   <!--Embed the shared resources -->

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Testing/MockCheckPointStorageTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Testing/MockCheckPointStorageTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Primitives;
+using Moq;
 using NUnit.Framework;
 
 namespace Azure.Messaging.EventHubs.Tests
@@ -431,25 +432,26 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var storageManager = new MockCheckPointStorage();
 
+            var mockEvent = new MockEventData(
+                eventBody: Array.Empty<byte>(),
+                offset: 10,
+                sequenceNumber: 20);
+
             await storageManager.UpdateCheckpointAsync(new EventProcessorCheckpoint
             {
                 FullyQualifiedNamespace = "namespace",
                 EventHubName = "eventHubName",
                 ConsumerGroup = "consumerGroup1",
-                PartitionId = "partitionId",
-                Offset = 10,
-                SequenceNumber = 20
-            });
+                PartitionId = "partitionId"
+            }, mockEvent);
 
             await storageManager.UpdateCheckpointAsync(new EventProcessorCheckpoint
             {
                 FullyQualifiedNamespace = "namespace",
                 EventHubName = "eventHubName",
                 ConsumerGroup = "consumerGroup2",
-                PartitionId = "partitionId",
-                Offset = 10,
-                SequenceNumber = 20
-            });
+                PartitionId = "partitionId"
+            }, mockEvent);
 
             IEnumerable<EventProcessorCheckpoint> storedCheckpointsList1 = await storageManager.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup1");
             IEnumerable<EventProcessorCheckpoint> storedCheckpointsList2 = await storageManager.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup2");
@@ -471,25 +473,26 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var storageManager = new MockCheckPointStorage();
 
+            var mockEvent = new MockEventData(
+                eventBody: Array.Empty<byte>(),
+                offset: 10,
+                sequenceNumber: 20);
+
             await storageManager.UpdateCheckpointAsync(new EventProcessorCheckpoint
             {
                 FullyQualifiedNamespace = "namespace",
                 EventHubName = "eventHubName1",
                 ConsumerGroup = "consumerGroup",
-                PartitionId = "partitionId",
-                Offset = 10,
-                SequenceNumber = 20
-            });
+                PartitionId = "partitionId"
+            }, mockEvent);
 
             await storageManager.UpdateCheckpointAsync(new EventProcessorCheckpoint
             {
                 FullyQualifiedNamespace = "namespace",
                 EventHubName = "eventHubName2",
                 ConsumerGroup = "consumerGroup",
-                PartitionId = "partitionId",
-                Offset = 10,
-                SequenceNumber = 20
-            });
+                PartitionId = "partitionId"
+            }, mockEvent);
 
             IEnumerable<EventProcessorCheckpoint> storedCheckpointsList1 = await storageManager.ListCheckpointsAsync("namespace", "eventHubName1", "consumerGroup");
             IEnumerable<EventProcessorCheckpoint> storedCheckpointsList2 = await storageManager.ListCheckpointsAsync("namespace", "eventHubName2", "consumerGroup");
@@ -511,25 +514,26 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var storageManager = new MockCheckPointStorage();
 
+            var mockEvent = new MockEventData(
+                eventBody: Array.Empty<byte>(),
+                offset: 10,
+                sequenceNumber: 20);
+
             await storageManager.UpdateCheckpointAsync(new EventProcessorCheckpoint
             {
                 FullyQualifiedNamespace = "namespace1",
                 EventHubName = "eventHubName",
                 ConsumerGroup = "consumerGroup",
-                PartitionId = "partitionId",
-                Offset = 10,
-                SequenceNumber = 20
-            });
+                PartitionId = "partitionId"
+            }, mockEvent);
 
             await storageManager.UpdateCheckpointAsync(new EventProcessorCheckpoint
             {
                 FullyQualifiedNamespace = "namespace2",
                 EventHubName = "eventHubName",
                 ConsumerGroup = "consumerGroup",
-                PartitionId = "partitionId",
-                Offset = 10,
-                SequenceNumber = 20
-            });
+                PartitionId = "partitionId"
+            }, mockEvent);
 
             IEnumerable<EventProcessorCheckpoint> storedCheckpointsList1 = await storageManager.ListCheckpointsAsync("namespace1", "eventHubName", "consumerGroup");
             IEnumerable<EventProcessorCheckpoint> storedCheckpointsList2 = await storageManager.ListCheckpointsAsync("namespace2", "eventHubName", "consumerGroup");
@@ -551,25 +555,26 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var storageManager = new MockCheckPointStorage();
 
-            await storageManager.UpdateCheckpointAsync(new EventProcessorCheckpoint
-            {
-                FullyQualifiedNamespace = "namespace",
-                EventHubName = "eventHubName",
-                ConsumerGroup = "consumerGroup",
-                PartitionId = "partitionId1",
-                Offset = 10,
-                SequenceNumber = 20
-            });
+            var mockEvent = new MockEventData(
+                eventBody: Array.Empty<byte>(),
+                offset: 10,
+                sequenceNumber: 20);
 
             await storageManager.UpdateCheckpointAsync(new EventProcessorCheckpoint
             {
                 FullyQualifiedNamespace = "namespace",
                 EventHubName = "eventHubName",
                 ConsumerGroup = "consumerGroup",
-                PartitionId = "partitionId2",
-                Offset = 10,
-                SequenceNumber = 20
-            });
+                PartitionId = "partitionId1"
+            }, mockEvent);
+
+            await storageManager.UpdateCheckpointAsync(new EventProcessorCheckpoint
+            {
+                FullyQualifiedNamespace = "namespace",
+                EventHubName = "eventHubName",
+                ConsumerGroup = "consumerGroup",
+                PartitionId = "partitionId2"
+            }, mockEvent);
 
             IEnumerable<EventProcessorCheckpoint> storedCheckpointsList = await storageManager.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup");
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -240,9 +240,32 @@ namespace Azure.Messaging.EventHubs.Primitives
         public string ConsumerGroup { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public string EventHubName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public string FullyQualifiedNamespace { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
-        public long? Offset { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public string PartitionId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
-        public long? SequenceNumber { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public Azure.Messaging.EventHubs.Consumer.EventPosition StartingPosition { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+    }
+    public partial class EventProcessorOptions
+    {
+        public EventProcessorOptions() { }
+        public Azure.Messaging.EventHubs.EventHubConnectionOptions ConnectionOptions { get { throw null; } set { } }
+        public Azure.Messaging.EventHubs.Consumer.EventPosition DefaultStartingPosition { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public string Identifier { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        public System.TimeSpan LoadBalancingUpdateInterval { get { throw null; } set { } }
+        public System.TimeSpan? MaximumWaitTime { get { throw null; } set { } }
+        public System.TimeSpan PartitionOwnershipExpirationInterval { get { throw null; } set { } }
+        public int PrefetchCount { get { throw null; } set { } }
+        public Azure.Messaging.EventHubs.EventHubsRetryOptions RetryOptions { get { throw null; } set { } }
+        public bool TrackLastEnqueuedEventProperties { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override string ToString() { throw null; }
+    }
+    public partial class EventProcessorPartition
+    {
+        public EventProcessorPartition() { }
+        public string PartitionId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
     }
     public partial class EventProcessorPartitionOwnership
     {
@@ -254,6 +277,36 @@ namespace Azure.Messaging.EventHubs.Primitives
         public string OwnerIdentifier { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public string PartitionId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public string Version { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
+    }
+    public abstract partial class EventProcessor<TPartition> where TPartition : Azure.Messaging.EventHubs.Primitives.EventProcessorPartition, new()
+    {
+        protected EventProcessor() { }
+        protected EventProcessor(int eventBatchMaximumSize, string consumerGroup, string connectionString, Azure.Messaging.EventHubs.Primitives.EventProcessorOptions options = null) { }
+        protected EventProcessor(int eventBatchMaximumSize, string consumerGroup, string fullyQualifiedNamespace, string eventHubName, Azure.Core.TokenCredential credential, Azure.Messaging.EventHubs.Primitives.EventProcessorOptions options = null) { }
+        protected EventProcessor(int eventBatchMaximumSize, string consumerGroup, string connectionString, string eventHubName, Azure.Messaging.EventHubs.Primitives.EventProcessorOptions options = null) { }
+        public string ConsumerGroup { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
+        public string EventHubName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
+        public string FullyQualifiedNamespace { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
+        public string Identifier { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
+        public bool IsRunning { get { throw null; } protected set { } }
+        protected abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.Primitives.EventProcessorPartitionOwnership>> ClaimOwnershipAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.Primitives.EventProcessorPartitionOwnership> desiredOwnership, System.Threading.CancellationToken cancellationToken);
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        protected abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.Primitives.EventProcessorCheckpoint>> ListCheckpointsAsync(System.Threading.CancellationToken cancellationToken);
+        protected abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.Primitives.EventProcessorPartitionOwnership>> ListOwnershipAsync(System.Threading.CancellationToken cancellationToken);
+        protected virtual System.Threading.Tasks.Task OnInitializingPartitionAsync(TPartition partition, System.Threading.CancellationToken cancellationToken) { throw null; }
+        protected virtual System.Threading.Tasks.Task OnPartitionProcessingStoppedAsync(TPartition partition, Azure.Messaging.EventHubs.Processor.ProcessingStoppedReason reason, System.Threading.CancellationToken cancellationToken) { throw null; }
+        protected abstract System.Threading.Tasks.Task OnProcessingErrorAsync(System.Exception exception, TPartition partition, string operationDescription, System.Threading.CancellationToken cancellationToken);
+        protected abstract System.Threading.Tasks.Task OnProcessingEventBatchAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.EventData> events, TPartition partition, System.Threading.CancellationToken cancellationToken);
+        protected virtual Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties ReadLastEnqueuedEventProperties(string partitionId) { throw null; }
+        public virtual void StartProcessing(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { }
+        public virtual System.Threading.Tasks.Task StartProcessingAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual void StopProcessing(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { }
+        public virtual System.Threading.Tasks.Task StopProcessingAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override string ToString() { throw null; }
     }
 }
 namespace Azure.Messaging.EventHubs.Processor

--- a/sdk/eventhub/Azure.Messaging.EventHubs/design/event-processor{T}-proposal.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/design/event-processor{T}-proposal.md
@@ -90,10 +90,10 @@ public class CustomProcessor : EventProcessor<EventProcessorPartition>
     protected override Task<IEnumerable<EventProcessorCheckpoint>> ListCheckpointsAsync(CancellationToken cancellationToken) =>
         CustomStorage.GetCheckpointsAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup);
     
-    protected override Task<IEnumerable<PartitionOwnership>> ListOwnershipAsync(CancellationToken cancellationToken) =>
+    protected override Task<IEnumerable<EventProcessorPartitionOwnership>> ListOwnershipAsync(CancellationToken cancellationToken) =>
         CustomStorage.GetOwnershipAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier);
     
-    protected override Task<IEnumerable<PartitionOwnership>> ClaimOwnershipAsync(IEnumerable<PartitionOwnership> desiredOwnership, CancellationToken cancellationToken) =>
+    protected override Task<IEnumerable<EventProcessorPartitionOwnership>> ClaimOwnershipAsync(IEnumerable<EventProcessorPartitionOwnership> desiredOwnership, CancellationToken cancellationToken) =>
         CustomStorage.TryUpdateOwnershipAsync(desiredOwnership);
 }
 ```
@@ -132,10 +132,10 @@ public class CustomProcessor : EventProcessor<CustomPartition>
     protected override Task<IEnumerable<EventProcessorCheckpoint>> ListCheckpointsAsync(CancellationToken cancellationToken) =>
         CustomStorage.GetCheckpointsAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup);
     
-    protected override Task<IEnumerable<PartitionOwnership>> ListOwnershipAsync(CancellationToken cancellationToken) =>
+    protected override Task<IEnumerable<EventProcessorPartitionOwnership>> ListOwnershipAsync(CancellationToken cancellationToken) =>
         CustomStorage.GetOwnershipAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier);
     
-    protected override Task<IEnumerable<PartitionOwnership>> ClaimOwnershipAsync(IEnumerable<PartitionOwnership> desiredOwnership, CancellationToken cancellationToken) =>
+    protected override Task<IEnumerable<EventProcessorPartitionOwnership>> ClaimOwnershipAsync(IEnumerable<EventProcessorPartitionOwnership> desiredOwnership, CancellationToken cancellationToken) =>
         CustomStorage.TryUpdateOwnershipAsync(desiredOwnership);
 }
 ```
@@ -238,17 +238,17 @@ public class CustomProcessor : EventProcessor<EventProcessorPartition>
     protected override Task<IEnumerable<EventProcessorCheckpoint>> ListCheckpointsAsync(CancellationToken cancellationToken) =>
         Storage.GetCheckpointsAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup);
     
-    protected override Task<IEnumerable<PartitionOwnership>> ListOwnershipAsync(CancellationToken cancellationToken) =>
+    protected override Task<IEnumerable<EventProcessorPartitionOwnership>> ListOwnershipAsync(CancellationToken cancellationToken) =>
         Storage.GetOwnershipAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, Identifier);
     
-    protected override Task<IEnumerable<PartitionOwnership>> ClaimOwnershipAsync(IEnumerable<PartitionOwnership> desiredOwnership, CancellationToken cancellationToken) =>
+    protected override Task<IEnumerable<EventProcessorPartitionOwnership>> ClaimOwnershipAsync(IEnumerable<EventProcessorPartitionOwnership> desiredOwnership, CancellationToken cancellationToken) =>
         Storage.TryClaimOwnershipAsync(desiredOwnership);
 }
 
 public class InMemoryStorage
 {
     private ConcurrentDictionary<string, ConcurrentDictionary<string, EventProcessorCheckpoint>> Checkpoints { get; } = new ConcurrentDictionary<string, ConcurrentDictionary<string, EventProcessorCheckpoint>>();
-    private ConcurrentDictionary<string, ConcurrentDictionary<string, PartitionOwnership>> Ownership { get; } = new ConcurrentDictionary<string, ConcurrentDictionary<string, PartitionOwnership>>();
+    private ConcurrentDictionary<string, ConcurrentDictionary<string, EventProcessorPartitionOwnership>> Ownership { get; } = new ConcurrentDictionary<string, ConcurrentDictionary<string, EventProcessorPartitionOwnership>>();
 
     public Task CreateCheckpointAsync(
         string fullyQualifiedNamespace,
@@ -269,8 +269,14 @@ public class InMemoryStorage
             PartitionId = partitionId
         });
         
-        partitionCheckpoint.Offset = offset;
-        partitionCheckpoint.SequenceNumber = sequenceNumber;
+        if (offset.HasValue)
+        {
+            partitionCheckpoint.StartingPosition = EventPosition.FromOffset(offset.Value, false);
+        }
+        else
+        {
+            partitionCheckpoint.StartingPosition = EventPosition.FromSequenceNumber(sequenceNumber.Value, false);
+        }
         
         return Task.CompletedTask;
     }
@@ -285,34 +291,34 @@ public class InMemoryStorage
         return Task.FromResult((IEnumerable<EventProcessorCheckpoint>)checkpoints.Values);
     }
 
-    public Task<IEnumerable<PartitionOwnership>> GetOwnershipAsync(
+    public Task<IEnumerable<EventProcessorPartitionOwnership>> GetOwnershipAsync(
         string fullyQualifiedNamespace,
         string eventHubName,
         string consumerGroup)
     {
         var key = CreateKey(fullyQualifiedNamespace, eventHubName, consumerGroup);
-        var ownership = Ownership.GetOrAdd(key, newKey => new ConcurrentDictionary<string, PartitionOwnership>());
+        var ownership = Ownership.GetOrAdd(key, newKey => new ConcurrentDictionary<string, EventProcessorPartitionOwnership>());
         return Task.FromResult(ownership.Values.Where(item => item.OwnerIdentifier != identifier));
     }
     
-    public Task<IEnumerable<PartitionOwnership>> TryClaimOwnershipAsync(
-        IEnumerable<PartitionOwnership> desiredOwnership)
+    public Task<IEnumerable<EventProcessorPartitionOwnership>> TryClaimOwnershipAsync(
+        IEnumerable<EventProcessorPartitionOwnership> desiredOwnership)
     {
         if (desiredOwnership == null)
         {
-            return Task.FromResult(Enumerable.Empty<PartitionOwnership>());
+            return Task.FromResult(Enumerable.Empty<EventProcessorPartitionOwnership>());
         }
         
-        var claimedOwnership = new List<PartitionOwnership>();
+        var claimedOwnership = new List<EventProcessorPartitionOwnership>();
 
         foreach (var claim in desiredOwnership)
         {
             var key = CreateKey(claim.FullyQualifiedNamespace, claim.EventHubName, claim.ConsumerGroup);
-            var claimedPartitions = Ownership.GetOrAdd(key, newKey => new ConcurrentDictionary<string, PartitionOwnership>());
+            var claimedPartitions = Ownership.GetOrAdd(key, newKey => new ConcurrentDictionary<string, EventProcessorPartitionOwnership>());
             var nextVersion = new Version(Guid.NewGuid().ToString());
 
             var ownership = claimedPartitions.AddOrUpdate(claim.PartitionId,
-                partitionId => new PartitionOwnership
+                partitionId => new EventProcessorPartitionOwnership
                 (
                     claim.FullyQualifiedNamespace,
                     claim.EventHubName,
@@ -329,7 +335,7 @@ public class InMemoryStorage
                         return existingOwnership;
                     }
 
-                    return new PartitionOwnership
+                    return new EventProcessorPartitionOwnership
                     (
                         claim.FullyQualifiedNamespace,
                         claim.EventHubName,
@@ -348,7 +354,7 @@ public class InMemoryStorage
             }
         }
 
-        return Task.FromResult((IEnumerable<PartitionOwnership>)claimedOwnership);
+        return Task.FromResult((IEnumerable<EventProcessorPartitionOwnership>)claimedOwnership);
     }
 
     private string CreateKey(
@@ -360,7 +366,7 @@ public class InMemoryStorage
 
 ## API skeleton
 
-### `Azure.Messaging.EventHubs.Specialized`
+### `Azure.Messaging.EventHubs.Primitives`
 
 ```csharp
 public abstract class EventProcessor<TPartition> where TPartition : EventProcessorPartition, new()
@@ -372,20 +378,20 @@ public abstract class EventProcessor<TPartition> where TPartition : EventProcess
     public bool IsRunning { get; protected set; }
     
     protected EventProcessor(
-        int eventBatchSize,
+        int eventBatchMaximumSize,
         string consumerGroup, 
         string connectionString, 
         EventProcessorOptions options = default);
         
     protected EventProcessor(
-        int eventBatchSize,
+        int eventBatchMaximumSize,
         string consumerGroup, 
         string connectionString, 
         string eventHubName, 
         EventProcessorOptions options = default);
     
     protected EventProcessor(
-        int eventBatchSize,
+        int eventBatchMaximumSize,
         string consumerGroup,  
         string fullyQualifiedNamespace, 
         string eventHubName, 
@@ -407,8 +413,8 @@ public abstract class EventProcessor<TPartition> where TPartition : EventProcess
     
     // Required extension points (storage operations)
     protected abstract Task<IEnumerable<EventProcessorCheckpoint>> ListCheckpointsAsync(CancellationToken cancellationToken);
-    protected abstract Task<IEnumerable<PartitionOwnership>> ListOwnershipAsync(CancellationToken cancellationToken);
-    protected abstract Task<IEnumerable<PartitionOwnership>> ClaimOwnershipAsync(IEnumerable<PartitionOwnership> desiredOwnership, CancellationToken cancellationToken);
+    protected abstract Task<IEnumerable<EventProcessorPartitionOwnership>> ListOwnershipAsync(CancellationToken cancellationToken);
+    protected abstract Task<IEnumerable<EventProcessorPartitionOwnership>> ClaimOwnershipAsync(IEnumerable<EventProcessorPartitionOwnership> desiredOwnership, CancellationToken cancellationToken);
     
     // Infrastructure
     protected virtual LastEnqueuedEventProperties ReadLastEnqueuedEventProperties(string partitionId);
@@ -429,7 +435,7 @@ public class EventProcessorOptions
 
 public class EventProcessorPartition
 {
-    public string PartitionId { get; set; }
+    public string PartitionId { get; internal set; }
 }
 
 public class EventProcessorCheckpoint
@@ -438,11 +444,10 @@ public class EventProcessorCheckpoint
     public string EventHubName { get; set; }
     public string ConsumerGroup { get; set; }
     public string PartitionId { get; set; }
-    public long? Offset { get; set; }
-    public long? SequenceNumber { get; set; }
+    public EventPosition StartingPosition { get; set; }
 }
 
-public class PartitionOwnership
+public class EventProcessorPartitionOwnership
 {
     public string FullyQualifiedNamespace { get; set; }
     public string EventHubName { get; set; }
@@ -458,15 +463,15 @@ public class PartitionOwnership
 
 ### Package: Azure.Messaging.EventHubs
 
-#### `Azure.Messaging.EventHubs.Specialized`
+#### `Azure.Messaging.EventHubs.Primitives`
 ```csharp
 public class EventProcessor<TPartition> {}
 public class EventProcessorOptions {}
 public class EventProcessorCheckpoint {}
 public class EventProcessorPartition {}
-public class PartitionOwnership {}
-public class PartitionReceiverClient {}
-public class PartitionReceiverClientOptions {}
+public class EventProcessorPartitionOwnership {}
+public class PartitionReceiver {}
+public class PartitionReceiverOptions {}
 ```
 
 #### `Azure.Messaging.EventHubs.Processor`

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
@@ -782,7 +782,9 @@ namespace Azure.Messaging.EventHubs.Amqp
                     // that the connection has been closed.  Ignore potential exceptions, as they won't impact operation.
                     // At worse, another timer tick will occur and the operation will be retried.
 
-                    try { refreshTimer.Change(Timeout.Infinite, Timeout.Infinite); } catch {}
+                    try
+                    { refreshTimer.Change(Timeout.Infinite, Timeout.Infinite); }
+                    catch { }
                 }
                 finally
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -34,11 +34,13 @@
   <Import Project="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs.Shared\src\Azure.Messaging.EventHubs.Shared.Core.projitems" Label="Core" />
   <Import Project="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs.Shared\src\Azure.Messaging.EventHubs.Shared.Diagnostics.projitems" Label="Diagnostics" />
   <Import Project="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs.Shared\src\Azure.Messaging.EventHubs.Shared.Authorization.projitems" Label="Authorization" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs.Shared\src\Azure.Messaging.EventHubs.Shared.Processor.projitems" Label="Processor" />
 
   <!-- Import Azure.Core shared source -->
   <ItemGroup>
     <Compile Include="$(AzureCoreSharedSources)Argument.cs" Link="SharedSource\Azure.Core\Argument.cs" />
     <Compile Include="$(AzureCoreSharedSources)HashCodeBuilder.cs" Link="SharedSource\Azure.Core\HashCodeBuilder.cs" />
+    <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" Link="SharedSource\Azure.Core\TaskExtensions.cs" />
   </ItemGroup>
 
   <!--Embed the shared resources -->

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
@@ -116,6 +116,8 @@ namespace Azure.Messaging.EventHubs.Consumer
         ///   Event Hub will result in a connection string that contains the name.
         /// </remarks>
         ///
+        /// <seealso href="https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string"/>
+        ///
         public EventHubConsumerClient(string consumerGroup,
                                       string connectionString) : this(consumerGroup, connectionString, null, null)
         {
@@ -138,6 +140,8 @@ namespace Azure.Messaging.EventHubs.Consumer
         ///   Event Hub will result in a connection string that contains the name.
         /// </remarks>
         ///
+        /// <seealso href="https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string"/>
+        ///
         public EventHubConsumerClient(string consumerGroup,
                                       string connectionString,
                                       EventHubConsumerClientOptions clientOptions) : this(consumerGroup, connectionString, null, clientOptions)
@@ -157,6 +161,8 @@ namespace Azure.Messaging.EventHubs.Consumer
         ///   and can be used directly without passing the <paramref name="eventHubName" />.  The name of the Event Hub should be
         ///   passed only once, either as part of the connection string or separately.
         /// </remarks>
+        ///
+        /// <seealso href="https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string"/>
         ///
         public EventHubConsumerClient(string consumerGroup,
                                       string connectionString,
@@ -178,6 +184,8 @@ namespace Azure.Messaging.EventHubs.Consumer
         ///   and can be used directly without passing the <paramref name="eventHubName" />.  The name of the Event Hub should be
         ///   passed only once, either as part of the connection string or separately.
         /// </remarks>
+        ///
+        /// <seealso href="https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string"/>
         ///
         public EventHubConsumerClient(string consumerGroup,
                                       string connectionString,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClientOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClientOptions.cs
@@ -8,7 +8,7 @@ using Azure.Messaging.EventHubs.Core;
 namespace Azure.Messaging.EventHubs.Consumer
 {
     /// <summary>
-    ///   The baseline set of options that can be specified when creating a <see cref="EventHubConsumerClient" />
+    ///   The set of options that can be specified when creating a <see cref="EventHubConsumerClient" />
     ///   to configure its behavior.
     /// </summary>
     ///
@@ -21,7 +21,7 @@ namespace Azure.Messaging.EventHubs.Consumer
         private EventHubsRetryOptions _retryOptions = new EventHubsRetryOptions();
 
         /// <summary>
-        ///   Gets or sets the options used for configuring the connection to the Event Hubs service.
+        ///   The options used for configuring the connection to the Event Hubs service.
         /// </summary>
         ///
         public EventHubConnectionOptions ConnectionOptions
@@ -37,7 +37,7 @@ namespace Azure.Messaging.EventHubs.Consumer
         /// <summary>
         ///   The set of options to use for determining whether a failed operation should be retried and,
         ///   if so, the amount of time to wait between retry attempts.  These options also control the
-        ///   amount of time allowed for publishing events and other interactions with the Event Hubs service.
+        ///   amount of time allowed for reading events and other interactions with the Event Hubs service.
         /// </summary>
         ///
         public EventHubsRetryOptions RetryOptions

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessorCheckpoint.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessorCheckpoint.cs
@@ -1,11 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Azure.Messaging.EventHubs.Consumer;
+
 namespace Azure.Messaging.EventHubs.Primitives
 {
     /// <summary>
     ///   Contains the information to reflect the state of event processing for a given Event Hub partition.
     /// </summary>
+    ///
+    /// <seealso cref="EventProcessor{TPartition}" />
     ///
     public class EventProcessorCheckpoint
     {
@@ -36,15 +40,9 @@ namespace Azure.Messaging.EventHubs.Primitives
         public string PartitionId { get; set; }
 
         /// <summary>
-        ///   The offset of the <see cref="EventData" /> this checkpoint is associated with.
+        ///   The starting position within the partition's event stream that this checkpoint is associated with.
         /// </summary>
         ///
-        public long? Offset { get; set; }
-
-        /// <summary>
-        ///   The sequence number assigned to the <see cref="EventData" /> this checkpoint is associated with.
-        /// </summary>
-        ///
-        public long? SequenceNumber { get; set; }
+        public EventPosition StartingPosition { get; set; }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessorOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessorOptions.cs
@@ -1,0 +1,243 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ComponentModel;
+using Azure.Core;
+using Azure.Messaging.EventHubs.Consumer;
+using Azure.Messaging.EventHubs.Core;
+
+namespace Azure.Messaging.EventHubs.Primitives
+{
+    /// <summary>
+    ///   The set of options that can be specified when creating an <see cref="EventProcessor{TPartition}" />
+    ///   to configure its behavior.
+    /// </summary>
+    ///
+    public class EventProcessorOptions
+    {
+        /// <summary>The set of options to use for configuring the connection to the Event Hubs service.</summary>
+        private EventHubConnectionOptions _connectionOptions = new EventHubConnectionOptions();
+
+        /// <summary>The set of options to govern retry behavior and try timeouts.</summary>
+        private EventHubsRetryOptions _retryOptions = new EventHubsRetryOptions();
+
+        /// <summary>The maximum amount of time to wait for a batch of events to become available before emitting an empty batch.</summary>
+        private TimeSpan? _maximumWaitTime = TimeSpan.FromSeconds(60);
+
+        /// <summary>The prefetch count to use for the event processor.</summary>
+        private int _prefetchCount = 300;
+
+        /// <summary>The desired amount of time to allow between load balancing verification attempts.</summary>
+        private TimeSpan _loadBalancingUpdateInterval = TimeSpan.FromSeconds(10);
+
+        /// <summary>The desired amount of time to consider a partition owned by a specific event processor.</summary>
+        private TimeSpan _partitionOwnershipExpirationInterval = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        ///   The options used for configuring the connection to the Event Hubs service.
+        /// </summary>
+        ///
+        public EventHubConnectionOptions ConnectionOptions
+        {
+            get => _connectionOptions;
+
+            set
+            {
+                Argument.AssertNotNull(value, nameof(ConnectionOptions));
+                _connectionOptions = value;
+            }
+        }
+
+        /// <summary>
+        ///   The set of options to use for determining whether a failed operation should be retried and,
+        ///   if so, the amount of time to wait between retry attempts.  These options also control the
+        ///   amount of time allowed for receiving event batches and other interactions with the Event Hubs service.
+        /// </summary>
+        ///
+        public EventHubsRetryOptions RetryOptions
+        {
+            get => _retryOptions;
+
+            set
+            {
+                Argument.AssertNotNull(value, nameof(RetryOptions));
+                _retryOptions = value;
+            }
+        }
+
+        /// <summary>
+        ///   The maximum amount of time to wait for an event to become available for a given partition before emitting
+        ///   an empty batch of events.
+        /// </summary>
+        ///
+        /// <value>
+        ///   If <c>null</c>, the processor will wait indefinitely for a batch of events to become available and will not
+        ///   dispatch them to be processed while waiting; otherwise, a batch will always be emitted within this interval, whether or not
+        ///   it is empty.
+        /// </value>
+        ///
+        public TimeSpan? MaximumWaitTime
+        {
+            get => _maximumWaitTime;
+
+            set
+            {
+                if (value.HasValue)
+                {
+                    Argument.AssertNotNegative(value.Value, nameof(MaximumWaitTime));
+                }
+
+                _maximumWaitTime = value;
+            }
+        }
+
+        /// <summary>
+        ///   The number of events that will be eagerly requested from the Event Hubs service and queued locally without regard to
+        ///   whether a processing is currently active, intended to help maximize throughput by allowing the event processor to read
+        ///   from a local cache rather than waiting on a service request.
+        /// </summary>
+        ///
+        /// <value>
+        ///   The <see cref="PrefetchCount" /> is a control that developers can use to help tune performance for the specific
+        ///   needs of an application, given its expected size of events, throughput needs, and expected scenarios for using
+        ///   Event Hubs.
+        /// </value>
+        ///
+        public int PrefetchCount
+        {
+            get => _prefetchCount;
+
+            set
+            {
+                Argument.AssertAtLeast(value, 0, nameof(PrefetchCount));
+                _prefetchCount = value;
+            }
+        }
+
+        /// <summary>
+        ///   The desired amount of time to allow between load balancing verification attempts.
+        /// </summary>
+        ///
+        /// <remarks>
+        ///   Because load balancing holds less priority than processing events, this interval
+        ///   should be considered the minimum time that will elapse between verification attempts; operations
+        ///   with higher priority may cause a minor delay longer than this interval for load balancing.
+        /// </remarks>
+        ///
+        public TimeSpan LoadBalancingUpdateInterval
+        {
+            get => _loadBalancingUpdateInterval;
+
+            set
+            {
+                Argument.AssertNotNegative(value, nameof(LoadBalancingUpdateInterval));
+                _loadBalancingUpdateInterval = value;
+            }
+        }
+
+        /// <summary>
+        ///   The desired amount of time to consider a partition owned by a specific event processor
+        ///   instance before the ownership is considered stale and the partition eligible to be requested
+        ///   by another event processor that wishes to assume responsibility for processing it.
+        /// </summary>
+        ///
+        public TimeSpan PartitionOwnershipExpirationInterval
+        {
+            get => _partitionOwnershipExpirationInterval;
+
+            set
+            {
+                Argument.AssertNotNegative(value, nameof(PartitionOwnershipExpirationInterval));
+                _partitionOwnershipExpirationInterval = value;
+            }
+        }
+
+        /// <summary>
+        ///   A unique name used to identify the event processor.  If <c>null</c> or empty, a GUID will be used as the
+        ///   identifier.
+        /// </summary>
+        ///
+        public string Identifier { get; set; }
+
+        /// <summary>
+        ///   Indicates whether or not the processor should request information on the last enqueued event on the partition
+        ///   associated with a given event, and track that information as events are received.
+        /// </summary>
+        ///
+        /// <value><c>true</c> if information about a partition's last event should be requested and tracked; otherwise, <c>false</c>.</value>
+        ///
+        /// <remarks>
+        ///   When information about a partition's last enqueued event is being tracked, each event received from the Event Hubs
+        ///   service will carry metadata about the partition that it otherwise would not. This results in a small amount of
+        ///   additional network bandwidth consumption that is generally a favorable trade-off when considered
+        ///   against periodically making requests for partition properties using one of the Event Hub clients.
+        /// </remarks>
+        ///
+        public bool TrackLastEnqueuedEventProperties { get; set; } = true;
+
+        /// <summary>
+        ///   The position within a partition where the event processor should
+        ///   begin reading events when no checkpoint can be found.
+        /// </summary>
+        ///
+        /// <remarks>
+        ///   In the event that a custom starting point is desired for a single partition, or each partition should start at a unique place,
+        ///   it is recommended that those values be returned by the <see cref="EventProcessor{TPartition}.ListCheckpointsAsync"/> method as
+        ///   if they were previously saved checkpoints.
+        /// </remarks>
+        ///
+        /// <seealso cref="EventProcessor{TPartition}.ListCheckpointsAsync"/>
+        ///
+        public EventPosition DefaultStartingPosition { get; set; } = EventPosition.Earliest;
+
+        /// <summary>
+        ///   Determines whether the specified <see cref="System.Object" /> is equal to this instance.
+        /// </summary>
+        ///
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+        ///
+        /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => base.Equals(obj);
+
+        /// <summary>
+        ///   Returns a hash code for this instance.
+        /// </summary>
+        ///
+        /// <returns>A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => base.GetHashCode();
+
+        /// <summary>
+        ///   Converts the instance to string representation.
+        /// </summary>
+        ///
+        /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override string ToString() => base.ToString();
+
+        /// <summary>
+        ///   Creates a new copy of the current <see cref="EventProcessorOptions" />, cloning its attributes into a new instance.
+        /// </summary>
+        ///
+        /// <returns>A new copy of <see cref="EventProcessorOptions" />.</returns>
+        ///
+        internal EventProcessorOptions Clone() =>
+            new EventProcessorOptions
+            {
+                _connectionOptions = ConnectionOptions.Clone(),
+                _retryOptions = RetryOptions.Clone(),
+                _prefetchCount = PrefetchCount,
+                _maximumWaitTime = MaximumWaitTime,
+                _loadBalancingUpdateInterval = LoadBalancingUpdateInterval,
+                _partitionOwnershipExpirationInterval = PartitionOwnershipExpirationInterval,
+                Identifier = Identifier,
+                TrackLastEnqueuedEventProperties = TrackLastEnqueuedEventProperties,
+                DefaultStartingPosition = DefaultStartingPosition
+            };
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessorPartition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessorPartition.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Messaging.EventHubs.Primitives
+{
+    /// <summary>
+    ///   A set of contextual information about an Event Hub partition for which an
+    ///   <see cref="EventProcessor{TPartition}" /> operation is being performed.
+    /// </summary>
+    ///
+    /// <remarks>
+    ///   This class represents a minimalist set of information and is intended to be
+    ///   extended for scenarios which require additional context for partitions.
+    /// </remarks>
+    ///
+    /// <seealso cref="EventProcessor{TPartition}" />
+    ///
+    public class EventProcessorPartition
+    {
+        /// <summary>
+        ///   The identifier of the partition.
+        /// </summary>
+        ///
+        public string PartitionId { get; internal set; }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessorPartitionOwnership.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessorPartitionOwnership.cs
@@ -6,11 +6,11 @@ using System;
 namespace Azure.Messaging.EventHubs.Primitives
 {
     /// <summary>
-    ///   Contains all the information needed to describe the status of the owner of a partition.  It's used by
-    ///   an <c>EventProcessor</c> for cooperative distribution of processing for the associated Event Hub.
+    ///   The set of information for describing the status of the partition ownership between <see cref="EventProcessor{TPartition}" />
+    ///   instances cooperating for distribution of processing for a given Event Hub.
     /// </summary>
     ///
-    /// <seealso href="https://www.nuget.org/packages/Azure.Messaging.EventHubs.Processor" />
+    /// <seealso cref="EventProcessor{TPartition}" />
     ///
     public class EventProcessorPartitionOwnership
     {
@@ -35,7 +35,7 @@ namespace Azure.Messaging.EventHubs.Primitives
         public string ConsumerGroup { get; set; }
 
         /// <summary>
-        ///   The identifier of the associated <c>EventProcessor</c> instance.
+        ///   The identifier of the associated <see cref="EventProcessor{TPartition}" /> instance.
         /// </summary>
         ///
         public string OwnerIdentifier { get; set; }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor{TPartition}.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor{TPartition}.cs
@@ -1,0 +1,433 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Azure.Messaging.EventHubs.Consumer;
+using Azure.Messaging.EventHubs.Core;
+using Azure.Messaging.EventHubs.Processor;
+
+namespace Azure.Messaging.EventHubs.Primitives
+{
+    /// <summary>
+    ///   Provides a base for creating a custom processor for consuming events across all partitions of a given Event Hub
+    ///   within the scope of a specific consumer group.  The processor is capable of collaborating with other instances for
+    ///   the same Event Hub and consumer group pairing to share work by using a common storage platform to communicate.  Fault
+    ///   tolerance is also built-in, allowing the processor to be resilient in the face of errors.
+    /// </summary>
+    ///
+    /// <typeparam name="TPartition">The context of the partition for which an operation is being performed.</typeparam>
+    ///
+    public abstract class EventProcessor<TPartition> where TPartition : EventProcessorPartition, new()
+    {
+        /// <summary>Indicates whether or not this event processor is currently running.  Used only for mocking purposes.</summary>
+        private bool? _isRunningOverride;
+
+        /// <summary>
+        ///   The fully qualified Event Hubs namespace that the processor is associated with.  This is likely
+        ///   to be similar to <c>{yournamespace}.servicebus.windows.net</c>.
+        /// </summary>
+        ///
+        public string FullyQualifiedNamespace { get; }
+
+        /// <summary>
+        ///   The name of the Event Hub that the processor is connected to, specific to the
+        ///   Event Hubs namespace that contains it.
+        /// </summary>
+        ///
+        public string EventHubName { get; }
+
+        /// <summary>
+        ///   The name of the consumer group this event processor is associated with.  Events will be
+        ///   read only in the context of this group.
+        /// </summary>
+        ///
+        public string ConsumerGroup { get; }
+
+        /// <summary>
+        ///   A unique name used to identify this event processor.
+        /// </summary>
+        ///
+        public string Identifier { get; }
+
+        /// <summary>
+        ///   Indicates whether or not this event processor is currently running.
+        /// </summary>
+        ///
+        public bool IsRunning
+        {
+            get
+            {
+                if (_isRunningOverride.HasValue)
+                {
+                    return _isRunningOverride.Value;
+                }
+
+                // TODO: Implement
+                throw new NotImplementedException();
+            }
+
+            protected set => _isRunningOverride = value;
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventProcessor{TPartition}"/> class.
+        /// </summary>
+        ///
+        /// <param name="eventBatchMaximumSize">The desired number of events to include in a batch to be processed.  This size is the maximum count in a batch; the actual count may be smaller, depending on whether events are available in the Event Hub.</param>
+        /// <param name="consumerGroup">The name of the consumer group the processor is associated with.  Events are read in the context of this group.</param>
+        /// <param name="connectionString">The connection string to use for connecting to the Event Hubs namespace; it is expected that the Event Hub name and the shared key properties are contained in this connection string.</param>
+        /// <param name="options">The set of options to use for the processor.</param>
+        ///
+        /// <remarks>
+        ///   If the connection string is copied from the Event Hubs namespace, it will likely not contain the name of the desired Event Hub,
+        ///   which is needed.  In this case, the name can be added manually by adding ";EntityPath=[[ EVENT HUB NAME ]]" to the end of the
+        ///   connection string.  For example, ";EntityPath=telemetry-hub".
+        ///
+        ///   If you have defined a shared access policy directly on the Event Hub itself, then copying the connection string from that
+        ///   Event Hub will result in a connection string that contains the name.
+        /// </remarks>
+        ///
+        /// <seealso href="https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string"/>
+        ///
+        protected EventProcessor(int eventBatchMaximumSize,
+                                 string consumerGroup,
+                                 string connectionString,
+                                 EventProcessorOptions options = default) : this(eventBatchMaximumSize, consumerGroup, connectionString, null, options)
+        {
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventProcessor{TPartition}"/> class.
+        /// </summary>
+        ///
+        /// <param name="eventBatchMaximumSize">The desired number of events to include in a batch to be processed.  This size is the maximum count in a batch; the actual count may be smaller, depending on whether events are available in the Event Hub.</param>
+        /// <param name="consumerGroup">The name of the consumer group the processor is associated with.  Events are read in the context of this group.</param>
+        /// <param name="connectionString">The connection string to use for connecting to the Event Hubs namespace; it is expected that the shared key properties are contained in this connection string, but not the Event Hub name.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub to associate the processor with.</param>
+        /// <param name="options">The set of options to use for the processor.</param>
+        ///
+        /// <remarks>
+        ///   If the connection string is copied from the Event Hub itself, it will contain the name of the desired Event Hub,
+        ///   and can be used directly without passing the <paramref name="eventHubName" />.  The name of the Event Hub should be
+        ///   passed only once, either as part of the connection string or separately.
+        /// </remarks>
+        ///
+        /// <seealso href="https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string"/>
+        ///
+        protected EventProcessor(int eventBatchMaximumSize,
+                                 string consumerGroup,
+                                 string connectionString,
+                                 string eventHubName,
+                                 EventProcessorOptions options = default)
+        {
+            Argument.AssertNotNullOrEmpty(consumerGroup, nameof(consumerGroup));
+            Argument.AssertNotNullOrEmpty(connectionString, nameof(connectionString));
+
+            // TODO: Implement
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventProcessor{TPartition}"/> class.
+        /// </summary>
+        ///
+        /// <param name="eventBatchMaximumSize">The desired number of events to include in a batch to be processed.  This size is the maximum count in a batch; the actual count may be smaller, depending on whether events are available in the Event Hub.</param>
+        /// <param name="consumerGroup">The name of the consumer group the processor is associated with.  Events are read in the context of this group.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace to connect to.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub to associate the processor with.</param>
+        /// <param name="credential">The Azure managed identity credential to use for authorization.  Access controls may be specified by the Event Hubs namespace or the requested Event Hub, depending on Azure configuration.</param>
+        /// <param name="options">The set of options to use for the processor.</param>
+        ///
+        protected EventProcessor(int eventBatchMaximumSize,
+                                 string consumerGroup,
+                                 string fullyQualifiedNamespace,
+                                 string eventHubName,
+                                 TokenCredential credential,
+                                 EventProcessorOptions options = default)
+        {
+            // TODO: Implement
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventProcessor{TPartition}"/> class.
+        /// </summary>
+        ///
+        protected EventProcessor()
+        {
+        }
+
+        /// <summary>
+        ///   Signals the <see cref="EventProcessor{TPartition}" /> to begin processing events.  Should this method be called while the processor
+        ///   is running, no action is taken.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the start operation.  This won't affect the <see cref="EventProcessor{TPartition}" /> once it starts running.</param>
+        ///
+        public virtual async Task StartProcessingAsync(CancellationToken cancellationToken = default) =>
+            await StartProcessingInternalAsync(true, cancellationToken).ConfigureAwait(false);
+
+        /// <summary>
+        ///   Signals the <see cref="EventProcessor{TPartition}" /> to begin processing events.  Should this method be called while the processor
+        ///   is running, no action is taken.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the start operation.  This won't affect the <see cref="EventProcessor{TPartition}" /> once it starts running.</param>
+        ///
+        public virtual void StartProcessing(CancellationToken cancellationToken = default) =>
+            StartProcessingInternalAsync(false, cancellationToken).EnsureCompleted();
+
+        /// <summary>
+        ///   Signals the <see cref="EventProcessor{TPartition}" /> to stop processing events.  Should this method be called while the processor
+        ///   is not running, no action is taken.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the stop operation.  If the operation is successfully canceled, the <see cref="EventProcessor{TPartition}" /> will keep running.</param>
+        ///
+        public virtual async Task StopProcessingAsync(CancellationToken cancellationToken = default) =>
+            await StopProcessingInternalAsync(true, cancellationToken).ConfigureAwait(false);
+
+        /// <summary>
+        ///   Signals the <see cref="EventProcessor{TPartition}" /> to stop processing events.  Should this method be called while the processor
+        ///   is not running, no action is taken.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the stop operation.  If the operation is successfully canceled, the <see cref="EventProcessor{TPartition}" /> will keep running.</param>
+        ///
+        public virtual void StopProcessing(CancellationToken cancellationToken = default) =>
+            StopProcessingInternalAsync(false, cancellationToken).EnsureCompleted();
+
+        /// <summary>
+        ///   Determines whether the specified <see cref="System.Object" /> is equal to this instance.
+        /// </summary>
+        ///
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+        ///
+        /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => base.Equals(obj);
+
+        /// <summary>
+        ///   Returns a hash code for this instance.
+        /// </summary>
+        ///
+        /// <returns>A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => base.GetHashCode();
+
+        /// <summary>
+        ///   Converts the instance to string representation.
+        /// </summary>
+        ///
+        /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override string ToString() => $"Event Processor<{ typeof(TPartition).Name }>: { Identifier }";
+
+        /// <summary>
+        ///   Produces a list of the available checkpoints for the Event Hub and consumer group associated with the
+        ///   event processor instance, so that processing for a given set of partitions can be properly initialized.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the processing.  This is most likely to occur when the processor is shutting down.</param>
+        ///
+        /// <returns>The set of checkpoints for the processor to take into account when initializing partitions.</returns>
+        ///
+        /// <remarks>
+        ///   Should a partition not have a corresponding checkpoint, the <see cref="EventProcessorOptions.DefaultStartingPosition" /> will
+        ///   be used to initialize the partition for processing.
+        ///
+        ///   In the event that a custom starting point is desired for a single partition, or each partition should start at a unique place,
+        ///   it is recommended that this method express that intent by returning checkpoints for those partitions with the desired custom
+        ///   starting location set.
+        /// </remarks>
+        ///
+        protected abstract Task<IEnumerable<EventProcessorCheckpoint>> ListCheckpointsAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        ///   Produces a list of the ownership assignments for partitions between each of the cooperating event processor
+        ///   instances for a given Event Hub and consumer group pairing.  This method is used when load balancing to allow
+        ///   the processor to discover other active collaborators and to made decisions about how to best balance work
+        ///   between them.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the processing.  This is most likely to occur when the processor is shutting down.</param>
+        ///
+        /// <returns>The set of ownership records to take into account when making load balancing decisions.</returns>
+        ///
+        protected abstract Task<IEnumerable<EventProcessorPartitionOwnership>> ListOwnershipAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        ///   Attempts to claim ownership of the specified partitions for processing.  This method is used by
+        ///   load balancing to allow event processor instances to distribute the responsibility for processing
+        ///   partitions for a given Event Hub and consumer group pairing amongst the active event processors.
+        /// </summary>
+        ///
+        /// <param name="desiredOwnership">The set of partition ownership desired by the event processor instance; this is the set of partitions that it will attempt to request responsibility for processing.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the processing.  This is most likely to occur when the processor is shutting down.</param>
+        ///
+        /// <returns>The set of ownership records for the partitions that were successfully claimed; this is expected to be the <paramref name="desiredOwnership"/> or a subset of those partitions.</returns>
+        ///
+        protected abstract Task<IEnumerable<EventProcessorPartitionOwnership>> ClaimOwnershipAsync(IEnumerable<EventProcessorPartitionOwnership> desiredOwnership,
+                                                                                                   CancellationToken cancellationToken);
+
+        /// <summary>
+        ///   Performs the tasks needed to process a batch of events for a given partition as they are read from the Event Hubs service.
+        /// </summary>
+        ///
+        /// <param name="events">The batch of events to be processed.</param>
+        /// <param name="partition">The context of the partition from which the events were read.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the processing.  This is most likely to occur when the processor is shutting down.</param>
+        ///
+        /// <remarks>
+        ///   <para>The number of events in the <paramref name="events"/> batch may vary.  The batch will contain a number of events between zero and batch size that was
+        ///   requested when the processor was created, depending on the availability of events in the partition within the requested <see cref="EventProcessorOptions.MaximumWaitTime"/>
+        ///   interval.
+        ///
+        ///   If there are enough events available in the Event Hub partition to fill a batch of the requested size, the processor will populate the batch and dispatch it to this method
+        ///   immediately.  If there were not a sufficient number of events available in the partition to populate a full batch, the event processor will continue reading from the partition
+        ///   to reach the requested batch size until the <see cref="EventProcessorOptions.MaximumWaitTime"/> has elapsed, at which point it will return a batch containing whatever events were
+        ///   available by the end of that period.
+        ///
+        ///   If a <see cref="EventProcessorOptions.MaximumWaitTime"/> was not requested, indicated by setting the option to <c>null</c>, the event processor will continue reading from the Event Hub
+        ///   partition until a full batch of the requested size could be populated and will not dispatch any partial batches to this method.</para>
+        ///
+        ///   <para>Should an exception occur within the code for this method, the event processor will allow it to bubble and will not surface to the error handler or attempt to handle
+        ///   it in any way.  Developers are strongly encouraged to take exception scenarios into account and guard against them using try/catch blocks and other means as appropriate.</para>
+        /// </remarks>
+        ///
+        protected abstract Task OnProcessingEventBatchAsync(IEnumerable<EventData> events,
+                                                            TPartition partition,
+                                                            CancellationToken cancellationToken);
+
+        /// <summary>
+        ///   Performs the tasks needed when an unexpected exception occurs within the operation of the
+        ///   event processor infrastructure.
+        /// </summary>
+        ///
+        /// <param name="exception">The exception that occurred during operation of the event processor.</param>
+        /// <param name="partition">The context of the partition associated with the error, if any; otherwise, <c>null</c>.</param>
+        /// <param name="operationDescription">A short textual description of the operation during which the exception occurred; intended to be informational only.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the processing.  This is most likely to occur when the processor is shutting down.</param>
+        ///
+        /// <remarks>
+        ///   This error handler is invoked when there is an exception observed within the event processor itself; it is not invoked for exceptions in
+        ///   code that has been implemented to process events or other overrides and extension points that are not critical to the processor's operation.
+        ///   The event processor will make every effort to recover from exceptions and continue processing.  Should an exception that cannot be recovered
+        ///   from be encountered, the processor will attempt to forfeit ownership of all partitions that it was processing so that work may be redistributed.
+        ///
+        ///   The exceptions surfaced to this method may be fatal or non-fatal; because the processor may not be able to accurately predict whether an
+        ///   exception was fatal or whether its state was corrupted, this method has responsibility for making the determination as to whether processing
+        ///   should be terminated or restarted.  The method may do so by calling Stop on the processor instance and then, if desired, calling Start on the processor.
+        ///
+        ///   It is recommended that, for production scenarios, the decision be made by considering observations made by this error handler, the method invoked
+        ///   when initializing processing for a partition, and the method invoked when processing for a partition is stopped.  Many developers will also include
+        ///   data from their monitoring platforms in this decision as well.
+        ///
+        ///   As with event processing, should an exception occur in the code for the error handler, the event processor will allow it to bubble and will not attempt to handle
+        ///   it in any way.  Developers are strongly encouraged to take exception scenarios into account and guard against them using try/catch blocks and other means as appropriate.
+        /// </remarks>
+        ///
+        protected abstract Task OnProcessingErrorAsync(Exception exception,
+                                                       TPartition partition,
+                                                       string operationDescription,
+                                                       CancellationToken cancellationToken);
+
+        /// <summary>
+        ///   Performs the tasks to initialize a partition, and its associated context, for event processing.
+        /// </summary>
+        ///
+        /// <param name="partition">The context of the partition being initialized.  Only the well-known members of the <see cref="EventProcessorPartition" /> will be populated.  If a custom context is being used, the implementor of this method is responsible for initializing custom members.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the initialization.  This is most likely to occur if the partition is claimed by another event processor instance or the processor is shutting down.</param>
+        ///
+        protected virtual Task OnInitializingPartitionAsync(TPartition partition,
+                                                            CancellationToken cancellationToken) => Task.CompletedTask;
+
+        /// <summary>
+        ///   Performs the tasks needed when processing for a partition is being stopped.  This commonly occurs when the partition
+        ///   is claimed by another event processor instance or when the current event processor instance is shutting down.
+        /// </summary>
+        ///
+        /// <param name="partition">The context of the partition for which processing is being stopped.</param>
+        /// <param name="reason">The reason that processing is being stopped for the partition.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the processing.  This is not expected to signal under normal circumstances and will only occur if the processor encounters an unrecoverable error.</param>
+        ///
+        protected virtual Task OnPartitionProcessingStoppedAsync(TPartition partition,
+                                                                 ProcessingStoppedReason reason,
+                                                                 CancellationToken cancellationToken) => Task.CompletedTask;
+
+        /// <summary>
+        ///   A set of information about the last enqueued event of a partition, as observed by the associated EventHubs client
+        ///   associated with this context as events are received from the Event Hubs service.  This is only available if the consumer was
+        ///   created with <see cref="ReadEventOptions.TrackLastEnqueuedEventProperties" /> set.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the Event Hub partition to read the properties from.</param>
+        ///
+        /// <returns>The set of properties for the last event that was enqueued to the partition.</returns>
+        ///
+        /// <remarks>
+        ///   When information about the partition's last enqueued event is being tracked, each event received from the Event Hubs
+        ///   service will carry metadata about the partition that it otherwise would not. This results in a small amount of
+        ///   additional network bandwidth consumption that is generally a favorable trade-off when considered
+        ///   against periodically making requests for partition properties using an Event Hub client.
+        /// </remarks>
+        ///
+        /// <exception cref="InvalidOperationException">Occurs when this method is invoked without <see cref="EventProcessorOptions.TrackLastEnqueuedEventProperties" /> set or when the processor is not running.</exception>
+        ///
+        protected virtual LastEnqueuedEventProperties ReadLastEnqueuedEventProperties(string partitionId) => throw new NotImplementedException();
+
+        /// <summary>
+        ///   Signals the <see cref="EventProcessor{TPartition}" /> to begin processing events. Should this method be called while the processor is running, no action is taken.
+        /// </summary>
+        ///
+        /// <param name="async">When <c>true</c>, the method will be executed asynchronously; otherwise, it will execute synchronously.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the start operation.  This won't affect the <see cref="EventProcessor{TPartition}" /> once it starts running.</param>
+        ///
+        private async Task StartProcessingInternalAsync(bool async,
+                                                        CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+
+            // TODO: Implement
+
+            if (async)
+            {
+                await Task.Delay(1).ConfigureAwait(false);
+            }
+
+            throw new NotImplementedException();
+        }
+
+
+        /// <summary>
+        ///   Signals the <see cref="EventProcessor{TPartition}" /> to stop processing events. Should this method be called while the processor is not running, no action is taken.
+        /// </summary>
+        ///
+        /// <param name="async">When <c>true</c>, the method will be executed asynchronously; otherwise, it will execute synchronously.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the stop operation.  If the operation is successfully canceled, the <see cref="EventProcessor{TPartition}" /> will keep running.</param>
+        ///
+        private async Task StopProcessingInternalAsync(bool async,
+                                                       CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+
+            // TODO: Implement
+
+            if (async)
+            {
+                await Task.Delay(1).ConfigureAwait(false);
+            }
+
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -114,6 +114,8 @@ namespace Azure.Messaging.EventHubs.Producer
         ///   Event Hub will result in a connection string that contains the name.
         /// </remarks>
         ///
+        /// <seealso href="https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string"/>
+        ///
         public EventHubProducerClient(string connectionString) : this(connectionString, null, null)
         {
         }
@@ -134,6 +136,8 @@ namespace Azure.Messaging.EventHubs.Producer
         ///   Event Hub will result in a connection string that contains the name.
         /// </remarks>
         ///
+        /// <seealso href="https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string"/>
+        ///
         public EventHubProducerClient(string connectionString,
                                       EventHubProducerClientOptions clientOptions) : this(connectionString, null, clientOptions)
         {
@@ -151,6 +155,8 @@ namespace Azure.Messaging.EventHubs.Producer
         ///   and can be used directly without passing the <paramref name="eventHubName" />.  The name of the Event Hub should be
         ///   passed only once, either as part of the connection string or separately.
         /// </remarks>
+        ///
+        /// <seealso href="https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string"/>
         ///
         public EventHubProducerClient(string connectionString,
                                       string eventHubName) : this(connectionString, eventHubName, null)
@@ -170,6 +176,8 @@ namespace Azure.Messaging.EventHubs.Producer
         ///   and can be used directly without passing the <paramref name="eventHubName" />.  The name of the Event Hub should be
         ///   passed only once, either as part of the connection string or separately.
         /// </remarks>
+        ///
+        /// <seealso href="https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string"/>
         ///
         public EventHubProducerClient(string connectionString,
                                       string eventHubName,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClientOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClientOptions.cs
@@ -21,7 +21,7 @@ namespace Azure.Messaging.EventHubs.Producer
         private EventHubsRetryOptions _retryOptions = new EventHubsRetryOptions();
 
         /// <summary>
-        ///   Gets or sets the options used for configuring the connection to the Event Hubs service.
+        ///   The options used for configuring the connection to the Event Hubs service.
         /// </summary>
         ///
         public EventHubConnectionOptions ConnectionOptions

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Azure.Messaging.EventHubs.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Azure.Messaging.EventHubs.Tests.csproj
@@ -35,7 +35,6 @@
 
   <!-- Import Event Hubs shared source -->
   <Import Project="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs.Shared\src\Azure.Messaging.EventHubs.Shared.Testing.projitems" Label="Testing" />
-  <Import Project="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs.Shared\src\Azure.Messaging.EventHubs.Shared.Processor.projitems" Label="Processor" />
 
   <!-- Import the Azure.Core test framework (shared source) -->
   <Import Project="..\..\..\core\Azure.Core\tests\TestFramework.props" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Connection/EventHubConnectionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Connection/EventHubConnectionTests.cs
@@ -14,7 +14,6 @@ using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Producer;
 using Moq;
 using NUnit.Framework;
-using NUnit.Framework.Constraints;
 
 namespace Azure.Messaging.EventHubs.Tests
 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorOptionsTests.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Messaging.EventHubs.Consumer;
+using Azure.Messaging.EventHubs.Core;
+using Azure.Messaging.EventHubs.Primitives;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="EventProcessorOptions" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class EventProcessorOptionsTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessorOptions.Clone" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CloneProducesACopy()
+        {
+            var options = new EventProcessorOptions
+            {
+                RetryOptions = new EventHubsRetryOptions { Mode = EventHubsRetryMode.Fixed },
+                ConnectionOptions = new EventHubConnectionOptions { TransportType = EventHubsTransportType.AmqpWebSockets },
+                MaximumWaitTime = TimeSpan.FromMilliseconds(9994),
+                PrefetchCount = 65,
+                LoadBalancingUpdateInterval = TimeSpan.FromDays(3),
+                PartitionOwnershipExpirationInterval = TimeSpan.FromHours(16),
+                Identifier = "Rick Springfield is a bad friend",
+                TrackLastEnqueuedEventProperties = false,
+                DefaultStartingPosition = EventPosition.FromOffset(555)
+            };
+
+            EventProcessorOptions clone = options.Clone();
+            Assert.That(clone, Is.Not.Null, "The clone should not be null.");
+            Assert.That(clone, Is.Not.SameAs(options), "The options should be a copy, not the same instance.");
+
+            Assert.That(clone.ConnectionOptions.TransportType, Is.EqualTo(options.ConnectionOptions.TransportType), "The connection options of the clone should copy properties.");
+            Assert.That(clone.ConnectionOptions, Is.Not.SameAs(options.ConnectionOptions), "The connection options of the clone should be a copy, not the same instance.");
+            Assert.That(clone.RetryOptions.IsEquivalentTo(options.RetryOptions), Is.True, "The retry options of the clone should be considered equal.");
+            Assert.That(clone.RetryOptions, Is.Not.SameAs(options.RetryOptions), "The retry options of the clone should be a copy, not the same instance.");
+            Assert.That(clone.MaximumWaitTime, Is.EqualTo(options.MaximumWaitTime), "The maximum wait time should match.");
+            Assert.That(clone.PrefetchCount, Is.EqualTo(options.PrefetchCount), "The prefetch count should match.");
+            Assert.That(clone.LoadBalancingUpdateInterval, Is.EqualTo(options.LoadBalancingUpdateInterval), "The load balancing update interval should match.");
+            Assert.That(clone.PartitionOwnershipExpirationInterval, Is.EqualTo(options.PartitionOwnershipExpirationInterval), "The partition ownership interval should match.");
+            Assert.That(clone.Identifier, Is.EqualTo(options.Identifier), "The identifier should match.");
+            Assert.That(clone.TrackLastEnqueuedEventProperties, Is.EqualTo(options.TrackLastEnqueuedEventProperties), "Tracking of last enqueued events should match.");
+            Assert.That(clone.DefaultStartingPosition, Is.EqualTo(options.DefaultStartingPosition), "The default starting position should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessorOptions.ConnectionOptions" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void ConnectionOptionsAreValidated()
+        {
+            Assert.That(() => new EventProcessorOptions { ConnectionOptions = null }, Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessorOptions.RetryOptions" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void RetryOptionsAreValidated()
+        {
+            Assert.That(() => new EventProcessorOptions { RetryOptions = null }, Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessorOptions.MaximumWaitTime" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(-1)]
+        [TestCase(-10)]
+        [TestCase(-100)]
+        public void MaximumWaitTimeIsValidated(int waitTimeSeconds)
+        {
+            Assert.That(() => new EventProcessorOptions { MaximumWaitTime = TimeSpan.FromSeconds(waitTimeSeconds) }, Throws.InstanceOf<ArgumentOutOfRangeException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessorOptions.PrefetchCount" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(-1)]
+        [TestCase(-10)]
+        [TestCase(-100)]
+        public void PrefetchCountIsValidated(int count)
+        {
+            Assert.That(() => new EventProcessorOptions { PrefetchCount = count }, Throws.InstanceOf<ArgumentOutOfRangeException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessorOptions.LoadBalancingUpdateInterval" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(-1)]
+        [TestCase(-10)]
+        [TestCase(-100)]
+        public void LoadBalancingUpdateIntervalIsValidated(int intervalSeconds)
+        {
+            Assert.That(() => new EventProcessorOptions { LoadBalancingUpdateInterval = TimeSpan.FromSeconds(intervalSeconds) }, Throws.InstanceOf<ArgumentOutOfRangeException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessorOptions.PartitionOwnershipExpirationInterval " />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(-1)]
+        [TestCase(-10)]
+        [TestCase(-100)]
+        public void PartitionOwnershipExpirationInterval(int intervalSeconds)
+        {
+            Assert.That(() => new EventProcessorOptions { PartitionOwnershipExpirationInterval = TimeSpan.FromSeconds(intervalSeconds) }, Throws.InstanceOf<ArgumentOutOfRangeException>());
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventDataBatchTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventDataBatchTests.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Producer;
 using NUnit.Framework;
-using NUnit.Framework.Constraints;
 
 namespace Azure.Messaging.EventHubs.Tests
 {

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -10,6 +10,6 @@ resources:
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
   parameters:
-    MaxParallel: 4
+    MaxParallel: 6
     ServiceDirectory: eventhub
     TimeoutInMinutes: 120


### PR DESCRIPTION
# Summary

The focus of these changes is to flesh out the public skeleton of the `EventProcessor<TPartition>` to match the [design](https://gist.github.com/jsquire/1f4a1e72fc02871f443ce365222d40f6), and author the public-facing doc comments to accompany them.  After these changes, the full set of types for the event processor should exist and be in the correct project/namespace to allow for implementation to move forward.

**Note:**  The design to which these changes belong has been reviewed and approved by the SDK architecture board and by the language architect.   Marking with the corresponding tag for tracking purposes.

# Last Upstream Rebase

Saturday, February 29, 8:17am (EST)

# References and Related Issues 

- [.NET Event Hubs Client: Event Processor<T> Proposal](https://gist.github.com/jsquire/1f4a1e72fc02871f443ce365222d40f6)
- [Implement the Event Processor Base](https://github.com/Azure/azure-sdk-for-net/issues/9324) (#9324)  
