### PR TITLE
Make .Net Release Pipeline Public

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -1,0 +1,250 @@
+parameters:
+  Artifacts: []
+  ArtifactName: 'not-specified'
+
+stages:
+  - stage: Signing
+    dependsOn: ${{parameters.DependsOn}}
+    jobs:
+      - deployment: SignPackage
+        environment: esrp
+        timeoutInMinutes: 20
+        pool:
+          vmImage: windows-2019
+
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - checkout: none
+
+                - download: current
+                  artifact: ${{parameters.ArtifactName}}
+                  timeoutInMinutes: 5
+
+                - ${{ each artifact in parameters.Artifacts }}:
+                  - pwsh: |
+                      New-Item -Type Directory -Name staging -Path $(Pipeline.Workspace) -Force
+                      Copy-Item $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}.[0-9]*.[0-9]*.[0-9]* $(Pipeline.Workspace)/staging
+                      Get-ChildItem $(Pipeline.Workspace)/staging
+                    displayName: Copying ${{artifact.name}} to staging directory
+
+                - template: pipelines/steps/net-signing.yml@azure-sdk-build-tools
+                  parameters:
+                    StagingDirectory: $(Pipeline.Workspace)/staging
+
+                - publish: $(Pipeline.Workspace)/staging
+                  artifact: ${{parameters.ArtifactName}}-signed
+                  displayName: 'Store signed packages in ${{parameters.ArtifactName}}-signed artifact'
+
+  - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
+    - ${{ each artifact in parameters.Artifacts }}:
+      - stage: Release_${{artifact.safeName}}
+        displayName: 'Release: ${{artifact.name}}'
+        dependsOn: Signing
+        condition: and(succeeded(), ne(variables['SetDevVersion'], 'true'), ne(variables['Skip.Release'], 'true'), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-net-pr'))
+        jobs:
+          - deployment: TagRepository
+            displayName: "Create release tag"
+            condition: ne(variables['Skip.TagRepository'], 'true')
+            environment: github
+
+            pool:
+              vmImage: vs2017-win2016
+
+            strategy:
+              runOnce:
+                deploy:
+                  steps:
+                    - checkout: none
+                    - template: ../../tools/clone-buildtools/clone-buildtools.yml
+                    - pwsh: |
+                        Get-ChildItem $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed
+                        New-Item -Type Directory -Name ${{artifact.safeName}} -Path $(Pipeline.Workspace)
+                        Copy-Item $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}.[0-9]*.[0-9]*.[0-9]* $(Pipeline.Workspace)/${{artifact.safeName}}
+                        Get-ChildItem $(Pipeline.Workspace)/${{artifact.safeName}}
+                      displayName: Stage artifacts
+                      timeoutInMinutes: 5
+                    - pwsh: |
+                        $(Pipeline.Workspace)/azure-sdk-build-tools/scripts/create-tags-and-git-release.ps1 -artifactLocation $(Pipeline.Workspace)/${{artifact.safeName}} -packageRepository Nuget -releaseSha $(Build.SourceVersion) -repoId $(Build.Repository.Name)
+                      displayName: 'Verify Package Tags and Create Git Releases'
+                      timeoutInMinutes: 5
+                      env:
+                        GH_TOKEN: $(azuresdk-github-pat)
+
+          - ${{if ne(artifact.options.skipPublishPackage, 'true')}}:
+            - deployment: PublishPackage
+              displayName: Publish package to Nuget.org
+              condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
+              environment: nuget
+              dependsOn: TagRepository
+
+              pool:
+                vmImage: ubuntu-16.04
+
+              strategy:
+                runOnce:
+                  deploy:
+                    steps:
+                      - checkout: none
+                      - template: ../../tools/clone-buildtools/clone-buildtools.yml
+                      - pwsh: |
+                          New-Item -Type Directory -Name staging -Path $(Pipeline.Workspace)
+                          Copy-Item $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}.[0-9]*.[0-9]*.[0-9]* $(Pipeline.Workspace)/staging
+                          Get-ChildItem $(Pipeline.Workspace)/staging
+                        displayName: Copying ${{artifact.name}} to staging directory
+                      - task: NuGetCommand@2
+                        displayName: 'Publish ${{artifact.name}} package to NuGet.org'
+                        inputs:
+                          command: push
+                          packagesToPush: '$(Pipeline.Workspace)/staging/**/*.nupkg;!$(Pipeline.Workspace)/staging/**/*.symbols.nupkg'
+                          nuGetFeedType: external
+                          publishFeedCredentials: Nuget.org
+
+          - ${{if ne(artifact.options.skipSymbolsUpload, 'true')}}:
+            - deployment: UploadSymbols
+              displayName: Upload Symbols to Symbols Server
+              condition: and(succeeded(), ne(variables['Skip.SymbolsUpload'], 'true'))
+              environment: nuget
+              dependsOn: PublishPackage
+
+              pool:
+                vmImage: windows-2019
+
+              strategy:
+                runOnce:
+                  deploy:
+                    steps:
+                      - checkout: none
+                      - template: ../../tools/clone-buildtools/clone-buildtools.yml
+                      - pwsh: |
+                          New-Item -Type Directory -Name staging -Path $(Pipeline.Workspace)
+                          Copy-Item $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}.[0-9]*.[0-9]*.[0-9]* $(Pipeline.Workspace)/staging
+                          Get-ChildItem $(Pipeline.Workspace)/staging
+                        displayName: Copying ${{artifact.name}} to staging directory
+                      - task: MSBuild@1
+                        displayName: 'Upload Symbols for ${{artifact.name}}'
+                        inputs:
+                          solution: '$(Pipeline.Workspace)/azure-sdk-build-tools/tools/symboltool/SymbolUploader.proj'
+                          msbuildArguments: '/p:PackagesPath=$(Pipeline.Workspace)/staging /p:MSPublicSymbolsPAT=$(azuresdk-microsoftpublicsymbols-devops-pat) /p:MSSymbolsPAT=$(azuresdk-microsoft-devops-pat) /p:AzureSDKSymbolsPAT=$(azuresdk-azure-sdk-devops-pat)'
+
+          - ${{if ne(artifact.options.skipPublishDocs, 'true')}}:
+            - deployment: PublishDocs
+              displayName: Publish Docs to GitHub pages
+              condition: and(succeeded(), ne(variables['Skip.PublishDocs'], 'true'))
+              environment: githubio
+
+              pool:
+                vmImage: windows-2019
+
+              strategy:
+                runOnce:
+                  deploy:
+                    steps:
+                      - checkout: none
+                      - template: ../../tools/clone-buildtools/clone-buildtools.yml
+                      - pwsh: |
+                          New-Item -Type Directory -Name ${{artifact.safeName}} -Path $(Pipeline.Workspace)
+                          New-Item -Type Directory -Name packages -Path $(Pipeline.Workspace)/${{artifact.safeName}}
+                          New-Item -Type Directory -Name Docs.${{artifact.name}} -Path $(Pipeline.Workspace)/${{artifact.safeName}}
+
+                          Copy-Item -Recurse $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}.[0-9]*.[0-9]*.[0-9]* $(Pipeline.Workspace)/${{artifact.safeName}}/packages
+                          Copy-Item -Recurse $(Pipeline.Workspace)/Docs.${{artifact.name}}/* $(Pipeline.Workspace)/${{artifact.safeName}}/Docs.${{artifact.name}}
+                        displayName: Stage artifacts
+                      - pwsh: |
+                          Get-ChildItem -Recurse $(Pipeline.Workspace)/${{artifact.safeName}}
+                        workingDirectory: $(Pipeline.Workspace)
+                        displayName: Output Visible Artifacts
+                      - template: ../../tools/generic-blob-upload/publish-blobs.yml
+                        parameters:
+                          FolderForUpload: '$(Pipeline.Workspace)/${{artifact.safeName}}'
+                          BlobSASKey: '$(azure-sdk-docs-prod-sas)'
+                          BlobName: '$(azure-sdk-docs-prod-blob-name)'
+                          TargetLanguage: 'dotnet'
+                          # we override the regular script path because we have cloned the build tools repo as a separate artifact.
+                          ScriptPath: '$(Pipeline.Workspace)/azure-sdk-build-tools/scripts/copy-docs-to-blobstorage.ps1'
+
+          - ${{if ne(artifact.options.skipUpdatePackageVersion, 'true')}}:
+            - deployment: UpdatePackageVersion
+              displayName: "Update Package Version"
+              condition: and(succeeded(), ne(variables['Skip.UpdatePackageVersion'], 'true'))
+              environment: github
+
+              pool:
+                vmImage: windows-2019
+
+              strategy:
+                runOnce:
+                  deploy:
+                    steps:
+                      - checkout: self
+                      - pwsh: |
+                          eng/Update-PkgVersion.ps1 -ServiceDirectory '${{parameters.ServiceDirectory}}' -PackageName '${{artifact.name}}' -PackageDirName '${{artifact.directoryName}}'
+                        displayName: Increment package version
+                      - template: ../../tools/clone-buildtools/clone-buildtools.yml
+                      - template: ../steps/create-pull-request.yml
+                        parameters:
+                          RepoName: azure-sdk-for-net
+                          PRBranchName: increment-package-version-${{ parameters.ServiceDirectory }}-$(Build.BuildId)
+                          CommitMsg: "Increment package version after release of ${{ artifact.name }}"
+                          PRTitle: "Increment version for ${{ parameters.ServiceDirectory }} releases"
+
+  - stage: Validation
+    dependsOn: Signing
+    jobs:
+    - job: PublishPackages
+      displayName: Publish package to burner feed
+      pool:
+        vmImage: ubuntu-16.04
+      steps:
+      - checkout: none
+      - template: ../../tools/clone-buildtools/clone-buildtools.yml
+      - template: ../../tools/burner-feed/burner-feed-create.yml
+
+      - download: current
+        artifact: ${{parameters.ArtifactName}}-signed
+        timeoutInMinutes: 5
+
+      - task: NuGetCommand@2
+        displayName: 'Publish package to feed: azure-sdk-$(Build.BuildId)'
+        inputs:
+          command: push
+          packagesToPush: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/**/*.nupkg;!$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/**/*.symbols.nupkg'
+          publishVstsFeed: 'public/azure-sdk-$(Build.BuildId)'
+
+  - stage: Integration
+    dependsOn: Validation
+    jobs:
+    - job: PublishPackages
+      condition: or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal')))
+      displayName: Publish package to daily feed
+      variables:
+        BlobFeedUrl: 'https://azuresdkartifacts.blob.core.windows.net/azure-sdk-for-net/index.json'
+      pool:
+        vmImage: windows-2019
+      steps:
+      - checkout: none
+      - template: ../../tools/clone-buildtools/clone-buildtools.yml
+      - download: current
+        artifact: ${{parameters.ArtifactName}}-signed
+      - task: MSBuild@1
+        displayName: 'Publish to blobfeed'
+        inputs:
+          solution: '$(Pipeline.Workspace)/azure-sdk-build-tools/tools/blobfeedtool/BlobFeedPublishHelper.proj'
+          msbuildArguments: '/p:AccountKey=$(azuresdkartifacts-access-key) /p:ExpectedFeedUrl=$(BlobFeedUrl) /p:PackagesPath="$(Pipeline.Workspace)/packages-signed"'
+
+  - stage: Cleanup
+    condition: always()
+    dependsOn:
+    - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
+      - ${{ each artifact in parameters.Artifacts }}:
+        - Release_${{artifact.safeName}}
+    - Integration
+
+    jobs:
+    - job: DeleteFeed
+      pool:
+        vmImage: ubuntu-16.04
+      steps:
+      - checkout: none
+      - template: ../../tools/burner-feed/burner-feed-delete.yml

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -29,9 +29,12 @@ stages:
                       Get-ChildItem $(Pipeline.Workspace)/staging
                     displayName: Copying ${{artifact.name}} to staging directory
 
