### PR TITLE
Address EventProcessessorClient timing issues with IsRunning and processing cancellation

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -222,11 +222,22 @@ namespace Azure.Messaging.EventHubs
                     return _isRunningOverride.Value;
                 }
 
-                // Capture the load balancing task so we don't end up with a race condition.
+                if (ActiveLoadBalancingTask == null)
+                {
+                    try
+                    {
+                        if (!RunningTaskSemaphore.Wait(100))
+                        {
+                            return false;
+                        }
+                    }
+                    finally
+                    {
+                        RunningTaskSemaphore.Release();
+                    }
+                }
 
-                var loadBalancingTask = ActiveLoadBalancingTask;
-
-                return loadBalancingTask != null && !loadBalancingTask.IsCompleted;
+                return (!ActiveLoadBalancingTask?.IsCompleted) ?? false;
             }
 
             protected set => _isRunningOverride = value;
@@ -961,9 +972,9 @@ namespace Azure.Messaging.EventHubs
                 }
             }
 
-            var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(RunningTaskTokenSource.Token);
-            var processingTask = RunPartitionProcessingAsync(partitionId, startingPosition, tokenSource.Token);
+            var processingTask = RunPartitionProcessingAsync(partitionId, startingPosition, RunningTaskTokenSource.Token);
 
+            var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(RunningTaskTokenSource.Token);
             ActivePartitionProcessors[partitionId] = (processingTask, tokenSource);
             Logger.StartPartitionProcessingComplete(Identifier);
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
@@ -48,6 +48,17 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
+        ///   Provides test cases iterations for the stress testing.
+        /// </summary>
+        ///
+        public static IEnumerable<object> StressTestCases()
+        {
+            return Enumerable.Range(0, 100)
+                    .Select(i => i.ToString())
+                    .ToArray();
+        }
+
+        /// <summary>
         ///   Verifies functionality of the <see cref="EventProcessorClient" />
         ///   constructor.
         /// </summary>
@@ -853,7 +864,6 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [Ignore("Test failing during nightly runs. (Tracked by: #10067)")]
         public async Task StopProcessingAsyncStopsProcessingForEveryPartition()
         {
             var maximumWaitTimeInMilli = 100;
@@ -3595,6 +3605,7 @@ namespace Azure.Messaging.EventHubs.Tests
             while (!cancellationToken.IsCancellationRequested)
             {
                 await Task.Delay(maximumWaitTime.Value, cancellationToken).ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
                 yield return new PartitionEvent();
             }
 


### PR DESCRIPTION
## Summary of Changes
**IsRunning** 
When tests wire up the `ProcessEventAsync` event and make assertions about `IsRunning` in the event handler, it exposed a timing issue where `IsRunning` returns false after `StartProcessingAsync` is called. This is because `ActiveLoadBalancingTask` could still evaluate to null after `RunAsync` was called. 

To address this, `IsRunning` now attempts to wait on `RunningTaskSemaphore` when `ActiveLoadBalancingTask` is null before evaluating its `IsCompleted` property to ensure that we aren't racing against `StartProcessingInternalAsync` completion.

**RunPartitionProcessingAsync cancellation**
`RunPartitionProcessingAsync` was previously called with the result of `CancellationTokenSource.CreateLinkedTokenSource(RunningTaskTokenSource.Token)`. This introduces a delay between when `RunningTaskTokenSource` is cancelled and when `ReadEventsFromPartitionAsync` recognizes the cancellation state. This is due to the delayed propagation of cancellation to all linked handlers from the source ([see comments for IsCancellationRequested](https://github.com/dotnet/runtime/blob/cf1976480661801172765546126d231cd18c45ef/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs#L84)). This was observed under the debugger where `RunningTaskTokenSource.IsCancellationRequested` was true while one of the linked token sources based on it being tracked in `ActivePartitionProcessors` still showed IsCancellationRequested of false for a short time. 

To address this, we now pass `RunningTaskTokenSource` directly to `RunPartitionProcessingAsync` to minimize cancellation delays.

#10067 