### PR TITLE
[EventHubs] Distributed Tracing: Linked send scopes to message scopes (Track Two)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
@@ -779,13 +779,19 @@ namespace Azure.Messaging.EventHubs.Tests
         ///   the producer being tested.
         /// </summary>
         ///
+        /// <remarks>
+        ///   <see cref="AsEnumerable{T}" /> must be overriden because it's called
+        ///   when instrumenting events for distributed tracing.  We can safely return
+        ///   <c>null</c> here because it's not being actually tested by this test class.
+        /// </remarks>
+        ///
         private class MockTransportBatch : TransportEventBatch
         {
             public override long MaximumSizeInBytes { get; }
             public override long SizeInBytes { get; }
             public override int Count { get; }
             public override bool TryAdd(EventData eventData) => throw new NotImplementedException();
-            public override IEnumerable<T> AsEnumerable<T>() => throw new NotImplementedException();
+            public override IEnumerable<T> AsEnumerable<T>() => null;
             public override void Dispose() => throw new NotImplementedException();
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
@@ -779,19 +779,13 @@ namespace Azure.Messaging.EventHubs.Tests
         ///   the producer being tested.
         /// </summary>
         ///
-        /// <remarks>
-        ///   <see cref="AsEnumerable{T}" /> must be overriden because it's called
-        ///   when instrumenting events for distributed tracing.  We can safely return
-        ///   <c>null</c> here because it's not being actually tested by this test class.
-        /// </remarks>
-        ///
         private class MockTransportBatch : TransportEventBatch
         {
             public override long MaximumSizeInBytes { get; }
             public override long SizeInBytes { get; }
             public override int Count { get; }
             public override bool TryAdd(EventData eventData) => throw new NotImplementedException();
-            public override IEnumerable<T> AsEnumerable<T>() => null;
+            public override IEnumerable<T> AsEnumerable<T>() => throw new NotImplementedException();
             public override void Dispose() => throw new NotImplementedException();
         }
     }


### PR DESCRIPTION
Fixes #9073.

- Added links to message scopes to send scope before sending a set of messages (both in batch and in array send).
- Added two new tests.