### PR TITLE
[EventHubs] Clean up EventPosition.Equals logic

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventPosition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventPosition.cs
@@ -134,11 +134,6 @@ namespace Azure.Messaging.EventHubs.Consumer
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool Equals(EventPosition other)
         {
-            if (ReferenceEquals(this, other))
-            {
-                return true;
-            }
-
             return (Offset == other.Offset)
                 && (SequenceNumber == other.SequenceNumber)
                 && (EnqueuedTime == other.EnqueuedTime)
@@ -158,7 +153,7 @@ namespace Azure.Messaging.EventHubs.Consumer
             obj switch
             {
                 EventPosition other => Equals(other),
-                _ => ReferenceEquals(this, obj)
+                _ => false
             };
 
         /// <summary>


### PR DESCRIPTION
Our logic for implementing `EventPosititon.Equals` had some extra code
that would try to use `object.ReferenceEquals` as a way to see if one
EventPosition was equal to another.

However, `EventPosition` is a struct, so it's not clear how this check
could ever really return true, since our calls to `ReferenceEquals` is
going to box both `EventPosition` arguments, so they will never be in
the same place in memory.