### PR TITLE
Update Azure.Core.csproj

### DIFF
--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is the implementation of the Azure Client Pipeline</Description>
     <AssemblyTitle>Microsoft Azure Client Pipeline</AssemblyTitle>
-    <Version>1.0.1</Version>
+    <Version>1.1.0-preview1</Version>
     <PackageTags>Microsoft Azure Client Pipeline</PackageTags>
     <PackageReleaseNotes>
       <![CDATA[


### PR DESCRIPTION
Symbols for Azure.Core version 1.0.1 was somehow not published.
Attempting to Repack version 1.0.1 of Azure.Core using the Pipeline so as to publish its symbols to the symbols server.

This PR is not intended to ever be merged as it is behind master.