### PR TITLE
[Text-analytics] Renames and more

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-preview.3 (Unreleased)
+## 1.0.0-preview.3 (2020-03-10)
 ### Breaking changes
 - In both `DocumentSentiment` and `SentenceSentiment` property `SentimentScores` has been renamed to `ConfidenceScores`.
 - In `LinkedEntity`, property `Id` has been renamed to `DataSourceEntityId`.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
@@ -1,18 +1,21 @@
 # Release History
 
 ## 1.0.0-preview.3 (Unreleased)
-- Renamed type `SentimentScorePerLabel` to `SentimentConfidenceScorePerLabel`.
+### Breaking changes
 - In both `DocumentSentiment` and `SentenceSentiment` property `SentimentScores` has been renamed to `ConfidenceScores`.
 - In `LinkedEntity`, property `Id` has been renamed to `DataSourceEntityId`.
 - Change wording in all documentation from `text inputs` to `documents`.
 - Properties `Length` and `Offset` have been renamed to `GraphemeLength` and `GraphemeOffset` for the `SentenceSentiment`,
 `CategorizedEntity`, `PiiEntity`, and `LinkedEntityMatch` objects, to make it clear that the offsets and lengths are in units of Unicode graphemes.
+- `CharacterCount` in `TextDocumentStatistics` has been renamed to `GraphemeCount`.
 - Unified `DocumentSentimentLabel` and `SentenceSentimentLabel` into `TextSentiment`.
 - `SentimentConfidenceScorePerLabel` renamed to `SentimentConfidenceScore`.
 - Extensible ENUM `SubCategory` has been deleted and managed as a string trhought the code.
+- `Score` has been renamed to `ConfidenceScore` for types `CategorizedEntity`, `LinkedEntityMatch`, and `PiiEntity`.
 
 ### New Features
  - Added `DetectLanguageInput.None` for user convenience when overriding the default behavior of `CountryHint`.