+                - template: tools/clone-buildtools/clone-buildtools.yml@azure-sdk-build-tools
+
                 - template: pipelines/steps/net-signing.yml@azure-sdk-build-tools
                   parameters:
-                    StagingDirectory: $(Pipeline.Workspace)/staging
+                    PackagesPath: $(Pipeline.Workspace)/staging
+                    BuildToolsPath: $(AzureSDKBuildToolsPath)
 
                 - publish: $(Pipeline.Workspace)/staging
                   artifact: ${{parameters.ArtifactName}}-signed
@@ -50,14 +53,13 @@ stages:
             environment: github
 
             pool:
-              vmImage: vs2017-win2016
+              vmImage: windows-2019
 
             strategy:
               runOnce:
                 deploy:
                   steps:
-                    - checkout: none
-                    - template: ../../tools/clone-buildtools/clone-buildtools.yml
+                    - checkout: azure-sdk-tools
                     - pwsh: |
                         Get-ChildItem $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed
                         New-Item -Type Directory -Name ${{artifact.safeName}} -Path $(Pipeline.Workspace)
@@ -65,12 +67,12 @@ stages:
                         Get-ChildItem $(Pipeline.Workspace)/${{artifact.safeName}}
                       displayName: Stage artifacts
                       timeoutInMinutes: 5
