### PR TITLE
Remove merge=union for csproj files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,8 +13,8 @@
 *.isma binary
 
 *.cs text diff=csharp
-*.csproj text merge=union
-*.sln text eol=crlf merge=union
+*.csproj text=auto
+*.sln text=auto eol=crlf
 
 # Automatically collapse Track 2 test recordings in github PRs
 **/SessionRecords/**/*.json linguist-generated=true


### PR DESCRIPTION
Recently seen some bad merges because of merge=union and cannot figure out any reason why we would need it so I'm removing it. Setting the csproj and sln file gitattributes to match that of the .NET team https://github.com/dotnet/runtime/blob/master/.gitattributes#L58

PTAL @heaths @chidozieononiwu @pakrym 