### PR TITLE
[EventHubs, Azure.Core Shared] Move enqueuedTime from root activity to linked activity (Track Two)

### DIFF
--- a/sdk/core/Azure.Core/tests/TestFramework/ClientDiagnosticListener.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/ClientDiagnosticListener.cs
@@ -55,7 +55,8 @@ namespace Azure.Core.Tests
                     {
                         Name = name,
                         Activity = Activity.Current,
-                        Links = links.Select(a => a.ParentId).ToList()
+                        Links = links.Select(a => a.ParentId).ToList(),
+                        LinkedActivities = links.ToList()
                     };
 
                     Scopes.Add(scope);
@@ -194,6 +195,7 @@ namespace Azure.Core.Tests
             public bool IsFailed => Exception != null;
             public Exception Exception { get; set; }
             public List<string> Links { get; set; } = new List<string>();
+            public List<Activity> LinkedActivities { get; set; } = new List<Activity>();
 
             public override string ToString()
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -726,8 +726,12 @@ namespace Azure.Messaging.EventHubs
                     && partitionEvent.Data != null
                     && EventDataInstrumentation.TryExtractDiagnosticId(partitionEvent.Data, out string diagnosticId))
                 {
-                    diagnosticScope.AddLink(diagnosticId);
-                    diagnosticScope.AddAttribute(DiagnosticProperty.EnqueuedTimeAttribute, partitionEvent.Data.EnqueuedTime.ToUnixTimeSeconds());
+                    var attributes = new Dictionary<string, string>()
+                    {
+                        { DiagnosticProperty.EnqueuedTimeAttribute, partitionEvent.Data.EnqueuedTime.ToUnixTimeSeconds().ToString() }
+                    };
+
+                    diagnosticScope.AddLink(diagnosticId, attributes);
                 }
 
                 diagnosticScope.Start();

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
@@ -175,7 +175,6 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         /// </summary>
         ///
         [Test]