-                    - pwsh: |
-                        $(Pipeline.Workspace)/azure-sdk-build-tools/scripts/create-tags-and-git-release.ps1 -artifactLocation $(Pipeline.Workspace)/${{artifact.safeName}} -packageRepository Nuget -releaseSha $(Build.SourceVersion) -repoId $(Build.Repository.Name)
-                      displayName: 'Verify Package Tags and Create Git Releases'
-                      timeoutInMinutes: 5
-                      env:
-                        GH_TOKEN: $(azuresdk-github-pat)
+                    - template: eng/pipelines/templates/scripts/create-tags-and-git-release.yml@azure-sdk-tools
+                      parameters:
+                        ArtifactLocation: $(Pipeline.Workspace)/${{artifact.safeName}}
+                        PackageRepository: Nuget
+                        ReleaseSha: $(Build.SourceVersion)
+                        RepoId: $(Build.Repository.Name)
 
           - ${{if ne(artifact.options.skipPublishPackage, 'true')}}:
             - deployment: PublishPackage
@@ -87,7 +89,6 @@ stages:
                   deploy:
                     steps:
                       - checkout: none
-                      - template: ../../tools/clone-buildtools/clone-buildtools.yml
                       - pwsh: |
                           New-Item -Type Directory -Name staging -Path $(Pipeline.Workspace)
                           Copy-Item $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}.[0-9]*.[0-9]*.[0-9]* $(Pipeline.Workspace)/staging
