### PR TITLE
Update AccountTests.ScenarioTests.cs

### DIFF
--- a/sdk/batch/Microsoft.Azure.Management.Batch/tests/ScenarioTests/AccountTests.ScenarioTests.cs
+++ b/sdk/batch/Microsoft.Azure.Management.Batch/tests/ScenarioTests/AccountTests.ScenarioTests.cs
@@ -21,8 +21,7 @@ namespace Batch.Tests.ScenarioTests
         [Fact]
         public async Task BatchAccountEndToEndAsync()
         {
-        // dummy update
-            using (MockContext context = StartMockContextAndInitializeClients(this.GetType()))
+            using (MockContext context = StartMockContextAndInitializeClients(this.GetType().FullName))
             {
                 string resourceGroupName = TestUtilities.GenerateName();
                 string batchAccountName = TestUtilities.GenerateName();

--- a/sdk/batch/Microsoft.Azure.Management.Batch/tests/ScenarioTests/AccountTests.ScenarioTests.cs
+++ b/sdk/batch/Microsoft.Azure.Management.Batch/tests/ScenarioTests/AccountTests.ScenarioTests.cs
@@ -21,6 +21,7 @@ namespace Batch.Tests.ScenarioTests
         [Fact]
         public async Task BatchAccountEndToEndAsync()
         {
+        // dummy update
             using (MockContext context = StartMockContextAndInitializeClients(this.GetType()))
             {
                 string resourceGroupName = TestUtilities.GenerateName();


### PR DESCRIPTION
Copied from Matthew's email:

> I just found a change which had been made a few months back didn’t compile.
> 
> https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/batch/Microsoft.Azure.Management.Batch/tests/ScenarioTests/AccountTests.ScenarioTests.cs#L24
> Has a Type being passed in.
> 
> But if you look at where that function is defined, it still only takes a string: https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/batch/Microsoft.Azure.Management.Batch/tests/ScenarioTests/BatchScenarioTestBase.cs#L23
> 
> I can fix the code, that's not a problem (I just need to change the signature of StartMockContextAndInitializeClients to take a Type and pass that to the MockContext.) 
> The issue I have is... how did this change ever get merged? This project doesn't compile so shouldn't it have failed CI?
> Even now, CI seems to be passing on azure-sdk-for-net yet this project isn’t compliable – I assume that means the tests in this project are also not being run
> 