### PR TITLE
[EventHubs] Partition Receiver Options (Track Two)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClientOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClientOptions.cs
@@ -8,7 +8,7 @@ using Azure.Messaging.EventHubs.Core;
 namespace Azure.Messaging.EventHubs.Consumer
 {
     /// <summary>
-    ///   The set of options that can be specified when creating a <see cref="EventHubConsumerClient" />
+    ///   The set of options that can be specified when creating an <see cref="EventHubConsumerClient" />
     ///   to configure its behavior.
     /// </summary>
     ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/ReadEventOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/ReadEventOptions.cs
@@ -29,6 +29,13 @@ namespace Azure.Messaging.EventHubs.Consumer
         ///
         /// <value>The relative priority to associate with an exclusive reader; for a non-exclusive reader, this value should be <c>null</c>.</value>
         ///
+        /// <remarks>
+        ///   An <see cref="EventHubsException"/> will occur if an <see cref="EventHubConsumerClient"/> is unable to read events from the
+        ///   requested Event Hub partition for the given consumer group.  In this case, the <see cref="EventHubsException.FailureReason"/>
+        ///   will be set to <see cref="EventHubsException.FailureReason.ConsumerDisconnected"/>.
+        /// </remarks>
+        ///
+        /// <seealso cref="EventHubsException"/>
         /// <seealso cref="EventHubsException.FailureReason.ConsumerDisconnected"/>
         ///
         public long? OwnerLevel { get; set; }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/ReadEventOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/ReadEventOptions.cs
@@ -19,7 +19,7 @@ namespace Azure.Messaging.EventHubs.Consumer
 
         /// <summary>
         ///   When populated, the owner level indicates that a reading is intended to be performed exclusively for events in the
-        ///   requested partition and an for the associated consumer group.  To do so, reading will attempt to assert ownership
+        ///   requested partition and for the associated consumer group.  To do so, reading will attempt to assert ownership
         ///   over the partition; in the case where more than one exclusive reader attempts to assert ownership for the same
         ///   partition/consumer group pair, the one having a larger <see cref="OwnerLevel"/> value will "win."
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/ReadEventOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/ReadEventOptions.cs
@@ -29,6 +29,8 @@ namespace Azure.Messaging.EventHubs.Consumer
         ///
         /// <value>The relative priority to associate with an exclusive reader; for a non-exclusive reader, this value should be <c>null</c>.</value>
         ///
+        /// <seealso cref="EventHubsException.FailureReason.ConsumerDisconnected"/>
+        ///
         public long? OwnerLevel { get; set; }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.ComponentModel;
+using System.Threading;
+using Azure.Messaging.EventHubs.Consumer;
+
+namespace Azure.Messaging.EventHubs.Primitives
+{
+    /// <summary>
+    ///   Allows events from a specific partition of an Event Hub, and in the context
+    ///   of a specific consumer group, to be read with a greater level of control over
+    ///   communication with the Event Hubs service than is offered by other event consumers.
+    /// </summary>
+    ///
+    /// <remarks>
+    ///   It is recommended that the <c>EventProcessorClient</c> or <see cref="EventHubConsumerClient" />
+    ///   be used for reading and processing events for the majority of scenarios.  The partition receiver is
+    ///   intended to enable scenarios with special needs which require more direct control.
+    /// </remarks>
+    ///
+    /// <seealso cref="EventHubConsumerClient.ReadEventsFromPartitionAsync(string, EventPosition, CancellationToken)"/>
+    /// <seealso cref="EventHubConsumerClient.ReadEventsFromPartitionAsync(string, EventPosition, ReadEventOptions, CancellationToken)"/>
+    ///
+    internal class PartitionReceiver
+    {
+        /// <summary>
+        ///   Determines whether the specified <see cref="System.Object" /> is equal to this instance.
+        /// </summary>
+        ///
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+        ///
+        /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => base.Equals(obj);
+
+        /// <summary>
+        ///   Returns a hash code for this instance.
+        /// </summary>
+        ///
+        /// <returns>A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => base.GetHashCode();
+
+        /// <summary>
+        ///   Converts the instance to string representation.
+        /// </summary>
+        ///
+        /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override string ToString() => base.ToString();
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
@@ -8,7 +8,7 @@ using Azure.Messaging.EventHubs.Consumer;
 namespace Azure.Messaging.EventHubs.Primitives
 {
     /// <summary>
-    ///   Allows events from a specific partition of an Event Hub, and in the context
+    ///   Allows reading events from a specific partition of an Event Hub, and in the context
     ///   of a specific consumer group, to be read with a greater level of control over
     ///   communication with the Event Hubs service than is offered by other event consumers.
     /// </summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiverOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiverOptions.cs
@@ -1,0 +1,173 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ComponentModel;
+using Azure.Core;
+using Azure.Messaging.EventHubs.Core;
+
+namespace Azure.Messaging.EventHubs.Primitives
+{
+    /// <summary>
+    ///   The set of options that can be specified when creating a <see cref="PartitionReceiver" />
+    ///   to configure its behavior.
+    /// </summary>
+    ///
+    internal class PartitionReceiverOptions
+    {
+        /// <summary>The set of options to use for configuring the connection to the Event Hubs service.</summary>
+        private EventHubConnectionOptions _connectionOptions = new EventHubConnectionOptions();
+
+        /// <summary>The set of options to govern retry behavior and try timeouts.</summary>
+        private EventHubsRetryOptions _retryOptions = new EventHubsRetryOptions();
+
+        /// <summary>The amount of time to wait for messages when reading.</summary>
+        private TimeSpan _defaultMaximumReceiveWaitTime = TimeSpan.FromMinutes(1);
+
+        /// <summary>The prefetch count to use for the partition receiver.</summary>
+        private int? _prefetchCount = null;
+
+        /// <summary>
+        ///   The options used for configuring the connection to the Event Hubs service.
+        /// </summary>
+        ///
+        public EventHubConnectionOptions ConnectionOptions
+        {
+            get => _connectionOptions;
+            set
+            {
+                Argument.AssertNotNull(value, nameof(ConnectionOptions));
+                _connectionOptions = value;
+            }
+        }
+
+        /// <summary>
+        ///   The set of options to use for determining whether a failed operation should be retried and,
+        ///   if so, the amount of time to wait between retry attempts.  These options also control the
+        ///   amount of time allowed for reading events and other interactions with the Event Hubs service.
+        /// </summary>
+        ///
+        public EventHubsRetryOptions RetryOptions
+        {
+            get => _retryOptions;
+            set
+            {
+                Argument.AssertNotNull(value, nameof(RetryOptions));
+                _retryOptions = value;
+            }
+        }
+
+        /// <summary>
+        ///   The default amount of time to wait for the requested amount of messages when reading; if this
+        ///   period elapses before the requested amount of messages were available or read, then the set of
+        ///   messages that were read will be returned.
+        /// </summary>
+        ///
+        public TimeSpan DefaultMaximumReceiveWaitTime
+        {
+            get => _defaultMaximumReceiveWaitTime;
+
+            set
+            {
+                Argument.AssertNotNegative(value, nameof(DefaultMaximumReceiveWaitTime));
+                _defaultMaximumReceiveWaitTime = value;
+            }
+        }
+
+        /// <summary>
+        ///   When populated, the owner level indicates that a reading is intended to be performed exclusively for events in the
+        ///   requested partition and for the associated consumer group.  To do so, reading will attempt to assert ownership
+        ///   over the partition; in the case where more than one exclusive reader attempts to assert ownership for the same
+        ///   partition/consumer group pair, the one having a larger <see cref="OwnerLevel"/> value will "win."
+        ///
+        ///   When an exclusive reader is used, other readers which are non-exclusive or which have a lower owner level will either
+        ///   not be allowed to be created, if they already exist, will encounter an exception during the next attempted operation.
+        /// </summary>
+        ///
+        /// <value>The relative priority to associate with an exclusive reader; for a non-exclusive reader, this value should be <c>null</c>.</value>
+        ///
+        public long? OwnerLevel { get; set; }
+
+        /// <summary>
+        ///   The count used by the partition receiver to control the number of messages it will actively
+        ///   read and queue locally without regard to whether a read operation is currently active.
+        /// </summary>
+        ///
+        public int? PrefetchCount
+        {
+            get => _prefetchCount;
+
+            set
+            {
+                if (value.HasValue)
+                {
+                    Argument.AssertAtLeast(value.Value, 0, nameof(PrefetchCount));
+                }
+
+                _prefetchCount = value;
+            }
+        }
+
+        /// <summary>
+        ///   Indicates whether or not the reader should request information on the last enqueued event on the partition
+        ///   associated with a given event, and track that information as events are read.
+        /// </summary>
+        ///
+        /// <value><c>true</c> if information about a partition's last event should be requested and tracked; otherwise, <c>false</c>.</value>
+        ///
+        /// <remarks>
+        ///   When information about a partition's last enqueued event is being tracked, each event received from the Event Hubs
+        ///   service will carry metadata about the partition that it otherwise would not. This results in a small amount of
+        ///   additional network bandwidth consumption that is generally a favorable trade-off when considered
+        ///   against periodically making requests for partition properties using one of the Event Hub clients.
+        /// </remarks>
+        ///
+        public bool TrackLastEnqueuedEventInformation { get; set; } = true;
+
+        /// <summary>
+        ///   Determines whether the specified <see cref="System.Object" /> is equal to this instance.
+        /// </summary>
+        ///
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+        ///
+        /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => base.Equals(obj);
+
+        /// <summary>
+        ///   Returns a hash code for this instance.
+        /// </summary>
+        ///
+        /// <returns>A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => base.GetHashCode();
+
+        /// <summary>
+        ///   Converts the instance to string representation.
+        /// </summary>
+        ///
+        /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override string ToString() => base.ToString();
+
+        /// <summary>
+        ///   Creates a new copy of the current <see cref="PartitionReceiverOptions" />, cloning its attributes into a new instance.
+        /// </summary>
+        ///
+        /// <returns>A new copy of <see cref="PartitionReceiverOptions" />.</returns>
+        ///
+        internal PartitionReceiverOptions Clone() =>
+            new PartitionReceiverOptions
+            {
+                _connectionOptions = ConnectionOptions.Clone(),
+                _retryOptions = RetryOptions.Clone(),
+                _defaultMaximumReceiveWaitTime = DefaultMaximumReceiveWaitTime,
+                OwnerLevel = OwnerLevel,
+                _prefetchCount = PrefetchCount,
+                TrackLastEnqueuedEventInformation = TrackLastEnqueuedEventInformation
+            };
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiverOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiverOptions.cs
@@ -22,10 +22,10 @@ namespace Azure.Messaging.EventHubs.Primitives
         private EventHubsRetryOptions _retryOptions = new EventHubsRetryOptions();
 
         /// <summary>The amount of time to wait for messages when reading.</summary>
-        private TimeSpan _defaultMaximumReceiveWaitTime = TimeSpan.FromMinutes(1);
+        private TimeSpan _defaultMaximumReceiveWaitTime = TimeSpan.FromSeconds(60);
 
         /// <summary>The prefetch count to use for the partition receiver.</summary>
-        private int? _prefetchCount = null;
+        private int _prefetchCount = 300;
 
         /// <summary>
         ///   The options used for configuring the connection to the Event Hubs service.
@@ -100,17 +100,13 @@ namespace Azure.Messaging.EventHubs.Primitives
         ///   Event Hubs.
         /// </value>
         ///
-        public int? PrefetchCount
+        public int PrefetchCount
         {
             get => _prefetchCount;
 
             set
             {
-                if (value.HasValue)
-                {
-                    Argument.AssertAtLeast(value.Value, 0, nameof(PrefetchCount));
-                }
-
+                Argument.AssertAtLeast(value, 0, nameof(PrefetchCount));
                 _prefetchCount = value;
             }
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiverOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiverOptions.cs
@@ -89,9 +89,16 @@ namespace Azure.Messaging.EventHubs.Primitives
         public long? OwnerLevel { get; set; }
 
         /// <summary>
-        ///   The count used by the partition receiver to control the number of messages it will actively
-        ///   read and queue locally without regard to whether a read operation is currently active.
+        ///   The number of events that will be eagerly requested from the Event Hubs service and queued locally without regard to
+        ///   whether a read operation is currently active, intended to help maximize throughput by allowing the partition receiver
+        ///   to read from a local cache rather than waiting on a service request.
         /// </summary>
+        ///
+        /// <value>
+        ///   The <see cref="PrefetchCount" /> is a control that developers can use to help tune performance for the specific
+        ///   needs of an application, given its expected size of events, throughput needs, and expected scenarios for using
+        ///   Event Hubs.
+        /// </value>
         ///
         public int? PrefetchCount
         {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiverOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiverOptions.cs
@@ -22,7 +22,7 @@ namespace Azure.Messaging.EventHubs.Primitives
         private EventHubsRetryOptions _retryOptions = new EventHubsRetryOptions();
 
         /// <summary>The amount of time to wait for messages when reading.</summary>
-        private TimeSpan _defaultMaximumReceiveWaitTime = TimeSpan.FromSeconds(60);
+        private TimeSpan? _defaultMaximumReceiveWaitTime = TimeSpan.FromSeconds(60);
 
         /// <summary>The prefetch count to use for the partition receiver.</summary>
         private int _prefetchCount = 300;
@@ -63,13 +63,17 @@ namespace Azure.Messaging.EventHubs.Primitives
         ///   messages that were read will be returned.
         /// </summary>
         ///
-        public TimeSpan DefaultMaximumReceiveWaitTime
+        public TimeSpan? DefaultMaximumReceiveWaitTime
         {
             get => _defaultMaximumReceiveWaitTime;
 
             set
             {
-                Argument.AssertNotNegative(value, nameof(DefaultMaximumReceiveWaitTime));
+                if (value.HasValue)
+                {
+                    Argument.AssertNotNegative(value.Value, nameof(DefaultMaximumReceiveWaitTime));
+                }
+
                 _defaultMaximumReceiveWaitTime = value;
             }
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiverOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiverOptions.cs
@@ -90,6 +90,13 @@ namespace Azure.Messaging.EventHubs.Primitives
         ///
         /// <value>The relative priority to associate with an exclusive reader; for a non-exclusive reader, this value should be <c>null</c>.</value>
         ///
+        /// <remarks>
+        ///   An <see cref="EventHubsException"/> will occur if a <see cref="PartitionReceiver"/> is unable to read events from the
+        ///   requested Event Hub partition for the given consumer group.  In this case, the <see cref="EventHubsException.FailureReason"/>
+        ///   will be set to <see cref="EventHubsException.FailureReason.ConsumerDisconnected"/>.
+        /// </remarks>
+        ///
+        /// <seealso cref="EventHubsException"/>
         /// <seealso cref="EventHubsException.FailureReason.ConsumerDisconnected"/>
         ///
         public long? OwnerLevel { get; set; }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiverOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiverOptions.cs
@@ -90,6 +90,8 @@ namespace Azure.Messaging.EventHubs.Primitives
         ///
         /// <value>The relative priority to associate with an exclusive reader; for a non-exclusive reader, this value should be <c>null</c>.</value>
         ///
+        /// <seealso cref="EventHubsException.FailureReason.ConsumerDisconnected"/>
+        ///
         public long? OwnerLevel { get; set; }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiverOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiverOptions.cs
@@ -122,7 +122,7 @@ namespace Azure.Messaging.EventHubs.Primitives
         ///   against periodically making requests for partition properties using one of the Event Hub clients.
         /// </remarks>
         ///
-        public bool TrackLastEnqueuedEventInformation { get; set; } = true;
+        public bool TrackLastEnqueuedEventProperties { get; set; } = true;
 
         /// <summary>
         ///   Determines whether the specified <see cref="System.Object" /> is equal to this instance.
@@ -167,7 +167,7 @@ namespace Azure.Messaging.EventHubs.Primitives
                 _defaultMaximumReceiveWaitTime = DefaultMaximumReceiveWaitTime,
                 OwnerLevel = OwnerLevel,
                 _prefetchCount = PrefetchCount,
-                TrackLastEnqueuedEventInformation = TrackLastEnqueuedEventInformation
+                TrackLastEnqueuedEventProperties = TrackLastEnqueuedEventProperties
             };
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverOptionsTests.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Messaging.EventHubs.Core;
+using Azure.Messaging.EventHubs.Primitives;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="PartitionReceiverOptions" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class PartitionReceiverOptionsTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionReceiverOptions.Clone" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CloneProducesACopy()
+        {
+            var options = new PartitionReceiverOptions
+            {
+                ConnectionOptions = new EventHubConnectionOptions { TransportType = EventHubsTransportType.AmqpWebSockets },
+                RetryOptions = new EventHubsRetryOptions { Mode = EventHubsRetryMode.Fixed },
+                DefaultMaximumReceiveWaitTime = TimeSpan.FromMilliseconds(9994),
+                OwnerLevel = 99,
+                PrefetchCount = 65,
+                TrackLastEnqueuedEventProperties = false
+            };
+
+            PartitionReceiverOptions clone = options.Clone();
+            Assert.That(clone, Is.Not.Null, "The clone should not be null.");
+            Assert.That(clone, Is.Not.SameAs(options), "The options should be a copy, not the same instance.");
+
+            Assert.That(clone.ConnectionOptions.TransportType, Is.EqualTo(options.ConnectionOptions.TransportType), "The connection options of the clone should copy properties.");
+            Assert.That(clone.ConnectionOptions, Is.Not.SameAs(options.ConnectionOptions), "The connection options of the clone should be a copy, not the same instance.");
+            Assert.That(clone.RetryOptions.IsEquivalentTo(options.RetryOptions), Is.True, "The retry options of the clone should be considered equal.");
+            Assert.That(clone.RetryOptions, Is.Not.SameAs(options.RetryOptions), "The retry options of the clone should be a copy, not the same instance.");
+            Assert.That(clone.DefaultMaximumReceiveWaitTime, Is.EqualTo(options.DefaultMaximumReceiveWaitTime), "The maximum wait time should match.");
+            Assert.That(clone.OwnerLevel, Is.EqualTo(options.OwnerLevel), "The owner level of the clone should match.");
+            Assert.That(clone.PrefetchCount, Is.EqualTo(options.PrefetchCount), "The prefetch count should match.");
+            Assert.That(clone.TrackLastEnqueuedEventProperties, Is.EqualTo(options.TrackLastEnqueuedEventProperties), "Tracking of last enqueued events should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionReceiverOptions.ConnectionOptions" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void ConnectionOptionsAreValidated()
+        {
+            Assert.That(() => new PartitionReceiverOptions { ConnectionOptions = null }, Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionReceiverOptions.RetryOptions" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void RetryOptionsAreValidated()
+        {
+            Assert.That(() => new PartitionReceiverOptions { RetryOptions = null }, Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionReceiverOptions.DefaultMaximumReceiveWaitTime" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(-1)]
+        [TestCase(-10)]
+        [TestCase(-100)]
+        public void DefaultMaximumReceiveWaitTimeIsValidated(int waitTimeSeconds)
+        {
+            Assert.That(() => new PartitionReceiverOptions { DefaultMaximumReceiveWaitTime = TimeSpan.FromSeconds(waitTimeSeconds) }, Throws.InstanceOf<ArgumentOutOfRangeException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionReceiverOptions.PrefetchCount" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(-1)]
+        [TestCase(-10)]
+        [TestCase(-100)]
+        public void PrefetchCountIsValidated(int count)
+        {
+            Assert.That(() => new PartitionReceiverOptions { PrefetchCount = count }, Throws.InstanceOf<ArgumentOutOfRangeException>());
+        }
+    }
+}


### PR DESCRIPTION
Included implementation and tests for the class `PartitionReceiverOptions`, which will be used to configure the `PartitionReceiver`. Names are not final and classes are `internal` for the time being.

This implementation is a simple adaptation of the `PartitionReceiver` that was present during previews and follows the [skeleton](https://gist.github.com/jsquire/4ea3368192cfee98dcbb4adfb29a9822) that will be used as a base for the final public API this class will have.

Related: 

- #9323 
- [Partition Receiver Design Proposal](https://gist.github.com/jsquire/4ea3368192cfee98dcbb4adfb29a9822)