@@ -116,7 +117,7 @@ stages:
                   deploy:
                     steps:
                       - checkout: none
-                      - template: ../../tools/clone-buildtools/clone-buildtools.yml
+                      - template: tools/clone-buildtools/clone-buildtools.yml@azure-sdk-build-tools
                       - pwsh: |
                           New-Item -Type Directory -Name staging -Path $(Pipeline.Workspace)
                           Copy-Item $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.name}}.[0-9]*.[0-9]*.[0-9]* $(Pipeline.Workspace)/staging
@@ -133,6 +134,7 @@ stages:
               displayName: Publish Docs to GitHub pages
               condition: and(succeeded(), ne(variables['Skip.PublishDocs'], 'true'))
               environment: githubio
+              dependsOn: PublishPackage
 
               pool:
                 vmImage: windows-2019
@@ -142,7 +144,7 @@ stages:
                   deploy:
                     steps:
                       - checkout: none
-                      - template: ../../tools/clone-buildtools/clone-buildtools.yml
+                      - template: tools/clone-buildtools/clone-buildtools.yml@azure-sdk-build-tools
                       - pwsh: |
                           New-Item -Type Directory -Name ${{artifact.safeName}} -Path $(Pipeline.Workspace)
                           New-Item -Type Directory -Name packages -Path $(Pipeline.Workspace)/${{artifact.safeName}}
