### PR TITLE
[EventHubs] Partition Receiver: GetPartitionPropertiesAsync (Track Two)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
@@ -243,6 +243,21 @@ namespace Azure.Messaging.EventHubs.Primitives
         }
 
         /// <summary>
+        ///   Retrieves information about the partition this client is associated to, including elements that describe the
+        ///   available events in the partition event stream.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        /// <returns>The set of information for the associated partition under the Event Hub this client is associated with.</returns>
+        ///
+        public virtual Task<PartitionProperties> GetPartitionPropertiesAsync(CancellationToken cancellationToken = default)
+        {
+            Argument.AssertNotClosed(IsClosed, nameof(PartitionReceiver));
+            return Connection.GetPartitionPropertiesAsync(PartitionId, RetryPolicy, cancellationToken);
+        }
+
+        /// <summary>
         ///   Closes the client.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
@@ -251,10 +251,10 @@ namespace Azure.Messaging.EventHubs.Primitives
         ///
         /// <returns>The set of information for the associated partition under the Event Hub this client is associated with.</returns>
         ///
-        public virtual Task<PartitionProperties> GetPartitionPropertiesAsync(CancellationToken cancellationToken = default)
+        public async virtual Task<PartitionProperties> GetPartitionPropertiesAsync(CancellationToken cancellationToken = default)
         {
             Argument.AssertNotClosed(IsClosed, nameof(PartitionReceiver));
-            return Connection.GetPartitionPropertiesAsync(PartitionId, RetryPolicy, cancellationToken);
+            return await Connection.GetPartitionPropertiesAsync(PartitionId, RetryPolicy, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
@@ -1953,11 +1953,10 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase(EventHubsTransportType.AmqpWebSockets)]
         public async Task ConsumerCanRetrievePartitionProperties(EventHubsTransportType transportType)
         {
-            var partitionCount = 4;
+            var partitionCount = 1;
 
             await using (EventHubScope scope = await EventHubScope.CreateAsync(partitionCount))
             {
-                var options = new EventHubConnectionOptions();
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var consumerOptions = new EventHubConsumerClientOptions { ConnectionOptions = new EventHubConnectionOptions { TransportType = transportType } };
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverLiveTests.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Consumer;
+using Azure.Messaging.EventHubs.Primitives;
+using Azure.Messaging.EventHubs.Producer;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of live tests for the <see cref="PartitionReceiver" />
+    ///   class.
+    /// </summary>
+    ///
+    /// <remarks>
+    ///   These tests have a dependency on live Azure services and may
+    ///   incur costs for the associated Azure subscription.
+    /// </remarks>
+    ///
+    [TestFixture]
+    [Category(TestCategory.Live)]
+    [Category(TestCategory.DisallowVisualStudioLiveUnitTesting)]
+    public class PartitionReceiverLiveTests
+    {
+        /// <summary>
+        ///   Verifies that the <see cref="PartitionReceiver" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(EventHubsTransportType.AmqpTcp)]
+        [TestCase(EventHubsTransportType.AmqpWebSockets)]
+        public async Task PartitionReceiverCanRetrievePartitionProperties(EventHubsTransportType transportType)
+        {
+            var partitionCount = 1;
+
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(partitionCount))
+            {
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var receiverOptions = new PartitionReceiverOptions { ConnectionOptions = new EventHubConnectionOptions { TransportType = transportType } };
+
+                var partitionId = default(string);
+
+                await using (var producer = new EventHubProducerClient(connectionString))
+                {
+                    partitionId = (await producer.GetPartitionIdsAsync()).First();
+                }
+
+                await using (var receiver = new PartitionReceiver(EventHubConsumerClient.DefaultConsumerGroupName, partitionId, EventPosition.Earliest, connectionString, receiverOptions))
+                {
+                    var cancellationSource = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+                    var partitionProperties = await receiver.GetPartitionPropertiesAsync(cancellationSource.Token);
+
+                    Assert.That(partitionProperties, Is.Not.Null, "A set of partition properties should have been returned.");
+                    Assert.That(partitionProperties.Id, Is.EqualTo(partitionId), "The partition identifier should match.");
+                    Assert.That(partitionProperties.EventHubName, Is.EqualTo(scope.EventHubName).Using((IEqualityComparer<string>)StringComparer.InvariantCultureIgnoreCase), "The Event Hub path should match.");
+                    Assert.That(partitionProperties.BeginningSequenceNumber, Is.Not.EqualTo(default(long)), "The beginning sequence number should have been populated.");
+                    Assert.That(partitionProperties.LastEnqueuedSequenceNumber, Is.Not.EqualTo(default(long)), "The last sequence number should have been populated.");
+                    Assert.That(partitionProperties.LastEnqueuedOffset, Is.Not.EqualTo(default(long)), "The last offset should have been populated.");
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="PartitionReceiver" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task PartitionReceiverCannotRetrievePartitionPropertiesWhenConnectionIsClosed()
+        {
+            var partitionCount = 1;
+
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(partitionCount))
+            {
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var connection = new EventHubConnection(connectionString);
+
+                var partitionId = default(string);
+
+                await using (var producer = new EventHubProducerClient(connection))
+                {
+                    partitionId = (await producer.GetPartitionIdsAsync()).First();
+                }
+
+                await using (var receiver = new PartitionReceiver(EventHubConsumerClient.DefaultConsumerGroupName, partitionId, EventPosition.Earliest, connection))
+                {
+                    Assert.That(async () => await receiver.GetPartitionPropertiesAsync(), Throws.Nothing);
+
+                    await connection.CloseAsync();
+
+                    Assert.That(async () => await receiver.GetPartitionPropertiesAsync(), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
+                }
+            }
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverTests.cs
@@ -430,21 +430,10 @@ namespace Azure.Messaging.EventHubs.Tests
             var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123";
             var receiver = new PartitionReceiver("cg", "pid", EventPosition.Earliest, connectionString, "someHub");
 
-            var capturedException = default(Exception);
-
             await receiver.CloseAsync(cancellationSource.Token);
 
-            try
-            {
-                await receiver.GetPartitionPropertiesAsync(cancellationSource.Token);
-            }
-            catch (EventHubsException ex) when (ex.Reason == EventHubsException.FailureReason.ClientClosed)
-            {
-                capturedException = ex;
-            }
-
+            Assert.That(async () => await receiver.GetPartitionPropertiesAsync(cancellationSource.Token), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
-            Assert.That(capturedException, Is.Not.Null, "An exception should have been thrown when closing.");
         }
 
         /// <summary>


### PR DESCRIPTION
Included partial implementation and tests for the class `PartitionReceiver`. Names are not final and class is `internal` for the time being.

Changes:
- `GetPartitionPropertiesAsync` method.

This implementation is a simple adaptation of the `PartitionReceiver` that was present during previews and follows the [skeleton](https://gist.github.com/jsquire/4ea3368192cfee98dcbb4adfb29a9822) that will be used as a base for the final public API this class will have.

Related: 

- #9323 
- [Partition Receiver Design Proposal](https://gist.github.com/jsquire/4ea3368192cfee98dcbb4adfb29a9822)