### PR TITLE
[Event Hub Client] Event Processor<T> Initialization

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/EventProcessorClientEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/EventProcessorClientEventSource.cs
@@ -17,7 +17,7 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
     /// </remarks>
     ///
     [EventSource(Name = EventSourceName)]
-    internal class EventProcessorEventSource : EventSource
+    internal class EventProcessorClientEventSource : EventSource
     {
         /// <summary>The name to use for the event source.</summary>
         private const string EventSourceName = "Azure-Messaging-EventHubs-Processor-EventProcessorClient";
@@ -27,14 +27,14 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         ///   use for logging.
         /// </summary>
         ///
-        public static EventProcessorEventSource Log { get; } = new EventProcessorEventSource();
+        public static EventProcessorClientEventSource Log { get; } = new EventProcessorClientEventSource();
 
         /// <summary>
-        ///   Prevents an instance of the <see cref="EventProcessorEventSource"/> class from being created
+        ///   Prevents an instance of the <see cref="EventProcessorClientEventSource"/> class from being created
         ///   outside the scope of this library.  Exposed for testing purposes only.
         /// </summary>
         ///
-        internal EventProcessorEventSource() : base(EventSourceName, EventSourceSettings.Default, AzureEventSourceListener.TraitName, AzureEventSourceListener.TraitValue)
+        internal EventProcessorClientEventSource() : base(EventSourceName, EventSourceSettings.Default, AzureEventSourceListener.TraitName, AzureEventSourceListener.TraitValue)
         {
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -245,10 +245,10 @@ namespace Azure.Messaging.EventHubs
         internal virtual TimeSpan OwnershipExpiration => TimeSpan.FromSeconds(30);
 
         /// <summary>
-        ///   The instance of <see cref="EventProcessorEventSource" /> which can be mocked for testing.
+        ///   The instance of <see cref="EventProcessorClientEventSource" /> which can be mocked for testing.
         /// </summary>
         ///
-        internal EventProcessorEventSource Logger { get; set; } = EventProcessorEventSource.Log;
+        internal EventProcessorClientEventSource Logger { get; set; } = EventProcessorClientEventSource.Log;
 
         /// <summary>
         ///   Responsible for ownership claim for load balancing.

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
@@ -1425,7 +1425,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var mockProcessor = new Mock<EventProcessorClient>(Mock.Of<StorageManager>(), "consumerGroup", "namespace", "eventHub", Mock.Of<Func<EventHubConnection>>(), default, default);
 
-            var mockLog = new Mock<EventProcessorEventSource>();
+            var mockLog = new Mock<EventProcessorClientEventSource>();
             mockProcessor.CallBase = true;
             mockProcessor.Object.Logger = mockLog.Object;
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -281,9 +281,9 @@ namespace Azure.Messaging.EventHubs.Primitives
     public abstract partial class EventProcessor<TPartition> where TPartition : Azure.Messaging.EventHubs.Primitives.EventProcessorPartition, new()
     {
         protected EventProcessor() { }
-        protected EventProcessor(int eventBatchMaximumSize, string consumerGroup, string connectionString, Azure.Messaging.EventHubs.Primitives.EventProcessorOptions options = null) { }
-        protected EventProcessor(int eventBatchMaximumSize, string consumerGroup, string fullyQualifiedNamespace, string eventHubName, Azure.Core.TokenCredential credential, Azure.Messaging.EventHubs.Primitives.EventProcessorOptions options = null) { }
-        protected EventProcessor(int eventBatchMaximumSize, string consumerGroup, string connectionString, string eventHubName, Azure.Messaging.EventHubs.Primitives.EventProcessorOptions options = null) { }
+        protected EventProcessor(int eventBatchMaximumCount, string consumerGroup, string connectionString, Azure.Messaging.EventHubs.Primitives.EventProcessorOptions options = null) { }
+        protected EventProcessor(int eventBatchMaximumCount, string consumerGroup, string fullyQualifiedNamespace, string eventHubName, Azure.Core.TokenCredential credential, Azure.Messaging.EventHubs.Primitives.EventProcessorOptions options = null) { }
+        protected EventProcessor(int eventBatchMaximumCount, string consumerGroup, string connectionString, string eventHubName, Azure.Messaging.EventHubs.Primitives.EventProcessorOptions options = null) { }
         public string ConsumerGroup { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
         public string EventHubName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
         public string FullyQualifiedNamespace { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/design/event-processor{T}-proposal.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/design/event-processor{T}-proposal.md
@@ -378,20 +378,20 @@ public abstract class EventProcessor<TPartition> where TPartition : EventProcess
     public bool IsRunning { get; protected set; }
     
     protected EventProcessor(
-        int eventBatchMaximumSize,
+        int eventBatchMaximumCount,
         string consumerGroup, 
         string connectionString, 
         EventProcessorOptions options = default);
         
     protected EventProcessor(
-        int eventBatchMaximumSize,
+        int eventBatchMaximumCount,
         string consumerGroup, 
         string connectionString, 
         string eventHubName, 
         EventProcessorOptions options = default);
     
     protected EventProcessor(
-        int eventBatchMaximumSize,
+        int eventBatchMaximumCount,
         string consumerGroup,  
         string fullyQualifiedNamespace, 
         string eventHubName, 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -10,8 +10,8 @@ using Azure.Messaging.EventHubs.Producer;
 namespace Azure.Messaging.EventHubs.Diagnostics
 {
     /// <summary>
-    ///   Serves as an ETW event source for logging of information about
-    ///   Event Hubs client.
+    ///   Serves as an ETW event source for logging of information about the
+    ///   Event Hubs client types.
     /// </summary>
     ///
     /// <remarks>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.cs
@@ -1,0 +1,187 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Messaging.EventHubs.Primitives;
+using Moq;
+using Moq.Protected;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="EventProcessor{TPartition}" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class EventProcessorTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the <see cref="StorageManager" />
+        ///   used by the processor.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ProcessorStorageManagerDelegatesCalls()
+        {
+            var listCheckpointsDelegated = false;
+            var listOwnershipDelegated = false;
+            var claimOwnershipDelegated = false;
+            var fqNamespace = "fqns";
+            var eventHub = "eh";
+            var consumerGroup = "cg";
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(25, consumerGroup, fqNamespace, eventHub, Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+
+            mockProcessor
+                .Protected()
+                .Setup<Task<IEnumerable<EventProcessorCheckpoint>>>("ListCheckpointsAsync", ItExpr.IsAny<CancellationToken>())
+                .Callback(() => listCheckpointsDelegated = true)
+                .Returns(Task.FromResult(default(IEnumerable<EventProcessorCheckpoint>)));
+
+            mockProcessor
+                .Protected()
+                .Setup<Task<IEnumerable<EventProcessorPartitionOwnership>>>("ListOwnershipAsync", ItExpr.IsAny<CancellationToken>())
+                .Callback(() => listOwnershipDelegated = true)
+                .Returns(Task.FromResult(default(IEnumerable<EventProcessorPartitionOwnership>)));
+
+            mockProcessor
+                .Protected()
+                .Setup<Task<IEnumerable<EventProcessorPartitionOwnership>>>("ClaimOwnershipAsync", ItExpr.IsAny<IEnumerable<EventProcessorPartitionOwnership>>(), ItExpr.IsAny<CancellationToken>())
+                .Callback(() => claimOwnershipDelegated = true)
+                .Returns(Task.FromResult(default(IEnumerable<EventProcessorPartitionOwnership>)));
+
+            var storageManager = mockProcessor.Object.CreateStorageManager(mockProcessor.Object);
+            Assert.That(storageManager, Is.Not.Null, "The storage manager should have been created.");
+
+            await storageManager.ListCheckpointsAsync("na", "na", "na", CancellationToken.None);
+            Assert.That(listCheckpointsDelegated, Is.True, $"The call to { nameof(storageManager.ListCheckpointsAsync) } should have been delegated.");
+
+            await storageManager.ListOwnershipAsync("na", "na", "na", CancellationToken.None);
+            Assert.That(listOwnershipDelegated, Is.True, $"The call to { nameof(storageManager.ListOwnershipAsync) } should have been delegated.");
+
+            await storageManager.ClaimOwnershipAsync(default(IEnumerable<EventProcessorPartitionOwnership>), CancellationToken.None);
+            Assert.That(claimOwnershipDelegated, Is.True, $"The call to { nameof(storageManager.ClaimOwnershipAsync) } should have been delegated.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="StorageManager" />
+        ///   used by the processor.
+        /// </summary>
+        ///
+        [Test]
+        public void ProcessorStorageManagerDoesNotAllowCheckpointUpdate()
+        {
+            var fqNamespace = "fqns";
+            var eventHub = "eh";
+            var consumerGroup = "cg";
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(25, consumerGroup, fqNamespace, eventHub, Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+
+            var storageManager = mockProcessor.Object.CreateStorageManager(mockProcessor.Object);
+            Assert.That(storageManager, Is.Not.Null, "The storage manager should have been created.");
+
+            Assert.That(() => storageManager.UpdateCheckpointAsync(new EventProcessorCheckpoint(), new EventData(Array.Empty<byte>()), CancellationToken.None), Throws.InstanceOf<NotImplementedException>(), "Calling to update checkpoints should not be implemented.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="StorageManager" />
+        ///   used by the processor.
+        /// </summary>
+        ///
+        [Test]
+        public async Task TheStorageManagerDoesNotKeepTheProcessorAlive()
+        {
+            var fqNamespace = "fqns";
+            var eventHub = "eh";
+            var consumerGroup = "cg";
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(25, consumerGroup, fqNamespace, eventHub, Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+            var storageManager = mockProcessor.Object.CreateStorageManager(mockProcessor.Object);
+
+            mockProcessor
+                .Protected()
+                .Setup<Task<IEnumerable<EventProcessorCheckpoint>>>("ListCheckpointsAsync", ItExpr.IsAny<CancellationToken>())
+                .Returns(Task.FromResult(default(IEnumerable<EventProcessorCheckpoint>)));
+
+            Assert.That(storageManager, Is.Not.Null, "The storage manager should have been created.");
+            Assert.That(() => storageManager.ListCheckpointsAsync(fqNamespace, eventHub, consumerGroup, CancellationToken.None), Throws.Nothing, "The initial call should be successful.");
+
+            // Attempt to clear out the processor and force GC.
+
+            mockProcessor = null;
+
+            // Because cleanup may be non-deterministic, allow a small set of retries.
+
+            var attempts = 0;
+            var maxAttempts = 5;
+
+            while (attempts <= maxAttempts)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1));
+
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+
+                try
+                {
+                    Assert.That(() => storageManager.ListCheckpointsAsync(fqNamespace, eventHub, consumerGroup, CancellationToken.None), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
+                }
+                catch (AssertionException)
+                {
+                    if (++attempts <= maxAttempts)
+                    {
+                        continue;
+                    }
+
+                    throw;
+                }
+
+                // If things have gotten here, the test passes.
+
+                break;
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}" />
+        ///   constructor.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ProcessorLoadBalancerUsesTheExpectedStorageManager()
+        {
+            var fqNamespace = "fqns";
+            var eventHub = "eh";
+            var consumerGroup = "cg";
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(25, consumerGroup, fqNamespace, eventHub, Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+            var loadBalancer = GetLoadBalancer(mockProcessor.Object);
+
+            Assert.That(loadBalancer, Is.Not.Null, "The load balancer should have been created.");
+            await loadBalancer.RelinquishOwnershipAsync(CancellationToken.None);
+
+            mockProcessor
+                .Protected()
+                .Verify<Task<IEnumerable<EventProcessorPartitionOwnership>>>("ClaimOwnershipAsync", Times.Once(), ItExpr.IsAny<IEnumerable<EventProcessorPartitionOwnership>>(), ItExpr.IsAny<CancellationToken>());
+        }
+
+        /// <summary>
+        ///   Retrieves the load balancer for an event processor instance, using its private accessor.
+        /// </summary>
+        ///
+        /// <typeparam name="T">The partition type to which the processor is bound.</typeparam>
+        ///
+        /// <param name="processor">The processor instance to read the load balancer for.</param>
+        ///
+        /// <returns>The load balancer used by the processor.</returns>
+        ///
+        private static PartitionLoadBalancer GetLoadBalancer<T>(EventProcessor<T> processor) where T : EventProcessorPartition, new() =>
+            (PartitionLoadBalancer)
+                typeof(EventProcessor<T>)
+                    .GetProperty("LoadBalancer", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .GetValue(processor);
+    }
+}


### PR DESCRIPTION
# Summary

The focus of these changes is to begin building out the `EventProcessor<T>` implementation, starting with private infrastructure and initializing state
during construction.

**Note:**  The design to which these changes belong has been reviewed and approved by the SDK architecture board and by the language architect.   Marking with the corresponding tag for tracking purposes.

# Last Upstream Rebase

Thursday, March 5, 2:11pm (EST)

# References and Related Issues 

- [.NET Event Hubs Client: Event Processor<T> Proposal](https://gist.github.com/jsquire/1f4a1e72fc02871f443ce365222d40f6)
- [Implement the Event Processor Base](https://github.com/Azure/azure-sdk-for-net/issues/9324) (#9324)  