@@ -155,7 +157,7 @@ stages:
                           Get-ChildItem -Recurse $(Pipeline.Workspace)/${{artifact.safeName}}
                         workingDirectory: $(Pipeline.Workspace)
                         displayName: Output Visible Artifacts
-                      - template: ../../tools/generic-blob-upload/publish-blobs.yml
+                      - template: tools/generic-blob-upload/publish-blobs.yml@azure-sdk-build-tools
                         parameters:
                           FolderForUpload: '$(Pipeline.Workspace)/${{artifact.safeName}}'
                           BlobSASKey: '$(azure-sdk-docs-prod-sas)'
@@ -169,6 +171,7 @@ stages:
               displayName: "Update Package Version"
               condition: and(succeeded(), ne(variables['Skip.UpdatePackageVersion'], 'true'))
               environment: github
+              dependsOn: PublishPackage
 
               pool:
                 vmImage: windows-2019
@@ -181,8 +184,8 @@ stages:
                       - pwsh: |
                           eng/Update-PkgVersion.ps1 -ServiceDirectory '${{parameters.ServiceDirectory}}' -PackageName '${{artifact.name}}' -PackageDirName '${{artifact.directoryName}}'
                         displayName: Increment package version
-                      - template: ../../tools/clone-buildtools/clone-buildtools.yml
-                      - template: ../steps/create-pull-request.yml
+                      - template: tools/clone-buildtools/clone-buildtools.yml@azure-sdk-build-tools
+                      - template: pipelines/steps/create-pull-request.yml@azure-sdk-build-tools
                         parameters:
                           RepoName: azure-sdk-for-net
                           PRBranchName: increment-package-version-${{ parameters.ServiceDirectory }}-$(Build.BuildId)
@@ -198,8 +201,8 @@ stages:
         vmImage: ubuntu-16.04
       steps:
       - checkout: none
-      - template: ../../tools/clone-buildtools/clone-buildtools.yml
-      - template: ../../tools/burner-feed/burner-feed-create.yml
+      - template: tools/clone-buildtools/clone-buildtools.yml@azure-sdk-build-tools
+      - template: tools/burner-feed/burner-feed-create.yml@azure-sdk-build-tools
 
       - download: current
         artifact: ${{parameters.ArtifactName}}-signed
@@ -224,7 +227,7 @@ stages:
         vmImage: windows-2019
       steps:
       - checkout: none
-      - template: ../../tools/clone-buildtools/clone-buildtools.yml
+      - template: tools/clone-buildtools/clone-buildtools.yml@azure-sdk-build-tools
       - download: current
         artifact: ${{parameters.ArtifactName}}-signed
       - task: MSBuild@1
@@ -247,4 +250,4 @@ stages:
         vmImage: ubuntu-16.04
       steps:
       - checkout: none
-      - template: ../../tools/burner-feed/burner-feed-delete.yml
+      - template: tools/burner-feed/burner-feed-delete.yml@azure-sdk-build-tools

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -72,7 +72,7 @@ stages:
                         ArtifactLocation: $(Pipeline.Workspace)/${{artifact.safeName}}
                         PackageRepository: Nuget
                         ReleaseSha: $(Build.SourceVersion)
-                        RepoId: $(Build.Repository.Name)
+                        RepoId: Azure/azure-sdk-for-net
 
           - ${{if ne(artifact.options.skipPublishPackage, 'true')}}:
             - deployment: PublishPackage
@@ -201,7 +201,6 @@ stages:
         vmImage: ubuntu-16.04
       steps:
       - checkout: none
