### PR TITLE
Only run code checks related to the service directory

### DIFF
--- a/eng/CodeChecks.ps1
+++ b/eng/CodeChecks.ps1
@@ -64,12 +64,12 @@ try {
 
     Write-Host "Re-generating readmes"
     Invoke-Block {
-        & $PSScriptRoot\Update-Snippets.ps1 $ServiceDirectory
+        & $PSScriptRoot\Update-Snippets.ps1 @script:PSBoundParameters
     }
 
     Write-Host "Re-generating listings"
     Invoke-Block {
-        & $PSScriptRoot\Export-API.ps1 $ServiceDirectory
+        & $PSScriptRoot\Export-API.ps1 @script:PSBoundParameters
     }
 
     Write-Host "Re-generating clients"

--- a/eng/CodeChecks.ps1
+++ b/eng/CodeChecks.ps1
@@ -10,12 +10,6 @@ param (
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 1
 
-$root = "$PSScriptRoot/../sdk"
-if ($ServiceDirectory) {
-    $root += '/' + $ServiceDirectory
-}
-
-$repoRoot = Resolve-Path "$root"
 
 [string[]] $errors = @()
 
@@ -52,7 +46,13 @@ try {
         & dotnet msbuild -version
     }
 
-    Get-ChildItem "$repoRoot/Azure.*.sln" -Recurse `
+    $root = "$PSScriptRoot/../sdk"
+    if ($ServiceDirectory) {
+        $root += '/' + $ServiceDirectory
+    }
+
+    Resolve-Path "$root" `
+        | % { Get-ChildItem $_ -Filter "Azure.*.sln" -Recurse } `
         | % {
             Write-Host "  Checking $(Split-Path -Leaf $_)"
             $slnDir = Split-Path -Parent $_
@@ -69,12 +69,12 @@ try {
 
     Write-Host "Re-generating readmes"
     Invoke-Block {
-        & $PSScriptRoot\Update-Snippets.ps1 @script:PSBoundParameters
+        & $PSScriptRoot\Update-Snippets.ps1 $ServiceDirectory
     }
 
     Write-Host "Re-generating listings"
     Invoke-Block {
-        & $PSScriptRoot\Export-API.ps1 @script:PSBoundParameters
+        & $PSScriptRoot\Export-API.ps1 $ServiceDirectory
     }
 
     Write-Host "Re-generating clients"

--- a/eng/CodeChecks.ps1
+++ b/eng/CodeChecks.ps1
@@ -39,19 +39,14 @@ function Invoke-Block([scriptblock]$cmd) {
 
 try {
 
-    Write-Host "Checking that solutions are up to date"
-
     Write-Host "Force .NET Welcome experience"
     Invoke-Block {
         & dotnet msbuild -version
     }
 
-    $root = "$PSScriptRoot/../sdk"
-    if ($ServiceDirectory) {
-        $root += '/' + $ServiceDirectory
-    }
-
-    Resolve-Path "$root" `
+    Write-Host "Checking that solutions are up to date"
+    Join-Path "$PSScriptRoot/../sdk" $ServiceDirectory  `
+        | Resolve-Path `
         | % { Get-ChildItem $_ -Filter "Azure.*.sln" -Recurse } `
         | % {
             Write-Host "  Checking $(Split-Path -Leaf $_)"

--- a/eng/Update-Snippets.ps1
+++ b/eng/Update-Snippets.ps1
@@ -7,10 +7,13 @@ param (
 
 $generatorProject = "$PSScriptRoot/SnippetGenerator/SnippetGenerator.csproj";
 $root = "$PSScriptRoot/../sdk"
-if ($ServiceDirectory) {
+
+# special casing * here because single invocation of SnippetGenerator if much faster than
+# running it per service directory
+if ($ServiceDirectory -and ($ServiceDirectory -ne "*")) {
     $root += '/' + $ServiceDirectory
 }
 
-$repoRoot = Resolve-Path "$root"
+$paths = Resolve-Path "$root"
 
-dotnet run -p $generatorProject -b "$repoRoot"
+Resolve-Path "$root" | %{ dotnet run -p $generatorProject -b "$_" }

--- a/eng/Update-Snippets.ps1
+++ b/eng/Update-Snippets.ps1
@@ -14,6 +14,4 @@ if ($ServiceDirectory -and ($ServiceDirectory -ne "*")) {
     $root += '/' + $ServiceDirectory
 }
 
-$paths = Resolve-Path "$root"
-
 Resolve-Path "$root" | %{ dotnet run -p $generatorProject -b "$_" }

--- a/eng/Update-Snippets.ps1
+++ b/eng/Update-Snippets.ps1
@@ -8,7 +8,7 @@ param (
 $generatorProject = "$PSScriptRoot/SnippetGenerator/SnippetGenerator.csproj";
 $root = "$PSScriptRoot/../sdk"
 
-# special casing * here because single invocation of SnippetGenerator if much faster than
+# special casing * here because single invocation of SnippetGenerator is much faster than
 # running it per service directory
 if ($ServiceDirectory -and ($ServiceDirectory -ne "*")) {
     $root += '/' + $ServiceDirectory

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -100,6 +100,7 @@ jobs:
           DOTNET_MULTILEVEL_LOOKUP: 0
         inputs:
           filePath: "eng/CodeChecks.ps1"
+          arguments: -ServiceDirectory ${{parameters.ServiceToBuild}}
           pwsh: true
           failOnStderr:  false
   - job: "Test"


### PR DESCRIPTION
Now that code checks might take longer because of generated code scope them down to a service directory.