### PR TITLE
Azure.Identity adding KnownAuthorityHosts constants

### DIFF
--- a/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
+++ b/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
@@ -97,6 +97,13 @@ namespace Azure.Identity
         public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
+    public static partial class KnownAuthorityHosts
+    {
+        public static readonly System.Uri AzureChinaCloud;
+        public static readonly System.Uri AzureCloud;
+        public static readonly System.Uri AzureGermanCloud;
+        public static readonly System.Uri AzureUsGovernment;
+    }
     public partial class ManagedIdentityCredential : Azure.Core.TokenCredential
     {
         protected ManagedIdentityCredential() { }

--- a/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
+++ b/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
@@ -102,7 +102,7 @@ namespace Azure.Identity
         public static readonly System.Uri AzureChinaCloud;
         public static readonly System.Uri AzureCloud;
         public static readonly System.Uri AzureGermanCloud;
-        public static readonly System.Uri AzureUsGovernment;
+        public static readonly System.Uri AzureUSGovernment;
     }
     public partial class ManagedIdentityCredential : Azure.Core.TokenCredential
     {

--- a/sdk/identity/Azure.Identity/src/KnownAuthorityHosts.cs
+++ b/sdk/identity/Azure.Identity/src/KnownAuthorityHosts.cs
@@ -28,6 +28,6 @@ namespace Azure.Identity
         /// <summary>
         /// The host of the Azure Active Directory authority for tenants in the Azure US Government Cloud.
         /// </summary>
-        public static readonly Uri AzureUsGovernment = new Uri("https://login.microsoftonline.us/");
+        public static readonly Uri AzureUSGovernment = new Uri("https://login.microsoftonline.us/");
     }
 }

--- a/sdk/identity/Azure.Identity/src/KnownAuthorityHosts.cs
+++ b/sdk/identity/Azure.Identity/src/KnownAuthorityHosts.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Identity
+{
+    /// <summary>
+    /// Defines fields exposing the well known authority hosts for the Azure Public Cloud and sovereign clouds.
+    /// </summary>
+    public static class KnownAuthorityHosts
+    {
+        /// <summary>
+        /// The host of the Azure Active Directory authority for tenants in the Azure Public Cloud.
+        /// </summary>
+        public static readonly Uri AzureCloud = new Uri("https://login.microsoftonline.com/");
+
+        /// <summary>
+        /// The host of the Azure Active Directory authority for tenants in the Azure China Cloud.
+        /// </summary>
+        public static readonly Uri AzureChinaCloud = new Uri("https://login.chinacloudapi.cn/");
+
+        /// <summary>
+        /// The host of the Azure Active Directory authority for tenants in the Azure German Cloud.
+        /// </summary>
+        public static readonly Uri AzureGermanCloud = new Uri("https://login.microsoftonline.de/");
+
+        /// <summary>
+        /// The host of the Azure Active Directory authority for tenants in the Azure US Government Cloud.
+        /// </summary>
+        public static readonly Uri AzureUsGovernment = new Uri("https://login.microsoftonline.us/");
+    }
+}

--- a/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
@@ -7,14 +7,12 @@ using Azure.Core;
 namespace Azure.Identity
 {
     /// <summary>
-    /// Options to configure requests made to the OAUTH identity service
+    /// Options to configure requests made to the OAUTH identity service.
     /// </summary>
     public class TokenCredentialOptions : ClientOptions
     {
-        private static readonly Uri s_defaultAuthorityHost = new Uri("https://login.microsoftonline.com/");
-
         /// <summary>
-        /// The host of the Azure Active Directory authority.   The default is https://login.microsoftonline.com/
+        /// The host of the Azure Active Directory authority. The default is https://login.microsoftonline.com/. For common authority hosts for known azure cloud instances see <see cref="KnownAuthorityHosts"/>.
         /// </summary>
         public Uri AuthorityHost { get; set; }
 
@@ -23,7 +21,7 @@ namespace Azure.Identity
         /// </summary>
         public TokenCredentialOptions()
         {
-            AuthorityHost = s_defaultAuthorityHost;
+            AuthorityHost = KnownAuthorityHosts.AzureCloud;
         }
     }
 }

--- a/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
@@ -12,7 +12,7 @@ namespace Azure.Identity
     public class TokenCredentialOptions : ClientOptions
     {
         /// <summary>
-        /// The host of the Azure Active Directory authority. The default is https://login.microsoftonline.com/. For common authority hosts for known azure cloud instances see <see cref="KnownAuthorityHosts"/>.
+        /// The host of the Azure Active Directory authority. The default is https://login.microsoftonline.com/. For well known authority hosts for Azure cloud instances see <see cref="KnownAuthorityHosts"/>.
         /// </summary>
         public Uri AuthorityHost { get; set; }
 


### PR DESCRIPTION
This pull request adds a static class `KnownAuthorityHosts` which defines fields for the authority host Uri's for all known azure cloud instances. 

Fixes #10228