-      - template: tools/clone-buildtools/clone-buildtools.yml@azure-sdk-build-tools
       - template: tools/burner-feed/burner-feed-create.yml@azure-sdk-build-tools
 
       - download: current

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -59,7 +59,7 @@ stages:
               runOnce:
                 deploy:
                   steps:
-                    - checkout: azure-sdk-tools
+                    - checkout: self
                     - pwsh: |
                         Get-ChildItem $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed
                         New-Item -Type Directory -Name ${{artifact.safeName}} -Path $(Pipeline.Workspace)
@@ -67,7 +67,7 @@ stages:
                         Get-ChildItem $(Pipeline.Workspace)/${{artifact.safeName}}
                       displayName: Stage artifacts
                       timeoutInMinutes: 5
-                    - template: eng/pipelines/templates/scripts/create-tags-and-git-release.yml@azure-sdk-tools
+                    - template: eng/pipelines/templates/steps/create-tags-and-git-release.yml@azure-sdk-tools
                       parameters:
                         ArtifactLocation: $(Pipeline.Workspace)/${{artifact.safeName}}
                         PackageRepository: Nuget
@@ -143,8 +143,7 @@ stages:
                 runOnce:
                   deploy:
                     steps:
-                      - checkout: none
-                      - template: tools/clone-buildtools/clone-buildtools.yml@azure-sdk-build-tools
+                      - checkout: azure-sdk-tools
                       - pwsh: |
                           New-Item -Type Directory -Name ${{artifact.safeName}} -Path $(Pipeline.Workspace)
                           New-Item -Type Directory -Name packages -Path $(Pipeline.Workspace)/${{artifact.safeName}}
@@ -157,14 +156,14 @@ stages:
                           Get-ChildItem -Recurse $(Pipeline.Workspace)/${{artifact.safeName}}
                         workingDirectory: $(Pipeline.Workspace)
                         displayName: Output Visible Artifacts
-                      - template: tools/generic-blob-upload/publish-blobs.yml@azure-sdk-build-tools
+                      - template: eng/pipelines/templates/steps/publish-blobs.yml@azure-sdk-tools
                         parameters:
                           FolderForUpload: '$(Pipeline.Workspace)/${{artifact.safeName}}'
                           BlobSASKey: '$(azure-sdk-docs-prod-sas)'
                           BlobName: '$(azure-sdk-docs-prod-blob-name)'
                           TargetLanguage: 'dotnet'
                           # we override the regular script path because we have cloned the build tools repo as a separate artifact.
-                          ScriptPath: '$(AzureSDKBuildToolsPath)/scripts/copy-docs-to-blobstorage.ps1'
+                          ScriptPath: 'scripts/powershell/copy-docs-to-blobstorage.ps1'
 
           - ${{if ne(artifact.options.skipUpdatePackageVersion, 'true')}}:
             - deployment: UpdatePackageVersion
@@ -185,37 +184,16 @@ stages:
                           eng/Update-PkgVersion.ps1 -ServiceDirectory '${{parameters.ServiceDirectory}}' -PackageName '${{artifact.name}}' -PackageDirName '${{artifact.directoryName}}'
                         displayName: Increment package version
                       - template: tools/clone-buildtools/clone-buildtools.yml@azure-sdk-build-tools
-                      - template: pipelines/steps/create-pull-request.yml@azure-sdk-build-tools
+                      - template: eng/pipelines/templates/steps/create-pull-request.yml@azure-sdk-tools
                         parameters:
                           RepoName: azure-sdk-for-net
                           PRBranchName: increment-package-version-${{ parameters.ServiceDirectory }}-$(Build.BuildId)
                           CommitMsg: "Increment package version after release of ${{ artifact.name }}"
                           PRTitle: "Increment version for ${{ parameters.ServiceDirectory }} releases"
