### PR TITLE
Unblock failures in Install Azure PowerShell module step

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -61,8 +61,7 @@ jobs:
 
       # TODO: Remove when eng/New-TestResources.ps1 bootstraps the Az module (https://github.com/Azure/azure-sdk-for-net/issues/9130).
       - pwsh: | 
-          Get-Module -ListAvailable -Name Az | Write-Host
-          Install-Module -Name Az -Scope CurrentUser -Force -AllowClobber
+          Install-Module -Name Az -Scope CurrentUser -Force -AllowClobber -Verbose
         displayName: "Install Azure PowerShell module"
 
         # Chomp the string literal to more easily read and update the New-TestResources parameters.

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -60,7 +60,11 @@ jobs:
           version: "$(DotNetCoreSDKVersion)"
 
       # TODO: Remove when eng/New-TestResources.ps1 bootstraps the Az module (https://github.com/Azure/azure-sdk-for-net/issues/9130).
-      - pwsh: Install-Module -Name Az -Scope CurrentUser -Force
+      - pwsh: | 
+          Get-Module -ListAvailable -Name Az
+          Install-Module -Name Az -Scope CurrentUser -Force -WhatIf
+          $installResult = Install-Module -Name Az -Scope CurrentUser -Force -PassThru
+          Write-Host $installResult
         displayName: "Install Azure PowerShell module"
 
         # Chomp the string literal to more easily read and update the New-TestResources parameters.

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -61,10 +61,8 @@ jobs:
 
       # TODO: Remove when eng/New-TestResources.ps1 bootstraps the Az module (https://github.com/Azure/azure-sdk-for-net/issues/9130).
       - pwsh: | 
-          Get-Module -ListAvailable -Name Az
-          Install-Module -Name Az -Scope CurrentUser -Force -WhatIf
-          $installResult = Install-Module -Name Az -Scope CurrentUser -Force -PassThru
-          Write-Host $installResult
+          Get-Module -ListAvailable -Name Az | Write-Host
+          Install-Module -Name Az -Scope CurrentUser -Force -AllowClobber
         displayName: "Install Azure PowerShell module"
 
         # Chomp the string literal to more easily read and update the New-TestResources parameters.


### PR DESCRIPTION
Adding `-AllowClobber` got us past the failing step: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=290473&view=logs&j=96d7b680-dcef-5cfd-cab1-6c247ea8b6c3&t=55143706-a9e7-51d2-1aa4-87584421e2b3