### PR TITLE
Remove maximum package version constraint from System.IdentityModel.T…

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -84,7 +84,7 @@
     <PackageReference Update="System.Diagnostics.Tools" Version="4.3.0" />
     <PackageReference Update="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Update="System.Globalization" Version="4.3.0" />
-    <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="[5.4.0, 6.0.0)" />
+    <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="5.4.0" />
     <PackageReference Update="System.IO.Compression" Version="4.3.0" />
     <PackageReference Update="System.Linq" Version="4.3.0" />
     <PackageReference Update="System.Net.Http" Version="4.3.4" />


### PR DESCRIPTION
…okens.Jwt dependency

Few other dependencies impose a maximum version constraint, and I need to use Azure libs with an internal version of this package greater than 6.0.0.