-
-  - stage: Validation
-    dependsOn: Signing
-    jobs:
-    - job: PublishPackages
-      displayName: Publish package to burner feed
-      pool:
-        vmImage: ubuntu-16.04
-      steps:
-      - checkout: none
-      - template: tools/burner-feed/burner-feed-create.yml@azure-sdk-build-tools
-
-      - download: current
-        artifact: ${{parameters.ArtifactName}}-signed
-        timeoutInMinutes: 5
-
-      - task: NuGetCommand@2
-        displayName: 'Publish package to feed: azure-sdk-$(Build.BuildId)'
-        inputs:
-          command: push
-          packagesToPush: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/**/*.nupkg;!$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/**/*.symbols.nupkg'
-          publishVstsFeed: 'public/azure-sdk-$(Build.BuildId)'
+                          BuildToolsPath: $(AzureSDKBuildToolsPath)
 
   - stage: Integration
-    dependsOn: Validation
+    dependsOn: Signing
     jobs:
     - job: PublishPackages
       condition: or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal')))
@@ -234,19 +212,3 @@ stages:
         inputs:
           solution: '$(AzureSDKBuildToolsPath)/tools/blobfeedtool/BlobFeedPublishHelper.proj'
           msbuildArguments: '/p:AccountKey=$(azuresdkartifacts-access-key) /p:ExpectedFeedUrl=$(BlobFeedUrl) /p:PackagesPath="$(Pipeline.Workspace)/packages-signed"'
-
-  - stage: Cleanup
-    condition: always()
-    dependsOn:
-    - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
-      - ${{ each artifact in parameters.Artifacts }}:
-        - Release_${{artifact.safeName}}
-    - Integration
-
-    jobs:
-    - job: DeleteFeed
-      pool:
-        vmImage: ubuntu-16.04
-      steps:
-      - checkout: none
-      - template: tools/burner-feed/burner-feed-delete.yml@azure-sdk-build-tools

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -126,7 +126,7 @@ stages:
                       - task: MSBuild@1
                         displayName: 'Upload Symbols for ${{artifact.name}}'
                         inputs:
-                          solution: '$(Pipeline.Workspace)/azure-sdk-build-tools/tools/symboltool/SymbolUploader.proj'
+                          solution: '$(AzureSDKBuildToolsPath)/tools/symboltool/SymbolUploader.proj'
                           msbuildArguments: '/p:PackagesPath=$(Pipeline.Workspace)/staging /p:MSPublicSymbolsPAT=$(azuresdk-microsoftpublicsymbols-devops-pat) /p:MSSymbolsPAT=$(azuresdk-microsoft-devops-pat) /p:AzureSDKSymbolsPAT=$(azuresdk-azure-sdk-devops-pat)'
 
           - ${{if ne(artifact.options.skipPublishDocs, 'true')}}:
@@ -164,7 +164,7 @@ stages:
                           BlobName: '$(azure-sdk-docs-prod-blob-name)'
                           TargetLanguage: 'dotnet'
                           # we override the regular script path because we have cloned the build tools repo as a separate artifact.
-                          ScriptPath: '$(Pipeline.Workspace)/azure-sdk-build-tools/scripts/copy-docs-to-blobstorage.ps1'
+                          ScriptPath: '$(AzureSDKBuildToolsPath)/scripts/copy-docs-to-blobstorage.ps1'
 
           - ${{if ne(artifact.options.skipUpdatePackageVersion, 'true')}}:
             - deployment: UpdatePackageVersion
@@ -233,7 +233,7 @@ stages:
       - task: MSBuild@1
         displayName: 'Publish to blobfeed'
         inputs:
-          solution: '$(Pipeline.Workspace)/azure-sdk-build-tools/tools/blobfeedtool/BlobFeedPublishHelper.proj'
+          solution: '$(AzureSDKBuildToolsPath)/tools/blobfeedtool/BlobFeedPublishHelper.proj'
           msbuildArguments: '/p:AccountKey=$(azuresdkartifacts-access-key) /p:ExpectedFeedUrl=$(BlobFeedUrl) /p:PackagesPath="$(Pipeline.Workspace)/packages-signed"'
 
   - stage: Cleanup

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -14,7 +14,7 @@ stages:
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
   - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
