### PR TITLE
Rolling back to WindowsAzure.Storage 9.3 due to API timeout issues.

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/AzureBlobLease.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/AzureBlobLease.cs
@@ -3,9 +3,10 @@
 
 namespace Microsoft.Azure.EventHubs.Processor
 {
-    using System.Threading.Tasks;
+	using System;
+	using System.Threading.Tasks;
+	using Microsoft.WindowsAzure.Storage.Blob;
 	using Newtonsoft.Json;
-	using Microsoft.Azure.Storage.Blob;
 
 	class AzureBlobLease : Lease
 	{

--- a/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/AzureStorageCheckpointLeaseManager.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/AzureStorageCheckpointLeaseManager.cs
@@ -9,9 +9,9 @@ namespace Microsoft.Azure.EventHubs.Processor
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.EventHubs.Primitives;
+    using Microsoft.WindowsAzure.Storage;
+    using Microsoft.WindowsAzure.Storage.Blob;
     using Newtonsoft.Json;
-    using Microsoft.Azure.Storage;
-    using Microsoft.Azure.Storage.Blob;
 
     class AzureStorageCheckpointLeaseManager : ICheckpointManager, ILeaseManager
     {

--- a/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/EventProcessorHost.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/EventProcessorHost.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.EventHubs.Processor
     using System;
     using System.Threading.Tasks;
     using Microsoft.Azure.EventHubs.Primitives;
-    using Microsoft.Azure.Storage;
+    using Microsoft.WindowsAzure.Storage;
 
     /// <summary>
     /// Represents a host for processing Event Hubs event data.

--- a/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/Microsoft.Azure.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/Microsoft.Azure.EventHubs.Processor.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault.Core" />
-    <PackageReference Include="Microsoft.Azure.Storage.Blob" />
+    <PackageReference Include="WindowsAzure.Storage" />
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 </Project>

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
@@ -1,31 +1,31 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Net.Sockets;
-using System.Runtime.CompilerServices;
-using System.Security.Authentication;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Azure.Management.EventHub;
-using Microsoft.Azure.Management.EventHub.Models;
-using Microsoft.Azure.Management.ResourceManager;
-using Microsoft.Azure.Management.Storage;
-using Microsoft.Azure.Storage;
-using Microsoft.IdentityModel.Clients.ActiveDirectory;
-using Microsoft.Rest;
-using Microsoft.Rest.Azure;
-using Polly;
-
-using StorageManagement = Microsoft.Azure.Management.Storage.Models;
-
 namespace Microsoft.Azure.EventHubs.Tests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Net.Sockets;
+    using System.Runtime.CompilerServices;
+    using System.Security.Authentication;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Management.EventHub;
+    using Microsoft.Azure.Management.EventHub.Models;
+    using Microsoft.Azure.Management.ResourceManager;
+    using Microsoft.Azure.Management.Storage;
+    using Microsoft.IdentityModel.Clients.ActiveDirectory;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Azure;
+    using Microsoft.WindowsAzure.Storage;
+    using Polly;
+
+    using StorageManagement = Microsoft.Azure.Management.Storage.Models;
+
     internal sealed class EventHubScope : IAsyncDisposable
     {
         private const int RetryMaximumAttempts = 20;

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Processor/ProcessorTestBase.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Processor/ProcessorTestBase.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
     using System.Threading.Tasks;
     using Microsoft.Azure.EventHubs.Primitives;
     using Microsoft.Azure.EventHubs.Processor;
-    using Microsoft.Azure.Storage;
     using Microsoft.IdentityModel.Clients.ActiveDirectory;
+    using Microsoft.WindowsAzure.Storage;
     using Xunit;
 
     public class ProcessorTestBase


### PR DESCRIPTION
Storage SDK stopped respecting ServicePointManager settings starting with 9.4 and this is causing issues for our customers since we moved up from 9.3.  I am rolling back to 9.3 until the issue is addressed.

Issue is tracked on Storage Github Repo - https://github.com/Azure/azure-storage-net/issues/971
