### PR TITLE
[Event Hubs Client] Event Processor<T> Startup/Shutdown

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -316,7 +316,7 @@ namespace Azure.Messaging.EventHubs
         ///   token sources that can be used to cancel the operation.  Partition ids are used as keys.
         /// </summary>
         ///
-        private ConcurrentDictionary<string, (Task, CancellationTokenSource)> ActivePartitionProcessors { get; set; } = new ConcurrentDictionary<string, (Task, CancellationTokenSource)>();
+        private ConcurrentDictionary<string, (Task, CancellationTokenSource)> ActivePartitionProcessors { get; } = new ConcurrentDictionary<string, (Task, CancellationTokenSource)>();
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="EventProcessorClient"/> class.
@@ -1181,7 +1181,7 @@ namespace Azure.Messaging.EventHubs
                         await Task.WhenAll(stopPartitionProcessingTasks).ConfigureAwait(false);
 
                         // Stop the LoadBalancer.
-                        await LoadBalancer.RelinquishOwnershipAsync(cancellationToken).ConfigureAwait(false);
+                        await LoadBalancer.RelinquishOwnershipAsync(CancellationToken.None).ConfigureAwait(false);
                     }
                     else
                     {
@@ -1189,7 +1189,7 @@ namespace Azure.Messaging.EventHubs
 
                         // Stop the LoadBalancer.
 #pragma warning disable AZC0102 // Do not use GetAwaiter().GetResult(). Use the TaskExtensions.EnsureCompleted() extension method instead.
-                        LoadBalancer.RelinquishOwnershipAsync(cancellationToken).GetAwaiter().GetResult();
+                        LoadBalancer.RelinquishOwnershipAsync(CancellationToken.None).GetAwaiter().GetResult();
 #pragma warning restore AZC0102 // Do not use GetAwaiter().GetResult(). Use the TaskExtensions.EnsureCompleted() extension method instead.
                     }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
@@ -39,10 +39,13 @@ namespace Azure.Messaging.EventHubs.Tests
         public static IEnumerable<object[]> ConstructorCreatesDefaultOptionsCases()
         {
             var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
+            var connectionStringNoHub = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123";
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
 
             yield return new object[] { new EventProcessorClient(Mock.Of<BlobContainerClient>(), "consumerGroup", connectionString), "connection string with default options" };
             yield return new object[] { new EventProcessorClient(Mock.Of<BlobContainerClient>(), "consumerGroup", connectionString, default(EventProcessorClientOptions)), "connection string with explicit null options" };
+            yield return new object[] { new EventProcessorClient(Mock.Of<BlobContainerClient>(), "consumerGroup", connectionStringNoHub, "hub"), "connection string with default options" };
+            yield return new object[] { new EventProcessorClient(Mock.Of<BlobContainerClient>(), "consumerGroup", connectionStringNoHub, "hub", default(EventProcessorClientOptions)), "connection string with explicit null options" };
             yield return new object[] { new EventProcessorClient(Mock.Of<BlobContainerClient>(), "consumerGroup", "namespace", "hub", credential.Object), "namespace with default options" };
             yield return new object[] { new EventProcessorClient(Mock.Of<BlobContainerClient>(), "consumerGroup", "namespace", "hub", credential.Object, default(EventProcessorClientOptions)), "namespace with explicit null options" };
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/design/event-processor{T}-proposal.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/design/event-processor{T}-proposal.md
@@ -425,9 +425,9 @@ public class EventProcessorOptions
     public EventHubConnectionOptions ConnectionOptions { get; set; }
     public EventHubsRetryOptions RetryOptions { get; set; }
     public string Identifier { get; set; }
-    public int? PrefetchCount { get; set; } 
+    public int PrefetchCount { get; set; } 
     public bool TrackLastEnqueuedEventProperties { get; set; }
-    public TimeSpan MaximumWaitTime { get; set; } = TimeSpan.FromSeconds(60);
+    public TimeSpan? MaximumWaitTime { get; set; } = TimeSpan.FromSeconds(60);
     public EventPosition DefaultStartingPosition { get; set; } = EventPosition.Earliest;
     public TimeSpan LoadBalancingUpdateInterval { get; set; } = TimeSpan.FromSeconds(10);
     public TimeSpan PartitionOwnershipExpirationInterval { get; set; } = TimeSpan.FromSeconds(30);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -761,7 +762,7 @@ namespace Azure.Messaging.EventHubs.Consumer
                     if (observedException != default)
                     {
                         EventHubsEventSource.Log.PublishPartitionEventsToChannelError(EventHubName, partitionId, observedException.Message);
-                        throw observedException;
+                        ExceptionDispatchInfo.Capture(observedException).Throw();
                     }
                 }
                 finally

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics.Tracing;
 using Azure.Core.Diagnostics;
 using Azure.Messaging.EventHubs.Consumer;
+using Azure.Messaging.EventHubs.Primitives;
 using Azure.Messaging.EventHubs.Producer;
 
 namespace Azure.Messaging.EventHubs.Diagnostics
@@ -20,7 +21,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
     /// </remarks>
     ///
     [EventSource(Name = EventSourceName)]