+ - Added `PersonType`, `Skill`, `Product`, `IP Address`, and `Event` to the `EntityCategory` ENUM.
 
 ## 1.0.0-preview.2 (2020-02-11)
 ### Breaking changes

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -191,7 +191,7 @@ IReadOnlyCollection<CategorizedEntity> entities = client.RecognizeEntities(input
 Console.WriteLine($"Recognized {entities.Count} entities:");
 foreach (CategorizedEntity entity in entities)
 {
-    Console.WriteLine($"Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Score: {entity.Score}");
+    Console.WriteLine($"Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
 }
 ```
 For samples on using the production recommended option `RecognizeEntitiesBatch` see [here](#recognize-entities-1).
@@ -209,7 +209,7 @@ IReadOnlyCollection<PiiEntity> entities = client.RecognizePiiEntities(input).Val
 Console.WriteLine($"Recognized {entities.Count()} PII entit{(entities.Count() > 1 ? "ies" : "y")}:");
 foreach (PiiEntity entity in entities)
 {
-    Console.WriteLine($"Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Score: {entity.Score}");
+    Console.WriteLine($"Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
 }
 ```
 
@@ -229,7 +229,7 @@ foreach (LinkedEntity linkedEntity in linkedEntities)
     Console.WriteLine($"Name: {linkedEntity.Name}, Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}, Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
     foreach (LinkedEntityMatch match in linkedEntity.Matches)
     {
-        Console.WriteLine($"    Match Text: {match.Text}, Score: {match.Score}");
+        Console.WriteLine($"    Match Text: {match.Text}, Confidence score: {match.ConfidenceScore}");
     }
 }
 ```
@@ -259,7 +259,7 @@ Response<IReadOnlyCollection<CategorizedEntity>> entities = await client.Recogni
 Console.WriteLine($"Recognized {entities.Value.Count} entities:");
 foreach (CategorizedEntity entity in entities.Value)
 {
-    Console.WriteLine($"Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Score: {entity.Score}");
+    Console.WriteLine($"Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
 }
 ```
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -48,7 +48,7 @@ For more information about creating the resource or how to get the location and 
 Install the Azure Text Analytics client library for .NET with [NuGet][nuget]:
 
 ```PowerShell
-Install-Package Azure.AI.TextAnalytics -Version 1.0.0-preview.2
+Install-Package Azure.AI.TextAnalytics -Version 1.0.0-preview.3
 ```
 
 ### Authenticate the client

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample4_RecognizeEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample4_RecognizeEntities.md
@@ -23,7 +23,7 @@ IReadOnlyCollection<CategorizedEntity> entities = client.RecognizeEntities(input
 Console.WriteLine($"Recognized {entities.Count} entities:");
 foreach (CategorizedEntity entity in entities)
 {
-    Console.WriteLine($"Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Score: {entity.Score}");
+    Console.WriteLine($"Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
 }
 ```
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample5_RecognizePiiEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample5_RecognizePiiEntities.md
@@ -23,7 +23,7 @@ IReadOnlyCollection<PiiEntity> entities = client.RecognizePiiEntities(input).Val
 Console.WriteLine($"Recognized {entities.Count()} PII entit{(entities.Count() > 1 ? "ies" : "y")}:");
 foreach (PiiEntity entity in entities)
 {
-    Console.WriteLine($"Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Score: {entity.Score}");
+    Console.WriteLine($"Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
 }
 ```
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
@@ -26,7 +26,7 @@ foreach (LinkedEntity linkedEntity in linkedEntities)
     Console.WriteLine($"Name: {linkedEntity.Name}, Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}, Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
     foreach (LinkedEntityMatch match in linkedEntity.Matches)
     {
-        Console.WriteLine($"    Match Text: {match.Text}, Score: {match.Score}");
+        Console.WriteLine($"    Match Text: {match.Text}, Confidence score: {match.ConfidenceScore}");
     }
 }
 ```

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/CategorizedEntity.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/CategorizedEntity.cs
@@ -18,7 +18,7 @@ namespace Azure.AI.TextAnalytics
             SubCategory = subCategory;
             GraphemeOffset = offset;
             GraphemeLength = length;
-            Score = score;
+            ConfidenceScore = score;
         }
 
         /// <summary>
@@ -57,6 +57,6 @@ namespace Azure.AI.TextAnalytics
         /// Gets a score between 0 and 1, indicating the confidence that the
         /// text substring matches this inferred entity.
         /// </summary>
-        public double Score { get; }
+        public double ConfidenceScore { get; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/EntityCategory.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/EntityCategory.cs
@@ -22,7 +22,12 @@ namespace Azure.AI.TextAnalytics
         public static readonly EntityCategory Person = new EntityCategory("Person");
 
         /// <summary>
-        /// Specifies that entity contains natural or human-made landmarks, structures, or geographical features.
+        /// Specifies that the entity corresponds to a job type or role held by a person.
+        /// </summary>
+        public static readonly EntityCategory PersonType = new EntityCategory("PersonType");
+
+        /// <summary>
+        /// Specifies that the entity contains natural or human-made landmarks, structures, or geographical features.
         /// </summary>
         public static readonly EntityCategory Location = new EntityCategory("Location");
 
@@ -30,6 +35,21 @@ namespace Azure.AI.TextAnalytics
         /// Specifies that the entity contains the name of an organization, corporation, agency, or other group of people.
         /// </summary>
         public static readonly EntityCategory Organization = new EntityCategory("Organization");
+
+        /// <summary>
+        /// Specifies that the entity contains historical, social and natural-occuring events.
+        /// </summary>
+        public static readonly EntityCategory Event = new EntityCategory("Event");
+
+        /// <summary>
+        /// Specifies that the entity contains physical objects of various categories.
+        /// </summary>
+        public static readonly EntityCategory Product = new EntityCategory("Product");
+
+        /// <summary>
+        /// Specifies an entity describing a capability or expertise.
+        /// </summary>
+        public static readonly EntityCategory Skill = new EntityCategory("Skill");
 
         /// <summary>
         /// Specifies that the entity contains a date, time or duration.
@@ -50,6 +70,11 @@ namespace Azure.AI.TextAnalytics
         /// Specifies that the entity contains an Internet URL.
         /// </summary>
         public static readonly EntityCategory Url = new EntityCategory("URL");
+
+        /// <summary>
+        /// Specifies that the entity contains an Internet Protocol Address.
+        /// </summary>
+        public static readonly EntityCategory IPAddress = new EntityCategory("IP");
 
         /// <summary>
         /// Specifies that the entity contains a number or numeric quantity.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/LinkedEntityMatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/LinkedEntityMatch.cs
@@ -13,7 +13,7 @@ namespace Azure.AI.TextAnalytics
         internal LinkedEntityMatch(string text, double score, int offset, int length)
         {
             Text = text;
-            Score = score;
+            ConfidenceScore = score;
             GraphemeOffset = offset;
             GraphemeLength = length;
         }
@@ -27,7 +27,7 @@ namespace Azure.AI.TextAnalytics
         /// Gets a score between 0 and 1, indicating the confidence that this
         /// substring matches the corresponding linked entity.
         /// </summary>
-        public double Score { get; }
+        public double ConfidenceScore { get; }
 
         /// <summary>
         /// Gets the starting position (in Unicode graphemes) for the matching text in the document.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/PiiEntity.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/PiiEntity.cs
@@ -18,7 +18,7 @@ namespace Azure.AI.TextAnalytics
             SubCategory = subCategory;
             GraphemeOffset = offset;
             GraphemeLength = length;
-            Score = score;
+            ConfidenceScore = score;
         }
 
         /// <summary>
@@ -57,6 +57,6 @@ namespace Azure.AI.TextAnalytics
         /// Gets a score between 0 and 1, indicating the confidence that the
         /// text substring matches this inferred entity.
         /// </summary>
-        public double Score { get; }
+        public double ConfidenceScore { get; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextDocumentStatistics.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextDocumentStatistics.cs
@@ -11,16 +11,16 @@ namespace Azure.AI.TextAnalytics
     /// </summary>
     public readonly struct TextDocumentStatistics
     {
-        internal TextDocumentStatistics(int characterCount, int transactionCount)
+        internal TextDocumentStatistics(int grahemeCount, int transactionCount)
         {
-            CharacterCount = characterCount;
+            GraphemeCount = grahemeCount;
             TransactionCount = transactionCount;
         }
 
         /// <summary>
-        /// Gets the number of characters the corresponding document contains.
+        /// Gets the number of characters (in Unicode graphemes) the corresponding document contains.
         /// </summary>
-        public int CharacterCount { get; }
+        public int GraphemeCount { get; }
 
         /// <summary>
         /// Gets the number of transactions used by the service to analyze the

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizeEntitiesCategories.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizeEntitiesCategories.json
@@ -4,13 +4,13 @@
       "RequestUri": "https://westus2.api.cognitive.microsoft.com/text/analytics/v3.0-preview.1/entities/recognition/general",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Content-Length": "233",
+        "Content-Length": "355",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d416e9b2568c9149b8245d13794b95f0-f9f3b569492f6841-00",
+        "traceparent": "00-8d411a0b2d8ded4aa2d52fa3485e42e0-d6334f77bc10784d-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200227.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200305.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "c23566a7af10e40859088ebc09aade1e",
         "x-ms-return-client-request-id": "true"
@@ -20,20 +20,20 @@
           {
             "language": "en",
             "id": "0",
-            "text": "Bill Gates | Microsoft | New Mexico | 800-102-1100 | help@microsoft.com | April 4, 1975 12:34 | April 4, 1975 | 12:34 | five seconds | 9 | third | 120% | \u20AC30 | 11m | 22 \u00B0C"
+            "text": "Bill Gates | Microsoft | New Mexico | 800-102-1100 | help@microsoft.com | April 4, 1975 12:34 | April 4, 1975 | 12:34 | five seconds | 9 | third | 120% | \u20AC30 | 11m | 22 \u00B0C |Software Engineer | Wedding | Microsoft Surface laptop | Coding | 127.0.0.1 | https://github.com/azure/azure-sdk-for-net"
           }
         ]
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "30b0abda-c0ce-46ba-86f5-246b416b0185",
+        "apim-request-id": "2519ee66-6a5b-4955-b4ca-b6dcf084c2fb",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1",
-        "Date": "Thu, 27 Feb 2020 17:33:52 GMT",
+        "Date": "Fri, 06 Mar 2020 03:38:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "156"
+        "x-envoy-upstream-service-time": "162"
       },
       "ResponseBody": {
         "documents": [
@@ -153,6 +153,48 @@
                 "subtype": "Temperature",
                 "offset": 166,
                 "length": 5,
+                "score": 0.8
+              },
+              {
+                "text": "Engineer",
+                "type": "PersonType",
+                "offset": 182,
+                "length": 8,
+                "score": 0.56
+              },
+              {
+                "text": "Wedding",
+                "type": "Event",
+                "offset": 193,
+                "length": 7,
+                "score": 0.39
+              },
+              {
+                "text": "Microsoft Surface laptop",
+                "type": "Product",
+                "offset": 203,
+                "length": 24,
+                "score": 0.53
+              },
+              {
+                "text": "Coding",
+                "type": "Skill",
+                "offset": 230,
+                "length": 6,
+                "score": 0.8
+              },
+              {
+                "text": "127.0.0.1",
+                "type": "IP",
+                "offset": 239,
+                "length": 9,
+                "score": 0.8
+              },
+              {
+                "text": "https://github.com/azure/azure-sdk-for-net",
+                "type": "URL",
+                "offset": 251,
+                "length": 42,
                 "score": 0.8
               }
             ]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizeEntitiesCategoriesAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizeEntitiesCategoriesAsync.json
@@ -4,13 +4,13 @@
       "RequestUri": "https://westus2.api.cognitive.microsoft.com/text/analytics/v3.0-preview.1/entities/recognition/general",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Content-Length": "233",
+        "Content-Length": "355",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-47d3613113d2b34cbf530135a147a48e-b14634724f0b374d-00",
+        "traceparent": "00-eb6ca5f97ac9ad4cb8866025a825c671-06c56d35cee54744-00",
         "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200227.1",
-          "(.NET Core 4.6.28325.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200305.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "afe45b4c015222e6582ce37ff532ba2e",
         "x-ms-return-client-request-id": "true"
@@ -20,20 +20,20 @@
           {
             "language": "en",
             "id": "0",
-            "text": "Bill Gates | Microsoft | New Mexico | 800-102-1100 | help@microsoft.com | April 4, 1975 12:34 | April 4, 1975 | 12:34 | five seconds | 9 | third | 120% | \u20AC30 | 11m | 22 \u00B0C"
+            "text": "Bill Gates | Microsoft | New Mexico | 800-102-1100 | help@microsoft.com | April 4, 1975 12:34 | April 4, 1975 | 12:34 | five seconds | 9 | third | 120% | \u20AC30 | 11m | 22 \u00B0C |Software Engineer | Wedding | Microsoft Surface laptop | Coding | 127.0.0.1 | https://github.com/azure/azure-sdk-for-net"
           }
         ]
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e413008b-38d2-4f80-8ed9-79a22e29bbfd",
+        "apim-request-id": "7a25a68f-c861-4192-84d3-deafd5d095da",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1",
-        "Date": "Thu, 27 Feb 2020 17:33:56 GMT",
+        "Date": "Fri, 06 Mar 2020 03:38:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "168"
+        "x-envoy-upstream-service-time": "154"
       },
       "ResponseBody": {
         "documents": [
@@ -153,6 +153,48 @@
                 "subtype": "Temperature",
                 "offset": 166,
                 "length": 5,
+                "score": 0.8
+              },
+              {
+                "text": "Engineer",
+                "type": "PersonType",
+                "offset": 182,
+                "length": 8,
+                "score": 0.56
+              },
+              {
+                "text": "Wedding",
+                "type": "Event",
+                "offset": 193,
+                "length": 7,
+                "score": 0.39
+              },
+              {
+                "text": "Microsoft Surface laptop",
+                "type": "Product",
+                "offset": 203,
+                "length": 24,
+                "score": 0.53
+              },
+              {
+                "text": "Coding",
+                "type": "Skill",
+                "offset": 230,
+                "length": 6,
+                "score": 0.8
+              },
+              {
+                "text": "127.0.0.1",
+                "type": "IP",
+                "offset": 239,
+                "length": 9,
+                "score": 0.8
+              },
+              {
+                "text": "https://github.com/azure/azure-sdk-for-net",
+                "type": "URL",
+                "offset": 251,
+                "length": 42,
                 "score": 0.8
               }
             ]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
@@ -126,7 +126,7 @@ namespace Azure.AI.TextAnalytics.Tests
             Assert.AreEqual("English", results[0].PrimaryLanguage.Name);
             Assert.AreEqual("English", results[1].PrimaryLanguage.Name);
             Assert.IsNotNull(results[0].Statistics);
-            Assert.IsNotNull(results[0].Statistics.CharacterCount);
+            Assert.IsNotNull(results[0].Statistics.GraphemeCount);
             Assert.IsNotNull(results[0].Statistics.TransactionCount);
         }
 
@@ -193,7 +193,7 @@ namespace Azure.AI.TextAnalytics.Tests
             Assert.AreEqual("Spanish", results[2].PrimaryLanguage.Name);
             Assert.AreEqual("English", results[3].PrimaryLanguage.Name);
             Assert.IsNotNull(results[0].Statistics);
-            Assert.IsNotNull(results[0].Statistics.CharacterCount);
+            Assert.IsNotNull(results[0].Statistics.GraphemeCount);
             Assert.IsNotNull(results[0].Statistics.TransactionCount);
         }
 
@@ -554,7 +554,7 @@ namespace Azure.AI.TextAnalytics.Tests
             foreach (CategorizedEntity entity in entities)
             {
                 Assert.IsTrue(entitiesList.Contains(entity.Text));
-                Assert.IsNotNull(entity.Score);
+                Assert.IsNotNull(entity.ConfidenceScore);
                 Assert.IsNotNull(entity.GraphemeOffset);
                 Assert.IsNotNull(entity.GraphemeLength);
                 Assert.Greater(entity.GraphemeLength, 0);
@@ -722,7 +722,7 @@ namespace Azure.AI.TextAnalytics.Tests
             foreach (PiiEntity entity in entities)
             {
                 Assert.IsTrue(entitiesList.Contains(entity.Text));
-                Assert.IsNotNull(entity.Score);
+                Assert.IsNotNull(entity.ConfidenceScore);
                 Assert.IsNotNull(entity.GraphemeOffset);
                 Assert.IsNotNull(entity.GraphemeLength);
                 Assert.Greater(entity.GraphemeLength, 0);
@@ -879,7 +879,7 @@ namespace Azure.AI.TextAnalytics.Tests
                 Assert.IsNotNull(entity.Matches);
                 Assert.IsNotNull(entity.Matches.First().GraphemeLength);
                 Assert.IsNotNull(entity.Matches.First().GraphemeOffset);
-                Assert.IsNotNull(entity.Matches.First().Score);
+                Assert.IsNotNull(entity.Matches.First().ConfidenceScore);
                 Assert.IsNotNull(entity.Matches.First().Text);
             }
         }
@@ -1016,12 +1016,13 @@ namespace Azure.AI.TextAnalytics.Tests
         public async Task RecognizeEntitiesCategories()
         {
             TextAnalyticsClient client = GetClient();
-            const string input = "Bill Gates | Microsoft | New Mexico | 800-102-1100 | help@microsoft.com | April 4, 1975 12:34 | April 4, 1975 | 12:34 | five seconds | 9 | third | 120% | €30 | 11m | 22 °C";
+            const string input = "Bill Gates | Microsoft | New Mexico | 800-102-1100 | help@microsoft.com | April 4, 1975 12:34 | April 4, 1975 | 12:34 | five seconds | 9 | third | 120% | €30 | 11m | 22 °C |" +
+                "Software Engineer | Wedding | Microsoft Surface laptop | Coding | 127.0.0.1 | https://github.com/azure/azure-sdk-for-net";
 
-            Response<IReadOnlyCollection<CategorizedEntity>> response = await client.RecognizeEntitiesAsync(input);
+            Response <IReadOnlyCollection<CategorizedEntity>> response = await client.RecognizeEntitiesAsync(input);
             List<CategorizedEntity> entities = response.Value.ToList();
 
-            Assert.AreEqual(15, entities.Count);
+            Assert.AreEqual(21, entities.Count);
 
             Assert.AreEqual(EntityCategory.Person, entities[0].Category);
 
@@ -1052,6 +1053,18 @@ namespace Azure.AI.TextAnalytics.Tests
             Assert.AreEqual(EntityCategory.Quantity, entities[13].Category);
 
             Assert.AreEqual(EntityCategory.Quantity, entities[14].Category);
+
+            Assert.AreEqual(EntityCategory.PersonType, entities[15].Category);
+
+            Assert.AreEqual(EntityCategory.Event, entities[16].Category);
+
+            Assert.AreEqual(EntityCategory.Product, entities[17].Category);
+
+            Assert.AreEqual(EntityCategory.Skill, entities[18].Category);
+
+            Assert.AreEqual(EntityCategory.IPAddress, entities[19].Category);
+
+            Assert.AreEqual(EntityCategory.Url, entities[20].Category);
         }
 
         [Test]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientMockTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientMockTests.cs
@@ -138,7 +138,7 @@ namespace Azure.AI.TextAnalytics.Tests
                             json.WriteString("subtype", JsonSerializer.Serialize(entity.SubCategory));
                             json.WriteNumber("offset", entity.GraphemeOffset);
                             json.WriteNumber("length", entity.GraphemeLength);
-                            json.WriteNumber("score", entity.Score);
+                            json.WriteNumber("score", entity.ConfidenceScore);
                             json.WriteEndObject();
                         }
                         json.WriteEndArray();

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatch.cs
@@ -65,7 +65,7 @@ namespace Azure.AI.TextAnalytics.Samples
                     Debug.WriteLine($"    Detected language {result.PrimaryLanguage.Name} with confidence {result.PrimaryLanguage.Score}.");
 
                     Debug.WriteLine($"    Document statistics:");
-                    Debug.WriteLine($"        Character count: {result.Statistics.CharacterCount}");
+                    Debug.WriteLine($"        Character count (in Unicode graphemes): {result.Statistics.GraphemeCount}");
                     Debug.WriteLine($"        Transaction count: {result.Statistics.TransactionCount}");
                     Debug.WriteLine("");
                 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatch.cs
@@ -78,7 +78,7 @@ namespace Azure.AI.TextAnalytics.Samples
                     }
 
                     Debug.WriteLine($"    Document statistics:");
-                    Debug.WriteLine($"        Character count: {result.Statistics.CharacterCount}");
+                    Debug.WriteLine($"        Character count (in Unicode graphemes): {result.Statistics.GraphemeCount}");
                     Debug.WriteLine($"        Transaction count: {result.Statistics.TransactionCount}");
                     Debug.WriteLine("");
                 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatch.cs
@@ -67,7 +67,7 @@ namespace Azure.AI.TextAnalytics.Samples
                     }
 
                     Debug.WriteLine($"    Document statistics:");
-                    Debug.WriteLine($"        Character count: {result.Statistics.CharacterCount}");
+                    Debug.WriteLine($"        Character count (in Unicode graphemes): {result.Statistics.GraphemeCount}");
                     Debug.WriteLine($"        Transaction count: {result.Statistics.TransactionCount}");
                     Debug.WriteLine("");
                 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntities.cs
@@ -30,7 +30,7 @@ namespace Azure.AI.TextAnalytics.Samples
             Console.WriteLine($"Recognized {entities.Count} entities:");
             foreach (CategorizedEntity entity in entities)
             {
-                Console.WriteLine($"Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Score: {entity.Score}");
+                Console.WriteLine($"Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
             }
             #endregion
         }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesAsync.cs
@@ -31,7 +31,7 @@ namespace Azure.AI.TextAnalytics.Samples
             Console.WriteLine($"Recognized {entities.Value.Count} entities:");
             foreach (CategorizedEntity entity in entities.Value)
             {
-                Console.WriteLine($"Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Score: {entity.Score}");
+                Console.WriteLine($"Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
             }
             #endregion
         }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatch.cs
@@ -63,11 +63,11 @@ namespace Azure.AI.TextAnalytics.Samples
 
                     foreach (CategorizedEntity entity in result.Entities)
                     {
-                        Debug.WriteLine($"        Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Score: {entity.Score}");
+                        Debug.WriteLine($"        Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
                     }
 
                     Debug.WriteLine($"    Document statistics:");
-                    Debug.WriteLine($"        Character count: {result.Statistics.CharacterCount}");
+                    Debug.WriteLine($"        Character count (in Unicode graphemes): {result.Statistics.GraphemeCount}");
                     Debug.WriteLine($"        Transaction count: {result.Statistics.TransactionCount}");
                     Debug.WriteLine("");
                 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchConvenience.cs
@@ -42,7 +42,7 @@ namespace Azure.AI.TextAnalytics.Samples
 
                 foreach (CategorizedEntity entity in result.Entities)
                 {
-                    Debug.WriteLine($"    Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Score: {entity.Score}");
+                    Debug.WriteLine($"    Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
                 }
             }
         }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntities.cs
@@ -30,7 +30,7 @@ namespace Azure.AI.TextAnalytics.Samples
             Console.WriteLine($"Recognized {entities.Count()} PII entit{(entities.Count() > 1 ? "ies" : "y")}:");
             foreach (PiiEntity entity in entities)
             {
-                Console.WriteLine($"Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Score: {entity.Score}");
+                Console.WriteLine($"Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
             }
             #endregion
         }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatch.cs
@@ -59,11 +59,11 @@ namespace Azure.AI.TextAnalytics.Samples
 
                     foreach (PiiEntity entity in result.Entities)
                     {
-                        Debug.WriteLine($"        Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Score: {entity.Score}");
+                        Debug.WriteLine($"        Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
                     }
 
                     Debug.WriteLine($"    Document statistics:");
-                    Debug.WriteLine($"        Character count: {result.Statistics.CharacterCount}");
+                    Debug.WriteLine($"        Character count (in Unicode graphemes): {result.Statistics.GraphemeCount}");
                     Debug.WriteLine($"        Transaction count: {result.Statistics.TransactionCount}");
                     Debug.WriteLine("");
                 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatchConvenience.cs
@@ -41,7 +41,7 @@ namespace Azure.AI.TextAnalytics.Samples
 
                 foreach (PiiEntity entity in result.Entities)
                 {
-                    Debug.WriteLine($"    Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Score: {entity.Score}");
+                    Debug.WriteLine($"    Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
                 }
             }
         }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntities.cs
@@ -34,7 +34,7 @@ namespace Azure.AI.TextAnalytics.Samples
                 Console.WriteLine($"Name: {linkedEntity.Name}, Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}, Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
                 foreach (LinkedEntityMatch match in linkedEntity.Matches)
                 {
-                    Console.WriteLine($"    Match Text: {match.Text}, Score: {match.Score}");
+                    Console.WriteLine($"    Match Text: {match.Text}, Confidence score: {match.ConfidenceScore}");
                 }
             }
             #endregion

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatch.cs
@@ -66,12 +66,12 @@ namespace Azure.AI.TextAnalytics.Samples
                         Debug.WriteLine($"    Name: \"{linkedEntity.Name}\", Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}, Entity Id in Data Source: \"{linkedEntity.DataSourceEntityId}\"");
                         foreach (LinkedEntityMatch match in linkedEntity.Matches)
                         {
-                            Debug.WriteLine($"        Match Text: \"{match.Text}\", Score: {match.Score}");
+                            Debug.WriteLine($"        Match Text: \"{match.Text}\", Confidence score: {match.ConfidenceScore}");
                         }
                     }
 
                     Debug.WriteLine($"    Document statistics:");
-                    Debug.WriteLine($"        Character count: {result.Statistics.CharacterCount}");
+                    Debug.WriteLine($"        Character count (in Unicode graphemes): {result.Statistics.GraphemeCount}");
                     Debug.WriteLine($"        Transaction count: {result.Statistics.TransactionCount}");
                     Debug.WriteLine("");
                 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenience.cs
@@ -45,7 +45,7 @@ namespace Azure.AI.TextAnalytics.Samples
                     Debug.WriteLine($"    Name: \"{linkedEntity.Name}\", Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}, Entity Id in Data Source: \"{linkedEntity.DataSourceEntityId}\"");
                     foreach (LinkedEntityMatch match in linkedEntity.Matches)
                     {
-                        Debug.WriteLine($"        Match Text: \"{match.Text}\", Score: {match.Score}");
+                        Debug.WriteLine($"        Match Text: \"{match.Text}\", Confidence score: {match.ConfidenceScore}");
                     }
                 }
 


### PR DESCRIPTION
- Renames:
  - `CharacterCount` to `GraphemeCount in `TextDocumentStatistics` 
  - `Score` to `ConfidenceScore` in `CategorizedEntity`, `LinkedEntityMatch`, and `PiiEntity`.
- Added new values to `EntityCategory` enum => https://docs.microsoft.com/en-us/azure/cognitive-services/Text-Analytics/named-entity-types?tabs=general