-        [Ignore("Unstable test. (Tracked by: #10067)")]
         public async Task RunPartitionProcessingAsyncAddsAttributesToLinkedActivities()
         {
             string fullyQualifiedNamespace = "namespace";

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
@@ -82,7 +82,6 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             var mockStorage = new MockCheckPointStorage();
             var mockConsumer = new Mock<EventHubConsumerClient>("cg", Mock.Of<EventHubConnection>(), default);
             var mockProcessor = new Mock<EventProcessorClient>(mockStorage, "cg", fullyQualifiedNamespace, eventHubName, Mock.Of<Func<EventHubConnection>>(), default, default) { CallBase = true };
-            var enqueuedTime = DateTimeOffset.UtcNow;
 
             using ClientDiagnosticListener listener = new ClientDiagnosticListener(DiagnosticSourceName);
             var completionSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -100,8 +99,8 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                     {
                         var context = new MockPartitionContext(partitionId);
 
-                        yield return new PartitionEvent(context, new MockEventData(Array.Empty<byte>(), enqueuedTime: enqueuedTime) { Properties = { { "Diagnostic-Id", "id" } } });
-                        yield return new PartitionEvent(context, new MockEventData(Array.Empty<byte>(), enqueuedTime: enqueuedTime) { Properties = { { "Diagnostic-Id", "id2" } } });
+                        yield return new PartitionEvent(context, new EventData(Array.Empty<byte>()) { Properties = { { "Diagnostic-Id", "id" } } });
+                        yield return new PartitionEvent(context, new EventData(Array.Empty<byte>()) { Properties = { { "Diagnostic-Id", "id2" } } });
 
                         while (!completionSource.Task.IsCompleted && !token.IsCancellationRequested)
                         {
@@ -161,14 +160,110 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             {
                 new KeyValuePair<string, string>(DiagnosticProperty.KindAttribute, DiagnosticProperty.ConsumerKind),
                 new KeyValuePair<string, string>(DiagnosticProperty.EventHubAttribute, eventHubName),
-                new KeyValuePair<string, string>(DiagnosticProperty.EndpointAttribute, fullyQualifiedNamespace),
-                new KeyValuePair<string, string>(DiagnosticProperty.EnqueuedTimeAttribute, enqueuedTime.ToUnixTimeSeconds().ToString())
+                new KeyValuePair<string, string>(DiagnosticProperty.EndpointAttribute, fullyQualifiedNamespace)
             };
 
             foreach (var scope in listener.Scopes)
             {
                 Assert.That(expectedTags, Is.SubsetOf(scope.Activity.Tags.ToList()));
             }
+        }
+
+        /// <summary>
+        ///   Verifies diagnostics functionality of the <see cref="EventProcessorClient.RunPartitionProcessingAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [Ignore("Unstable test. (Tracked by: #10067)")]
+        public async Task RunPartitionProcessingAsyncAddsAttributesToLinkedActivities()
+        {
+            string fullyQualifiedNamespace = "namespace";
+            string eventHubName = "eventHub";
+
+            var mockStorage = new MockCheckPointStorage();
+            var mockConsumer = new Mock<EventHubConsumerClient>("cg", Mock.Of<EventHubConnection>(), default);
+            var mockProcessor = new Mock<EventProcessorClient>(mockStorage, "cg", fullyQualifiedNamespace, eventHubName, Mock.Of<Func<EventHubConnection>>(), default, default) { CallBase = true };
+            var enqueuedTime = DateTimeOffset.UtcNow;
+
+            using ClientDiagnosticListener listener = new ClientDiagnosticListener(DiagnosticSourceName);
+            var completionSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var processEventCalled = false;
+
+            mockConsumer
+                .Setup(consumer => consumer.ReadEventsFromPartitionAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<EventPosition>(),
+                    It.IsAny<ReadEventOptions>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns<string, EventPosition, ReadEventOptions, CancellationToken>((partitionId, position, options, token) =>
+                {
+                    async IAsyncEnumerable<PartitionEvent> mockPartitionEventEnumerable()
+                    {
+                        var context = new MockPartitionContext(partitionId);
+
+                        yield return new PartitionEvent(context, new MockEventData(Array.Empty<byte>(), enqueuedTime: enqueuedTime) { Properties = { { "Diagnostic-Id", "id" } } });
+
+                        while (!completionSource.Task.IsCompleted && !token.IsCancellationRequested)
+                        {
+                            await Task.Delay(TimeSpan.FromSeconds(1));
+                            yield return new PartitionEvent();
+                        }
+
+                        yield break;
+                    };
+
+                    return mockPartitionEventEnumerable();
+                });
+
+            mockProcessor
+                .Setup(processor => processor.CreateConsumer(
+                    It.IsAny<string>(),
+                    It.IsAny<EventHubConnection>(),
+                    It.IsAny<EventHubConsumerClientOptions>()))
+                .Returns(mockConsumer.Object);
+
+            mockProcessor.Object.ProcessEventAsync += eventArgs =>
+            {
+                if (!processEventCalled)
+                {
+                    processEventCalled = true;
+                    completionSource.SetResult(null);
+                }
+
+                return Task.CompletedTask;
+            };
+
+            // RunPartitionProcessingAsync does not invoke the error handler, but we are setting it here in case
+            // this fact changes in the future.
+
+            mockProcessor.Object.ProcessErrorAsync += eventArgs => Task.CompletedTask;
+
+            // Start processing and wait for the consumer to be invoked.  Set a cancellation for backup to ensure
+            // that the test completes deterministically.
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            using var partitionProcessingTask = Task.Run(() => mockProcessor.Object.RunPartitionProcessingAsync("pid", default, cancellationSource.Token));
+            await Task.WhenAny(Task.Delay(-1, cancellationSource.Token), completionSource.Task);
+            await Task.WhenAny(Task.Delay(-1, cancellationSource.Token), partitionProcessingTask);
+
+            // Validate that cancellation did not take place.
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The processor should have stopped without cancellation.");
+
+            // Validate diagnostics functionality.
+
+            var processingScope = listener.Scopes.Single(s => s.Name == DiagnosticProperty.EventProcessorProcessingActivityName);
+            var linkedActivity = processingScope.LinkedActivities.Single(a => a.ParentId == "id");
+
+            var expectedTags = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>(DiagnosticProperty.EnqueuedTimeAttribute, enqueuedTime.ToUnixTimeSeconds().ToString())
+            };
+
+            Assert.That(linkedActivity.Tags, Is.EquivalentTo(expectedTags));
         }
 
         private class MockConnection : EventHubConnection

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
@@ -99,8 +99,8 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                     {
                         var context = new MockPartitionContext(partitionId);
 
-                        yield return new PartitionEvent(context, new EventData(Array.Empty<byte>()) { Properties = { { "Diagnostic-Id", "id" } } });
-                        yield return new PartitionEvent(context, new EventData(Array.Empty<byte>()) { Properties = { { "Diagnostic-Id", "id2" } } });
+                        yield return new PartitionEvent(context, new EventData(Array.Empty<byte>()) { Properties = { { DiagnosticProperty.DiagnosticIdAttribute, "id" } } });
+                        yield return new PartitionEvent(context, new EventData(Array.Empty<byte>()) { Properties = { { DiagnosticProperty.DiagnosticIdAttribute, "id2" } } });
 
                         while (!completionSource.Task.IsCompleted && !token.IsCancellationRequested)
                         {
@@ -201,7 +201,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                     {
                         var context = new MockPartitionContext(partitionId);
 
-                        yield return new PartitionEvent(context, new MockEventData(Array.Empty<byte>(), enqueuedTime: enqueuedTime) { Properties = { { "Diagnostic-Id", "id" } } });
+                        yield return new PartitionEvent(context, new MockEventData(Array.Empty<byte>(), enqueuedTime: enqueuedTime) { Properties = { { DiagnosticProperty.DiagnosticIdAttribute, "id" } } });
 
                         while (!completionSource.Task.IsCompleted && !token.IsCancellationRequested)
                         {

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Diagnostics/DiagnosticProperty.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Diagnostics/DiagnosticProperty.cs
@@ -22,7 +22,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         public const string EndpointAttribute = "peer.address";
 
         /// <summary>The attribute which represents the UNIX Epoch enqueued time of an event to associate with diagnostics information.</summary>
-        public const string EnqueuedTimeAttribute = "x-opt-enqueued-time";
+        public const string EnqueuedTimeAttribute = "enqueuedTime";
 
         /// <summary>The value which identifies the Event Hubs diagnostics context.</summary>
         public const string EventHubsServiceContext = "eventhubs";


### PR DESCRIPTION
Fixes #10324

Event Hubs:
- Renamed enqueued time attribute from `x-opt-enqueued-time` to `enqueuedTime`.
- Removed the enqueued time attribute from the root processing activity and put it in the linked activity instead.
- Created a new test. It's currently being ignored because it's very similar to `RunPartitionProcessingAsyncCreatesScopeForEventProcessing`, so it's expected to be flaky during nightly runs. It's already being tracked by #10067. No issues when running locally.

Core:
- Updated the `ClientDiagnosticListener` test helper to track linked activities as well, not only their parent ids. I'm keeping the `Links` property since it's already being used in multiple tests across the repo.