### PR TITLE
Allow flushing read-only streams produced by SDK

### DIFF
--- a/sdk/core/Azure.Core/src/Pipeline/Internal/ReadOnlyStream.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/ReadOnlyStream.cs
@@ -22,7 +22,7 @@ namespace Azure.Core.Pipeline
 
         public override void Flush()
         {
-            throw new NotSupportedException();
+            // Flush is allowed on read-only stream
         }
     }
 }

--- a/sdk/core/Azure.Core/src/Shared/RetriableStream.cs
+++ b/sdk/core/Azure.Core/src/Shared/RetriableStream.cs
@@ -174,7 +174,7 @@ namespace Azure.Core.Pipeline
 
             public override void Flush()
             {
-                throw new NotSupportedException();
+                // Flush is allowed on read-only stream
             }
         }
     }

--- a/sdk/core/Azure.Core/tests/RetriableStreamTests.cs
+++ b/sdk/core/Azure.Core/tests/RetriableStreamTests.cs
@@ -277,6 +277,17 @@ namespace Azure.Core.Tests
                 5));
         }
 
+        [Test]
+        public async Task FlushDoesntThrow()
+        {
+            Stream reliableStream = await CreateAsync(
+                offset => new MemoryStream(),
+                offset => new ValueTask<Stream>(new MemoryStream()),
+                new ResponseClassifier(), maxRetries: 5);
+
+            await reliableStream.FlushAsync();
+        }
+
         private void AssertReads(byte[] buffer, int length)
         {
             for (int i = 0; i < length; i++)

--- a/sdk/storage/Azure.Storage.Blobs.Batch/src/Shared/MultipartReaderStream.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/src/Shared/MultipartReaderStream.cs
@@ -143,7 +143,6 @@ namespace Azure.Core.Http.Multipart
 
         public override void Flush()
         {
-            throw new NotSupportedException();
         }
 
         private void PositionInnerStream()

--- a/sdk/storage/Azure.Storage.Blobs.Batch/src/Shared/MultipartReaderStream.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/src/Shared/MultipartReaderStream.cs
@@ -143,6 +143,7 @@ namespace Azure.Core.Http.Multipart
 
         public override void Flush()
         {
+            // Flush is allowed on read-only stream
         }
 
         private void PositionInnerStream()

--- a/sdk/storage/Azure.Storage.Common/src/Shared/StreamPartition.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/StreamPartition.cs
@@ -88,7 +88,10 @@ namespace Azure.Storage
 
         private bool _disposedValue = false; // To detect redundant calls
 
-        public override void Flush() => throw Errors.NotImplemented();
+        public override void Flush()
+        {
+            // Flush is allowed on read-only stream
+        }
 
         public int Read(out ReadOnlyMemory<byte> buffer, int count)
         {


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/10487