### PR TITLE
Speed up ReadEventsAsyncPublishesEventsWithxIterators tests

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
@@ -2310,7 +2310,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 }
             }
 
-            public override Task<IEnumerable<EventData>> ReceiveAsync(int maximumMessageCount, TimeSpan? maximumWaitTime, CancellationToken cancellationToken)
+            public override async Task<IEnumerable<EventData>> ReceiveAsync(int maximumMessageCount, TimeSpan? maximumWaitTime, CancellationToken cancellationToken)
             {
                 var stopWatch = Stopwatch.StartNew();
                 PublishDelayCallback?.Invoke();
@@ -2318,7 +2318,11 @@ namespace Azure.Messaging.EventHubs.Tests
 
                 if (((maximumWaitTime.HasValue) && (stopWatch.Elapsed >= maximumWaitTime)) || (PublishIndex >= EventsToPublish.Count))
                 {
-                    return Task.FromResult(Enumerable.Empty<EventData>());
+                    // Delay execution in this path to prevent a tight loop, starving other Tasks.
+
+                    await Task.Delay(100);
+
+                    return Enumerable.Empty<EventData>();
                 }
 
                 var index = PublishIndex;
@@ -2332,7 +2336,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 PublishIndex = (index + maximumMessageCount);
                 var source = EventsToPublish.Skip(index).Take(maximumMessageCount).ToList();
 
-                return Task.FromResult((IEnumerable<EventData>)source);
+                return (IEnumerable<EventData>)source;
             }
 
             public override Task CloseAsync(CancellationToken cancellationToken) => Task.CompletedTask;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
@@ -2320,7 +2320,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     // Delay execution in this path to prevent a tight loop, starving other Tasks.
 
-                    await Task.Delay(100);
+                    await Task.Delay(100).ConfigureAwait(false);
 
                     return Enumerable.Empty<EventData>();
                 }


### PR DESCRIPTION
## Summary of Changes
The `ReadEventsAsyncPublishesEventsWithMultipleIterators` and `ReadEventsAsyncPublishesEventsWithOneIterator` tests have been fluctuating between sub-second runtime and 25+ seconds of runtime. This PR introduces a short `Task.Delay` call in the `PublishingTransportConsumerMock.ReceiveAsync` method, which reduces `Task` starvation in these test runs.

This change will trim up to a 50+ seconds of CI runtime per iteration of these two tests.

![image](https://user-images.githubusercontent.com/1279263/75632914-30498c00-5bc6-11ea-9d3d-eda148a91e49.png)
![image](https://user-images.githubusercontent.com/1279263/75632926-52dba500-5bc6-11ea-96d7-e2a996c0d595.png)


