### PR TITLE
[Azure.Core Shared] Adding link to Diagnostic Scope should take attributes

### DIFF
--- a/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
+++ b/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs
@@ -49,13 +49,21 @@ namespace Azure.Core.Pipeline
             }
         }
 
-        public void AddLink(string id)
+        public void AddLink(string id, IDictionary<string, string>? attributes = null)
         {
             if (_activity != null)
             {
                 var linkedActivity = new Activity("LinkedActivity");
                 linkedActivity.SetW3CFormat();
                 linkedActivity.SetParentId(id);
+
+                if (attributes != null)
+                {
+                    foreach (var kvp in attributes)
+                    {
+                        linkedActivity.AddTag(kvp.Key, kvp.Value);
+                    }
+                }
 
                 _activity.AddLink(linkedActivity);
             }


### PR DESCRIPTION
Including `attributes` parameter to `DiagnosticScope.AddLink`. Changes are necessary because the newly created linked activity is not exposed, and tags could not be added otherwise.

Related issue: #10324 