-    - template: pipelines/stages/archetype-net-release.yml@azure-sdk-build-tools
+    - template: archetype-net-release.yml
       parameters:
         ServiceDirectory: ${{parameters.ServiceDirectory}}
         DependsOn: Build

--- a/sdk/template/Azure.Template/CHANGELOG.md
+++ b/sdk/template/Azure.Template/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 1.0.2-preview.7 (2020-03-06)
+- Testing out release pipeline
+
 ## 1.0.2-preview.6 (2020-02-24)
 ### Added
 - Testing Changelog added section

--- a/sdk/template/Azure.Template/CHANGELOG.md
+++ b/sdk/template/Azure.Template/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 1.0.2-preview.8 (2020-03-10)
+- Testing out release pipeline
+
 ## 1.0.2-preview.7 (2020-03-06)
 - Testing out release pipeline
 

--- a/sdk/template/Azure.Template/CHANGELOG.md
+++ b/sdk/template/Azure.Template/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Release History
 
+## 1.0.2-preview.9 (Unreleased)
+
 ## 1.0.2-preview.8 (2020-03-10)
 - Testing out release pipeline
 

--- a/sdk/template/Azure.Template/src/Azure.Template.csproj
+++ b/sdk/template/Azure.Template/src/Azure.Template.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is a template project to demonstrate how to create a package that uses code generation as well as use for testing our build and release pipelines</Description>
     <AssemblyTitle>Azure SDK Template</AssemblyTitle>
-    <Version>1.0.2-preview.6</Version>
+    <Version>1.0.2-preview.7</Version>
     <PackageTags>Azure Template</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <EnableApiCompat>false</EnableApiCompat>

--- a/sdk/template/Azure.Template/src/Azure.Template.csproj
+++ b/sdk/template/Azure.Template/src/Azure.Template.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is a template project to demonstrate how to create a package that uses code generation as well as use for testing our build and release pipelines</Description>
     <AssemblyTitle>Azure SDK Template</AssemblyTitle>
-    <Version>1.0.2-preview.8</Version>
+    <Version>1.0.2-preview.9</Version>
     <PackageTags>Azure Template</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <EnableApiCompat>false</EnableApiCompat>

--- a/sdk/template/Azure.Template/src/Azure.Template.csproj
+++ b/sdk/template/Azure.Template/src/Azure.Template.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is a template project to demonstrate how to create a package that uses code generation as well as use for testing our build and release pipelines</Description>
     <AssemblyTitle>Azure SDK Template</AssemblyTitle>
-    <Version>1.0.2-preview.7</Version>
+    <Version>1.0.2-preview.8</Version>
     <PackageTags>Azure Template</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <EnableApiCompat>false</EnableApiCompat>

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -7,9 +7,11 @@ resources:
       type: github
       name: Azure/azure-sdk-tools
       endpoint: azure
+      ref: refs/heads/MakingToolsOpenSource
     - repository: azure-sdk-build-tools
       type: git
       name: internal/azure-sdk-build-tools
+      ref: refs/heads/MakeEngSysToolsPublic
 
 trigger:
   branches:

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -7,11 +7,9 @@ resources:
       type: github
       name: Azure/azure-sdk-tools
       endpoint: azure
-      ref: refs/heads/MakingToolsOpenSource
     - repository: azure-sdk-build-tools
       type: git
       name: internal/azure-sdk-build-tools
-      ref: refs/heads/MakeEngSysToolsPublic
 
 trigger:
   branches:


### PR DESCRIPTION
- Move `archetype-net-release.yml` into the public repo, Except for signing stage.
- Add `dependsOn: PublishPackage` for PublishDocs and UpdatePackageVersion deployments.
- Tested with [Azure.Template.1.0.2-preview.7](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=282912&view=results) and [Azure.Template.1.0.2-preview.8](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=295193&view=results)
- Included version changes to Azure.Template

Depends on https://github.com/Azure/azure-sdk-tools/pull/416 and https://dev.azure.com/azure-sdk/internal/_git/azure-sdk-build-tools/pullrequest/149?_a=overview