### PR TITLE
[EventHubs] Partition Receiver: Inner Transport Consumer (Track Two)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
@@ -653,7 +653,7 @@ namespace Azure.Messaging.EventHubs.Consumer
 
             if (transportConsumerException != default)
             {
-                throw transportConsumerException;
+                ExceptionDispatchInfo.Capture(transportConsumerException).Throw();
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
@@ -273,10 +273,10 @@ namespace Azure.Messaging.EventHubs.Consumer
         ///
         /// <returns>The set of information for the Event Hub that this client is associated with.</returns>
         ///
-        public virtual Task<EventHubProperties> GetEventHubPropertiesAsync(CancellationToken cancellationToken = default)
+        public virtual async Task<EventHubProperties> GetEventHubPropertiesAsync(CancellationToken cancellationToken = default)
         {
             Argument.AssertNotClosed(IsClosed, nameof(EventHubConsumerClient));
-            return Connection.GetPropertiesAsync(RetryPolicy, cancellationToken);
+            return await Connection.GetPropertiesAsync(RetryPolicy, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -293,11 +293,11 @@ namespace Azure.Messaging.EventHubs.Consumer
         ///   No new or extended information is presented.
         /// </remarks>
         ///
-        public virtual Task<string[]> GetPartitionIdsAsync(CancellationToken cancellationToken = default)
+        public virtual async Task<string[]> GetPartitionIdsAsync(CancellationToken cancellationToken = default)
         {
 
             Argument.AssertNotClosed(IsClosed, nameof(EventHubConsumerClient));
-            return Connection.GetPartitionIdsAsync(RetryPolicy, cancellationToken);
+            return await Connection.GetPartitionIdsAsync(RetryPolicy, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -310,11 +310,11 @@ namespace Azure.Messaging.EventHubs.Consumer
         ///
         /// <returns>The set of information for the requested partition under the Event Hub this client is associated with.</returns>
         ///
-        public virtual Task<PartitionProperties> GetPartitionPropertiesAsync(string partitionId,
+        public virtual async Task<PartitionProperties> GetPartitionPropertiesAsync(string partitionId,
                                                                              CancellationToken cancellationToken = default)
         {
             Argument.AssertNotClosed(IsClosed, nameof(EventHubConsumerClient));
-            return Connection.GetPartitionPropertiesAsync(partitionId, RetryPolicy, cancellationToken);
+            return await Connection.GetPartitionPropertiesAsync(partitionId, RetryPolicy, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnection.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnection.cs
@@ -231,7 +231,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///
-        public async virtual Task CloseAsync(CancellationToken cancellationToken = default)
+        public virtual async Task CloseAsync(CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             EventHubsEventSource.Log.ClientCloseStart(typeof(EventHubConnection), EventHubName, FullyQualifiedNamespace);
@@ -299,8 +299,8 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <returns>The set of information for the Event Hub that this connection is associated with.</returns>
         ///
-        internal virtual Task<EventHubProperties> GetPropertiesAsync(EventHubsRetryPolicy retryPolicy,
-                                                                     CancellationToken cancellationToken = default) => InnerClient.GetPropertiesAsync(retryPolicy, cancellationToken);
+        internal virtual async Task<EventHubProperties> GetPropertiesAsync(EventHubsRetryPolicy retryPolicy,
+                                                                           CancellationToken cancellationToken = default) => await InnerClient.GetPropertiesAsync(retryPolicy, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         ///   Retrieves the set of identifiers for the partitions of an Event Hub.
@@ -332,9 +332,9 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <returns>The set of information for the requested partition under the Event Hub this connection is associated with.</returns>
         ///
-        internal virtual Task<PartitionProperties> GetPartitionPropertiesAsync(string partitionId,
-                                                                               EventHubsRetryPolicy retryPolicy,
-                                                                               CancellationToken cancellationToken = default) => InnerClient.GetPartitionPropertiesAsync(partitionId, retryPolicy, cancellationToken);
+        internal virtual async Task<PartitionProperties> GetPartitionPropertiesAsync(string partitionId,
+                                                                                     EventHubsRetryPolicy retryPolicy,
+                                                                                     CancellationToken cancellationToken = default) => await InnerClient.GetPartitionPropertiesAsync(partitionId, retryPolicy, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         ///   Creates a producer strongly aligned with the active protocol and transport,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -174,7 +175,7 @@ namespace Azure.Messaging.EventHubs.Primitives
             PartitionId = partitionId;
             InitialPosition = eventPosition;
             RetryPolicy = options.RetryOptions.ToRetryPolicy();
-            InnerConsumer = CreateTransportConsumer(consumerGroup, partitionId, eventPosition, RetryPolicy, options.TrackLastEnqueuedEventProperties, options.OwnerLevel, (uint?)options.PrefetchCount);
+            InnerConsumer = CreateTransportConsumer(consumerGroup, partitionId, eventPosition, RetryPolicy, options);
         }
 
         /// <summary>
@@ -210,7 +211,7 @@ namespace Azure.Messaging.EventHubs.Primitives
             PartitionId = partitionId;
             InitialPosition = eventPosition;
             RetryPolicy = options.RetryOptions.ToRetryPolicy();
-            InnerConsumer = CreateTransportConsumer(consumerGroup, partitionId, eventPosition, RetryPolicy, options.TrackLastEnqueuedEventProperties, options.OwnerLevel, (uint?)options.PrefetchCount);
+            InnerConsumer = CreateTransportConsumer(consumerGroup, partitionId, eventPosition, RetryPolicy, options);
         }
 
         /// <summary>
@@ -241,7 +242,7 @@ namespace Azure.Messaging.EventHubs.Primitives
             PartitionId = partitionId;
             InitialPosition = eventPosition;
             RetryPolicy = options.RetryOptions.ToRetryPolicy();
-            InnerConsumer = CreateTransportConsumer(consumerGroup, partitionId, eventPosition, RetryPolicy, options.TrackLastEnqueuedEventProperties, options.OwnerLevel, (uint?)options.PrefetchCount);
+            InnerConsumer = CreateTransportConsumer(consumerGroup, partitionId, eventPosition, RetryPolicy, options);
         }
 
         /// <summary>
@@ -353,7 +354,7 @@ namespace Azure.Messaging.EventHubs.Primitives
 
             if (transportConsumerException != default)
             {
-                throw transportConsumerException;
+                ExceptionDispatchInfo.Capture(transportConsumerException).Throw();
             }
         }
 
@@ -401,9 +402,7 @@ namespace Azure.Messaging.EventHubs.Primitives
         /// <param name="partitionId">The identifier of the Event Hub partition from which events will be received.</param>
         /// <param name="eventPosition">The position within the partition where the consumer should begin reading events.</param>
         /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
-        /// <param name="trackLastEnqueuedEventProperties">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
-        /// <param name="ownerLevel">The relative priority to associate with the link; for a non-exclusive link, this value should be <c>null</c>.</param>
-        /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.  If <c>null</c> a default will be used.</param>
+        /// <param name="options">A set of options to apply when configuring the consumer.</param>
         ///
         /// <returns>A <see cref="TransportConsumer" /> configured in the requested manner.</returns>
         ///
@@ -411,9 +410,7 @@ namespace Azure.Messaging.EventHubs.Primitives
                                                                    string partitionId,
                                                                    EventPosition eventPosition,
                                                                    EventHubsRetryPolicy retryPolicy,
-                                                                   bool trackLastEnqueuedEventProperties,
-                                                                   long? ownerLevel,
-                                                                   uint? prefetchCount) =>
-            Connection.CreateTransportConsumer(consumerGroup, partitionId, eventPosition, retryPolicy, trackLastEnqueuedEventProperties, ownerLevel, prefetchCount);
+                                                                   PartitionReceiverOptions options) =>
+            Connection.CreateTransportConsumer(consumerGroup, partitionId, eventPosition, retryPolicy, options.TrackLastEnqueuedEventProperties, options.OwnerLevel, (uint?)options.PrefetchCount);
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
@@ -174,7 +174,7 @@ namespace Azure.Messaging.EventHubs.Primitives
             PartitionId = partitionId;
             InitialPosition = eventPosition;
             RetryPolicy = options.RetryOptions.ToRetryPolicy();
-            InnerConsumer = Connection.CreateTransportConsumer(consumerGroup, partitionId, eventPosition, RetryPolicy, options.TrackLastEnqueuedEventProperties, options.OwnerLevel, (uint?)options.PrefetchCount);
+            InnerConsumer = CreateTransportConsumer(consumerGroup, partitionId, eventPosition, RetryPolicy, options.TrackLastEnqueuedEventProperties, options.OwnerLevel, (uint?)options.PrefetchCount);
         }
 
         /// <summary>
@@ -210,7 +210,7 @@ namespace Azure.Messaging.EventHubs.Primitives
             PartitionId = partitionId;
             InitialPosition = eventPosition;
             RetryPolicy = options.RetryOptions.ToRetryPolicy();
-            InnerConsumer = Connection.CreateTransportConsumer(consumerGroup, partitionId, eventPosition, RetryPolicy, options.TrackLastEnqueuedEventProperties, options.OwnerLevel, (uint?)options.PrefetchCount);
+            InnerConsumer = CreateTransportConsumer(consumerGroup, partitionId, eventPosition, RetryPolicy, options.TrackLastEnqueuedEventProperties, options.OwnerLevel, (uint?)options.PrefetchCount);
         }
 
         /// <summary>
@@ -241,7 +241,7 @@ namespace Azure.Messaging.EventHubs.Primitives
             PartitionId = partitionId;
             InitialPosition = eventPosition;
             RetryPolicy = options.RetryOptions.ToRetryPolicy();
-            InnerConsumer = Connection.CreateTransportConsumer(consumerGroup, partitionId, eventPosition, RetryPolicy, options.TrackLastEnqueuedEventProperties, options.OwnerLevel, (uint?)options.PrefetchCount);
+            InnerConsumer = CreateTransportConsumer(consumerGroup, partitionId, eventPosition, RetryPolicy, options.TrackLastEnqueuedEventProperties, options.OwnerLevel, (uint?)options.PrefetchCount);
         }
 
         /// <summary>
@@ -392,5 +392,28 @@ namespace Azure.Messaging.EventHubs.Primitives
         ///
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override string ToString() => base.ToString();
+
+        /// <summary>
+        ///   Creates an <see cref="TransportConsumer" /> to use for reading events.
+        /// </summary>
+        ///
+        /// <param name="consumerGroup">The name of the consumer group the consumer will be associated with.  Events will be read in the context of this group.</param>
+        /// <param name="partitionId">The identifier of the Event Hub partition from which events will be received.</param>
+        /// <param name="eventPosition">The position within the partition where the consumer should begin reading events.</param>
+        /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
+        /// <param name="trackLastEnqueuedEventProperties">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
+        /// <param name="ownerLevel">The relative priority to associate with the link; for a non-exclusive link, this value should be <c>null</c>.</param>
+        /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.  If <c>null</c> a default will be used.</param>
+        ///
+        /// <returns>A <see cref="TransportConsumer" /> configured in the requested manner.</returns>
+        ///
+        internal virtual TransportConsumer CreateTransportConsumer(string consumerGroup,
+                                                                   string partitionId,
+                                                                   EventPosition eventPosition,
+                                                                   EventHubsRetryPolicy retryPolicy,
+                                                                   bool trackLastEnqueuedEventProperties,
+                                                                   long? ownerLevel,
+                                                                   uint? prefetchCount) =>
+            Connection.CreateTransportConsumer(consumerGroup, partitionId, eventPosition, retryPolicy, trackLastEnqueuedEventProperties, ownerLevel, prefetchCount);
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
@@ -278,9 +278,9 @@ namespace Azure.Messaging.EventHubs.Primitives
         ///
         /// <returns>TODO.</returns>
         ///
-        public async virtual Task<IEnumerable<EventData>> ReceiveBatchAsync(int maximumEventCount,
-                                                                            TimeSpan maximumWaitTime,
-                                                                            CancellationToken cancellationToken = default)
+        public virtual Task<IEnumerable<EventData>> ReceiveBatchAsync(int maximumEventCount,
+                                                                      TimeSpan maximumWaitTime,
+                                                                      CancellationToken cancellationToken = default)
         {
             Argument.AssertNotClosed(IsClosed, nameof(PartitionReceiver));
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
@@ -288,7 +288,8 @@ namespace Azure.Messaging.EventHubs.Primitives
             Argument.AssertInRange(maximumEventCount, 1, int.MaxValue, nameof(maximumEventCount));
             Argument.AssertNotNegative(maximumWaitTime, nameof(maximumWaitTime));
 
-            await Task.CompletedTask.ConfigureAwait(false);
+            // TODO: implement method.
+
             return default;
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
@@ -262,7 +262,7 @@ namespace Azure.Messaging.EventHubs.Primitives
         ///
         /// <returns>The set of information for the associated partition under the Event Hub this client is associated with.</returns>
         ///
-        public async virtual Task<PartitionProperties> GetPartitionPropertiesAsync(CancellationToken cancellationToken = default)
+        public virtual async Task<PartitionProperties> GetPartitionPropertiesAsync(CancellationToken cancellationToken = default)
         {
             Argument.AssertNotClosed(IsClosed, nameof(PartitionReceiver));
             return await Connection.GetPartitionPropertiesAsync(PartitionId, RetryPolicy, cancellationToken).ConfigureAwait(false);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
@@ -269,14 +269,14 @@ namespace Azure.Messaging.EventHubs.Primitives
         }
 
         /// <summary>
-        ///   TODO.
+        ///   Receives a batch of <see cref="EventData" /> from the Event Hub partition this client is associated with.
         /// </summary>
         ///
-        /// <param name="maximumEventCount">TODO.</param>
-        /// <param name="maximumWaitTime">TODO.</param>
+        /// <param name="maximumEventCount">The maximum number of messages to receive in this batch.</param>
+        /// <param name="maximumWaitTime">The maximum amount of time to wait to build up the requested message count for the batch; if not specified, the default wait time specified by the options when the client was created will be used.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
-        /// <returns>TODO.</returns>
+        /// <returns>The batch of <see cref="EventData" /> from the Event Hub partition this client is associated with.  If no events are present, an empty enumerable is returned.</returns>
         ///
         public virtual Task<IEnumerable<EventData>> ReceiveBatchAsync(int maximumEventCount,
                                                                       TimeSpan maximumWaitTime,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
@@ -255,6 +256,30 @@ namespace Azure.Messaging.EventHubs.Primitives
         {
             Argument.AssertNotClosed(IsClosed, nameof(PartitionReceiver));
             return await Connection.GetPartitionPropertiesAsync(PartitionId, RetryPolicy, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   TODO.
+        /// </summary>
+        ///
+        /// <param name="maximumEventCount">TODO.</param>
+        /// <param name="maximumWaitTime">TODO.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        /// <returns>TODO.</returns>
+        ///
+        public async virtual Task<IEnumerable<EventData>> ReceiveBatchAsync(int maximumEventCount,
+                                                                            TimeSpan maximumWaitTime,
+                                                                            CancellationToken cancellationToken = default)
+        {
+            Argument.AssertNotClosed(IsClosed, nameof(PartitionReceiver));
+            cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+
+            Argument.AssertInRange(maximumEventCount, 1, int.MaxValue, nameof(maximumEventCount));
+            Argument.AssertNotNegative(maximumWaitTime, nameof(maximumWaitTime));
+
+            await Task.CompletedTask.ConfigureAwait(false);
+            return default;
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -279,10 +279,10 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         /// <returns>The set of information for the Event Hub that this client is associated with.</returns>
         ///
-        public virtual Task<EventHubProperties> GetEventHubPropertiesAsync(CancellationToken cancellationToken = default)
+        public virtual async Task<EventHubProperties> GetEventHubPropertiesAsync(CancellationToken cancellationToken = default)
         {
             Argument.AssertNotClosed(IsClosed, nameof(EventHubProducerClient));
-            return Connection.GetPropertiesAsync(RetryPolicy, cancellationToken);
+            return await Connection.GetPropertiesAsync(RetryPolicy, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -299,11 +299,11 @@ namespace Azure.Messaging.EventHubs.Producer
         ///   No new or extended information is presented.
         /// </remarks>
         ///
-        public virtual Task<string[]> GetPartitionIdsAsync(CancellationToken cancellationToken = default)
+        public virtual async Task<string[]> GetPartitionIdsAsync(CancellationToken cancellationToken = default)
         {
 
             Argument.AssertNotClosed(IsClosed, nameof(EventHubProducerClient));
-            return Connection.GetPartitionIdsAsync(RetryPolicy, cancellationToken);
+            return await Connection.GetPartitionIdsAsync(RetryPolicy, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -316,11 +316,11 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         /// <returns>The set of information for the requested partition under the Event Hub this client is associated with.</returns>
         ///
-        public virtual Task<PartitionProperties> GetPartitionPropertiesAsync(string partitionId,
-                                                                             CancellationToken cancellationToken = default)
+        public virtual async Task<PartitionProperties> GetPartitionPropertiesAsync(string partitionId,
+                                                                                   CancellationToken cancellationToken = default)
         {
             Argument.AssertNotClosed(IsClosed, nameof(EventHubProducerClient));
-            return Connection.GetPartitionPropertiesAsync(partitionId, RetryPolicy, cancellationToken);
+            return await Connection.GetPartitionPropertiesAsync(partitionId, RetryPolicy, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -338,11 +338,11 @@ namespace Azure.Messaging.EventHubs.Producer
         /// <seealso cref="SendAsync(IEnumerable{EventData}, SendEventOptions, CancellationToken)" />
         /// <seealso cref="SendAsync(EventDataBatch, CancellationToken)" />
         ///
-        internal virtual Task SendAsync(EventData eventData,
-                                        CancellationToken cancellationToken = default)
+        internal virtual async Task SendAsync(EventData eventData,
+                                              CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(eventData, nameof(eventData));
-            return SendAsync(new[] { eventData }, null, cancellationToken);
+            await SendAsync(new[] { eventData }, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -361,12 +361,12 @@ namespace Azure.Messaging.EventHubs.Producer
         /// <seealso cref="SendAsync(IEnumerable{EventData}, SendEventOptions, CancellationToken)" />
         /// <seealso cref="SendAsync(EventDataBatch, CancellationToken)" />
         ///
-        internal virtual Task SendAsync(EventData eventData,
-                                        SendEventOptions options,
-                                        CancellationToken cancellationToken = default)
+        internal virtual async Task SendAsync(EventData eventData,
+                                              SendEventOptions options,
+                                              CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(eventData, nameof(eventData));
-            return SendAsync(new[] { eventData }, options, cancellationToken);
+            await SendAsync(new[] { eventData }, options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -381,8 +381,8 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         /// <seealso cref="SendAsync(IEnumerable{EventData}, SendEventOptions, CancellationToken)"/>
         ///
-        internal virtual Task SendAsync(IEnumerable<EventData> events,
-                                        CancellationToken cancellationToken = default) => SendAsync(events, null, cancellationToken);
+        internal virtual async Task SendAsync(IEnumerable<EventData> events,
+                                              CancellationToken cancellationToken = default) => await SendAsync(events, null, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         ///   Sends a set of events to the associated Event Hub using a batched approach.  If the size of events exceed the
@@ -526,7 +526,7 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         /// <seealso cref="CreateBatchAsync(CreateBatchOptions, CancellationToken)" />
         ///
-        public virtual ValueTask<EventDataBatch> CreateBatchAsync(CancellationToken cancellationToken = default) => CreateBatchAsync(null, cancellationToken);
+        public virtual async ValueTask<EventDataBatch> CreateBatchAsync(CancellationToken cancellationToken = default) => await CreateBatchAsync(null, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         ///   Creates a size-constraint batch to which <see cref="EventData" /> may be added using a try-based pattern.  If an event would

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -8,6 +8,7 @@ using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -626,7 +627,7 @@ namespace Azure.Messaging.EventHubs.Producer
 
             if (transportProducerException != default)
             {
-                throw transportProducerException;
+                ExceptionDispatchInfo.Capture(transportProducerException).Throw();
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
@@ -2408,7 +2408,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 return Task.FromResult(new EventHubProperties(EventHubName, DateTimeOffset.Parse("2015-10-27T00:00:00Z"), new string[] { "0", "1" }));
             }
 
-            internal async override Task<string[]> GetPartitionIdsAsync(EventHubsRetryPolicy retryPolicy,
+            internal override async Task<string[]> GetPartitionIdsAsync(EventHubsRetryPolicy retryPolicy,
                                                                         CancellationToken cancellationToken = default)
             {
                 GetPartitionIdsInvokedWith = retryPolicy;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverTests.cs
@@ -158,6 +158,85 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        public void ConnectionStringConstructorCreatesTheTransportConsumer()
+        {
+            var expectedRetryPolicy = Mock.Of<EventHubsRetryPolicy>();
+            var expectedOptions = new PartitionReceiverOptions
+            {
+                RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = expectedRetryPolicy },
+                OwnerLevel = 99,
+                PrefetchCount = 42,
+                TrackLastEnqueuedEventProperties = false
+            };
+            var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
+            var receiver = new ObservableConsumerPartitionReceiver("cg", "pid", EventPosition.Earliest, connectionString, expectedOptions);
+
+            Assert.That(receiver.TransportConsumerCreatedWithConsumerGroup, Is.EqualTo(receiver.ConsumerGroup));
+            Assert.That(receiver.TransportConsumerCreatedWithPartitionId, Is.EqualTo(receiver.PartitionId));
+            Assert.That(receiver.TransportConsumerCreatedWithEventPosition, Is.EqualTo(receiver.InitialPosition));
+            Assert.That(receiver.TransportConsumerCreatedWithRetryPolicy, Is.SameAs(expectedRetryPolicy));
+            Assert.That(receiver.TransportConsumerCreatedWithTrackLastEnqueuedEventProperties, Is.EqualTo(expectedOptions.TrackLastEnqueuedEventProperties));
+            Assert.That(receiver.TransportConsumerCreatedWithOwnerLevel, Is.EqualTo(expectedOptions.OwnerLevel));
+            Assert.That(receiver.TransportConsumerCreatedWithPrefetchCount, Is.EqualTo(expectedOptions.PrefetchCount));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ExpandedConstructorCreatesTheTransportConsumer()
+        {
+            var expectedRetryPolicy = Mock.Of<EventHubsRetryPolicy>();
+            var expectedOptions = new PartitionReceiverOptions
+            {
+                RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = expectedRetryPolicy },
+                OwnerLevel = 99,
+                PrefetchCount = 42,
+                TrackLastEnqueuedEventProperties = false
+            };
+            var receiver = new ObservableConsumerPartitionReceiver("cg", "pid", EventPosition.Earliest, "fqns", "eh", Mock.Of<TokenCredential>(), expectedOptions);
+
+            Assert.That(receiver.TransportConsumerCreatedWithConsumerGroup, Is.EqualTo(receiver.ConsumerGroup));
+            Assert.That(receiver.TransportConsumerCreatedWithPartitionId, Is.EqualTo(receiver.PartitionId));
+            Assert.That(receiver.TransportConsumerCreatedWithEventPosition, Is.EqualTo(receiver.InitialPosition));
+            Assert.That(receiver.TransportConsumerCreatedWithRetryPolicy, Is.SameAs(expectedRetryPolicy));
+            Assert.That(receiver.TransportConsumerCreatedWithTrackLastEnqueuedEventProperties, Is.EqualTo(expectedOptions.TrackLastEnqueuedEventProperties));
+            Assert.That(receiver.TransportConsumerCreatedWithOwnerLevel, Is.EqualTo(expectedOptions.OwnerLevel));
+            Assert.That(receiver.TransportConsumerCreatedWithPrefetchCount, Is.EqualTo(expectedOptions.PrefetchCount));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConnectionConstructorCreatesTheTransportConsumer()
+        {
+            var expectedRetryPolicy = Mock.Of<EventHubsRetryPolicy>();
+            var expectedOptions = new PartitionReceiverOptions
+            {
+                RetryOptions = new EventHubsRetryOptions { CustomRetryPolicy = expectedRetryPolicy },
+                OwnerLevel = 99,
+                PrefetchCount = 42,
+                TrackLastEnqueuedEventProperties = false
+            };
+            var receiver = new ObservableConsumerPartitionReceiver("cg", "pid", EventPosition.Earliest, Mock.Of<EventHubConnection>(), expectedOptions);
+
+            Assert.That(receiver.TransportConsumerCreatedWithConsumerGroup, Is.EqualTo(receiver.ConsumerGroup));
+            Assert.That(receiver.TransportConsumerCreatedWithPartitionId, Is.EqualTo(receiver.PartitionId));
+            Assert.That(receiver.TransportConsumerCreatedWithEventPosition, Is.EqualTo(receiver.InitialPosition));
+            Assert.That(receiver.TransportConsumerCreatedWithRetryPolicy, Is.SameAs(expectedRetryPolicy));
+            Assert.That(receiver.TransportConsumerCreatedWithTrackLastEnqueuedEventProperties, Is.EqualTo(expectedOptions.TrackLastEnqueuedEventProperties));
+            Assert.That(receiver.TransportConsumerCreatedWithOwnerLevel, Is.EqualTo(expectedOptions.OwnerLevel));
+            Assert.That(receiver.TransportConsumerCreatedWithPrefetchCount, Is.EqualTo(expectedOptions.PrefetchCount));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
         public void ConnectionStringConstructorCreatesDefaultOptions()
         {
             var expected = new PartitionReceiverOptions().RetryOptions;
@@ -869,5 +948,66 @@ namespace Azure.Messaging.EventHubs.Tests
                 typeof(PartitionReceiver)
                     .GetProperty("RetryPolicy", BindingFlags.Instance | BindingFlags.NonPublic)
                     .GetValue(partitionReceiver);
+
+        /// <summary>
+        ///   Allows the observation of the creation of a <see cref="TransportConsumer"/>
+        ///   for testing purposes.
+        /// </summary>
+        ///
+        private class ObservableConsumerPartitionReceiver : PartitionReceiver
+        {
+            public string TransportConsumerCreatedWithConsumerGroup { get; private set; }
+            public string TransportConsumerCreatedWithPartitionId { get; private set; }
+            public EventPosition TransportConsumerCreatedWithEventPosition { get; private set; }
+            public EventHubsRetryPolicy TransportConsumerCreatedWithRetryPolicy { get; private set; }
+            public bool TransportConsumerCreatedWithTrackLastEnqueuedEventProperties { get; private set; }
+            public long? TransportConsumerCreatedWithOwnerLevel { get; private set; }
+            public uint? TransportConsumerCreatedWithPrefetchCount { get; private set; }
+
+            public ObservableConsumerPartitionReceiver(string consumerGroup,
+                                                       string partitionId,
+                                                       EventPosition eventPosition,
+                                                       string connectionString,
+                                                       PartitionReceiverOptions options = default) : base(consumerGroup, partitionId, eventPosition, connectionString, options)
+            {
+            }
+
+            public ObservableConsumerPartitionReceiver(string consumerGroup,
+                                                       string partitionId,
+                                                       EventPosition eventPosition,
+                                                       string fullyQualifiedNamespace,
+                                                       string eventHubName,
+                                                       TokenCredential credential,
+                                                       PartitionReceiverOptions options = default) : base(consumerGroup, partitionId, eventPosition, fullyQualifiedNamespace, eventHubName, credential, options)
+            {
+            }
+
+            public ObservableConsumerPartitionReceiver(string consumerGroup,
+                                                       string partitionId,
+                                                       EventPosition eventPosition,
+                                                       EventHubConnection connection,
+                                                       PartitionReceiverOptions options = default) : base(consumerGroup, partitionId, eventPosition, connection, options)
+            {
+            }
+
+            internal override TransportConsumer CreateTransportConsumer(string consumerGroup,
+                                                                        string partitionId,
+                                                                        EventPosition eventPosition,
+                                                                        EventHubsRetryPolicy retryPolicy,
+                                                                        bool trackLastEnqueuedEventProperties,
+                                                                        long? ownerLevel,
+                                                                        uint? prefetchCount)
+            {
+                TransportConsumerCreatedWithConsumerGroup = consumerGroup;
+                TransportConsumerCreatedWithPartitionId = partitionId;
+                TransportConsumerCreatedWithEventPosition = eventPosition;
+                TransportConsumerCreatedWithRetryPolicy = retryPolicy;
+                TransportConsumerCreatedWithTrackLastEnqueuedEventProperties = trackLastEnqueuedEventProperties;
+                TransportConsumerCreatedWithOwnerLevel = ownerLevel;
+                TransportConsumerCreatedWithPrefetchCount = prefetchCount;
+
+                return base.CreateTransportConsumer(consumerGroup, partitionId, eventPosition, retryPolicy, trackLastEnqueuedEventProperties, ownerLevel, prefetchCount);
+            }
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverTests.cs
@@ -171,13 +171,14 @@ namespace Azure.Messaging.EventHubs.Tests
             var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
             var receiver = new ObservableConsumerPartitionReceiver("cg", "pid", EventPosition.Earliest, connectionString, expectedOptions);
 
-            Assert.That(receiver.TransportConsumerCreatedWithConsumerGroup, Is.EqualTo(receiver.ConsumerGroup));
-            Assert.That(receiver.TransportConsumerCreatedWithPartitionId, Is.EqualTo(receiver.PartitionId));
-            Assert.That(receiver.TransportConsumerCreatedWithEventPosition, Is.EqualTo(receiver.InitialPosition));
-            Assert.That(receiver.TransportConsumerCreatedWithRetryPolicy, Is.SameAs(expectedRetryPolicy));
-            Assert.That(receiver.TransportConsumerCreatedWithTrackLastEnqueuedEventProperties, Is.EqualTo(expectedOptions.TrackLastEnqueuedEventProperties));
-            Assert.That(receiver.TransportConsumerCreatedWithOwnerLevel, Is.EqualTo(expectedOptions.OwnerLevel));
-            Assert.That(receiver.TransportConsumerCreatedWithPrefetchCount, Is.EqualTo(expectedOptions.PrefetchCount));
+            Assert.That(receiver.TransportConsumerCreatedWithConsumerGroup, Is.EqualTo(receiver.ConsumerGroup), "The constructor should have used the correct consumer group.");
+            Assert.That(receiver.TransportConsumerCreatedWithPartitionId, Is.EqualTo(receiver.PartitionId), "The constructor should have used the correct partition id.");
+            Assert.That(receiver.TransportConsumerCreatedWithEventPosition, Is.EqualTo(receiver.InitialPosition), "The constructor should have used the correct initial position.");
+            Assert.That(receiver.TransportConsumerCreatedWithRetryPolicy, Is.SameAs(expectedRetryPolicy), "The constructor should have used the correct retry policy.");
+            Assert.That(receiver.TransportConsumerCreatedWithOptions, Is.Not.SameAs(expectedOptions), "The constructor should have cloned the options.");
+            Assert.That(receiver.TransportConsumerCreatedWithOptions.TrackLastEnqueuedEventProperties, Is.EqualTo(expectedOptions.TrackLastEnqueuedEventProperties), "The constructor should have used the correct track last enqueued event properties.");
+            Assert.That(receiver.TransportConsumerCreatedWithOptions.OwnerLevel, Is.EqualTo(expectedOptions.OwnerLevel), "The constructor should have used the correct owner level.");
+            Assert.That(receiver.TransportConsumerCreatedWithOptions.PrefetchCount, Is.EqualTo(expectedOptions.PrefetchCount), "The constructor should have used the correct prefetch count.");
         }
 
         /// <summary>
@@ -197,13 +198,14 @@ namespace Azure.Messaging.EventHubs.Tests
             };
             var receiver = new ObservableConsumerPartitionReceiver("cg", "pid", EventPosition.Earliest, "fqns", "eh", Mock.Of<TokenCredential>(), expectedOptions);
 
-            Assert.That(receiver.TransportConsumerCreatedWithConsumerGroup, Is.EqualTo(receiver.ConsumerGroup));
-            Assert.That(receiver.TransportConsumerCreatedWithPartitionId, Is.EqualTo(receiver.PartitionId));
-            Assert.That(receiver.TransportConsumerCreatedWithEventPosition, Is.EqualTo(receiver.InitialPosition));
-            Assert.That(receiver.TransportConsumerCreatedWithRetryPolicy, Is.SameAs(expectedRetryPolicy));
-            Assert.That(receiver.TransportConsumerCreatedWithTrackLastEnqueuedEventProperties, Is.EqualTo(expectedOptions.TrackLastEnqueuedEventProperties));
-            Assert.That(receiver.TransportConsumerCreatedWithOwnerLevel, Is.EqualTo(expectedOptions.OwnerLevel));
-            Assert.That(receiver.TransportConsumerCreatedWithPrefetchCount, Is.EqualTo(expectedOptions.PrefetchCount));
+            Assert.That(receiver.TransportConsumerCreatedWithConsumerGroup, Is.EqualTo(receiver.ConsumerGroup), "The constructor should have used the correct consumer group.");
+            Assert.That(receiver.TransportConsumerCreatedWithPartitionId, Is.EqualTo(receiver.PartitionId), "The constructor should have used the correct partition id.");
+            Assert.That(receiver.TransportConsumerCreatedWithEventPosition, Is.EqualTo(receiver.InitialPosition), "The constructor should have used the correct initial position.");
+            Assert.That(receiver.TransportConsumerCreatedWithRetryPolicy, Is.SameAs(expectedRetryPolicy), "The constructor should have used the correct retry policy.");
+            Assert.That(receiver.TransportConsumerCreatedWithOptions, Is.Not.SameAs(expectedOptions), "The constructor should have cloned the options.");
+            Assert.That(receiver.TransportConsumerCreatedWithOptions.TrackLastEnqueuedEventProperties, Is.EqualTo(expectedOptions.TrackLastEnqueuedEventProperties), "The constructor should have used the correct track last enqueued event properties.");
+            Assert.That(receiver.TransportConsumerCreatedWithOptions.OwnerLevel, Is.EqualTo(expectedOptions.OwnerLevel), "The constructor should have used the correct owner level.");
+            Assert.That(receiver.TransportConsumerCreatedWithOptions.PrefetchCount, Is.EqualTo(expectedOptions.PrefetchCount), "The constructor should have used the correct prefetch count.");
         }
 
         /// <summary>
@@ -223,13 +225,14 @@ namespace Azure.Messaging.EventHubs.Tests
             };
             var receiver = new ObservableConsumerPartitionReceiver("cg", "pid", EventPosition.Earliest, Mock.Of<EventHubConnection>(), expectedOptions);
 
-            Assert.That(receiver.TransportConsumerCreatedWithConsumerGroup, Is.EqualTo(receiver.ConsumerGroup));
-            Assert.That(receiver.TransportConsumerCreatedWithPartitionId, Is.EqualTo(receiver.PartitionId));
-            Assert.That(receiver.TransportConsumerCreatedWithEventPosition, Is.EqualTo(receiver.InitialPosition));
-            Assert.That(receiver.TransportConsumerCreatedWithRetryPolicy, Is.SameAs(expectedRetryPolicy));
-            Assert.That(receiver.TransportConsumerCreatedWithTrackLastEnqueuedEventProperties, Is.EqualTo(expectedOptions.TrackLastEnqueuedEventProperties));
-            Assert.That(receiver.TransportConsumerCreatedWithOwnerLevel, Is.EqualTo(expectedOptions.OwnerLevel));
-            Assert.That(receiver.TransportConsumerCreatedWithPrefetchCount, Is.EqualTo(expectedOptions.PrefetchCount));
+            Assert.That(receiver.TransportConsumerCreatedWithConsumerGroup, Is.EqualTo(receiver.ConsumerGroup), "The constructor should have used the correct consumer group.");
+            Assert.That(receiver.TransportConsumerCreatedWithPartitionId, Is.EqualTo(receiver.PartitionId), "The constructor should have used the correct partition id.");
+            Assert.That(receiver.TransportConsumerCreatedWithEventPosition, Is.EqualTo(receiver.InitialPosition), "The constructor should have used the correct initial position.");
+            Assert.That(receiver.TransportConsumerCreatedWithRetryPolicy, Is.SameAs(expectedRetryPolicy), "The constructor should have used the correct retry policy.");
+            Assert.That(receiver.TransportConsumerCreatedWithOptions, Is.Not.SameAs(expectedOptions), "The constructor should have cloned the options.");
+            Assert.That(receiver.TransportConsumerCreatedWithOptions.TrackLastEnqueuedEventProperties, Is.EqualTo(expectedOptions.TrackLastEnqueuedEventProperties), "The constructor should have used the correct track last enqueued event properties.");
+            Assert.That(receiver.TransportConsumerCreatedWithOptions.OwnerLevel, Is.EqualTo(expectedOptions.OwnerLevel), "The constructor should have used the correct owner level.");
+            Assert.That(receiver.TransportConsumerCreatedWithOptions.PrefetchCount, Is.EqualTo(expectedOptions.PrefetchCount), "The constructor should have used the correct prefetch count.");
         }
 
         /// <summary>
@@ -239,16 +242,18 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConnectionStringConstructorCreatesDefaultOptions()
         {
-            var expected = new PartitionReceiverOptions().RetryOptions;
+            var defaultOptions = new PartitionReceiverOptions();
             var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
-            var receiver = new PartitionReceiver("cg", "pid", EventPosition.Earliest, connectionString);
+            var receiver = new ObservableConsumerPartitionReceiver("cg", "pid", EventPosition.Earliest, connectionString);
+            var options = receiver.TransportConsumerCreatedWithOptions;
 
-            var policy = GetRetryPolicy(receiver);
-            Assert.That(policy, Is.Not.Null, "There should have been a retry policy set.");
-            Assert.That(policy, Is.InstanceOf<BasicRetryPolicy>(), "The default retry policy should be a basic policy.");
-
-            var actual = ((BasicRetryPolicy)policy).Options;
-            Assert.That(actual.IsEquivalentTo(expected), Is.True, "The default retry policy should be based on the default retry options.");
+            Assert.That(options.ConnectionOptions.TransportType, Is.EqualTo(defaultOptions.ConnectionOptions.TransportType), $"The constructor should have set the correct connection type.");
+            Assert.That(options.ConnectionOptions.Proxy, Is.EqualTo(defaultOptions.ConnectionOptions.Proxy), $"The constructor should have set the correct proxy.");
+            Assert.That(options.RetryOptions.IsEquivalentTo(defaultOptions.RetryOptions), Is.True, $"The retry options should be equivalent.");
+            Assert.That(options.DefaultMaximumReceiveWaitTime, Is.EqualTo(defaultOptions.DefaultMaximumReceiveWaitTime), "The constructor should have set the correct default maximum receive wait time.");
+            Assert.That(options.OwnerLevel, Is.EqualTo(defaultOptions.OwnerLevel), "The constructor should have set the correct owner level.");
+            Assert.That(options.PrefetchCount, Is.EqualTo(defaultOptions.PrefetchCount), "The constructor should have set the correct prefetch count.");
+            Assert.That(options.TrackLastEnqueuedEventProperties, Is.EqualTo(defaultOptions.TrackLastEnqueuedEventProperties), "The constructor should have set the correct track last enqueued event properties.");
         }
 
         /// <summary>
@@ -258,15 +263,17 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ExpandedConstructorCreatesDefaultOptions()
         {
-            var expected = new PartitionReceiverOptions().RetryOptions;
-            var receiver = new PartitionReceiver("cg", "pid", EventPosition.Earliest, "fqns", "eh", Mock.Of<TokenCredential>());
+            var defaultOptions = new PartitionReceiverOptions();
+            var receiver = new ObservableConsumerPartitionReceiver("cg", "pid", EventPosition.Earliest, "fqns", "eh", Mock.Of<TokenCredential>());
+            var options = receiver.TransportConsumerCreatedWithOptions;
 
-            var policy = GetRetryPolicy(receiver);
-            Assert.That(policy, Is.Not.Null, "There should have been a retry policy set.");
-            Assert.That(policy, Is.InstanceOf<BasicRetryPolicy>(), "The default retry policy should be a basic policy.");
-
-            var actual = ((BasicRetryPolicy)policy).Options;
-            Assert.That(actual.IsEquivalentTo(expected), Is.True, "The default retry policy should be based on the default retry options.");
+            Assert.That(options.ConnectionOptions.TransportType, Is.EqualTo(defaultOptions.ConnectionOptions.TransportType), $"The constructor should have set the correct connection type.");
+            Assert.That(options.ConnectionOptions.Proxy, Is.EqualTo(defaultOptions.ConnectionOptions.Proxy), $"The constructor should have set the correct proxy.");
+            Assert.That(options.RetryOptions.IsEquivalentTo(defaultOptions.RetryOptions), Is.True, $"The retry options should be equivalent.");
+            Assert.That(options.DefaultMaximumReceiveWaitTime, Is.EqualTo(defaultOptions.DefaultMaximumReceiveWaitTime), "The constructor should have set the correct default maximum receive wait time.");
+            Assert.That(options.OwnerLevel, Is.EqualTo(defaultOptions.OwnerLevel), "The constructor should have set the correct owner level.");
+            Assert.That(options.PrefetchCount, Is.EqualTo(defaultOptions.PrefetchCount), "The constructor should have set the correct prefetch count.");
+            Assert.That(options.TrackLastEnqueuedEventProperties, Is.EqualTo(defaultOptions.TrackLastEnqueuedEventProperties), "The constructor should have set the correct track last enqueued event properties.");
         }
 
         /// <summary>
@@ -276,15 +283,17 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConnectionConstructorCreatesDefaultOptions()
         {
-            var expected = new PartitionReceiverOptions().RetryOptions;
-            var receiver = new PartitionReceiver("cg", "pid", EventPosition.Earliest, Mock.Of<EventHubConnection>());
+            var defaultOptions = new PartitionReceiverOptions();
+            var receiver = new ObservableConsumerPartitionReceiver("cg", "pid", EventPosition.Earliest, Mock.Of<EventHubConnection>());
+            var options = receiver.TransportConsumerCreatedWithOptions;
 
-            var policy = GetRetryPolicy(receiver);
-            Assert.That(policy, Is.Not.Null, "There should have been a retry policy set.");
-            Assert.That(policy, Is.InstanceOf<BasicRetryPolicy>(), "The default retry policy should be a basic policy.");
-
-            var actual = ((BasicRetryPolicy)policy).Options;
-            Assert.That(actual.IsEquivalentTo(expected), Is.True, "The default retry policy should be based on the default retry options.");
+            Assert.That(options.ConnectionOptions.TransportType, Is.EqualTo(defaultOptions.ConnectionOptions.TransportType), $"The constructor should have set the correct connection type.");
+            Assert.That(options.ConnectionOptions.Proxy, Is.EqualTo(defaultOptions.ConnectionOptions.Proxy), $"The constructor should have set the correct proxy.");
+            Assert.That(options.RetryOptions.IsEquivalentTo(defaultOptions.RetryOptions), Is.True, $"The retry options should be equivalent.");
+            Assert.That(options.DefaultMaximumReceiveWaitTime, Is.EqualTo(defaultOptions.DefaultMaximumReceiveWaitTime), "The constructor should have set the correct default maximum receive wait time.");
+            Assert.That(options.OwnerLevel, Is.EqualTo(defaultOptions.OwnerLevel), "The constructor should have set the correct owner level.");
+            Assert.That(options.PrefetchCount, Is.EqualTo(defaultOptions.PrefetchCount), "The constructor should have set the correct prefetch count.");
+            Assert.That(options.TrackLastEnqueuedEventProperties, Is.EqualTo(defaultOptions.TrackLastEnqueuedEventProperties), "The constructor should have set the correct track last enqueued event properties.");
         }
 
         /// <summary>
@@ -435,6 +444,43 @@ namespace Azure.Messaging.EventHubs.Tests
             var receiver = new PartitionReceiver("cg", "pid", EventPosition.Earliest, mockConnection);
 
             Assert.That(receiver.EventHubName, Is.EqualTo(expected));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionReceiver.CreateTransportConsumer"/>
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CreateTransportConsumerDelegatesToTheConnection()
+        {
+            var connectionString = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub";
+            var mockConnection = new Mock<EventHubConnection>(connectionString);
+            var receiver = new PartitionReceiver("cg", "pid", EventPosition.Earliest, mockConnection.Object);
+
+            var expectedConsumerGroup = "consumerGroup";
+            var expectedPartitionId = "partitionId";
+            var expectedPosition = EventPosition.FromOffset(55);
+            var expectedRetryPolicy = Mock.Of<EventHubsRetryPolicy>();
+            var expectedOptions = new PartitionReceiverOptions
+            {
+                OwnerLevel = 99,
+                PrefetchCount = 42,
+                TrackLastEnqueuedEventProperties = false
+            };
+
+            receiver.CreateTransportConsumer(expectedConsumerGroup, expectedPartitionId, expectedPosition, expectedRetryPolicy, expectedOptions);
+
+            mockConnection
+                .Verify(connection => connection.CreateTransportConsumer(
+                    expectedConsumerGroup,
+                    expectedPartitionId,
+                    expectedPosition,
+                    expectedRetryPolicy,
+                    expectedOptions.TrackLastEnqueuedEventProperties,
+                    expectedOptions.OwnerLevel,
+                    (uint?)expectedOptions.PrefetchCount),
+                Times.Once);
         }
 
         /// <summary>
@@ -674,7 +720,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             mockConsumer
                 .Verify(consumer => consumer.CloseAsync(
-                    It.IsAny<CancellationToken>()),
+                    CancellationToken.None),
                 Times.Once);
         }
 
@@ -684,7 +730,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task CloseAsyncSurfacesExceptionsForTheTransportConsumer()
+        public void CloseAsyncSurfacesExceptionsForTheTransportConsumer()
         {
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
@@ -711,19 +757,10 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Returns(mockConsumer.Object);
 
             var receiver = new PartitionReceiver("cg", "pid", EventPosition.Earliest, mockConnection.Object);
-            var capturedException = default(Exception);
 
-            try
-            {
-                await receiver.CloseAsync(cancellationSource.Token);
-            }
-            catch (InsufficientMemoryException ex)
-            {
-                capturedException = ex;
-            }
-
+            Assert.That(async () => await receiver.CloseAsync(cancellationSource.Token), Throws.TypeOf(expectedException.GetType()).And.EqualTo(expectedException));
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
-            Assert.That(capturedException, Is.EqualTo(expectedException));
+            Assert.That(receiver.IsClosed, Is.True, "The partition receiver should have been closed.");
         }
 
         /// <summary>
@@ -960,15 +997,29 @@ namespace Azure.Messaging.EventHubs.Tests
             public string TransportConsumerCreatedWithPartitionId { get; private set; }
             public EventPosition TransportConsumerCreatedWithEventPosition { get; private set; }
             public EventHubsRetryPolicy TransportConsumerCreatedWithRetryPolicy { get; private set; }
-            public bool TransportConsumerCreatedWithTrackLastEnqueuedEventProperties { get; private set; }
-            public long? TransportConsumerCreatedWithOwnerLevel { get; private set; }
-            public uint? TransportConsumerCreatedWithPrefetchCount { get; private set; }
+            public PartitionReceiverOptions TransportConsumerCreatedWithOptions { get; private set; }
+
+            public ObservableConsumerPartitionReceiver(string consumerGroup,
+                                                       string partitionId,
+                                                       EventPosition eventPosition,
+                                                       string connectionString) : base(consumerGroup, partitionId, eventPosition, connectionString)
+            {
+            }
 
             public ObservableConsumerPartitionReceiver(string consumerGroup,
                                                        string partitionId,
                                                        EventPosition eventPosition,
                                                        string connectionString,
-                                                       PartitionReceiverOptions options = default) : base(consumerGroup, partitionId, eventPosition, connectionString, options)
+                                                       PartitionReceiverOptions options) : base(consumerGroup, partitionId, eventPosition, connectionString, options)
+            {
+            }
+
+            public ObservableConsumerPartitionReceiver(string consumerGroup,
+                                                       string partitionId,
+                                                       EventPosition eventPosition,
+                                                       string fullyQualifiedNamespace,
+                                                       string eventHubName,
+                                                       TokenCredential credential) : base(consumerGroup, partitionId, eventPosition, fullyQualifiedNamespace, eventHubName, credential)
             {
             }
 
@@ -978,7 +1029,14 @@ namespace Azure.Messaging.EventHubs.Tests
                                                        string fullyQualifiedNamespace,
                                                        string eventHubName,
                                                        TokenCredential credential,
-                                                       PartitionReceiverOptions options = default) : base(consumerGroup, partitionId, eventPosition, fullyQualifiedNamespace, eventHubName, credential, options)
+                                                       PartitionReceiverOptions options) : base(consumerGroup, partitionId, eventPosition, fullyQualifiedNamespace, eventHubName, credential, options)
+            {
+            }
+
+            public ObservableConsumerPartitionReceiver(string consumerGroup,
+                                                       string partitionId,
+                                                       EventPosition eventPosition,
+                                                       EventHubConnection connection) : base(consumerGroup, partitionId, eventPosition, connection)
             {
             }
 
@@ -986,7 +1044,7 @@ namespace Azure.Messaging.EventHubs.Tests
                                                        string partitionId,
                                                        EventPosition eventPosition,
                                                        EventHubConnection connection,
-                                                       PartitionReceiverOptions options = default) : base(consumerGroup, partitionId, eventPosition, connection, options)
+                                                       PartitionReceiverOptions options) : base(consumerGroup, partitionId, eventPosition, connection, options)
             {
             }
 
@@ -994,19 +1052,15 @@ namespace Azure.Messaging.EventHubs.Tests
                                                                         string partitionId,
                                                                         EventPosition eventPosition,
                                                                         EventHubsRetryPolicy retryPolicy,
-                                                                        bool trackLastEnqueuedEventProperties,
-                                                                        long? ownerLevel,
-                                                                        uint? prefetchCount)
+                                                                        PartitionReceiverOptions options)
             {
                 TransportConsumerCreatedWithConsumerGroup = consumerGroup;
                 TransportConsumerCreatedWithPartitionId = partitionId;
                 TransportConsumerCreatedWithEventPosition = eventPosition;
                 TransportConsumerCreatedWithRetryPolicy = retryPolicy;
-                TransportConsumerCreatedWithTrackLastEnqueuedEventProperties = trackLastEnqueuedEventProperties;
-                TransportConsumerCreatedWithOwnerLevel = ownerLevel;
-                TransportConsumerCreatedWithPrefetchCount = prefetchCount;
+                TransportConsumerCreatedWithOptions = options;
 
-                return base.CreateTransportConsumer(consumerGroup, partitionId, eventPosition, retryPolicy, trackLastEnqueuedEventProperties, ownerLevel, prefetchCount);
+                return base.CreateTransportConsumer(consumerGroup, partitionId, eventPosition, retryPolicy, options);
             }
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverTests.cs
@@ -422,6 +422,35 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        public async Task GetPartitionPropertiesUsesTheCancellationToken()
+        {
+            var mockConnection = new Mock<EventHubConnection>();
+            using var cancellationSource = new CancellationTokenSource();
+            var receiver = new PartitionReceiver("cg", "pid", EventPosition.Earliest, mockConnection.Object);
+
+            mockConnection
+                .Setup(connection => connection.GetPartitionPropertiesAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<EventHubsRetryPolicy>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(default(PartitionProperties)));
+
+            await receiver.GetPartitionPropertiesAsync(cancellationSource.Token);
+
+            mockConnection
+                .Verify(connection => connection.GetPartitionPropertiesAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<EventHubsRetryPolicy>(),
+                    cancellationSource.Token),
+                Times.Once);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="PartitionReceiver.GetPartitionPropertiesAsync"/>
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
         public async Task GetPartitionPropertiesFailsWhenPartitionReceiverIsClosed()
         {
             using var cancellationSource = new CancellationTokenSource();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
@@ -743,7 +743,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 return Task.FromResult(new EventHubProperties(EventHubName, DateTimeOffset.Parse("2015-10-27T00:00:00Z"), new string[] { "0", "1" }));
             }
 
-            internal async override Task<string[]> GetPartitionIdsAsync(EventHubsRetryPolicy retryPolicy,
+            internal override async Task<string[]> GetPartitionIdsAsync(EventHubsRetryPolicy retryPolicy,
                                                                         CancellationToken cancellationToken = default)
             {
                 GetPartitionIdsInvokedWith = retryPolicy;


### PR DESCRIPTION
Included partial implementation and tests for the class `PartitionReceiver`. Names are not final and class is `internal` for the time being.

Changes:
- The `InnerConsumer` property is now present in the `PartitionReceiver`. It's being created by the constructors and being disposed of by the `CloseAsync` method. Tests were added accordingly.
- Added one of the `ReceiveBatchAsync` overloads, but implementation is missing (only cancellation token, arguments and client being closed are being verified). I intended to include the implementation in this PR, but it was getting bigger than I expected (way more tests would be required, probably).
- Updated other clients (Consumer, Producer and Connection) to follow [David Fowler's guidance](https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md#prefer-asyncawait-over-directly-returning-task).
- Included new tests for the `PartitionReceiver` and updated the existing ones to always include a time-constrained cancellation token in async operations to avoid hanging tests.

This implementation is an adaptation of the `PartitionReceiver` that was present during previews and follows the [skeleton](https://gist.github.com/jsquire/4ea3368192cfee98dcbb4adfb29a9822) that will be used as a base for the final public API this class will have.

Related: 

- #9323 
- [Partition Receiver Design Proposal](https://gist.github.com/jsquire/4ea3368192cfee98dcbb4adfb29a9822)