### PR TITLE
Azure.Identity Fixing AzureCliCredential check for no logged in account

### DIFF
--- a/sdk/identity/Azure.Identity/src/AzureCliCredentialClient.cs
+++ b/sdk/identity/Azure.Identity/src/AzureCliCredentialClient.cs
@@ -68,7 +68,9 @@ namespace Azure.Identity
 
             if (exitCode != 0)
             {
-                bool isLoginError = output.StartsWith("Please run 'az login'", StringComparison.CurrentCultureIgnoreCase);
+                bool isLoginError = output.Contains("az login") || output.Contains("az account set");
+
+
                 bool isWinError = output.StartsWith(WinAzureCLIError, StringComparison.CurrentCultureIgnoreCase);
 
                 bool isOtherOsError = AzNotFoundPattern.IsMatch(output);

--- a/sdk/identity/Azure.Identity/src/AzureCliCredentialClient.cs
+++ b/sdk/identity/Azure.Identity/src/AzureCliCredentialClient.cs
@@ -68,8 +68,7 @@ namespace Azure.Identity
 
             if (exitCode != 0)
             {
-                bool isLoginError = output.Contains("az login") || output.Contains("az account set");
-
+                bool isLoginError = output.IndexOf("az login", StringComparison.OrdinalIgnoreCase) != -1 || output.IndexOf("az account set", StringComparison.OrdinalIgnoreCase) != -1;
 
                 bool isWinError = output.StartsWith(WinAzureCLIError, StringComparison.CurrentCultureIgnoreCase);
 


### PR DESCRIPTION
There are actually multiple error messages the CLI might return when no account is logged in. This PR updates the error check which detects that login is required.