-    internal sealed class EventHubsEventSource : EventSource
+    internal class EventHubsEventSource : EventSource
     {
         /// <summary>The name to use for the event source.</summary>
         private const string EventSourceName = "Azure-Messaging-EventHubs";
@@ -37,7 +38,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         ///   outside the scope of the <see cref="Log" /> instance.
         /// </summary>
         ///
-        private EventHubsEventSource() : base(EventSourceName, EventSourceSettings.Default, AzureEventSourceListener.TraitName, AzureEventSourceListener.TraitValue)
+        protected EventHubsEventSource() : base(EventSourceName, EventSourceSettings.Default, AzureEventSourceListener.TraitName, AzureEventSourceListener.TraitValue)
         {
         }
 
@@ -49,8 +50,8 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="eventHubName">The name of the Event Hub associated with the client.</param>
         ///
         [Event(1, Level = EventLevel.Verbose, Message = "Creating EventHubClient (Namespace '{0}'; EventHub '{1}').")]
-        public void EventHubClientCreateStart(string eventHubsNamespace,
-                                              string eventHubName)
+        public virtual void EventHubClientCreateStart(string eventHubsNamespace,
+                                                      string eventHubName)
         {
             if (IsEnabled())
             {
@@ -66,8 +67,8 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="eventHubName">The name of the Event Hub associated with the client.</param>
         ///
         [Event(2, Level = EventLevel.Verbose, Message = "EventHubClient created (Namespace '{0}'; EventHub '{1}').")]
-        public void EventHubClientCreateComplete(string eventHubsNamespace,
-                                                 string eventHubName)
+        public virtual void EventHubClientCreateComplete(string eventHubsNamespace,
+                                                         string eventHubName)
         {
             if (IsEnabled())
             {
@@ -84,9 +85,9 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="eventHash">The hash of the event or set of events being published.</param>
         ///
         [Event(3, Level = EventLevel.Informational, Message = "Publishing events for Event Hub: {0} (Partition Id/Key: '{1}', Event Hash: '{2}').")]
-        public void EventPublishStart(string eventHubName,
-                                      string partitionIdOrKey,
-                                      string eventHash)
+        public virtual void EventPublishStart(string eventHubName,
+                                              string partitionIdOrKey,
+                                              string eventHash)
         {
             if (IsEnabled())
             {
@@ -103,9 +104,9 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="eventHash">The hash of the event or set of events being published.</param>
         ///
         [Event(4, Level = EventLevel.Informational, Message = "Completed publishing events for Event Hub: {0} (Partition Id/Key: '{1}', Event Hash: '{2}').")]
-        public void EventPublishComplete(string eventHubName,
-                                         string partitionIdOrKey,
-                                         string eventHash)
+        public virtual void EventPublishComplete(string eventHubName,
+                                                 string partitionIdOrKey,
+                                                 string eventHash)
         {
             if (IsEnabled())
             {
@@ -123,10 +124,10 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="errorMessage">The message for the exception that occurred.</param>
         ///
         [Event(5, Level = EventLevel.Error, Message = "An exception occurred while publishing events for Event Hub: {0} (Partition Id/Key: '{1}', Event Hash: '{2}'). Error Message: '{3}'")]
-        public void EventPublishError(string eventHubName,
-                                      string partitionIdOrKey,
-                                      string eventHash,
-                                      string errorMessage)
+        public virtual void EventPublishError(string eventHubName,
+                                              string partitionIdOrKey,
+                                              string eventHash,
+                                              string errorMessage)
         {
             if (IsEnabled())
             {
@@ -143,9 +144,9 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="partitionId">The identifier of the partition events are being received from.</param>
         ///
         [Event(6, Level = EventLevel.Informational, Message = "Receiving events for Event Hub: {0} (Consumer Group: '{1}', Partition Id: '{2}').")]
-        public void EventReceiveStart(string eventHubName,
-                                      string consumerGroup,
-                                      string partitionId)
+        public virtual void EventReceiveStart(string eventHubName,
+                                              string consumerGroup,
+                                              string partitionId)
         {
             if (IsEnabled())
             {
@@ -163,10 +164,10 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="eventCount">The number of events that were received in the batch.</param>
         ///
         [Event(7, Level = EventLevel.Informational, Message = "Completed receiving events for Event Hub: {0} (Consumer Group: '{1}', Partition Id: '{2}').  Event Count: '{3}'")]
-        public void EventReceiveComplete(string eventHubName,
-                                         string consumerGroup,
-                                         string partitionId,
-                                         int eventCount)
+        public virtual void EventReceiveComplete(string eventHubName,
+                                                 string consumerGroup,
+                                                 string partitionId,
+                                                 int eventCount)
         {
             if (IsEnabled())
             {
@@ -184,10 +185,10 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="errorMessage">The message for the exception that occurred.</param>
         ///
         [Event(8, Level = EventLevel.Error, Message = "An exception occurred while receiving events for Event Hub: {0} (Consumer Group: '{1}', Partition Id: '{2}'). Error Message: '{3}'")]
-        public void EventReceiveError(string eventHubName,
-                                      string consumerGroup,
-                                      string partitionId,
-                                      string errorMessage)
+        public virtual void EventReceiveError(string eventHubName,
+                                              string consumerGroup,
+                                              string partitionId,
+                                              string errorMessage)
         {
             if (IsEnabled())
             {
@@ -205,9 +206,9 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="clientId">An identifier to associate with the client.</param>
         ///
         [Event(9, Level = EventLevel.Verbose, Message = "Closing an {0} (EventHub '{1}'; Identifier '{2}').")]
-        public void ClientCloseStart(Type clientType,
-                                     string eventHubName,
-                                     string clientId)
+        public virtual void ClientCloseStart(Type clientType,
+                                             string eventHubName,
+                                             string clientId)
         {
             if (IsEnabled())
             {
@@ -225,9 +226,9 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="clientId">An identifier to associate with the client.</param>
         ///
         [Event(10, Level = EventLevel.Verbose, Message = "An {0} has been closed (EventHub '{1}'; Identifier '{2}').")]
-        public void ClientCloseComplete(Type clientType,
-                                        string eventHubName,
-                                        string clientId)
+        public virtual void ClientCloseComplete(Type clientType,
+                                                string eventHubName,
+                                                string clientId)
         {
             if (IsEnabled())
             {
@@ -246,10 +247,10 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="errorMessage">The message for the exception that occurred.</param>
         ///
         [Event(11, Level = EventLevel.Error, Message = "An exception occurred while closing an {0} (EventHub '{1}'; Identifier '{2}'). Error Message: '{3}'")]
-        public void ClientCloseError(Type clientType,
-                                     string eventHubName,
-                                     string clientId,
-                                     string errorMessage)
+        public virtual void ClientCloseError(Type clientType,
+                                             string eventHubName,
+                                             string clientId,
+                                             string errorMessage)
         {
             if (IsEnabled())
             {
@@ -264,7 +265,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="eventHubName">The name of the Event Hub that properties are being retrieved for.</param>
         ///
         [Event(12, Level = EventLevel.Informational, Message = "Retrieving properties for Event Hub: {0}.")]
-        public void GetPropertiesStart(string eventHubName)
+        public virtual void GetPropertiesStart(string eventHubName)
         {
             if (IsEnabled())
             {
@@ -279,7 +280,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="eventHubName">The name of the Event Hub that properties are being retrieved for.</param>
         ///
         [Event(13, Level = EventLevel.Informational, Message = "Completed retrieving properties for Event Hub: {0}.")]
-        public void GetPropertiesComplete(string eventHubName)
+        public virtual void GetPropertiesComplete(string eventHubName)
         {
             if (IsEnabled())
             {
@@ -295,8 +296,8 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="errorMessage">The message for the exception that occurred.</param>
         ///
         [Event(14, Level = EventLevel.Error, Message = "An exception occurred while retrieving properties for Event Hub: {0}. Error Message: '{1}'")]
-        public void GetPropertiesError(string eventHubName,
-                                       string errorMessage)
+        public virtual void GetPropertiesError(string eventHubName,
+                                               string errorMessage)
         {
             if (IsEnabled())
             {
@@ -312,8 +313,8 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="partitionId">The identifier of the partition that properties are being retrieved for.</param>
         ///
         [Event(15, Level = EventLevel.Informational, Message = "Retrieving properties for Event Hub: {0} (Partition Id: '{1}').")]
-        public void GetPartitionPropertiesStart(string eventHubName,
-                                                string partitionId)
+        public virtual void GetPartitionPropertiesStart(string eventHubName,
+                                                        string partitionId)
         {
             if (IsEnabled())
             {
@@ -329,8 +330,8 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="partitionId">The identifier of the partition that properties are being retrieved for.</param>
         ///
         [Event(16, Level = EventLevel.Informational, Message = "Completed retrieving properties for Event Hub: {0} (Partition Id: '{1}').")]
-        public void GetPartitionPropertiesComplete(string eventHubName,
-                                                   string partitionId)
+        public virtual void GetPartitionPropertiesComplete(string eventHubName,
+                                                           string partitionId)
         {
             if (IsEnabled())
             {
@@ -347,9 +348,9 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="errorMessage">The message for the exception that occurred.</param>
         ///
         [Event(17, Level = EventLevel.Error, Message = "An exception occurred while retrieving properties for Event Hub: {0} (Partition Id: '{1}'). Error Message: '{2}'")]
-        public void GetPartitionPropertiesError(string eventHubName,
-                                                string partitionId,
-                                                string errorMessage)
+        public virtual void GetPartitionPropertiesError(string eventHubName,
+                                                        string partitionId,
+                                                        string errorMessage)
         {
             if (IsEnabled())
             {
@@ -365,8 +366,8 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="partitionId">The identifier of the partition that properties are being read from.</param>
         ///
         [Event(18, Level = EventLevel.Informational, Message = "Beginning to publish events to a background channel for Event Hub: {0} (Partition Id: '{1}').")]
-        public void PublishPartitionEventsToChannelStart(string eventHubName,
-                                                         string partitionId)
+        public virtual void PublishPartitionEventsToChannelStart(string eventHubName,
+                                                                 string partitionId)
         {
             if (IsEnabled())
             {
@@ -382,8 +383,8 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="partitionId">The identifier of the partition that properties are being read from.</param>
         ///
         [Event(19, Level = EventLevel.Informational, Message = "Completed publishing events to a background channel for Event Hub: {0} (Partition Id: '{1}').")]
-        public void PublishPartitionEventsToChannelComplete(string eventHubName,
-                                                            string partitionId)
+        public virtual void PublishPartitionEventsToChannelComplete(string eventHubName,
+                                                                    string partitionId)
         {
             if (IsEnabled())
             {
@@ -400,9 +401,9 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="errorMessage">The message for the exception that occurred.</param>
         ///
         [Event(20, Level = EventLevel.Error, Message = "An exception occurred while publishing events to a background channel for Event Hub: {0} (Partition Id: '{1}'). Error Message: '{2}'")]
-        public void PublishPartitionEventsToChannelError(string eventHubName,
-                                                         string partitionId,
-                                                         string errorMessage)
+        public virtual void PublishPartitionEventsToChannelError(string eventHubName,
+                                                                 string partitionId,
+                                                                 string errorMessage)
         {
             if (IsEnabled())
             {
@@ -417,8 +418,8 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="partitionId">The identifier of the partition that properties are being read from.</param>
         ///
         [Event(21, Level = EventLevel.Informational, Message = "Beginning to read events for Event Hub: {0} (Partition Id: '{1}').")]
-        public void ReadEventsFromPartitionStart(string eventHubName,
-                                                 string partitionId)
+        public virtual void ReadEventsFromPartitionStart(string eventHubName,
+                                                         string partitionId)
         {
             if (IsEnabled())
             {
@@ -434,8 +435,8 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="partitionId">The identifier of the partition that properties are being read from.</param>
         ///
         [Event(22, Level = EventLevel.Informational, Message = "Completed reading events for Event Hub: {0} (Partition Id: '{1}').")]
-        public void ReadEventsFromPartitionComplete(string eventHubName,
-                                                    string partitionId)
+        public virtual void ReadEventsFromPartitionComplete(string eventHubName,
+                                                            string partitionId)
         {
             if (IsEnabled())
             {
@@ -452,9 +453,9 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="errorMessage">The message for the exception that occurred.</param>
         ///
         [Event(23, Level = EventLevel.Error, Message = "An exception occurred while reading events for Event Hub: {0} (Partition Id: '{1}'). Error Message: '{2}'")]
-        public void ReadEventsFromPartitionError(string eventHubName,
-                                                 string partitionId,
-                                                 string errorMessage)
+        public virtual void ReadEventsFromPartitionError(string eventHubName,
+                                                         string partitionId,
+                                                         string errorMessage)
         {
             if (IsEnabled())
             {
@@ -469,7 +470,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="eventHubName">The name of the Event Hub that events are being read from.</param>
         ///
         [Event(24, Level = EventLevel.Informational, Message = "Beginning to read events for all partitions of Event Hub: {0}.")]
-        public void ReadAllEventsStart(string eventHubName)
+        public virtual void ReadAllEventsStart(string eventHubName)
         {
             if (IsEnabled())
             {
@@ -484,7 +485,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="eventHubName">The name of the Event Hub that events are being read from.</param>
         ///
         [Event(25, Level = EventLevel.Informational, Message = "Completed reading events for all partitions of Event Hub: {0}.")]
-        public void ReadAllEventsComplete(string eventHubName)
+        public virtual void ReadAllEventsComplete(string eventHubName)
         {
             if (IsEnabled())
             {
@@ -500,8 +501,8 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="errorMessage">The message for the exception that occurred.</param>
         ///
         [Event(26, Level = EventLevel.Error, Message = "An exception occurred while reading events for all partitions of Event Hub: {0}. Error Message: '{1}'")]
-        public void ReadAllEventsError(string eventHubName,
-                                       string errorMessage)
+        public virtual void ReadAllEventsError(string eventHubName,
+                                               string errorMessage)
         {
             if (IsEnabled())
             {
@@ -517,8 +518,8 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="endpoint">The service endpoint that the link is bound to for communication.</param>
         ///
         [Event(27, Level = EventLevel.Informational, Message = "Beginning refresh of AMQP link authorization for Event Hub: {0} (Service Endpoint: '{1}').")]
-        public void AmqpLinkAuthorizationRefreshStart(string eventHubName,
-                                                      string endpoint)
+        public virtual void AmqpLinkAuthorizationRefreshStart(string eventHubName,
+                                                              string endpoint)
         {
             if (IsEnabled())
             {
@@ -534,8 +535,8 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="endpoint">The service endpoint that the link is bound to for communication.</param>
         ///
         [Event(28, Level = EventLevel.Informational, Message = "Completed refresh of AMQP link authorization for Event Hub: {0} (Service Endpoint: '{1}').")]
-        public void AmqpLinkAuthorizationRefreshComplete(string eventHubName,
-                                                         string endpoint)
+        public virtual void AmqpLinkAuthorizationRefreshComplete(string eventHubName,
+                                                                 string endpoint)
         {
             if (IsEnabled())
             {
@@ -552,13 +553,152 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="errorMessage">The message for the exception that occurred.</param>
         ///
         [Event(29, Level = EventLevel.Error, Message = "An exception occurred while refreshing AMQP link authorization for Event Hub: {0} (Service Endpoint: '{1}'). Error Message: '{2}'")]
-        public void AmqpLinkAuthorizationRefreshError(string eventHubName,
-                                                      string endpoint,
-                                                      string errorMessage)
+        public virtual void AmqpLinkAuthorizationRefreshError(string eventHubName,
+                                                              string endpoint,
+                                                              string errorMessage)
         {
             if (IsEnabled())
             {
                 WriteEvent(29, eventHubName ?? string.Empty, endpoint ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an <see cref="EventProcessor{TPartition}" /> instance is about to begin processing events.
+        /// </summary>
+        ///
+        /// <param name="identifier">A unique name used to identify the event processor.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        ///
+        [Event(30, Level = EventLevel.Informational, Message = "Starting a new event processor instance with identifier '{0}' for Event Hub: {1} and Consumer Group: {2}.")]
+        public virtual void EventProcessorStart(string identifier,
+                                                string eventHubName,
+                                                string consumerGroup)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(30, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an <see cref="EventProcessor{TPartition}" /> instance is about to begin processing events.
+        /// </summary>
+        ///
+        /// <param name="identifier">A unique name used to identify the event processor.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        ///
+        [Event(31, Level = EventLevel.Informational, Message = "The new event processor instance with identifier '{0}' for Event Hub: {1} and Consumer Group: {2} has completed starting.")]
+        public virtual void EventProcessorStartComplete(string identifier,
+                                                        string eventHubName,
+                                                        string consumerGroup)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(31, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an <see cref="EventProcessor{TPartition}" /> instance has encountered an exception while starting to process events.
+        /// </summary>
+        ///
+        /// <param name="identifier">A unique name used to identify the event processor.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(32, Level = EventLevel.Error, Message = "An exception occurred while starting a new event processor instance with identifier '{0}' for Event Hub: {1} and Consumer Group: {2}.  Error Message: '{3}'")]
+        public virtual void EventProcessorStartError(string identifier,
+                                                     string eventHubName,
+                                                     string consumerGroup,
+                                                     string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(32, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an <see cref="EventProcessor{TPartition}" /> instance is beginning to stop processing events.
+        /// </summary>
+        ///
+        /// <param name="identifier">A unique name used to identify the event processor.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        ///
+        [Event(33, Level = EventLevel.Informational, Message = "The event processor instance with identifier '{0}' for Event Hub: {1} and Consumer Group: {2} is beginning to shut down.")]
+        public virtual void EventProcessorStop(string identifier,
+                                               string eventHubName,
+                                               string consumerGroup)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(33, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an <see cref="EventProcessor{TPartition}" /> instance has been stopped and is no longer processing events.
+        /// </summary>
+        ///
+        /// <param name="identifier">A unique name used to identify the event processor.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        ///
+        [Event(34, Level = EventLevel.Informational, Message = "The event processor instance with identifier '{0}' for Event Hub: {1} and Consumer Group: {2} has completed shutting down.")]
+        public virtual void EventProcessorStopComplete(string identifier,
+                                                       string eventHubName,
+                                                       string consumerGroup)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(34, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an <see cref="EventProcessor{TPartition}" /> instance has encountered an exception while stopping.
+        /// </summary>
+        ///
+        /// <param name="identifier">A unique name used to identify the event processor.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(35, Level = EventLevel.Error, Message = "An exception occurred while stopping the event processor instance with identifier '{0}' for Event Hub: {1} and Consumer Group: {2}.  Error Message: '{3}'")]
+        public virtual void EventProcessorStopError(string identifier,
+                                                    string eventHubName,
+                                                    string consumerGroup,
+                                                    string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(35, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an <see cref="EventProcessor{TPartition}" /> instance has encountered an error during processing or load balancing.
+        /// </summary>
+        ///
+        /// <param name="identifier">A unique name used to identify the event processor.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(36, Level = EventLevel.Error, Message = "An exception occurred during partition processing or load balancing for processor instance with identifier '{0}' for Event Hub: {1} and Consumer Group: {2}.  Error Message: '{3}'")]
+        public virtual void EventProcessingTaskError(string identifier,
+                                                     string eventHubName,
+                                                     string consumerGroup,
+                                                     string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(36, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty);
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpClientTests.cs
@@ -300,7 +300,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var eventHubName = "myName";
             var tokenValue = "123ABC";
             var retryPolicy = new BasicRetryPolicy(retryOptions);
-            var retriableException = AmqpError.CreateExceptionForError(new Error { Value = AmqpError.ServerBusyError }, "dummy");
+            var retriableException = AmqpError.CreateExceptionForError(new Error { Condition = AmqpError.ServerBusyError }, "dummy");
             var mockConverter = new Mock<AmqpMessageConverter>();
             var mockCredential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
             var mockScope = new Mock<AmqpConnectionScope>();
@@ -587,7 +587,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var partitionId = "Barney";
             var tokenValue = "123ABC";
             var retryPolicy = new BasicRetryPolicy(retryOptions);
-            var retriableException = AmqpError.CreateExceptionForError(new Error { Value = AmqpError.ServerBusyError }, "dummy");
+            var retriableException = AmqpError.CreateExceptionForError(new Error { Condition = AmqpError.ServerBusyError }, "dummy");
             var mockConverter = new Mock<AmqpMessageConverter>();
             var mockCredential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");
             var mockScope = new Mock<AmqpConnectionScope>();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConsumerTests.cs
@@ -314,7 +314,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var ownerLevel = 123L;
             var tokenValue = "123ABC";
             var retryPolicy = new BasicRetryPolicy(retryOptions);
-            var retriableException = AmqpError.CreateExceptionForError(new Error { Value = AmqpError.ServerBusyError }, "dummy");
+            var retriableException = AmqpError.CreateExceptionForError(new Error { Condition = AmqpError.ServerBusyError }, "dummy");
             var mockConverter = new Mock<AmqpMessageConverter>();
             var mockCredential = new Mock<TokenCredential>();
             var mockScope = new Mock<AmqpConnectionScope>();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
@@ -424,7 +424,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CreateBatchAsyncAppliesTheRetryPolicyForAmqpErrors(EventHubsRetryOptions retryOptions)
         {
             var partitionId = "testMe";
-            var retriableException = AmqpError.CreateExceptionForError(new Error { Value = AmqpError.ServerBusyError }, "dummy");
+            var retriableException = AmqpError.CreateExceptionForError(new Error { Condition = AmqpError.ServerBusyError }, "dummy");
             var retryPolicy = new BasicRetryPolicy(retryOptions);
 
             var producer = new Mock<AmqpProducer>("aHub", partitionId, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
@@ -713,7 +713,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SendEnumerableAppliesTheRetryPolicyForAmqpErrors(EventHubsRetryOptions retryOptions)
         {
             var partitionId = "testMe";
-            var retriableException = AmqpError.CreateExceptionForError(new Error { Value = AmqpError.ServerBusyError }, "dummy");
+            var retriableException = AmqpError.CreateExceptionForError(new Error { Condition = AmqpError.ServerBusyError }, "dummy");
             var retryPolicy = new BasicRetryPolicy(retryOptions);
 
             var producer = new Mock<AmqpProducer>("aHub", partitionId, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
@@ -1116,7 +1116,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var partitionKey = "testMe";
             var options = new CreateBatchOptions { PartitionKey = partitionKey };
-            var retriableException = AmqpError.CreateExceptionForError(new Error { Value = AmqpError.ServerBusyError }, "dummy");
+            var retriableException = AmqpError.CreateExceptionForError(new Error { Condition = AmqpError.ServerBusyError }, "dummy");
             var retryPolicy = new BasicRetryPolicy(retryOptions);
             var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options.ToSendOptions());
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.cs
@@ -7,6 +7,8 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
+using Azure.Messaging.EventHubs.Consumer;
+using Azure.Messaging.EventHubs.Diagnostics;
 using Azure.Messaging.EventHubs.Primitives;
 using Moq;
 using Moq.Protected;
@@ -22,6 +24,926 @@ namespace Azure.Messaging.EventHubs.Tests
     [TestFixture]
     public class EventProcessorTests
     {
+        /// <summary>
+        ///   Provides test cases for the constructor tests.
+        /// </summary>
+        ///
+        public static IEnumerable<object[]> ConstructorCreatesDefaultOptionsCases()
+        {
+            var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
+            var connectionStringNoHub = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123";
+            var credential = Mock.Of<TokenCredential>();
+
+            yield return new object[] { new BasicProcessorMock(99, "consumerGroup", connectionString), "connection string with default options" };
+            yield return new object[] { new BasicProcessorMock(99, "consumerGroup", connectionStringNoHub, "hub", default), "connection string with default options" };
+            yield return new object[] { new BasicProcessorMock(99, "consumerGroup", "namespace", "hub", credential, default(EventProcessorOptions)), "namespace with explicit null options" };
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}" />
+        ///   constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(-100)]
+        [TestCase(-10)]
+        [TestCase(-1)]
+        [TestCase(0)]
+        public void ConstructorValidatesTheEventBatchMaximumCount(int constructorArgument)
+        {
+            Assert.That(() => new BasicProcessorMock(constructorArgument, "dummyGroup", "dummyConnection", new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The connection string constructor should validate the maximum batch size.");
+            Assert.That(() => new BasicProcessorMock(constructorArgument, "dummyGroup", "dummyNamespace", "dummyEventHub", Mock.Of<TokenCredential>(), new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The namespace constructor should validate the maximum batch size.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}" />
+        ///   constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void ConstructorValidatesTheConsumerGroup(string constructorArgument)
+        {
+            Assert.That(() => new BasicProcessorMock(1, constructorArgument, "dummyConnection", new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The connection string constructor should validate the consumer group.");
+            Assert.That(() => new BasicProcessorMock(1, constructorArgument, "dummyNamespace", "dummyEventHub", Mock.Of<TokenCredential>(), new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The namespace constructor should validate the consumer group.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}" />
+        ///   constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void ConstructorValidatesTheConnectionString(string connectionString)
+        {
+            Assert.That(() => new BasicProcessorMock(1, EventHubConsumerClient.DefaultConsumerGroupName, connectionString), Throws.InstanceOf<ArgumentException>(), "The constructor without options should ensure a connection string.");
+            Assert.That(() => new BasicProcessorMock(1, EventHubConsumerClient.DefaultConsumerGroupName, connectionString, "dummy", new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The constructor with options should ensure a connection string.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}" />
+        ///   constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void ConstructorValidatesTheNamespace(string constructorArgument)
+        {
+            Assert.That(() => new BasicProcessorMock(1, EventHubConsumerClient.DefaultConsumerGroupName, constructorArgument, "dummy", Mock.Of<TokenCredential>()), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}" />
+        ///   constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void ConstructorValidatesTheEventHub(string constructorArgument)
+        {
+            Assert.That(() => new BasicProcessorMock(100, EventHubConsumerClient.DefaultConsumerGroupName, "namespace", constructorArgument, Mock.Of<TokenCredential>()), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}" />
+        ///   constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorValidatesTheCredential()
+        {
+            Assert.That(() => new BasicProcessorMock(5, EventHubConsumerClient.DefaultConsumerGroupName, "namespace", "hubName", default(TokenCredential)), Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}" />
+        ///   constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(ConstructorCreatesDefaultOptionsCases))]
+        public void ConstructorCreatesDefaultOptions(BasicProcessorMock eventProcessor,
+                                                     string constructorDescription)
+        {
+            var defaultOptions = new EventProcessorOptions();
+            var connectionOptions = GetConnectionOptions(eventProcessor);
+
+            Assert.That(connectionOptions.TransportType, Is.EqualTo(defaultOptions.ConnectionOptions.TransportType), $"The { constructorDescription } constructor should have a default set of connection options.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}" />
+        ///   constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConnectionStringConstructorClonesTheConnectionOptions()
+        {
+            var expectedTransportType = EventHubsTransportType.AmqpWebSockets;
+            var otherTransportType = EventHubsTransportType.AmqpTcp;
+
+            var options = new EventProcessorOptions
+            {
+                ConnectionOptions = new EventHubConnectionOptions { TransportType = expectedTransportType }
+            };
+
+            var eventProcessor = new BasicProcessorMock(1, "consumerGroup", "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub", options);
+
+            // Simply retrieving the options from an inner connection won't be enough to prove the processor clones
+            // its connection options because the cloning step also happens in the EventHubConnection constructor.
+            // For this reason, we will change the transport type and verify that it won't affect the returned
+            // connection options.
+
+            options.ConnectionOptions.TransportType = otherTransportType;
+
+            var connectionOptions = GetConnectionOptions(eventProcessor);
+            Assert.That(connectionOptions.TransportType, Is.EqualTo(expectedTransportType), $"The connection options should have been cloned.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}" />
+        ///   constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void NamespaceConstructorClonesTheConnectionOptions()
+        {
+            var expectedTransportType = EventHubsTransportType.AmqpWebSockets;
+            var otherTransportType = EventHubsTransportType.AmqpTcp;
+
+            var options = new EventProcessorOptions
+            {
+                ConnectionOptions = new EventHubConnectionOptions { TransportType = expectedTransportType }
+            };
+
+            var eventProcessor = new BasicProcessorMock(11, "consumerGroup", "namespace", "hub", Mock.Of<TokenCredential>(), options);
+
+            // Simply retrieving the options from an inner connection won't be enough to prove the processor clones
+            // its connection options because the cloning step also happens in the EventHubConnection constructor.
+            // For this reason, we will change the transport type and verify that it won't affect the returned
+            // connection options.
+
+            options.ConnectionOptions.TransportType = otherTransportType;
+
+            var connectionOptions = GetConnectionOptions(eventProcessor);
+            Assert.That(connectionOptions.TransportType, Is.EqualTo(expectedTransportType), $"The connection options should have been cloned.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}" />
+        ///   constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConnectionStringConstructorSetsTheIdentifier()
+        {
+            var options = new EventProcessorOptions
+            {
+                Identifier = Guid.NewGuid().ToString()
+            };
+
+            var eventProcessor = new BasicProcessorMock(72, "consumerGroup", "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub", options);
+
+            Assert.That(eventProcessor.Identifier, Is.Not.Null);
+            Assert.That(eventProcessor.Identifier, Is.EqualTo(options.Identifier));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}" />
+        ///   constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void NamespaceConstructorSetsTheIdentifier()
+        {
+            var options = new EventProcessorOptions
+            {
+                Identifier = Guid.NewGuid().ToString()
+            };
+
+            var eventProcessor = new BasicProcessorMock(65, "consumerGroup", "namespace", "hub", Mock.Of<TokenCredential>(), options);
+
+            Assert.That(eventProcessor.Identifier, Is.Not.Null);
+            Assert.That(eventProcessor.Identifier, Is.EqualTo(options.Identifier));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}" />
+        ///   constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void ConnectionStringConstructorCreatesTheIdentifierWhenNotSpecified(string identifier)
+        {
+            var options = new EventProcessorOptions
+            {
+                Identifier = identifier
+            };
+
+            var eventProcessor = new BasicProcessorMock(34, "consumerGroup", "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub", options);
+
+            Assert.That(eventProcessor.Identifier, Is.Not.Null);
+            Assert.That(eventProcessor.Identifier, Is.Not.Empty);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}" />
+        ///   constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void NamespaceConstructorCreatesTheIdentifierWhenNotSpecified(string identifier)
+        {
+            var options = new EventProcessorOptions
+            {
+                Identifier = identifier
+            };
+
+            var eventProcessor = new BasicProcessorMock(665, "consumerGroup", "namespace", "hub", Mock.Of<TokenCredential>(), options);
+
+            Assert.That(eventProcessor.Identifier, Is.Not.Null);
+            Assert.That(eventProcessor.Identifier, Is.Not.Empty);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.StartProcessing" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void StartProcessingRespectsACanceledToken(bool async)
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.Cancel();
+
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(4, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+
+            if (async)
+            {
+                Assert.That(async () => await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>(), "The asynchronous call should have been canceled.");
+            }
+            else
+            {
+                Assert.That(() => mockProcessor.Object.StartProcessing(cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>(), "The synchronous call should have been canceled.");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.StartProcessing" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task StartProcessingStartsTheProcessing(bool async)
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(4, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(Mock.Of<EventHubConnection>());
+
+            if (async)
+            {
+                await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
+            }
+            else
+            {
+                mockProcessor.Object.StartProcessing(cancellationSource.Token);
+            }
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+            Assert.That(mockProcessor.Object.IsRunning, Is.True, "The processor should report that it is running.");
+            Assert.That(GetRunningProcessorTask(mockProcessor.Object).IsCompleted, Is.False, "The task for processing should be active.");
+            mockProcessor.Verify(processor => processor.CreateConnection(), Times.Once);
+
+            // Shut the processor down to ensure resource clean-up, but ignore any errors since it isn't the
+            // subject of this test.
+
+            try
+            { await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token); }
+            catch { }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.StartProcessing" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task StartProcessingDoesNotAttemptToStartWhenRunning(bool async)
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(4, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(Mock.Of<EventHubConnection>());
+
+            if (async)
+            {
+                await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
+            }
+            else
+            {
+                mockProcessor.Object.StartProcessing(cancellationSource.Token);
+            }
+
+            Assert.That(mockProcessor.Object.IsRunning, Is.True, "The processor should report that it is running.");
+
+            // The processor is confirmed running; attempt to start again.
+
+            if (async)
+            {
+                await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
+            }
+            else
+            {
+                mockProcessor.Object.StartProcessing(cancellationSource.Token);
+            }
+
+            // Only a single connection should have been created.
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+            mockProcessor.Verify(processor => processor.CreateConnection(), Times.Once);
+
+            // Shut the processor down to ensure resource clean-up, but ignore any errors since it isn't the
+            // subject of this test.
+
+            try
+            { await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token); }
+            catch { }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.StartProcessing" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task StartProcessingLogsNormalStartup(bool async)
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var mockEventSource = new Mock<EventHubsEventSource>() { CallBase = true };
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(4, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+
+            mockProcessor.Object.Logger = mockEventSource.Object;
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(Mock.Of<EventHubConnection>());
+
+            if (async)
+            {
+                await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
+            }
+            else
+            {
+                mockProcessor.Object.StartProcessing(cancellationSource.Token);
+            }
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+            mockEventSource
+                .Verify(log => log.EventProcessorStart(
+                    mockProcessor.Object.Identifier,
+                    mockProcessor.Object.EventHubName,
+                    mockProcessor.Object.ConsumerGroup),
+                Times.Once);
+
+            mockEventSource
+                .Verify(log => log.EventProcessorStartComplete(
+                    mockProcessor.Object.Identifier,
+                    mockProcessor.Object.EventHubName,
+                    mockProcessor.Object.ConsumerGroup),
+                Times.Once);
+
+            // Shut the processor down to ensure resource clean-up, but ignore any errors since it isn't the
+            // subject of this test.
+
+            try
+            { await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token); }
+            catch { }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.StartProcessing" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task StartProcessingLogsErrorDuringStartup(bool async)
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var mockEventSource = new Mock<EventHubsEventSource>() { CallBase = true };
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(4, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+
+            mockEventSource
+                .Setup(log => log.EventProcessorStart(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .Callback(() => cancellationSource.Cancel());
+
+            mockProcessor.Object.Logger = mockEventSource.Object;
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(Mock.Of<EventHubConnection>());
+
+            if (async)
+            {
+                Assert.That(async () => await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>(), "Task cancellation should have been injected while starting.");
+            }
+            else
+            {
+                Assert.That(() => mockProcessor.Object.StartProcessing(cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>(), "Task cancellation should have been injected while starting.");
+            }
+
+            mockEventSource
+                .Verify(log => log.EventProcessorStart(
+                    mockProcessor.Object.Identifier,
+                    mockProcessor.Object.EventHubName,
+                    mockProcessor.Object.ConsumerGroup),
+                Times.Once);
+
+            mockEventSource
+                .Verify(log => log.EventProcessorStartError(
+                    mockProcessor.Object.Identifier,
+                    mockProcessor.Object.EventHubName,
+                    mockProcessor.Object.ConsumerGroup,
+                    It.IsAny<string>()),
+                Times.Once);
+
+            mockEventSource
+                .Verify(log => log.EventProcessorStartComplete(
+                    mockProcessor.Object.Identifier,
+                    mockProcessor.Object.EventHubName,
+                    mockProcessor.Object.ConsumerGroup),
+                Times.Once);
+
+            // Shut the processor down to ensure resource clean-up, but ignore any errors since it isn't the
+            // subject of this test.
+
+            try
+            { await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token); }
+            catch { }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.StopProcessing" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void StopProcessingRespectsACanceledToken(bool async)
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.Cancel();
+
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(65, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+
+            if (async)
+            {
+                Assert.That(async () => await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>(), "The asynchronous call should have been canceled.");
+            }
+            else
+            {
+                Assert.That(() => mockProcessor.Object.StopProcessing(cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>(), "The synchronous call should have been canceled.");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.StopProcessing" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task StopProcessingStopsProcessing(bool async)
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(65, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(Mock.Of<EventHubConnection>());
+
+            await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
+            Assert.That(mockProcessor.Object.IsRunning, Is.True, "The processor should report that it is running.");
+            Assert.That(GetRunningProcessorTask(mockProcessor.Object).IsCompleted, Is.False, "The task for processing should be active.");
+
+            if (async)
+            {
+                await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token);
+            }
+            else
+            {
+                mockProcessor.Object.StopProcessing(cancellationSource.Token);
+            }
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+            Assert.That(mockProcessor.Object.IsRunning, Is.False, "The processor should report that it is stopped.");
+            Assert.That(GetRunningProcessorTask(mockProcessor.Object), Is.Null, "There should be no active task for processing.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.StopProcessing" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void StopProcessingIsSafeToCallWhenNotProcessing(bool async)
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(65, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+
+            if (async)
+            {
+                Assert.That(async () => await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token), Throws.Nothing, "The asynchronous stop processing should be safe to call when not processing.");
+                Assert.That(async () => await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token), Throws.Nothing, "The asynchronous stop processing should be safe to call when not processing.");
+            }
+            else
+            {
+                Assert.That(() => mockProcessor.Object.StopProcessing(cancellationSource.Token), Throws.Nothing, "The synchronous stop processing should be safe to call when not processing.");
+                Assert.That(() => mockProcessor.Object.StopProcessing(cancellationSource.Token), Throws.Nothing, "The synchronous stop processing should be safe to call when not processing.");
+            }
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+            Assert.That(mockProcessor.Object.IsRunning, Is.False, "The processor should report that it is stopped.");
+            Assert.That(GetRunningProcessorTask(mockProcessor.Object), Is.Null, "There should be no active task for processing.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.StopProcessing" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task StopProcessingIsSafeToCallAfterStopping(bool async)
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(65, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(Mock.Of<EventHubConnection>());
+
+            await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
+            Assert.That(mockProcessor.Object.IsRunning, Is.True, "The processor should report that it is running.");
+            Assert.That(GetRunningProcessorTask(mockProcessor.Object).IsCompleted, Is.False, "The task for processing should be active.");
+
+            if (async)
+            {
+                await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token);
+            }
+            else
+            {
+                mockProcessor.Object.StopProcessing(cancellationSource.Token);
+            }
+
+            Assert.That(mockProcessor.Object.IsRunning, Is.False, "The processor should report that it is stopped.");
+            Assert.That(GetRunningProcessorTask(mockProcessor.Object), Is.Null, "There should be no active task for processing.");
+
+            if (async)
+            {
+                Assert.That(async () => await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token), Throws.Nothing, "The asynchronous stop processing should be safe to call when not processing.");
+                Assert.That(async () => await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token), Throws.Nothing, "The asynchronous stop processing should be safe to call when not processing.");
+            }
+            else
+            {
+                Assert.That(() => mockProcessor.Object.StopProcessing(cancellationSource.Token), Throws.Nothing, "The synchronous stop processing should be safe to call when not processing.");
+                Assert.That(() => mockProcessor.Object.StopProcessing(cancellationSource.Token), Throws.Nothing, "The synchronous stop processing should be safe to call when not processing.");
+            }
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been triggered.");
+            Assert.That(mockProcessor.Object.IsRunning, Is.False, "The processor should report that it is stopped.");
+            Assert.That(GetRunningProcessorTask(mockProcessor.Object), Is.Null, "There should be no active task for processing.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.StopProcessing" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task StopProcessingSurfacesExceptions(bool async)
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var expectedException = new DivideByZeroException("BOOM!");
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(65, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Throws(expectedException);
+
+            await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
+
+            if (async)
+            {
+                Assert.That(async () => await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token), Throws.Exception.SameAs(expectedException), "The asynchronous close call should bubble the exception.");
+            }
+            else
+            {
+                Assert.That(() => mockProcessor.Object.StopProcessing(cancellationSource.Token), Throws.Exception.SameAs(expectedException), "The synchronous close call should bubble the exception.");
+            }
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation source should not have been triggered.");
+            Assert.That(mockProcessor.Object.IsRunning, Is.False, "The processor should report that it is stopped.");
+            Assert.That(GetRunningProcessorTask(mockProcessor.Object), Is.Null, "There should be no active task for processing.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.StopProcessing" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task StopProcessingResetsState(bool async)
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var expectedException = new DivideByZeroException("BOOM!");
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(65, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+
+            mockProcessor
+                .SetupSequence(processor => processor.CreateConnection())
+                .Throws(expectedException)
+                .Returns(default(EventHubConnection));
+
+            // Starting the processor should result in an exception on the first call, which should leave it in a faulted state.
+
+            await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
+            Assert.That(mockProcessor.Object.IsRunning, Is.False, "The start call should have triggered an exception.");
+            Assert.That(GetRunningProcessorTask(mockProcessor.Object).IsFaulted, Is.True, "The task for processing should be faulted.");
+
+            // The processor should not reset the faulted state when calling start a second time.
+
+            await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
+            Assert.That(mockProcessor.Object.IsRunning, Is.False, "The start call should not have been able to reset the failure state.");
+            Assert.That(GetRunningProcessorTask(mockProcessor.Object).IsFaulted, Is.True, "The task for processing should be faulted.");
+
+            // Stopping the processor should clear the faulted state, as well as surface the fault.
+
+            if (async)
+            {
+                Assert.That(async () => await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token), Throws.Exception.SameAs(expectedException), "The asynchronous close call should bubble the exception.");
+            }
+            else
+            {
+                Assert.That(() => mockProcessor.Object.StopProcessing(cancellationSource.Token), Throws.Exception.SameAs(expectedException), "The synchronous close call should bubble the exception.");
+            }
+
+            Assert.That(GetRunningProcessorTask(mockProcessor.Object), Is.Null, "There should be no active task for processing.");
+
+            // After stopping, the processor state should be reset and it should be able to start.
+
+            await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
+            Assert.That(mockProcessor.Object.IsRunning, Is.True, "The start call should succeed after stopping to reset the state.");
+            Assert.That(GetRunningProcessorTask(mockProcessor.Object).IsCompleted, Is.False, "The task for processing should be active.");
+
+            // Shut down the processor now that it is running and confirm that the second shutdown resets state.
+
+            if (async)
+            {
+                await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token);
+            }
+            else
+            {
+                mockProcessor.Object.StopProcessing(cancellationSource.Token);
+            }
+
+            Assert.That(mockProcessor.Object.IsRunning, Is.False, "The processor should report that it is stopped.");
+            Assert.That(GetRunningProcessorTask(mockProcessor.Object), Is.Null, "There should be no active task for processing.");
+
+            // Ensure that the cancellation token used to prevent test hangs didn't get signaled, which could invalidate the
+            // test results.
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation source should not have been triggered.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.StopProcessing" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task StopProcessingLogsNormalShutdown(bool async)
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var mockEventSource = new Mock<EventHubsEventSource>() { CallBase = true };
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(4, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+
+            mockProcessor.Object.Logger = mockEventSource.Object;
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(Mock.Of<EventHubConnection>());
+
+            await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
+            Assert.That(mockProcessor.Object.IsRunning, Is.True, "The processor should have started.");
+
+            if (async)
+            {
+                await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token);
+            }
+            else
+            {
+                mockProcessor.Object.StopProcessing(cancellationSource.Token);
+            }
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+            mockEventSource
+                .Verify(log => log.EventProcessorStop(
+                    mockProcessor.Object.Identifier,
+                    mockProcessor.Object.EventHubName,
+                    mockProcessor.Object.ConsumerGroup),
+                Times.Once);
+
+            mockEventSource
+                .Verify(log => log.EventProcessorStopComplete(
+                    mockProcessor.Object.Identifier,
+                    mockProcessor.Object.EventHubName,
+                    mockProcessor.Object.ConsumerGroup),
+                Times.Once);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.StopProcessing" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task StopProcessingLogsErrorDuringShutdown(bool async)
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var mockEventSource = new Mock<EventHubsEventSource>() { CallBase = true };
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(4, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+
+            mockEventSource
+                .Setup(log => log.EventProcessorStop(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .Callback(() => cancellationSource.Cancel());
+
+            mockProcessor.Object.Logger = mockEventSource.Object;
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(default(EventHubConnection));
+
+            await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
+            Assert.That(mockProcessor.Object.IsRunning, Is.True, "The processor should be running.");
+
+            if (async)
+            {
+                Assert.That(async () => await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>(), "The asynchronous close call should encounter an exception.");
+            }
+            else
+            {
+                Assert.That(() => mockProcessor.Object.StopProcessing(cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>(), "The synchronous close call should encounter an exception.");
+            }
+
+            mockEventSource
+                .Verify(log => log.EventProcessorStop(
+                    mockProcessor.Object.Identifier,
+                    mockProcessor.Object.EventHubName,
+                    mockProcessor.Object.ConsumerGroup),
+                Times.Once);
+
+            mockEventSource
+               .Verify(log => log.EventProcessorStopError(
+                   mockProcessor.Object.Identifier,
+                   mockProcessor.Object.EventHubName,
+                   mockProcessor.Object.ConsumerGroup,
+                   It.IsAny<string>()),
+               Times.Once);
+
+            mockEventSource
+                .Verify(log => log.EventProcessorStopComplete(
+                    mockProcessor.Object.Identifier,
+                    mockProcessor.Object.EventHubName,
+                    mockProcessor.Object.ConsumerGroup),
+                Times.Once);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.StopProcessing" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task StopProcessingLogsFaultedTaskDuringShutdown(bool async)
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var expectedException = new DivideByZeroException("BOOM!");
+            var mockEventSource = new Mock<EventHubsEventSource>() { CallBase = true };
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(4, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+
+            mockProcessor.Object.Logger = mockEventSource.Object;
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Throws(expectedException);
+
+            await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
+            Assert.That(mockProcessor.Object.IsRunning, Is.False, "The processor should have faulted during startup.");
+
+            if (async)
+            {
+                Assert.That(async () => await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token), Throws.Exception, "The asynchronous close call should encounter an exception.");
+            }
+            else
+            {
+                Assert.That(() => mockProcessor.Object.StopProcessing(cancellationSource.Token), Throws.Exception, "The synchronous close call should encounter an exception.");
+            }
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+            mockEventSource
+                .Verify(log => log.EventProcessorStop(
+                    mockProcessor.Object.Identifier,
+                    mockProcessor.Object.EventHubName,
+                    mockProcessor.Object.ConsumerGroup),
+                Times.Once);
+
+            mockEventSource
+               .Verify(log => log.EventProcessingTaskError(
+                   mockProcessor.Object.Identifier,
+                   mockProcessor.Object.EventHubName,
+                   mockProcessor.Object.ConsumerGroup,
+                   expectedException.Message),
+               Times.Once);
+
+            mockEventSource
+                .Verify(log => log.EventProcessorStopComplete(
+                    mockProcessor.Object.Identifier,
+                    mockProcessor.Object.EventHubName,
+                    mockProcessor.Object.ConsumerGroup),
+                Times.Once);
+        }
+
         /// <summary>
         ///   Verifies functionality of the <see cref="StorageManager" />
         ///   used by the processor.
@@ -89,64 +1011,6 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="StorageManager" />
-        ///   used by the processor.
-        /// </summary>
-        ///
-        [Test]
-        public async Task TheStorageManagerDoesNotKeepTheProcessorAlive()
-        {
-            var fqNamespace = "fqns";
-            var eventHub = "eh";
-            var consumerGroup = "cg";
-            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(25, consumerGroup, fqNamespace, eventHub, Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
-            var storageManager = mockProcessor.Object.CreateStorageManager(mockProcessor.Object);
-
-            mockProcessor
-                .Protected()
-                .Setup<Task<IEnumerable<EventProcessorCheckpoint>>>("ListCheckpointsAsync", ItExpr.IsAny<CancellationToken>())
-                .Returns(Task.FromResult(default(IEnumerable<EventProcessorCheckpoint>)));
-
-            Assert.That(storageManager, Is.Not.Null, "The storage manager should have been created.");
-            Assert.That(() => storageManager.ListCheckpointsAsync(fqNamespace, eventHub, consumerGroup, CancellationToken.None), Throws.Nothing, "The initial call should be successful.");
-
-            // Attempt to clear out the processor and force GC.
-
-            mockProcessor = null;
-
-            // Because cleanup may be non-deterministic, allow a small set of retries.
-
-            var attempts = 0;
-            var maxAttempts = 5;
-
-            while (attempts <= maxAttempts)
-            {
-                await Task.Delay(TimeSpan.FromSeconds(1));
-
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-
-                try
-                {
-                    Assert.That(() => storageManager.ListCheckpointsAsync(fqNamespace, eventHub, consumerGroup, CancellationToken.None), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
-                }
-                catch (AssertionException)
-                {
-                    if (++attempts <= maxAttempts)
-                    {
-                        continue;
-                    }
-
-                    throw;
-                }
-
-                // If things have gotten here, the test passes.
-
-                break;
-            }
-        }
-
-        /// <summary>
         ///   Verifies functionality of the <see cref="EventProcessor{TPartition}" />
         ///   constructor.
         /// </summary>
@@ -174,7 +1038,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         /// <typeparam name="T">The partition type to which the processor is bound.</typeparam>
         ///
-        /// <param name="processor">The processor instance to read the load balancer for.</param>
+        /// <param name="processor">The processor instance to operate on.</param>
         ///
         /// <returns>The load balancer used by the processor.</returns>
         ///
@@ -183,5 +1047,69 @@ namespace Azure.Messaging.EventHubs.Tests
                 typeof(EventProcessor<T>)
                     .GetProperty("LoadBalancer", BindingFlags.Instance | BindingFlags.NonPublic)
                     .GetValue(processor);
+
+        /// <summary>
+        ///   Creates a connection using a processor client's ConnectionFactory and returns its ConnectionOptions.
+        /// </summary>
+        ///
+        /// <typeparam name="T">The partition type to which the processor is bound.</typeparam>
+        ///
+        /// <param name="processor">The processor instance to operate on.</param>
+        ///
+        /// <returns>The set of options used by the connection.</returns>
+        ///
+        private static EventHubConnectionOptions GetConnectionOptions<T>(EventProcessor<T> processor) where T : EventProcessorPartition, new() =>
+            (EventHubConnectionOptions)
+                typeof(EventHubConnection)
+                    .GetProperty("Options", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .GetValue(processor.CreateConnection());
+
+        /// <summary>
+        ///   Retrieves the task used to track the processor's activity when running, using its private accessor.
+        /// </summary>
+        ///
+        /// <typeparam name="T">The partition type to which the processor is bound.</typeparam>
+        ///
+        /// <param name="processor">The processor instance to operate on.</param>
+        ///
+        /// <returns>The task for tracking the processor's activity when running.</returns>
+        ///
+        private static Task GetRunningProcessorTask<T>(EventProcessor<T> processor) where T : EventProcessorPartition, new() =>
+            (Task)
+                typeof(EventProcessor<T>)
+                    .GetField("_runningProcessorTask", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .GetValue(processor);
+
+        /// <summary>
+        ///   A basic mock of the event processor, allowing for testing of specific base class
+        ///   functionality.
+        /// </summary>
+        ///
+        public class BasicProcessorMock : EventProcessor<EventProcessorPartition>
+        {
+            public BasicProcessorMock(int eventBatchMaximumCount,
+                                      string consumerGroup,
+                                      string connectionString,
+                                      EventProcessorOptions options = default) : base(eventBatchMaximumCount, consumerGroup, connectionString, options) { }
+
+            public BasicProcessorMock(int eventBatchMaximumCount,
+                                      string consumerGroup,
+                                      string connectionString,
+                                      string eventHubName,
+                                      EventProcessorOptions options = default) : base(eventBatchMaximumCount, consumerGroup, connectionString, eventHubName, options) { }
+
+            public BasicProcessorMock(int eventBatchMaximumCount,
+                                      string consumerGroup,
+                                      string fullyQualifiedNamespace,
+                                      string eventHubName,
+                                      TokenCredential credential,
+                                      EventProcessorOptions options = default) : base(eventBatchMaximumCount, consumerGroup, fullyQualifiedNamespace, eventHubName, credential, options) { }
+
+            protected override Task<IEnumerable<EventProcessorPartitionOwnership>> ClaimOwnershipAsync(IEnumerable<EventProcessorPartitionOwnership> desiredOwnership, CancellationToken cancellationToken) => throw new NotImplementedException();
+            protected override Task<IEnumerable<EventProcessorCheckpoint>> ListCheckpointsAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
+            protected override Task<IEnumerable<EventProcessorPartitionOwnership>> ListOwnershipAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
+            protected override Task OnProcessingErrorAsync(Exception exception, EventProcessorPartition partition, string operationDescription, CancellationToken cancellationToken) => throw new NotImplementedException();
+            protected override Task OnProcessingEventBatchAsync(IEnumerable<EventData> events, EventProcessorPartition partition, CancellationToken cancellationToken) => throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to implement the startup and shutdown functionality for the event processor, along with enhancing the tests to cover the previously
implemented constructors.  At this time, partition processing and load balancing are not implemented; these areas remain stubbed to allow for testing and will be part of a new workstream.

# Last Upstream Rebase

Saturday, March 7, 11:52am (EST)

# References and Related Issues 

- [.NET Event Hubs Client: Event Processor<T> Proposal](https://gist.github.com/jsquire/1f4a1e72fc02871f443ce365222d40f6)
- [Implement the Event Processor Base](https://github.com/Azure/azure-sdk-for-net/issues/9324) (#9324)  