### PR TITLE
API Updates

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClient.cs
@@ -114,19 +114,19 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///   Creates a producer strongly aligned with the active protocol and transport,
         ///   responsible for publishing <see cref="ServiceBusMessage" /> to the Service Bus entity.
         /// </summary>
-        /// <param name="entityName"></param>
+        /// <param name="entityPath"></param>
         ///
         /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
         ///
         /// <returns>A <see cref="TransportSender"/> configured in the requested manner.</returns>
         ///
-        public override TransportSender CreateSender(string entityName, ServiceBusRetryPolicy retryPolicy)
+        public override TransportSender CreateSender(string entityPath, ServiceBusRetryPolicy retryPolicy)
         {
             Argument.AssertNotClosed(_closed, nameof(AmqpClient));
 
             return new AmqpSender
             (
-                entityName,
+                entityPath,
                 ConnectionScope,
                 retryPolicy
             );
@@ -136,7 +136,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///   Creates a consumer strongly aligned with the active protocol and transport, responsible
         ///   for reading <see cref="ServiceBusMessage" /> from a specific Service Bus entity.
         /// </summary>
-        /// <param name="entityName"></param>
+        /// <param name="entityPath"></param>
         ///
         /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
         /// <param name="receiveMode">The <see cref="ReceiveMode"/> used to specify how messages are received. Defaults to PeekLock mode.</param>
@@ -148,7 +148,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <returns>A <see cref="TransportReceiver" /> configured in the requested manner.</returns>
         ///
         public override TransportReceiver CreateReceiver(
-            string entityName,
+            string entityPath,
             ServiceBusRetryPolicy retryPolicy,
             ReceiveMode receiveMode,
             uint prefetchCount,
@@ -160,7 +160,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
             return new AmqpReceiver
             (
-                entityName,
+                entityPath,
                 receiveMode,
                 prefetchCount,
                 ConnectionScope,
@@ -186,12 +186,8 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
             _closed = true;
 
-            var clientId = GetHashCode().ToString();
-            var clientType = GetType();
-
             try
             {
-                //ServiceBusEventSource.Log.ClientCloseStart(clientType, EntityName, clientId);
                 cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
                 ConnectionScope?.Dispose();
                 return Task.CompletedTask;
@@ -199,13 +195,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             catch (Exception)
             {
                 _closed = false;
-                //ServiceBusEventSource.Log.ClientCloseError(clientType, EntityName, clientId, ex.Message);
-
                 throw;
-            }
-            finally
-            {
-                //ServiceBusEventSource.Log.ClientCloseComplete(clientType, EntityName, clientId);
             }
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -93,7 +93,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// Initializes a new instance of the <see cref="AmqpReceiver"/> class.
         /// </summary>
         ///
-        /// <param name="entityName">The name of the Service Bus entity from which events will be consumed.</param>
+        /// <param name="entityPath">The name of the Service Bus entity from which events will be consumed.</param>
         /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.  If <c>null</c> a default will be used.</param>
         /// <param name="receiveMode">The <see cref="ReceiveMode"/> used to specify how messages are received. Defaults to PeekLock mode.</param>
         /// <param name="connectionScope">The AMQP connection context for operations .</param>
@@ -111,7 +111,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// caller.
         /// </remarks>
         public AmqpReceiver(
-            string entityName,
+            string entityPath,
             ReceiveMode receiveMode,
             uint prefetchCount,
             AmqpConnectionScope connectionScope,
@@ -120,11 +120,11 @@ namespace Azure.Messaging.ServiceBus.Amqp
             string sessionId,
             bool isSessionReceiver)
         {
-            Argument.AssertNotNullOrEmpty(entityName, nameof(entityName));
+            Argument.AssertNotNullOrEmpty(entityPath, nameof(entityPath));
             Argument.AssertNotNull(connectionScope, nameof(connectionScope));
             Argument.AssertNotNull(retryPolicy, nameof(retryPolicy));
 
-            _entityPath = entityName;
+            _entityPath = entityPath;
             ConnectionScope = connectionScope;
             _retryPolicy = retryPolicy;
             _isSessionReceiver = isSessionReceiver;
@@ -135,7 +135,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             _receiveLink = new FaultTolerantAmqpObject<ReceivingAmqpLink>(
                 timeout =>
                     ConnectionScope.OpenReceiverLinkAsync(
-                        entityName: _entityPath,
+                        entityPath: _entityPath,
                         timeout: timeout,
                         prefetchCount: prefetchCount,
                         receiveMode: receiveMode,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -679,15 +679,10 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 amqpRequestMessage.Map[ManagementConstants.Properties.SessionId] = sessionId;
             }
 
-            if (isSessionReceiver)
-            {
-                ThrowIfSessionLockLost();
-            }
+            AmqpResponseMessage amqpResponseMessage = await ExecuteRequest(
+                timeout,
+                amqpRequestMessage).ConfigureAwait(false);
 
-            AmqpResponseMessage amqpResponseMessage = await ManagementUtilities.ExecuteRequestResponseAsync(
-                _managementLink,
-                amqpRequestMessage,
-                timeout).ConfigureAwait(false);
             if (amqpResponseMessage.StatusCode != AmqpResponseStatusCode.OK)
             {
                 throw amqpResponseMessage.ToMessagingContractException();
@@ -909,10 +904,9 @@ namespace Azure.Messaging.ServiceBus.Amqp
             }
             amqpRequestMessage.Map[ManagementConstants.Properties.LockTokens] = new[] { new Guid(lockToken) };
 
-            AmqpResponseMessage amqpResponseMessage = await ManagementUtilities.ExecuteRequestResponseAsync(
-                _managementLink,
-                amqpRequestMessage,
-                timeout).ConfigureAwait(false);
+            AmqpResponseMessage amqpResponseMessage = await ExecuteRequest(
+                timeout,
+                amqpRequestMessage).ConfigureAwait(false);
 
             if (amqpResponseMessage.StatusCode == AmqpResponseStatusCode.OK)
             {
@@ -925,6 +919,16 @@ namespace Azure.Messaging.ServiceBus.Amqp
             }
 
             return lockedUntilUtc;
+        }
+
+        private async Task<AmqpResponseMessage> ExecuteRequest(TimeSpan timeout, AmqpRequestMessage amqpRequestMessage)
+        {
+            ThrowIfSessionLockLost();
+            AmqpResponseMessage amqpResponseMessage = await ManagementUtilities.ExecuteRequestResponseAsync(
+                _managementLink,
+                amqpRequestMessage,
+                timeout).ConfigureAwait(false);
+            return amqpResponseMessage;
         }
 
         /// <summary>
@@ -974,10 +978,9 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
                 amqpRequestMessage.Map[ManagementConstants.Properties.SessionId] = SessionId;
 
-                AmqpResponseMessage amqpResponseMessage = await ManagementUtilities.ExecuteRequestResponseAsync(
-                    _managementLink,
-                    amqpRequestMessage,
-                    timeout).ConfigureAwait(false);
+                AmqpResponseMessage amqpResponseMessage = await ExecuteRequest(
+                    timeout,
+                    amqpRequestMessage).ConfigureAwait(false);
 
                 DateTime lockedUntilUtc;
                 if (amqpResponseMessage.StatusCode == AmqpResponseStatusCode.OK)
@@ -1039,10 +1042,9 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     amqpRequestMessage.Map[ManagementConstants.Properties.SessionId] = SessionId;
                 }
 
-                var response = await ManagementUtilities.ExecuteRequestResponseAsync(
-                    _managementLink,
-                    amqpRequestMessage,
-                    timeout).ConfigureAwait(false);
+                var response = await ExecuteRequest(
+                    timeout,
+                    amqpRequestMessage).ConfigureAwait(false);
 
                 if (response.StatusCode == AmqpResponseStatusCode.OK)
                 {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
@@ -44,10 +44,10 @@ namespace Azure.Messaging.ServiceBus.Amqp
         public override bool IsClosed => _closed;
 
         /// <summary>
-        ///   The name of the Service Bus entity to which the producer is bound.
+        ///   The name of the Service Bus entity to which the sender is bound.
         /// </summary>
         ///
-        private readonly string _entityName;
+        private readonly string _entityPath;
 
         /// <summary>
         ///   The policy to use for determining retry behavior for when an operation fails.
@@ -100,7 +100,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             Argument.AssertNotNull(connectionScope, nameof(connectionScope));
             Argument.AssertNotNull(retryPolicy, nameof(retryPolicy));
 
-            _entityName = entityName;
+            _entityPath = entityName;
             _retryPolicy = retryPolicy;
             _connectionScope = connectionScope;
 
@@ -114,7 +114,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
             _managementLink = new FaultTolerantAmqpObject<RequestResponseAmqpLink>(
                 timeout => _connectionScope.OpenManagementLinkAsync(
-                    _entityName,
+                    _entityPath,
                     timeout,
                     CancellationToken.None),
                 link =>
@@ -229,7 +229,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
                 if (batchMessage.SerializedMessageSize > MaximumMessageSize)
                 {
-                    throw new ServiceBusException(string.Format(Resources1.MessageSizeExceeded, messageHash, batchMessage.SerializedMessageSize, MaximumMessageSize, _entityName), ServiceBusException.FailureReason.MessageSizeExceeded);
+                    throw new ServiceBusException(string.Format(Resources1.MessageSizeExceeded, messageHash, batchMessage.SerializedMessageSize, MaximumMessageSize, _entityPath), ServiceBusException.FailureReason.MessageSizeExceeded);
                 }
 
                 // Attempt to send the message batch.
@@ -509,7 +509,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             CancellationToken cancellationToken)
         {
             SendingAmqpLink link = await _connectionScope.OpenSenderLinkAsync(
-                _entityName,
+                _entityPath,
                 timeout,
                 cancellationToken).ConfigureAwait(false);
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
@@ -78,7 +78,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///   Initializes a new instance of the <see cref="AmqpSender"/> class.
         /// </summary>
         ///
-        /// <param name="entityName">The name of the entity to which messages will be sent.</param>
+        /// <param name="entityPath">The name of the entity to which messages will be sent.</param>
         /// <param name="connectionScope">The AMQP connection context for operations.</param>
         /// <param name="retryPolicy">The retry policy to consider when an operation fails.</param>
         ///
@@ -92,15 +92,15 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// </remarks>
         ///
         public AmqpSender(
-            string entityName,
+            string entityPath,
             AmqpConnectionScope connectionScope,
             ServiceBusRetryPolicy retryPolicy)
         {
-            Argument.AssertNotNullOrEmpty(entityName, nameof(entityName));
+            Argument.AssertNotNullOrEmpty(entityPath, nameof(entityPath));
             Argument.AssertNotNull(connectionScope, nameof(connectionScope));
             Argument.AssertNotNull(retryPolicy, nameof(retryPolicy));
 
-            _entityPath = entityName;
+            _entityPath = entityPath;
             _retryPolicy = retryPolicy;
             _connectionScope = connectionScope;
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/ConnectionStringProperties.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/ConnectionStringProperties.cs
@@ -24,7 +24,7 @@ namespace Azure.Messaging.ServiceBus.Core
         ///   The name of the specific Service Bus entity instance under the associated Service Bus namespace.
         /// </summary>
         ///
-        public string EntityName { get; }
+        public string EntityPath { get; }
 
         /// <summary>
         ///   The name of the shared access key, either for the Service Bus namespace
@@ -56,7 +56,7 @@ namespace Azure.Messaging.ServiceBus.Core
             string sharedAccessKey)
         {
             Endpoint = endpoint;
-            EntityName = entityName;
+            EntityPath = entityName;
             SharedAccessKeyName = sharedAccessKeyName;
             SharedAccessKey = sharedAccessKey;
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportClient.cs
@@ -53,7 +53,7 @@ namespace Azure.Messaging.ServiceBus.Core
         ///   Creates a consumer strongly aligned with the active protocol and transport, responsible
         ///   for reading <see cref="ServiceBusMessage" /> from a specific Service Bus entity.
         /// </summary>
-        /// <param name="entityName"></param>
+        /// <param name="entityPath"></param>
         ///
         /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
         /// <param name="receiveMode">The <see cref="ReceiveMode"/> used to specify how messages are received. Defaults to PeekLock mode.</param>
@@ -65,7 +65,7 @@ namespace Azure.Messaging.ServiceBus.Core
         /// <returns>A <see cref="TransportReceiver" /> configured in the requested manner.</returns>
         ///
         public abstract TransportReceiver CreateReceiver(
-            string entityName,
+            string entityPath,
             ServiceBusRetryPolicy retryPolicy,
             ReceiveMode receiveMode,
             uint prefetchCount,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportClient.cs
@@ -41,13 +41,13 @@ namespace Azure.Messaging.ServiceBus.Core
         ///   Creates a producer strongly aligned with the active protocol and transport,
         ///   responsible for publishing <see cref="ServiceBusMessage" /> to the entity.
         /// </summary>
-        /// <param name="entityName"></param>
+        /// <param name="entityPath"></param>
         ///
         /// <param name="retryPolicy">The policy which governs retry behavior and try timeouts.</param>
         ///
         /// <returns>A <see cref="TransportSender"/> configured in the requested manner.</returns>
         ///
-        public abstract TransportSender CreateSender(string entityName, ServiceBusRetryPolicy retryPolicy);
+        public abstract TransportSender CreateSender(string entityPath, ServiceBusRetryPolicy retryPolicy);
 
         /// <summary>
         ///   Creates a consumer strongly aligned with the active protocol and transport, responsible

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
@@ -68,7 +68,7 @@ namespace Azure.Messaging.ServiceBus.Core
         /// Completes a <see cref="ServiceBusReceivedMessage"/>. This will delete the message from the service.
         /// </summary>
         ///
-        /// <param name="receivedMessages">The <see cref="ServiceBusReceivedMessage"/> message to complete.</param>
+        /// <param name="lockTokens">An <see cref="IEnumerable{T}"/> containing the lock tokens of the corresponding messages to complete.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <remarks>
@@ -78,12 +78,12 @@ namespace Azure.Messaging.ServiceBus.Core
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         public abstract Task CompleteAsync(
-            IEnumerable<ServiceBusReceivedMessage> receivedMessages,
+            IEnumerable<string> lockTokens,
             CancellationToken cancellationToken);
 
         /// <summary> Indicates that the receiver wants to defer the processing for the message.</summary>
         ///
-        /// <param name="message">The <see cref="ServiceBusReceivedMessage"/> to defer.</param>
+        /// <param name="lockToken">The lockToken of the <see cref="ServiceBusReceivedMessage"/> to defer.</param>
         /// <param name="propertiesToModify">The properties of the message to modify while deferring the message.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
@@ -98,7 +98,7 @@ namespace Azure.Messaging.ServiceBus.Core
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         public abstract Task DeferAsync(
-            ServiceBusReceivedMessage message,
+            string lockToken,
             IDictionary<string, object> propertiesToModify = null,
             CancellationToken cancellationToken = default);
 
@@ -126,7 +126,7 @@ namespace Azure.Messaging.ServiceBus.Core
         /// Abandons a <see cref="ServiceBusReceivedMessage"/>. This will make the message available again for processing.
         /// </summary>
         ///
-        /// <param name="message">The <see cref="ServiceBusReceivedMessage"/> to abandon.</param>
+        /// <param name="lockToken">The lock token of the <see cref="ServiceBusReceivedMessage"/> to abandon.</param>
         /// <param name="propertiesToModify">The properties of the message to modify while abandoning the message.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
@@ -138,7 +138,7 @@ namespace Azure.Messaging.ServiceBus.Core
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         public abstract Task AbandonAsync(
-            ServiceBusReceivedMessage message,
+            string lockToken,
             IDictionary<string, object> propertiesToModify = null,
             CancellationToken cancellationToken = default);
 
@@ -146,7 +146,7 @@ namespace Azure.Messaging.ServiceBus.Core
         /// Moves a message to the deadletter sub-queue.
         /// </summary>
         ///
-        /// <param name="message">The <see cref="ServiceBusReceivedMessage"/> to deadletter.</param>
+        /// <param name="lockToken">The lock token of the <see cref="ServiceBusReceivedMessage"/> to deadletter.</param>
         /// <param name="deadLetterReason">The reason for deadlettering the message.</param>
         /// <param name="deadLetterErrorDescription">The error description for deadlettering the message.</param>
         /// <param name="propertiesToModify">The properties of the message to modify while moving to sub-queue.</param>
@@ -162,7 +162,7 @@ namespace Azure.Messaging.ServiceBus.Core
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         public abstract Task DeadLetterAsync(
-            ServiceBusReceivedMessage message,
+            string lockToken,
             string deadLetterReason = default,
             string deadLetterErrorDescription = default,
             IDictionary<string, object> propertiesToModify = default,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
@@ -106,7 +106,7 @@ namespace Azure.Messaging.ServiceBus.Core
         /// Fetches the next batch of active messages without changing the state of the receiver or the message source.
         /// </summary>
         ///
-        /// <param name="fromSequenceNumber">The sequence number from where to read the message.</param>
+        /// <param name="sequenceNumber">The sequence number from where to read the message.</param>
         /// <param name="messageCount">The maximum number of messages that will be fetched.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
@@ -118,7 +118,7 @@ namespace Azure.Messaging.ServiceBus.Core
         /// </remarks>
         /// <returns></returns>
         public abstract Task<IList<ServiceBusReceivedMessage>> PeekBatchAtAsync(
-            long? fromSequenceNumber,
+            long? sequenceNumber,
             int messageCount = 1,
             CancellationToken cancellationToken = default);
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/DiagnosticUtilities.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/DiagnosticUtilities.cs
@@ -9,7 +9,7 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
 {
     internal static class DiagnosticUtilities
     {
-        internal static string GenerateIdentifier(string entityName) =>
-            $"{entityName}-{Guid.NewGuid()}";
+        internal static string GenerateIdentifier(string entityPath) =>
+            $"{entityPath}-{Guid.NewGuid()}";
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -175,12 +175,12 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         }
 
         [Event(16, Level = EventLevel.Informational, Message = "{0}: CompleteAsync start. MessageCount = {1}, LockTokens = {2}")]
-        public void CompleteMessageStart(string identifier, int messageCount, IList<ServiceBusReceivedMessage> messages)
+        public void CompleteMessageStart(string identifier, int messageCount, IList<string> lockTokens)
         {
             if (IsEnabled())
             {
-                var formattedMessageIds = StringUtility.GetFormattedMessageIds(messages.Select(message => message.MessageId).ToList());
-                WriteEvent(16, identifier, messageCount, formattedMessageIds);
+                var formattedLockTokens = StringUtility.GetFormattedLockTokens(lockTokens);
+                WriteEvent(16, identifier, messageCount, formattedLockTokens);
             }
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -460,7 +460,7 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
 
         /// <summary>
         ///   Indicates that a client is closing, which may correspond to an <see cref="ServiceBusConnection" />,
-        ///   <see cref="ServiceBusSender" />, <see cref="ServiceBusProcessor" />, or <c>EventProcessorClient</c>.
+        ///   <see cref="ServiceBusSender" />, <see cref="ServiceBusProcessor" />, or <see cref="ServiceBusReceiver"/>.
         /// </summary>
         ///
         /// <param name="clientType">The type of client being closed.</param>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/StringUtility.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/StringUtility.cs
@@ -21,17 +21,6 @@ namespace Azure.Messaging.ServiceBus.Primitives
             return lockTokenBuilder.ToString();
         }
 
-        public static string GetFormattedMessageIds(IEnumerable<string> messageIds)
-        {
-            var messageIdBuilder = new StringBuilder();
-            foreach (var messageId in messageIds)
-            {
-                messageIdBuilder.AppendFormat(CultureInfo.InvariantCulture, "<LockToken>{0}</LockToken>", messageId);
-            }
-
-            return messageIdBuilder.ToString();
-        }
-
         public static string GetFormattedSequenceNumbers(IEnumerable<long> sequenceNumbers)
         {
             var sequenceNumberBuilder = new StringBuilder();

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessErrorEventArgs.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessErrorEventArgs.cs
@@ -17,15 +17,15 @@ namespace Azure.Messaging.ServiceBus
         ///
         /// <param name="exception">The exception that this event data belongs to.</param>
         /// <param name="action">The action associated with the message.</param>
-        /// <param name="endpoint">The endpoint used when this exception occurred.</param>
-        /// <param name="entityName">The entity path used when this exception occurred.</param>
+        /// <param name="fullyQualifiedNamespace">The endpoint used when this exception occurred.</param>
+        /// <param name="entityPath">The entity path used when this exception occurred.</param>
         /// <param name="identifier">The Client Id can be used to associate with the  cref="QueueClient"/>,  cref="SubscriptionClient"/>,  cref="MessageSender"/> or  cref="MessageReceiver"/>that encountered the exception.</param>
-        public ProcessErrorEventArgs(Exception exception, ExceptionReceivedEventArgsAction action, string endpoint, string entityName, string identifier)
+        public ProcessErrorEventArgs(Exception exception, ExceptionReceivedEventArgsAction action, string fullyQualifiedNamespace, string entityPath, string identifier)
         {
             Exception = exception;
             Action = action;
-            FullyQualifiedNamespace = endpoint;
-            EntityName = entityName;
+            FullyQualifiedNamespace = fullyQualifiedNamespace;
+            EntityPath = entityPath;
             Identifier = identifier;
         }
 
@@ -43,7 +43,7 @@ namespace Azure.Messaging.ServiceBus
         public string FullyQualifiedNamespace { get; }
 
         /// <summary>The entity path used when this exception occurred.</summary>
-        public string EntityName { get; }
+        public string EntityPath { get; }
 
         /// <summary>The Client Id associated with the sender, receiver or session when this exception occurred.</summary>
         public string Identifier { get; }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessErrorEventArgs.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessErrorEventArgs.cs
@@ -19,14 +19,16 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="action">The action associated with the message.</param>
         /// <param name="fullyQualifiedNamespace">The endpoint used when this exception occurred.</param>
         /// <param name="entityPath">The entity path used when this exception occurred.</param>
-        /// <param name="identifier">The Client Id can be used to associate with the  cref="QueueClient"/>,  cref="SubscriptionClient"/>,  cref="MessageSender"/> or  cref="MessageReceiver"/>that encountered the exception.</param>
-        public ProcessErrorEventArgs(Exception exception, ExceptionReceivedEventArgsAction action, string fullyQualifiedNamespace, string entityPath, string identifier)
+        public ProcessErrorEventArgs(
+            Exception exception,
+            ExceptionReceivedEventArgsAction action,
+            string fullyQualifiedNamespace,
+            string entityPath)
         {
             Exception = exception;
             Action = action;
             FullyQualifiedNamespace = fullyQualifiedNamespace;
             EntityPath = entityPath;
-            Identifier = identifier;
         }
 
         /// <summary>Gets the parent class exception to which this Service bus message belongs.</summary>
@@ -39,13 +41,11 @@ namespace Azure.Messaging.ServiceBus
         /// <value>The action associated with the event.</value>
         public ExceptionReceivedEventArgsAction Action { get; }
 
-        /// <summary>The namespace name used when this exception occurred.</summary>
+        /// <summary>The namespace name used when this exception occurred. This is likely
+        ///  to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</summary>
         public string FullyQualifiedNamespace { get; }
 
         /// <summary>The entity path used when this exception occurred.</summary>
         public string EntityPath { get; }
-
-        /// <summary>The Client Id associated with the sender, receiver or session when this exception occurred.</summary>
-        public string Identifier { get; }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -638,9 +638,10 @@ namespace Azure.Messaging.ServiceBus
                     new ProcessErrorEventArgs(ex, action, FullyQualifiedNamespace, EntityPath)).ConfigureAwait(false);
 
                 // if the message or session lock was lost, do not attempt to abandon the message
-                if (!(ex is ServiceBusException sbException) ||
+                if (ReceiveMode == ReceiveMode.PeekLock &&
+                    (!(ex is ServiceBusException sbException) ||
                     (sbException.Reason != ServiceBusException.FailureReason.SessionLockLost) &&
-                     sbException.Reason != ServiceBusException.FailureReason.MessageLockLost)
+                     sbException.Reason != ServiceBusException.FailureReason.MessageLockLost))
                 {
                     await receiver.AbandonAsync(message.LockToken).ConfigureAwait(false);
                 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -628,7 +628,7 @@ namespace Azure.Messaging.ServiceBus
                 {
                     action = ExceptionReceivedEventArgsAction.Complete;
                     await receiver.CompleteAsync(
-                        message,
+                        message.LockToken,
                         cancellationToken)
                         .ConfigureAwait(false);
                 }
@@ -639,7 +639,7 @@ namespace Azure.Messaging.ServiceBus
 
                 await RaiseExceptionReceived(
                     new ProcessErrorEventArgs(ex, action, FullyQualifiedNamespace, EntityPath, Identifier)).ConfigureAwait(false);
-                await receiver.AbandonAsync(message).ConfigureAwait(false);
+                await receiver.AbandonAsync(message.LockToken).ConfigureAwait(false);
             }
             finally
             {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -31,8 +31,6 @@ namespace Azure.Messaging.ServiceBus
         /// </summary>
         private SemaphoreSlim MaxConcurrentAcceptSessionsSemaphore { get; set; }
 
-        private TimeSpan _maxAutoRenewDuration = TimeSpan.FromMinutes(5);
-
         /// <summary>The primitive for synchronizing access during start and close operations.</summary>
         private readonly SemaphoreSlim ProcessingStartStopSemaphore = new SemaphoreSlim(1, 1);
 
@@ -63,7 +61,7 @@ namespace Azure.Messaging.ServiceBus
         public string FullyQualifiedNamespace => _connection.FullyQualifiedNamespace;
 
         /// <summary>
-        /// The name of the Service Bus entity that the processor is connected to, specific to the
+        /// The path of the Service Bus entity that the processor is connected to, specific to the
         /// Service Bus namespace that contains it.
         /// </summary>
         public string EntityPath { get; private set; }
@@ -568,7 +566,7 @@ namespace Azure.Messaging.ServiceBus
                 if (!(ex is TaskCanceledException))
                 {
                     await RaiseExceptionReceived(
-                            new ProcessErrorEventArgs(ex, action, FullyQualifiedNamespace, EntityPath, Identifier)).ConfigureAwait(false);
+                            new ProcessErrorEventArgs(ex, action, FullyQualifiedNamespace, EntityPath)).ConfigureAwait(false);
                 }
             }
             finally
@@ -638,7 +636,7 @@ namespace Azure.Messaging.ServiceBus
                 cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
                 await RaiseExceptionReceived(
-                    new ProcessErrorEventArgs(ex, action, FullyQualifiedNamespace, EntityPath, Identifier)).ConfigureAwait(false);
+                    new ProcessErrorEventArgs(ex, action, FullyQualifiedNamespace, EntityPath)).ConfigureAwait(false);
                 await receiver.AbandonAsync(message.LockToken).ConfigureAwait(false);
             }
             finally
@@ -722,8 +720,7 @@ namespace Azure.Messaging.ServiceBus
                                 exception,
                                 ExceptionReceivedEventArgsAction.RenewLock,
                                 FullyQualifiedNamespace,
-                                EntityPath,
-                                Identifier)).ConfigureAwait(false);
+                                EntityPath)).ConfigureAwait(false);
                     }
 
                     // if the error was not transient, break out of the loop

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessorOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessorOptions.cs
@@ -1,0 +1,171 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ComponentModel;
+using Azure.Core;
+using Azure.Messaging.ServiceBus.Core;
+using Azure.Messaging.ServiceBus.Primitives;
+
+namespace Azure.Messaging.ServiceBus
+{
+    /// <summary>
+    /// The baseline set of options that can be specified when creating a <see cref="ServiceBusReceiver"/> or <see cref="ServiceBusProcessor" />
+    /// to configure its behavior.
+    /// </summary>
+    public class ServiceBusProcessorOptions
+    {
+        /// <summary>
+        /// The set of options to use for configuring the connection to the Service Bus entities.
+        /// </summary>
+        internal ServiceBusClientOptions _connectionOptions = new ServiceBusClientOptions();
+
+        /// <summary>
+        /// The set of options to govern retry behavior and try timeouts.
+        /// </summary>
+        internal ServiceBusRetryOptions _retryOptions = new ServiceBusRetryOptions();
+
+        /// <summary>
+        /// The number of messages that will be eagerly requested from Queues or Subscriptions and queued locally without regard to
+        /// whether a processing is currently active, intended to help maximize throughput by allowing the receiver to receive
+        /// from a local cache rather than waiting on a service request.
+        /// </summary>
+        public int PrefetchCount
+        {
+            get
+            {
+                return _prefetchCount;
+            }
+            set
+            {
+                if (value < 0)
+                {
+                    throw Fx.Exception.ArgumentOutOfRange(nameof(PrefetchCount), value, "Value cannot be less than 0.");
+                }
+                _prefetchCount = value;
+            }
+        }
+        private int _prefetchCount = 0;
+
+        /// <summary>
+        /// The <see cref="ReceiveMode"/> used to specify how messages are received. Defaults to PeekLock mode.
+        /// </summary>
+        public ReceiveMode ReceiveMode { get; set; } = ReceiveMode.PeekLock;
+
+        /// <summary>
+        /// Gets or sets the options used for configuring the connection to the Service Bus entities.
+        /// </summary>
+        internal ServiceBusClientOptions ConnectionOptions
+        {
+            get => _connectionOptions;
+            set
+            {
+                Argument.AssertNotNull(value, nameof(ConnectionOptions));
+                _connectionOptions = value;
+            }
+        }
+
+        /// <summary>
+        /// The set of options to use for determining whether a failed operation should be retried and,
+        /// if so, the amount of time to wait between retry attempts.  These options also control the
+        /// amount of time allowed for receiving messages and other interactions with the Service Bus service.
+        /// </summary>
+        public ServiceBusRetryOptions RetryOptions
+        {
+            get => _retryOptions;
+            set
+            {
+                Argument.AssertNotNull(value, nameof(RetryOptions));
+                _retryOptions = value;
+            }
+        }
+
+        /// <summary>Gets or sets a value that indicates whether the message-pump should call
+        /// Receiver.CompleteAsync() on messages after the callback has completed processing.</summary>
+        /// <value>true to complete the message processing automatically on successful execution of the operation; otherwise, false.</value>
+        public bool AutoComplete { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum duration within which the lock will be renewed automatically. This
+        /// value should be greater than the longest message lock duration; for example, the LockDuration Property.
+        /// </summary>
+        ///
+        /// <value>The maximum duration during which locks are automatically renewed.</value>
+        ///
+        /// <remarks>The message renew can continue for sometime in the background
+        /// after completion of message and result in a few false MessageLockLostExceptions temporarily.</remarks>
+        public TimeSpan MaxAutoLockRenewalDuration
+        {
+            get => _maxAutoRenewDuration;
+
+            set
+            {
+                TimeoutHelper.ThrowIfNegativeArgument(value, nameof(value));
+                _maxAutoRenewDuration = value;
+            }
+        }
+        private TimeSpan _maxAutoRenewDuration = TimeSpan.FromMinutes(5);
+
+        /// <summary>Gets or sets the maximum number of concurrent calls to the callback the message pump should initiate.</summary>
+        /// <value>The maximum number of concurrent calls to the callback.</value>
+        public int MaxConcurrentCalls
+        {
+            get => _maxConcurrentCalls;
+
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(Resources.MaxConcurrentCallsMustBeGreaterThanZero.FormatForUser(value));
+                }
+
+                _maxConcurrentCalls = value;
+            }
+        }
+
+        private int _maxConcurrentCalls;
+
+        /// <summary>
+        /// Determines whether the specified <see cref="System.Object" /> is equal to this instance.
+        /// </summary>
+        ///
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+        ///
+        /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => base.Equals(obj);
+
+        /// <summary>
+        /// Returns a hash code for this instance.
+        /// </summary>
+        ///
+        /// <returns>A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => base.GetHashCode();
+
+        /// <summary>
+        /// Converts the instance to string representation.
+        /// </summary>
+        ///
+        /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override string ToString() => base.ToString();
+
+        /// <summary>
+        /// Creates a new copy of the current <see cref="ServiceBusReceiverOptions" />, cloning its attributes into a new instance.
+        /// </summary>
+        ///
+        /// <returns>A new copy of <see cref="ServiceBusReceiverOptions" />.</returns>
+        internal ServiceBusProcessorOptions Clone() =>
+            new ServiceBusProcessorOptions
+            {
+                _connectionOptions = ConnectionOptions.Clone(),
+                _retryOptions = RetryOptions.Clone(),
+                ReceiveMode = ReceiveMode,
+                AutoComplete = AutoComplete,
+                MaxAutoLockRenewalDuration = MaxAutoLockRenewalDuration
+            };
+    }
+}

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessorOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessorOptions.cs
@@ -82,9 +82,9 @@ namespace Azure.Messaging.ServiceBus
 
         /// <summary>Gets or sets a value that indicates whether the message-pump should call
         /// Receiver.CompleteAsync() on messages after the callback has completed processing.
-        /// The default value is false.</summary>
+        /// The default value is true.</summary>
         /// <value>true to complete the message processing automatically on successful execution of the operation; otherwise, false.</value>
-        public bool AutoComplete { get; set; } = false;
+        public bool AutoComplete { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the maximum duration within which the lock will be renewed automatically. This

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessorOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessorOptions.cs
@@ -81,9 +81,10 @@ namespace Azure.Messaging.ServiceBus
         }
 
         /// <summary>Gets or sets a value that indicates whether the message-pump should call
-        /// Receiver.CompleteAsync() on messages after the callback has completed processing.</summary>
+        /// Receiver.CompleteAsync() on messages after the callback has completed processing.
+        /// The default value is false.</summary>
         /// <value>true to complete the message processing automatically on successful execution of the operation; otherwise, false.</value>
-        public bool AutoComplete { get; set; }
+        public bool AutoComplete { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the maximum duration within which the lock will be renewed automatically. This
@@ -106,7 +107,7 @@ namespace Azure.Messaging.ServiceBus
         }
         private TimeSpan _maxAutoRenewDuration = TimeSpan.FromMinutes(5);
 
-        /// <summary>Gets or sets the maximum number of concurrent calls to the callback the message pump should initiate.</summary>
+        /// <summary>Gets or sets the maximum number of concurrent calls to the callback the message pump should initiate. The default value when used with a session processor is 8. For a non-session processor, the default is 1.</summary>
         /// <value>The maximum number of concurrent calls to the callback.</value>
         public int MaxConcurrentCalls
         {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -27,7 +27,7 @@ namespace Azure.Messaging.ServiceBus
         public string FullyQualifiedNamespace => _connection.FullyQualifiedNamespace;
 
         /// <summary>
-        /// The name of the Service Bus entity that the receiver is connected to, specific to the
+        /// The path of the Service Bus entity that the receiver is connected to, specific to the
         /// Service Bus namespace that contains it.
         /// </summary>
         public string EntityPath { get; }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.Designer.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.Designer.cs
@@ -124,6 +124,15 @@ namespace Azure.Messaging.ServiceBus {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Messages cannot be locked when working with session-enabled entities. Locks are handled at the session level..
+        /// </summary>
+        internal static string CannotLockMessageOnSessionEntity {
+            get {
+                return ResourceManager.GetString("CannotLockMessageOnSessionEntity", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to When using a sessionful entity, the Session event handler must be used..
         /// </summary>
         internal static string CannotRegisterNonSessionEventHandlerWhenUsingSession {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.resx
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.resx
@@ -225,4 +225,7 @@
   <data name="CannotRegisterSessionEventHandlerWhenNotUsingSessions" xml:space="preserve">
     <value>When not using a sessionful entity, the non-session event handler must be used.</value>
   </data>
+  <data name="CannotLockMessageOnSessionEntity" xml:space="preserve">
+    <value>Messages cannot be locked when working with session-enabled entities. Locks are handled at the session level.</value>
+  </data>
 </root>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -35,7 +35,7 @@ namespace Azure.Messaging.ServiceBus
         ///   Service Bus namespace that contains it.
         /// </summary>
         ///
-        public string EntityPath { get; }
+        public string EntityName { get; }
 
         /// <summary>
         ///   Indicates whether or not this <see cref="ServiceBusSender"/> has been closed.
@@ -76,7 +76,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         ///   Initializes a new instance of the <see cref="ServiceBusSender"/> class.
         /// </summary>
-        /// <param name="entityPath"></param>
+        /// <param name="entityName"></param>
         /// <param name="connection"></param>
         /// <param name="options">A set of options to apply when configuring the producer.</param>
         /// <remarks>
@@ -86,23 +86,23 @@ namespace Azure.Messaging.ServiceBus
         /// </remarks>
         ///
         internal ServiceBusSender(
-            string entityPath,
+            string entityName,
             ServiceBusConnection connection,
             ServiceBusSenderOptions options)
         {
             Argument.AssertNotNull(connection, nameof(connection));
             Argument.AssertNotNull(options, nameof(options));
             Argument.AssertNotNull(options.RetryOptions, nameof(options.RetryOptions));
-            Argument.AssertNotNullOrWhiteSpace(entityPath, nameof(entityPath));
+            Argument.AssertNotNullOrWhiteSpace(entityName, nameof(entityName));
             connection.ThrowIfClosed();
 
-            EntityPath = entityPath;
-            Identifier = DiagnosticUtilities.GenerateIdentifier(EntityPath);
+            EntityName = entityName;
+            Identifier = DiagnosticUtilities.GenerateIdentifier(EntityName);
             options = options?.Clone() ?? new ServiceBusSenderOptions();
             _connection = connection;
             _retryPolicy = options.RetryOptions.ToRetryPolicy();
             _innerSender = _connection.CreateTransportSender(
-                entityPath,
+                entityName,
                 _retryPolicy);
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -31,11 +31,11 @@ namespace Azure.Messaging.ServiceBus
         public string FullyQualifiedNamespace => _connection.FullyQualifiedNamespace;
 
         /// <summary>
-        ///   The name of the entity that the sender is connected to, specific to the
+        ///   The path of the entity that the sender is connected to, specific to the
         ///   Service Bus namespace that contains it.
         /// </summary>
         ///
-        public string EntityName { get; }
+        public string EntityPath { get; }
 
         /// <summary>
         ///   Indicates whether or not this <see cref="ServiceBusSender"/> has been closed.
@@ -76,7 +76,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         ///   Initializes a new instance of the <see cref="ServiceBusSender"/> class.
         /// </summary>
-        /// <param name="entityName"></param>
+        /// <param name="entityPath"></param>
         /// <param name="connection"></param>
         /// <param name="options">A set of options to apply when configuring the producer.</param>
         /// <remarks>
@@ -86,23 +86,23 @@ namespace Azure.Messaging.ServiceBus
         /// </remarks>
         ///
         internal ServiceBusSender(
-            string entityName,
+            string entityPath,
             ServiceBusConnection connection,
             ServiceBusSenderOptions options)
         {
             Argument.AssertNotNull(connection, nameof(connection));
             Argument.AssertNotNull(options, nameof(options));
             Argument.AssertNotNull(options.RetryOptions, nameof(options.RetryOptions));
-            Argument.AssertNotNullOrWhiteSpace(entityName, nameof(entityName));
+            Argument.AssertNotNullOrWhiteSpace(entityPath, nameof(entityPath));
             connection.ThrowIfClosed();
 
-            EntityName = entityName;
-            Identifier = DiagnosticUtilities.GenerateIdentifier(EntityName);
+            EntityPath = entityPath;
+            Identifier = DiagnosticUtilities.GenerateIdentifier(EntityPath);
             options = options?.Clone() ?? new ServiceBusSenderOptions();
             _connection = connection;
             _retryPolicy = options.RetryOptions.ToRetryPolicy();
             _innerSender = _connection.CreateTransportSender(
-                entityName,
+                entityPath,
                 _retryPolicy);
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -31,11 +31,11 @@ namespace Azure.Messaging.ServiceBus
         public string FullyQualifiedNamespace => _connection.FullyQualifiedNamespace;
 
         /// <summary>
-        ///   The name of the entity that the producer is connected to, specific to the
+        ///   The name of the entity that the sender is connected to, specific to the
         ///   Service Bus namespace that contains it.
         /// </summary>
         ///
-        public string EntityName { get; }
+        public string EntityPath { get; }
 
         /// <summary>
         ///   Indicates whether or not this <see cref="ServiceBusSender"/> has been closed.
@@ -51,7 +51,7 @@ namespace Azure.Messaging.ServiceBus
         /// Gets the ID to identify this client. This can be used to correlate logs and exceptions.
         /// </summary>
         /// <remarks>Every new client has a unique ID.</remarks>
-        public string Identifier { get; private set; }
+        internal string Identifier { get; private set; }
 
         /// <summary>
         ///   The policy to use for determining retry behavior for when an operation fails.
@@ -74,14 +74,9 @@ namespace Azure.Messaging.ServiceBus
         private readonly TransportSender _innerSender;
 
         /// <summary>
-        ///
-        /// </summary>
-        private ClientDiagnostics ClientDiagnostics { get; set; }
-
-        /// <summary>
         ///   Initializes a new instance of the <see cref="ServiceBusSender"/> class.
         /// </summary>
-        /// <param name="entityName"></param>
+        /// <param name="entityPath"></param>
         /// <param name="connection"></param>
         /// <param name="options">A set of options to apply when configuring the producer.</param>
         /// <remarks>
@@ -91,21 +86,23 @@ namespace Azure.Messaging.ServiceBus
         /// </remarks>
         ///
         internal ServiceBusSender(
-            string entityName,
+            string entityPath,
             ServiceBusConnection connection,
             ServiceBusSenderOptions options)
         {
-            Argument.AssertNotNullOrWhiteSpace(entityName, nameof(entityName));
+            Argument.AssertNotNull(connection, nameof(connection));
+            Argument.AssertNotNull(options, nameof(options));
+            Argument.AssertNotNull(options.RetryOptions, nameof(options.RetryOptions));
+            Argument.AssertNotNullOrWhiteSpace(entityPath, nameof(entityPath));
             connection.ThrowIfClosed();
 
-            EntityName = entityName;
-            Identifier = DiagnosticUtilities.GenerateIdentifier(EntityName);
+            EntityPath = entityPath;
+            Identifier = DiagnosticUtilities.GenerateIdentifier(EntityPath);
             options = options?.Clone() ?? new ServiceBusSenderOptions();
-            ClientDiagnostics = new ClientDiagnostics(options);
             _connection = connection;
             _retryPolicy = options.RetryOptions.ToRetryPolicy();
             _innerSender = _connection.CreateTransportSender(
-                entityName,
+                entityPath,
                 _retryPolicy);
         }
 
@@ -299,23 +296,22 @@ namespace Azure.Messaging.ServiceBus
         }
 
         /// <summary>
-        ///   Closes the producer.
+        ///   Performs the task needed to clean up resources used by the <see cref="ServiceBusSender" />,
+        ///   including ensuring that the client itself has been closed.
         /// </summary>
-        ///
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///
-        public virtual async Task CloseAsync(CancellationToken cancellationToken = default)
+        [SuppressMessage("Usage", "AZC0002:Ensure all service methods take an optional CancellationToken parameter.", Justification = "This signature must match the IAsyncDisposable interface.")]
+        public virtual async ValueTask DisposeAsync()
         {
-            cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             IsClosed = true;
 
             ServiceBusEventSource.Log.ClientCloseStart(typeof(ServiceBusSender), Identifier);
 
             try
             {
-                await _innerSender.CloseAsync(cancellationToken).ConfigureAwait(false);
+                await _innerSender.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -325,16 +321,6 @@ namespace Azure.Messaging.ServiceBus
 
             ServiceBusEventSource.Log.ClientCloseComplete(typeof(ServiceBusSender), Identifier);
         }
-
-        /// <summary>
-        ///   Performs the task needed to clean up resources used by the <see cref="ServiceBusSender" />,
-        ///   including ensuring that the client itself has been closed.
-        /// </summary>
-        ///
-        /// <returns>A task to be resolved on when the operation has completed.</returns>
-        ///
-        [SuppressMessage("Usage", "AZC0002:Ensure all service methods take an optional CancellationToken parameter.", Justification = "This signature must match the IAsyncDisposable interface.")]
-        public virtual async ValueTask DisposeAsync() => await CloseAsync().ConfigureAwait(false);
 
         /// <summary>
         ///   Determines whether the specified <see cref="System.Object" /> is equal to this instance.
@@ -364,25 +350,6 @@ namespace Azure.Messaging.ServiceBus
         ///
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override string ToString() => base.ToString();
-
-        /// <summary>
-        ///   Creates and configures a diagnostics scope to be used for instrumenting
-        ///   events.
-        /// </summary>
-        ///
-        /// <returns>The requested <see cref="DiagnosticScope" />.</returns>
-        ///
-        internal virtual DiagnosticScope CreateDiagnosticScope()
-        {
-            DiagnosticScope scope = ClientDiagnostics.CreateScope(DiagnosticProperty.SenderActivityName);
-            scope.AddAttribute(DiagnosticProperty.TypeAttribute, DiagnosticProperty.ServiceBusSenderType);
-            scope.AddAttribute(DiagnosticProperty.ServiceContextAttribute, DiagnosticProperty.ServiceBusServiceContext);
-            scope.AddAttribute(DiagnosticProperty.ServiceBusAttribute, EntityName);
-            scope.AddAttribute(DiagnosticProperty.EndpointAttribute, _connection.ServiceEndpoint);
-            scope.Start();
-
-            return scope;
-        }
 
         /// <summary>
         ///   Performs the actions needed to instrument a set of events.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSenderOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSenderOptions.cs
@@ -12,7 +12,7 @@ namespace Azure.Messaging.ServiceBus
     ///   to configure its behavior.
     /// </summary>
     ///
-    public class ServiceBusSenderOptions : ClientOptions
+    public class ServiceBusSenderOptions
     {
         /// <summary>The set of options to use for configuring the connection to the Service Bus service.</summary>
         private ServiceBusClientOptions _connectionOptions = new ServiceBusClientOptions();

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/ServiceBusClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/ServiceBusClient.cs
@@ -39,26 +39,31 @@ namespace Azure.Messaging.ServiceBus
         public ServiceBusTransportType TransportType { get; }
 
         /// <summary>
+        /// Subscription manager is used for all basic interactions with a Service Bus Subscription.
+        /// </summary>
+        public ServiceBusSubscriptionRuleManager SubscriptionRuleManager { get; private set; }
+
+        /// <summary>
         ///   A unique name used to identify this client.
         /// </summary>
         ///
-        public string Identifier { get; }
+        internal string Identifier { get; }
 
         /// <summary>
-        ///   Closes the connection to the Service Bus namespace and associated Service Bus entity.
+        ///   Performs the task needed to clean up resources used by the <see cref="ServiceBusConnection" />,
+        ///   including ensuring that the connection itself has been closed.
         /// </summary>
-        ///
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///
-        public async virtual Task CloseAsync(CancellationToken cancellationToken = default)
+        [SuppressMessage("Usage", "AZC0002:Ensure all service methods take an optional CancellationToken parameter.", Justification = "This signature must match the IAsyncDisposable interface.")]
+        public virtual async ValueTask DisposeAsync()
         {
             ServiceBusEventSource.Log.ClientCloseStart(typeof(ServiceBusConnection), Identifier);
 
             try
             {
-                await Connection.CloseAsync(cancellationToken).ConfigureAwait(false);
+                await Connection.CloseAsync(CancellationToken.None).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -70,17 +75,6 @@ namespace Azure.Messaging.ServiceBus
                 ServiceBusEventSource.Log.ClientCloseComplete(typeof(ServiceBusConnection), Identifier);
             }
         }
-
-
-        /// <summary>
-        ///   Performs the task needed to clean up resources used by the <see cref="ServiceBusConnection" />,
-        ///   including ensuring that the connection itself has been closed.
-        /// </summary>
-        ///
-        /// <returns>A task to be resolved on when the operation has completed.</returns>
-        ///
-        [SuppressMessage("Usage", "AZC0002:Ensure all service methods take an optional CancellationToken parameter.", Justification = "This signature must match the IAsyncDisposable interface.")]
-        public virtual async ValueTask DisposeAsync() => await CloseAsync().ConfigureAwait(false);
 
         /// <summary>
         /// Can be used for mocking.
@@ -112,6 +106,7 @@ namespace Azure.Messaging.ServiceBus
         {
             Connection = new ServiceBusConnection(connectionString, options);
             Identifier = DiagnosticUtilities.GenerateIdentifier(Connection.FullyQualifiedNamespace);
+            SubscriptionRuleManager = new ServiceBusSubscriptionRuleManager();
         }
 
         /// <summary>
@@ -137,6 +132,7 @@ namespace Azure.Messaging.ServiceBus
                 fullyQualifiedNamespace,
                 credential,
                 options);
+            SubscriptionRuleManager = new ServiceBusSubscriptionRuleManager();
         }
 
         /// <summary>
@@ -146,17 +142,9 @@ namespace Azure.Messaging.ServiceBus
         /// <returns></returns>
         public ServiceBusSender GetSender(string entityName) =>
             new ServiceBusSender(
-                entityName: entityName,
+                entityPath: entityName,
                 connection: Connection,
                 options: new ServiceBusSenderOptions());
-
-        private void ValidateEntityName(string entityName)
-        {
-            if (Connection.EntityName != null && entityName != Connection.EntityName)
-            {
-                throw new ArgumentException();
-            }
-        }
 
         /// <summary>
         ///
@@ -166,7 +154,7 @@ namespace Azure.Messaging.ServiceBus
         /// <returns></returns>
         public ServiceBusSender GetSender(string entityName, ServiceBusSenderOptions options) =>
             new ServiceBusSender(
-                entityName: entityName,
+                entityPath: entityName,
                 connection: Connection,
                 options: options);
 
@@ -176,9 +164,11 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="queueName"></param>
         /// <returns></returns>
         public ServiceBusReceiver GetReceiver(string queueName) =>
-            ServiceBusReceiver.CreateReceiver(
-                entityName: queueName,
-                connection: Connection);
+            new ServiceBusReceiver(
+                connection: Connection,
+                entityPath: queueName,
+                isSessionEntity: false,
+                options: new ServiceBusReceiverOptions());
 
         /// <summary>
         ///
@@ -187,9 +177,10 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="options"></param>
         /// <returns></returns>
         public ServiceBusReceiver GetReceiver(string queueName, ServiceBusReceiverOptions options) =>
-            ServiceBusReceiver.CreateReceiver(
-                entityName: queueName,
+            new ServiceBusReceiver(
                 connection: Connection,
+                entityPath: queueName,
+                isSessionEntity: false,
                 options: options);
 
         /// <summary>
@@ -199,9 +190,11 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="subscriptionName"></param>
         /// <returns></returns>
         public ServiceBusReceiver GetReceiver(string topicName, string subscriptionName) =>
-            ServiceBusReceiver.CreateReceiver(
-                entityName: EntityNameFormatter.FormatSubscriptionPath(topicName, subscriptionName),
-                connection: Connection);
+            new ServiceBusReceiver(
+                connection: Connection,
+                entityPath: EntityNameFormatter.FormatSubscriptionPath(topicName, subscriptionName),
+                isSessionEntity: false,
+                options: new ServiceBusReceiverOptions());
 
         /// <summary>
         ///
@@ -214,31 +207,11 @@ namespace Azure.Messaging.ServiceBus
             string topicName,
             string subscriptionName,
             ServiceBusReceiverOptions options) =>
-            ServiceBusReceiver.CreateReceiver(
-                entityName: EntityNameFormatter.FormatSubscriptionPath(topicName, subscriptionName),
+            new ServiceBusReceiver(
                 connection: Connection,
+                entityPath: EntityNameFormatter.FormatSubscriptionPath(topicName, subscriptionName),
+                isSessionEntity: false,
                 options: options);
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="queueName"></param>
-        /// <returns></returns>
-        public ServiceBusProcessor GetProcessor(string queueName) =>
-            new ServiceBusProcessor(
-                entityName: queueName,
-                connection: Connection);
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="topicName"></param>
-        /// <param name="subscriptionName"></param>
-        /// <returns></returns>
-        public ServiceBusProcessor GetProcessor(string topicName, string subscriptionName) =>
-            new ServiceBusProcessor(
-                entityName: EntityNameFormatter.FormatSubscriptionPath(topicName, subscriptionName),
-                connection: Connection);
 
         /// <summary>
         ///
@@ -250,7 +223,7 @@ namespace Azure.Messaging.ServiceBus
             string sessionId = default,
             CancellationToken cancellationToken = default) =>
             await ServiceBusReceiver.CreateSessionReceiverAsync(
-                entityName: queueName,
+                entityPath: queueName,
                 connection: Connection,
                 sessionId: sessionId,
                 options: options,
@@ -261,16 +234,104 @@ namespace Azure.Messaging.ServiceBus
         /// </summary>
         /// <returns></returns>
         public virtual async Task<ServiceBusReceiver> GetSessionReceiverAsync(
-            string subscriptionName,
             string topicName,
+            string subscriptionName,
             ServiceBusReceiverOptions options = default,
             string sessionId = default,
             CancellationToken cancellationToken = default) =>
             await ServiceBusReceiver.CreateSessionReceiverAsync(
-                entityName: EntityNameFormatter.FormatSubscriptionPath(topicName, subscriptionName),
+                entityPath: EntityNameFormatter.FormatSubscriptionPath(topicName, subscriptionName),
                 connection: Connection,
                 sessionId: sessionId,
                 options: options,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="queueName"></param>
+        /// <returns></returns>
+        public ServiceBusProcessor GetProcessor(string queueName) =>
+            new ServiceBusProcessor(
+                entityPath: queueName,
+                connection: Connection,
+                isSessionEntity: false,
+                options: new ServiceBusProcessorOptions());
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="queueName"></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        public ServiceBusProcessor GetProcessor(string queueName, ServiceBusProcessorOptions options) =>
+            new ServiceBusProcessor(
+                entityPath: queueName,
+                connection: Connection,
+                isSessionEntity: false,
+                options: options);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="topicName"></param>
+        /// <param name="subscriptionName"></param>
+        /// <returns></returns>
+        public ServiceBusProcessor GetProcessor(string topicName, string subscriptionName) =>
+            new ServiceBusProcessor(
+                entityPath: EntityNameFormatter.FormatSubscriptionPath(topicName, subscriptionName),
+                connection: Connection,
+                isSessionEntity: false,
+                options: new ServiceBusProcessorOptions());
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="topicName"></param>
+        /// <param name="subscriptionName"></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        public ServiceBusProcessor GetProcessor(
+            string topicName,
+            string subscriptionName,
+            ServiceBusProcessorOptions options) =>
+            new ServiceBusProcessor(
+                entityPath: EntityNameFormatter.FormatSubscriptionPath(topicName, subscriptionName),
+                connection: Connection,
+                isSessionEntity: false,
+                options: options);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <returns></returns>
+        public ServiceBusProcessor GetSessionProcessor(
+            string queueName,
+            ServiceBusProcessorOptions options = default,
+            string sessionId = default,
+            CancellationToken cancellationToken = default) =>
+            new ServiceBusProcessor(
+                entityPath: queueName,
+                connection: Connection,
+                isSessionEntity: true,
+                sessionId: sessionId,
+                options: options ?? new ServiceBusProcessorOptions());
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <returns></returns>
+        public ServiceBusProcessor GetSessionProcessor(
+            string topicName,
+            string subscriptionName,
+            ServiceBusProcessorOptions options = default,
+            string sessionId = default,
+            CancellationToken cancellationToken = default) =>
+            new ServiceBusProcessor(
+                entityPath: EntityNameFormatter.FormatSubscriptionPath(topicName, subscriptionName),
+                connection: Connection,
+                isSessionEntity: true,
+                sessionId: sessionId,
+                options: options ?? new ServiceBusProcessorOptions());
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/ServiceBusClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/ServiceBusClient.cs
@@ -142,7 +142,7 @@ namespace Azure.Messaging.ServiceBus
         /// <returns></returns>
         public ServiceBusSender GetSender(string entityName) =>
             new ServiceBusSender(
-                entityPath: entityName,
+                entityName: entityName,
                 connection: Connection,
                 options: new ServiceBusSenderOptions());
 
@@ -154,7 +154,7 @@ namespace Azure.Messaging.ServiceBus
         /// <returns></returns>
         public ServiceBusSender GetSender(string entityName, ServiceBusSenderOptions options) =>
             new ServiceBusSender(
-                entityPath: entityName,
+                entityName: entityName,
                 connection: Connection,
                 options: options);
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/ServiceBusClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/ServiceBusClient.cs
@@ -142,7 +142,7 @@ namespace Azure.Messaging.ServiceBus
         /// <returns></returns>
         public ServiceBusSender GetSender(string entityName) =>
             new ServiceBusSender(
-                entityName: entityName,
+                entityPath: entityName,
                 connection: Connection,
                 options: new ServiceBusSenderOptions());
 
@@ -154,7 +154,7 @@ namespace Azure.Messaging.ServiceBus
         /// <returns></returns>
         public ServiceBusSender GetSender(string entityName, ServiceBusSenderOptions options) =>
             new ServiceBusSender(
-                entityName: entityName,
+                entityPath: entityName,
                 connection: Connection,
                 options: options);
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/ServiceBusConnection.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/ServiceBusConnection.cs
@@ -44,7 +44,7 @@ namespace Azure.Messaging.ServiceBus
         ///
         public bool IsClosed => _innerClient.IsClosed;
 
-        public string EntityName { get; }
+        public string EntityPath { get; }
 
         /// <summary>
         ///   The endpoint for the Service Bus service to which the connection is associated.
@@ -93,10 +93,10 @@ namespace Azure.Messaging.ServiceBus
 
             FullyQualifiedNamespace = builder.FullyQualifiedNamespace;
             TransportType = options.TransportType;
-            EntityName = builder.EntityName;
+            EntityPath = builder.EntityName;
             var sharedAccessSignature = new SharedAccessSignature
             (
-                 BuildAudienceResource(options.TransportType, FullyQualifiedNamespace, EntityName),
+                 BuildAudienceResource(options.TransportType, FullyQualifiedNamespace, EntityPath),
                  builder.SasKeyName,
                  builder.SasKey
             );
@@ -104,7 +104,7 @@ namespace Azure.Messaging.ServiceBus
             var sharedCredentials = new SharedAccessSignatureCredential(sharedAccessSignature);
             var tokenCredentials = new ServiceBusTokenCredential(
                 sharedCredentials,
-                BuildAudienceResource(options.TransportType, FullyQualifiedNamespace, EntityName));
+                BuildAudienceResource(options.TransportType, FullyQualifiedNamespace, EntityPath));
             _innerClient = CreateTransportClient(tokenCredentials, options);
         }
 
@@ -134,11 +134,11 @@ namespace Azure.Messaging.ServiceBus
                     break;
 
                 case ServiceBusSharedKeyCredential sharedKeyCredential:
-                    credential = sharedKeyCredential.AsSharedAccessSignatureCredential(BuildAudienceResource(options.TransportType, fullyQualifiedNamespace, EntityName));
+                    credential = sharedKeyCredential.AsSharedAccessSignatureCredential(BuildAudienceResource(options.TransportType, fullyQualifiedNamespace, EntityPath));
                     break;
             }
 
-            var tokenCredential = new ServiceBusTokenCredential(credential, BuildAudienceResource(options.TransportType, fullyQualifiedNamespace, EntityName));
+            var tokenCredential = new ServiceBusTokenCredential(credential, BuildAudienceResource(options.TransportType, fullyQualifiedNamespace, EntityPath));
 
             FullyQualifiedNamespace = fullyQualifiedNamespace;
             TransportType = options.TransportType;
@@ -154,7 +154,7 @@ namespace Azure.Messaging.ServiceBus
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///
-        public async virtual Task CloseAsync(CancellationToken cancellationToken = default) =>
+        public virtual async Task CloseAsync(CancellationToken cancellationToken = default) =>
             await _innerClient.CloseAsync(cancellationToken).ConfigureAwait(false);
 
 
@@ -200,7 +200,7 @@ namespace Azure.Messaging.ServiceBus
             _innerClient.CreateSender(entityName, retryPolicy);
 
         internal virtual TransportReceiver CreateTransportReceiver(
-            string entityName,
+            string entityPath,
             ServiceBusRetryPolicy retryPolicy,
             ReceiveMode receiveMode,
             uint prefetchCount,
@@ -208,7 +208,7 @@ namespace Azure.Messaging.ServiceBus
             string sessionId = default,
             bool isSessionReceiver = default) =>
                 _innerClient.CreateReceiver(
-                    entityName,
+                    entityPath,
                     retryPolicy,
                     receiveMode,
                     prefetchCount,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/ServiceBusException.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/ServiceBusException.cs
@@ -36,7 +36,7 @@ namespace Azure.Messaging.ServiceBus
         ///
         /// <value>The name of the Service Bus entity, if available; otherwise, <c>null</c>.</value>
         ///
-        public string EntityName { get; }
+        public string EntityPath { get; }
 
         /// <summary>
         ///   Gets a message that describes the current exception.
@@ -46,12 +46,12 @@ namespace Azure.Messaging.ServiceBus
         {
             get
             {
-                if (string.IsNullOrEmpty(EntityName))
+                if (string.IsNullOrEmpty(EntityPath))
                 {
                     return base.Message;
                 }
 
-                return string.Format(CultureInfo.InvariantCulture, "{0} ({1})", base.Message, EntityName);
+                return string.Format(CultureInfo.InvariantCulture, "{0} ({1})", base.Message, EntityPath);
             }
         }
 
@@ -62,14 +62,14 @@ namespace Azure.Messaging.ServiceBus
         ///
         /// <param name="message">The error message that explains the reason for the exception.</param>
         /// <param name="reason">The reason for the failure that resulted in the exception.</param>
-        /// <param name="entityName">The name of the Service Bus entity to which the exception is associated.</param>
+        /// <param name="entityPath">The name of the Service Bus entity to which the exception is associated.</param>
         /// <param name="innerException"></param>
         ///
         public ServiceBusException(
             string message,
             FailureReason reason,
-            string entityName = default,
-            Exception innerException = default) : this(default, entityName, message, reason, innerException)
+            string entityPath = default,
+            Exception innerException = default) : this(default, entityPath, message, reason, innerException)
         {
             switch (reason)
             {
@@ -102,7 +102,7 @@ namespace Azure.Messaging.ServiceBus
                                   Exception innerException = default) : base(message, innerException)
         {
             IsTransient = isTransient;
-            EntityName = entityName;
+            EntityPath = entityName;
             Reason = reason;
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/ServiceBusReceivedMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/ServiceBusReceivedMessage.cs
@@ -48,12 +48,6 @@ namespace Azure.Messaging.ServiceBus
         }
 
         /// <summary>
-        /// Specifies whether or not there is a lock token set on the current message.
-        /// </summary>
-        /// <remarks>A lock token will only be specified if the message was received using ReceiveMode.PeekLock</remarks>
-        public bool IsLockTokenSet => _lockTokenGuid != default;
-
-        /// <summary>
         /// Gets the lock token for the current message.
         /// </summary>
         /// <remarks>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/ServiceBusSubscriptionRuleManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/ServiceBusSubscriptionRuleManager.cs
@@ -12,7 +12,7 @@ namespace Azure.Messaging.ServiceBus
     /// <summary>
     ///
     /// </summary>
-    public class ServiceBusSubscriptionManager
+    public class ServiceBusSubscriptionRuleManager
     {
         /// <summary>
         /// Adds a rule to the current subscription to filter the messages reaching from topic to the subscription.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/AmqpReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/AmqpReceiverTests.cs
@@ -44,7 +44,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ConstructorRequiresEntityName(string entityName)
         {
             Assert.That(() => new AmqpReceiver(
-                entityName: entityName,
+                entityPath: entityName,
                 receiveMode: ReceiveMode.PeekLock,
                 prefetchCount: 0,
                 connectionScope: Mock.Of<AmqpConnectionScope>(),
@@ -63,7 +63,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ConstructorRequiresConnectionScope()
         {
             Assert.That(() => new AmqpReceiver(
-                entityName: "someQueue",
+                entityPath: "someQueue",
                 receiveMode: ReceiveMode.PeekLock,
                 prefetchCount: 0,
                 connectionScope: null,
@@ -82,7 +82,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ConstructorRequiresTheRetryPolicy()
         {
             Assert.That(() => new AmqpReceiver(
-                entityName: "someQueue",
+                entityPath: "someQueue",
                 receiveMode: ReceiveMode.PeekLock,
                 prefetchCount: 0,
                 connectionScope: Mock.Of<AmqpConnectionScope>(),

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/TestEnvironment.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/TestEnvironment.cs
@@ -227,7 +227,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                 return new NamespaceProperties
                 (
                     parsed.Endpoint.Host.Substring(0, parsed.Endpoint.Host.IndexOf('.')),
-                    ServiceBusOverrideConnectionString.Value.Replace($";EntityPath={ parsed.EntityName }", string.Empty),
+                    ServiceBusOverrideConnectionString.Value.Replace($";EntityPath={ parsed.EntityPath }", string.Empty),
                     false
                 );
             }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
@@ -85,7 +85,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                 await client.GetSender(scope.QueueName).SendAsync(maxSizeMessage);
                 var receiver = client.GetReceiver(scope.QueueName);
                 var receivedMaxSizeMessage = await receiver.ReceiveAsync();
-                await receiver.CompleteAsync(receivedMaxSizeMessage);
+                await receiver.CompleteAsync(receivedMaxSizeMessage.LockToken);
                 Assert.AreEqual(maxPayload, receivedMaxSizeMessage.Body.ToArray());
             }
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
@@ -59,7 +59,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                     {
                         var receiver = args.Receiver;
                         var message = args.Message;
-                        await receiver.CompleteAsync(message);
+                        await receiver.CompleteAsync(message.LockToken);
                         Interlocked.Increment(ref messageCt);
                     }
                     finally
@@ -253,7 +253,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                     {
                         var message = args.Message;
                         var receiver = args.Receiver;
-                        await receiver.CompleteAsync(message);
+                        await receiver.CompleteAsync(message.LockToken);
                         Interlocked.Increment(ref messageCt);
                         sessions.TryRemove(message.SessionId, out bool _);
                         Assert.AreEqual(message.SessionId, receiver.SessionManager.SessionId);
@@ -326,7 +326,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                     {
                         var receiver = args.Receiver;
                         var message = args.Message;
-                        await receiver.CompleteAsync(message);
+                        await receiver.CompleteAsync(message.LockToken);
                         sessions.TryRemove(message.SessionId, out bool _);
                         Assert.AreEqual(message.SessionId, receiver.SessionManager.SessionId);
                         Assert.IsNotNull(receiver.SessionManager.LockedUntilUtc);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
@@ -168,7 +168,6 @@ namespace Azure.Messaging.ServiceBus.Tests
             {
                 Assert.NotNull(args);
                 Assert.NotNull(args.Exception);
-                Assert.AreEqual(processor.Identifier, args.Identifier);
                 Assert.AreEqual(processor.FullyQualifiedNamespace, args.FullyQualifiedNamespace);
                 Assert.AreEqual(ExceptionReceivedEventArgsAction.Receive, args.Action);
                 Assert.AreEqual(processor.EntityPath, args.EntityPath);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Azure.Amqp.Framing;
 using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests
@@ -35,11 +36,14 @@ namespace Azure.Messaging.ServiceBus.Tests
                 }
 
                 var ct = 0;
-                foreach (ServiceBusMessage peekedMessage in await receiver.PeekBatchAsync(
-                    maxMessages: messageCt))
+                while (ct < messageCt)
                 {
-                    var peekedText = Encoding.Default.GetString(peekedMessage.Body.ToArray());
-                    ct++;
+                    foreach (ServiceBusMessage peekedMessage in await receiver.PeekBatchAsync(
+                    maxMessages: messageCt))
+                    {
+                        var peekedText = Encoding.Default.GetString(peekedMessage.Body.ToArray());
+                        ct++;
+                    }
                 }
                 Assert.AreEqual(messageCt, ct);
             }
@@ -63,12 +67,15 @@ namespace Azure.Messaging.ServiceBus.Tests
                 var receivedMessageCount = 0;
                 var messageEnum = messages.GetEnumerator();
 
-                foreach (var item in await receiver.ReceiveBatchAsync(messageCount))
+                while (receivedMessageCount < messageCount)
                 {
-                    receivedMessageCount++;
-                    messageEnum.MoveNext();
-                    Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
-                    Assert.AreEqual(item.DeliveryCount, 1);
+                    foreach (var item in await receiver.ReceiveBatchAsync(messageCount))
+                    {
+                        receivedMessageCount++;
+                        messageEnum.MoveNext();
+                        Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
+                        Assert.AreEqual(item.DeliveryCount, 1);
+                    }
                 }
                 Assert.AreEqual(messageCount, receivedMessageCount);
 
@@ -99,12 +106,16 @@ namespace Azure.Messaging.ServiceBus.Tests
                 var receivedMessageCount = 0;
                 var messageEnum = messages.GetEnumerator();
 
-                foreach (var item in await receiver.ReceiveBatchAsync(messageCount))
+
+                while (receivedMessageCount < messageCount)
                 {
-                    receivedMessageCount++;
-                    messageEnum.MoveNext();
-                    Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
-                    await receiver.CompleteAsync(item.LockToken);
+                    foreach (var item in await receiver.ReceiveBatchAsync(messageCount))
+                    {
+                        receivedMessageCount++;
+                        messageEnum.MoveNext();
+                        Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
+                        await receiver.CompleteAsync(item.LockToken);
+                    }
                 }
                 Assert.AreEqual(messageCount, receivedMessageCount);
 
@@ -131,13 +142,16 @@ namespace Azure.Messaging.ServiceBus.Tests
                 var receivedMessageCount = 0;
                 var messageEnum = messages.GetEnumerator();
 
-                foreach (var item in await receiver.ReceiveBatchAsync(messageCount))
+                while (receivedMessageCount < messageCount)
                 {
-                    receivedMessageCount++;
-                    messageEnum.MoveNext();
-                    Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
-                    await receiver.AbandonAsync(item.LockToken);
-                    Assert.AreEqual(item.DeliveryCount, 1);
+                    foreach (var item in await receiver.ReceiveBatchAsync(messageCount))
+                    {
+                        receivedMessageCount++;
+                        messageEnum.MoveNext();
+                        Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
+                        await receiver.AbandonAsync(item.LockToken);
+                        Assert.AreEqual(item.DeliveryCount, 1);
+                    }
                 }
                 Assert.AreEqual(messageCount, receivedMessageCount);
 
@@ -188,12 +202,15 @@ namespace Azure.Messaging.ServiceBus.Tests
                 string deadLetterQueuePath = EntityNameFormatter.FormatDeadLetterPath(scope.QueueName);
                 var deadLetterReceiver = client.GetReceiver(deadLetterQueuePath);
 
-                foreach (var item in await deadLetterReceiver.ReceiveBatchAsync(messageCount))
+                while (receivedMessageCount < messageCount)
                 {
-                    receivedMessageCount++;
-                    messageEnum.MoveNext();
-                    Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
-                    await deadLetterReceiver.CompleteAsync(item.LockToken);
+                    foreach (var item in await deadLetterReceiver.ReceiveBatchAsync(messageCount))
+                    {
+                        receivedMessageCount++;
+                        messageEnum.MoveNext();
+                        Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
+                        await deadLetterReceiver.CompleteAsync(item.LockToken);
+                    }
                 }
                 Assert.AreEqual(messageCount, receivedMessageCount);
 
@@ -221,13 +238,16 @@ namespace Azure.Messaging.ServiceBus.Tests
                 var messageEnum = messages.GetEnumerator();
                 IList<long> sequenceNumbers = new List<long>();
 
-                foreach (var item in await receiver.ReceiveBatchAsync(messageCount))
+                while (receivedMessageCount < messageCount)
                 {
-                    receivedMessageCount++;
-                    messageEnum.MoveNext();
-                    Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
-                    sequenceNumbers.Add(item.SequenceNumber);
-                    await receiver.DeferAsync(item.LockToken);
+                    foreach (var item in await receiver.ReceiveBatchAsync(messageCount))
+                    {
+                        receivedMessageCount++;
+                        messageEnum.MoveNext();
+                        Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
+                        sequenceNumbers.Add(item.SequenceNumber);
+                        await receiver.DeferAsync(item.LockToken);
+                    }
                 }
                 Assert.AreEqual(messageCount, receivedMessageCount);
 
@@ -264,11 +284,14 @@ namespace Azure.Messaging.ServiceBus.Tests
                 var receivedMessageCount = 0;
                 var messageEnum = messages.GetEnumerator();
 
-                foreach (var item in await receiver.ReceiveBatchAsync(messageCount).ConfigureAwait(false))
+                while (receivedMessageCount < messageCount)
                 {
-                    messageEnum.MoveNext();
-                    Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
-                    receivedMessageCount++;
+                    foreach (var item in await receiver.ReceiveBatchAsync(messageCount).ConfigureAwait(false))
+                    {
+                        messageEnum.MoveNext();
+                        Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
+                        receivedMessageCount++;
+                    }
                 }
                 Assert.AreEqual(messageCount, receivedMessageCount);
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -64,20 +64,14 @@ namespace Azure.Messaging.ServiceBus.Tests
                 await sender.SendBatchAsync(batch);
 
                 var receiver = client.GetReceiver(scope.QueueName);
-                var receivedMessageCount = 0;
                 var messageEnum = messages.GetEnumerator();
 
-                while (receivedMessageCount < messageCount)
+                foreach (var item in await receiver.ReceiveBatchAsync(messageCount))
                 {
-                    foreach (var item in await receiver.ReceiveBatchAsync(messageCount))
-                    {
-                        receivedMessageCount++;
-                        messageEnum.MoveNext();
-                        Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
-                        Assert.AreEqual(item.DeliveryCount, 1);
-                    }
+                    messageEnum.MoveNext();
+                    Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
+                    Assert.AreEqual(item.DeliveryCount, 1);
                 }
-                Assert.AreEqual(messageCount, receivedMessageCount);
 
                 messageEnum.Reset();
                 foreach (var item in await receiver.PeekBatchAsync(messageCount))
@@ -139,24 +133,19 @@ namespace Azure.Messaging.ServiceBus.Tests
                 await sender.SendBatchAsync(batch);
 
                 var receiver = client.GetReceiver(scope.QueueName);
-                var receivedMessageCount = 0;
+
                 var messageEnum = messages.GetEnumerator();
 
-                while (receivedMessageCount < messageCount)
+                foreach (var item in await receiver.ReceiveBatchAsync(messageCount))
                 {
-                    foreach (var item in await receiver.ReceiveBatchAsync(messageCount))
-                    {
-                        receivedMessageCount++;
-                        messageEnum.MoveNext();
-                        Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
-                        await receiver.AbandonAsync(item.LockToken);
-                        Assert.AreEqual(item.DeliveryCount, 1);
-                    }
+                    messageEnum.MoveNext();
+                    Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
+                    await receiver.AbandonAsync(item.LockToken);
+                    Assert.AreEqual(item.DeliveryCount, 1);
                 }
-                Assert.AreEqual(messageCount, receivedMessageCount);
 
                 messageEnum.Reset();
-                receivedMessageCount = 0;
+                var receivedMessageCount = 0;
                 foreach (var item in await receiver.PeekBatchAsync(messageCount))
                 {
                     receivedMessageCount++;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -104,7 +104,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                     receivedMessageCount++;
                     messageEnum.MoveNext();
                     Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
-                    await receiver.CompleteAsync(item);
+                    await receiver.CompleteAsync(item.LockToken);
                 }
                 Assert.AreEqual(messageCount, receivedMessageCount);
 
@@ -136,7 +136,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                     receivedMessageCount++;
                     messageEnum.MoveNext();
                     Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
-                    await receiver.AbandonAsync(item);
+                    await receiver.AbandonAsync(item.LockToken);
                     Assert.AreEqual(item.DeliveryCount, 1);
                 }
                 Assert.AreEqual(messageCount, receivedMessageCount);
@@ -176,7 +176,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                     receivedMessageCount++;
                     messageEnum.MoveNext();
                     Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
-                    await receiver.MoveToDeadLetterQueueAsync(item);
+                    await receiver.MoveToDeadLetterQueueAsync(item.LockToken);
                 }
                 Assert.AreEqual(messageCount, receivedMessageCount);
 
@@ -193,7 +193,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                     receivedMessageCount++;
                     messageEnum.MoveNext();
                     Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
-                    await deadLetterReceiver.CompleteAsync(item);
+                    await deadLetterReceiver.CompleteAsync(item.LockToken);
                 }
                 Assert.AreEqual(messageCount, receivedMessageCount);
 
@@ -227,7 +227,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                     messageEnum.MoveNext();
                     Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
                     sequenceNumbers.Add(item.SequenceNumber);
-                    await receiver.DeferAsync(item);
+                    await receiver.DeferAsync(item.LockToken);
                 }
                 Assert.AreEqual(messageCount, receivedMessageCount);
 
@@ -325,7 +325,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                 Assert.True(receivedMessage.LockedUntilUtc >= firstLockedUntilUtcTime + TimeSpan.FromSeconds(10));
 
                 // Complete Messages
-                await receiver.CompleteAsync(receivedMessage);
+                await receiver.CompleteAsync(receivedMessage.LockToken);
 
                 Assert.AreEqual(messageCount, receivedMessages.Length);
                 Assert.AreEqual(message.MessageId, receivedMessage.MessageId);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
@@ -37,6 +37,20 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
             Assert.IsTrue(receiver.IsSessionReceiver);
         }
 
+        [Test]
+        public void SessionReceiverCannotPerformMessageLock()
+        {
+            var receiver = new ServiceBusReceiver(
+                Mock.Of<ServiceBusConnection>(),
+                "fakeQueue",
+                true,
+                options: new ServiceBusReceiverOptions());
+
+            Assert.That(async () => await receiver.RenewMessageLockAsync(
+                new ServiceBusReceivedMessage()),
+                Throws.InstanceOf<InvalidOperationException>());
+        }
+
         //[Test]
         // TODO add test that validates service error thrown
         // now that we removed assumption that subscription path
@@ -69,7 +83,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
             var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(GetRandomBuffer(64))}";
             var queueName = Encoding.Default.GetString(GetRandomBuffer(12));
             var receiver = new ServiceBusClient(connString).GetReceiver(queueName);
-            Assert.AreEqual(queueName, receiver.EntityName);
+            Assert.AreEqual(queueName, receiver.EntityPath);
             Assert.AreEqual(fullyQualifiedNamespace, receiver.FullyQualifiedNamespace);
             Assert.IsNotNull(receiver.Identifier);
             Assert.IsFalse(receiver.IsSessionReceiver);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
@@ -231,18 +231,15 @@ namespace Azure.Messaging.ServiceBus.Tests
 
                 ServiceBusReceiver receiver = await client.GetSessionReceiverAsync(scope.QueueName);
 
-                var receivedMessageCount = 0;
                 var messageEnum = messages.GetEnumerator();
 
                 foreach (var item in await receiver.ReceiveBatchAsync(messageCount))
                 {
-                    receivedMessageCount++;
                     messageEnum.MoveNext();
                     Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
                     Assert.AreEqual(messageEnum.Current.SessionId, item.SessionId);
                     Assert.AreEqual(item.DeliveryCount, 1);
                 }
-                Assert.AreEqual(messageCount, receivedMessageCount);
 
                 messageEnum.Reset();
                 foreach (var item in await receiver.PeekBatchAsync(messageCount))
@@ -357,25 +354,19 @@ namespace Azure.Messaging.ServiceBus.Tests
                 ServiceBusReceiver receiver = await client.GetSessionReceiverAsync(
                     scope.QueueName,
                     sessionId: useSpecificSession ? sessionId : null);
-                var receivedMessageCount = 0;
                 var messageEnum = messages.GetEnumerator();
 
-                while (receivedMessageCount < messageCount)
+                foreach (var item in await receiver.ReceiveBatchAsync(messageCount))
                 {
-                    foreach (var item in await receiver.ReceiveBatchAsync(messageCount))
-                    {
-                        receivedMessageCount++;
-                        messageEnum.MoveNext();
-                        Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
-                        Assert.AreEqual(messageEnum.Current.SessionId, item.SessionId);
-                        await receiver.AbandonAsync(item.LockToken);
-                        Assert.AreEqual(item.DeliveryCount, 1);
-                    }
+                    messageEnum.MoveNext();
+                    Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
+                    Assert.AreEqual(messageEnum.Current.SessionId, item.SessionId);
+                    await receiver.AbandonAsync(item.LockToken);
+                    Assert.AreEqual(item.DeliveryCount, 1);
                 }
-                Assert.AreEqual(messageCount, receivedMessageCount);
 
                 messageEnum.Reset();
-                receivedMessageCount = 0;
+                var receivedMessageCount = 0;
                 foreach (var item in await receiver.PeekBatchAsync(messageCount))
                 {
                     receivedMessageCount++;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
@@ -319,13 +319,16 @@ namespace Azure.Messaging.ServiceBus.Tests
                 var receivedMessageCount = 0;
                 var messageEnum = messages.GetEnumerator();
 
-                foreach (var item in await receiver.ReceiveBatchAsync(messageCount))
+                while (receivedMessageCount < messageCount)
                 {
-                    receivedMessageCount++;
-                    messageEnum.MoveNext();
-                    Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
-                    Assert.AreEqual(messageEnum.Current.SessionId, item.SessionId);
-                    await receiver.CompleteAsync(item.LockToken);
+                    foreach (var item in await receiver.ReceiveBatchAsync(messageCount))
+                    {
+                        receivedMessageCount++;
+                        messageEnum.MoveNext();
+                        Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
+                        Assert.AreEqual(messageEnum.Current.SessionId, item.SessionId);
+                        await receiver.CompleteAsync(item.LockToken);
+                    }
                 }
                 Assert.AreEqual(messageCount, receivedMessageCount);
 
@@ -357,14 +360,17 @@ namespace Azure.Messaging.ServiceBus.Tests
                 var receivedMessageCount = 0;
                 var messageEnum = messages.GetEnumerator();
 
-                foreach (var item in await receiver.ReceiveBatchAsync(messageCount))
+                while (receivedMessageCount < messageCount)
                 {
-                    receivedMessageCount++;
-                    messageEnum.MoveNext();
-                    Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
-                    Assert.AreEqual(messageEnum.Current.SessionId, item.SessionId);
-                    await receiver.AbandonAsync(item.LockToken);
-                    Assert.AreEqual(item.DeliveryCount, 1);
+                    foreach (var item in await receiver.ReceiveBatchAsync(messageCount))
+                    {
+                        receivedMessageCount++;
+                        messageEnum.MoveNext();
+                        Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
+                        Assert.AreEqual(messageEnum.Current.SessionId, item.SessionId);
+                        await receiver.AbandonAsync(item.LockToken);
+                        Assert.AreEqual(item.DeliveryCount, 1);
+                    }
                 }
                 Assert.AreEqual(messageCount, receivedMessageCount);
 
@@ -461,14 +467,17 @@ namespace Azure.Messaging.ServiceBus.Tests
                 var receivedMessageCount = 0;
                 var messageEnum = messages.GetEnumerator();
                 IList<long> sequenceNumbers = new List<long>();
-                foreach (var item in await receiver.ReceiveBatchAsync(messageCount))
+                while (receivedMessageCount < messageCount)
                 {
-                    receivedMessageCount++;
-                    messageEnum.MoveNext();
-                    Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
-                    Assert.AreEqual(messageEnum.Current.SessionId, item.SessionId);
-                    sequenceNumbers.Add(item.SequenceNumber);
-                    await receiver.DeferAsync(item.LockToken);
+                    foreach (var item in await receiver.ReceiveBatchAsync(messageCount))
+                    {
+                        receivedMessageCount++;
+                        messageEnum.MoveNext();
+                        Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
+                        Assert.AreEqual(messageEnum.Current.SessionId, item.SessionId);
+                        sequenceNumbers.Add(item.SequenceNumber);
+                        await receiver.DeferAsync(item.LockToken);
+                    }
                 }
                 Assert.AreEqual(messageCount, receivedMessageCount);
                 IList<ServiceBusReceivedMessage> deferedMessages = await receiver.ReceiveDeferredMessageBatchAsync(sequenceNumbers);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
@@ -51,7 +51,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                 // verify peeked == send
                 var ct = 0;
                 foreach (ServiceBusReceivedMessage peekedMessage in await receiver.PeekBatchAtAsync(
-                    fromSequenceNumber: (long)sequenceNumber,
+                    sequenceNumber: (long)sequenceNumber,
                     maxMessages: messageCt))
                 {
                     var peekedText = Encoding.Default.GetString(peekedMessage.Body.ToArray());
@@ -201,7 +201,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                     ServiceBusReceiver receiver = await client.GetSessionReceiverAsync(scope.QueueName);
 
                     foreach (ServiceBusMessage peekedMessage in await receiver.PeekBatchAtAsync(
-                        fromSequenceNumber: 1,
+                        sequenceNumber: 1,
                         maxMessages: 10))
                     {
                         var sessionId = receiver.SessionManager.SessionId;
@@ -209,7 +209,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                     }
 
                     // Close the receiver client when we are done with it. Since the sessionClient doesn't own the underlying connection, the connection remains open, but the session link will be closed.
-                    await receiver.CloseAsync();
+                    await receiver.DisposeAsync();
                 }
             }
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/SessionReceiverLiveTests.cs
@@ -325,7 +325,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                     messageEnum.MoveNext();
                     Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
                     Assert.AreEqual(messageEnum.Current.SessionId, item.SessionId);
-                    await receiver.CompleteAsync(item);
+                    await receiver.CompleteAsync(item.LockToken);
                 }
                 Assert.AreEqual(messageCount, receivedMessageCount);
 
@@ -363,7 +363,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                     messageEnum.MoveNext();
                     Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
                     Assert.AreEqual(messageEnum.Current.SessionId, item.SessionId);
-                    await receiver.AbandonAsync(item);
+                    await receiver.AbandonAsync(item.LockToken);
                     Assert.AreEqual(item.DeliveryCount, 1);
                 }
                 Assert.AreEqual(messageCount, receivedMessageCount);
@@ -409,7 +409,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                     messageEnum.MoveNext();
                     Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
                     Assert.AreEqual(messageEnum.Current.SessionId, item.SessionId);
-                    await receiver.MoveToDeadLetterQueueAsync(item);
+                    await receiver.MoveToDeadLetterQueueAsync(item.LockToken);
                 }
                 Assert.AreEqual(messageCount, receivedMessageCount);
 
@@ -468,7 +468,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                     Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
                     Assert.AreEqual(messageEnum.Current.SessionId, item.SessionId);
                     sequenceNumbers.Add(item.SequenceNumber);
-                    await receiver.DeferAsync(item);
+                    await receiver.DeferAsync(item.LockToken);
                 }
                 Assert.AreEqual(messageCount, receivedMessageCount);
                 IList<ServiceBusReceivedMessage> deferedMessages = await receiver.ReceiveDeferredMessageBatchAsync(sequenceNumbers);
@@ -517,7 +517,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                 Assert.True(receiver.SessionManager.LockedUntilUtc >= firstLockedUntilUtcTime + TimeSpan.FromSeconds(10));
 
                 // Complete Messages
-                await receiver.CompleteAsync(receivedMessage);
+                await receiver.CompleteAsync(receivedMessage.LockToken);
 
                 Assert.AreEqual(messageCount, receivedMessages.Length);
                 if (isSessionSpecified)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
@@ -167,7 +167,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
             {
                 await using var sender = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString).GetSender(scope.QueueName);
-                Assert.AreEqual(scope.QueueName, sender.EntityPath);
+                Assert.AreEqual(scope.QueueName, sender.EntityName);
                 Assert.AreEqual(TestEnvironment.FullyQualifiedNamespace, sender.FullyQualifiedNamespace);
             }
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
@@ -167,7 +167,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
             {
                 await using var sender = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString).GetSender(scope.QueueName);
-                Assert.AreEqual(scope.QueueName, sender.EntityName);
+                Assert.AreEqual(scope.QueueName, sender.EntityPath);
                 Assert.AreEqual(TestEnvironment.FullyQualifiedNamespace, sender.FullyQualifiedNamespace);
             }
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
@@ -167,7 +167,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
             {
                 await using var sender = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString).GetSender(scope.QueueName);
-                Assert.AreEqual(scope.QueueName, sender.EntityName);
+                Assert.AreEqual(scope.QueueName, sender.EntityPath);
                 Assert.AreEqual(TestEnvironment.FullyQualifiedNamespace, sender.FullyQualifiedNamespace);
             }
         }
@@ -183,11 +183,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 var sequenceNum = await sender.ScheduleMessageAsync(GetMessage(), scheduleTime);
 
                 await using var receiver = client.GetReceiver(scope.QueueName);
-                ServiceBusMessage msg = await receiver.PeekAt(sequenceNum);
+                ServiceBusMessage msg = await receiver.PeekAtAsync(sequenceNum);
                 Assert.AreEqual(0, Convert.ToInt32(new TimeSpan(scheduleTime.Ticks - msg.ScheduledEnqueueTimeUtc.Ticks).TotalSeconds));
 
                 await sender.CancelScheduledMessageAsync(sequenceNum);
-                msg = await receiver.PeekAt(sequenceNum);
+                msg = await receiver.PeekAtAsync(sequenceNum);
                 Assert.IsNull(msg);
             }
         }
@@ -201,7 +201,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 var sender = client.GetSender(scope.QueueName);
                 var scheduleTime = DateTimeOffset.UtcNow.AddHours(10);
                 var sequenceNum = await sender.ScheduleMessageAsync(GetMessage(), scheduleTime);
-                await sender.CloseAsync(); // shouldn't close connection, but should close send link
+                await sender.DisposeAsync(); // shouldn't close connection, but should close send link
 
                 Assert.That(async () => await sender.SendAsync(GetMessage()),
                     Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusException.FailureReason.ClientClosed));
@@ -210,7 +210,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
 
                 // receive should still work
                 await using var receiver = client.GetReceiver(scope.QueueName);
-                ServiceBusMessage msg = await receiver.PeekAt(sequenceNum);
+                ServiceBusMessage msg = await receiver.PeekAtAsync(sequenceNum);
                 Assert.AreEqual(0, Convert.ToInt32(new TimeSpan(scheduleTime.Ticks - msg.ScheduledEnqueueTimeUtc.Ticks).TotalSeconds));
             }
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
@@ -79,7 +79,7 @@ namespace Azure.Messaging.ServiceBus.Tests
             var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(GetRandomBuffer(64))}";
             var queueName = Encoding.Default.GetString(GetRandomBuffer(12));
             var sender = new ServiceBusClient(connString).GetSender(queueName);
-            Assert.AreEqual(queueName, sender.EntityName);
+            Assert.AreEqual(queueName, sender.EntityPath);
             Assert.AreEqual(fullyQualifiedNamespace, sender.FullyQualifiedNamespace);
             Assert.IsNotNull(sender.Identifier);
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
@@ -79,7 +79,7 @@ namespace Azure.Messaging.ServiceBus.Tests
             var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(GetRandomBuffer(64))}";
             var queueName = Encoding.Default.GetString(GetRandomBuffer(12));
             var sender = new ServiceBusClient(connString).GetSender(queueName);
-            Assert.AreEqual(queueName, sender.EntityPath);
+            Assert.AreEqual(queueName, sender.EntityName);
             Assert.AreEqual(fullyQualifiedNamespace, sender.FullyQualifiedNamespace);
             Assert.IsNotNull(sender.Identifier);
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/ServiceBusClientLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/ServiceBusClientLiveTests.cs
@@ -23,7 +23,7 @@ namespace Azure.Messaging.ServiceBus.Tests
 
                 var message = GetMessage(useSessions ? "sessionId" : null);
                 await sender.SendAsync(message);
-                await sender.CloseAsync();
+                await sender.DisposeAsync();
                 ServiceBusReceiver receiver;
                 if (!useSessions)
                 {
@@ -36,7 +36,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                 var receivedMessage = await receiver.ReceiveAsync().ConfigureAwait(false);
                 Assert.True(Encoding.UTF8.GetString(receivedMessage.Body.ToArray()) == Encoding.UTF8.GetString(message.Body.ToArray()));
 
-                await client.CloseAsync();
+                await client.DisposeAsync();
                 if (!useSessions)
                 {
                     Assert.Throws<ObjectDisposedException>(() => client.GetReceiver(scope.QueueName));
@@ -64,7 +64,7 @@ namespace Azure.Messaging.ServiceBus.Tests
 
                 var message = GetMessage(useSessions ? "sessionId" : null);
                 await sender.SendAsync(message);
-                await sender.CloseAsync();
+                await sender.DisposeAsync();
                 ServiceBusReceiver receiver;
                 if (!useSessions)
                 {
@@ -86,7 +86,7 @@ namespace Azure.Messaging.ServiceBus.Tests
                 else
                 {
                     // close old receiver so we can get session lock
-                    await receiver.CloseAsync();
+                    await receiver.DisposeAsync();
                     await client.GetSessionReceiverAsync(scope.QueueName);
                 }
                 client.GetProcessor(scope.QueueName);


### PR DESCRIPTION
- `EntityName` renamed to `EntityPath` for receiver/processor (since it might be the topicName/subscription). Also use `EntityPath` for the sender for consistency.
- `fromSequenceNumber` parameter renamed to `sequenceNumber` in PeekAt/PeekBatchAt
- `Identifier` made internal - this is used to uniquely identify a client in event source logs. If customers request it, we can expose it later.
- `ServiceBusSubscriptionManager` renamed to `ServiceBusSubscriptionRuleManager` and moved to `ServiceBusClient`
- `ServiceBusProcessorOptions` added and removed ability to set the corresponding properties directly on `ServiceBusProcessor`
- Added `GetSessionProcessor` to `ServiceBusClient` - note this is not async as we don't actually open any links until `StartProcessingAsync` is called.
- Remove `CloseAsync` from types implementing IAsyncDisposable - DisposeAsync can be used instead
- Remove `IsLockTokenSet` from `ServiceBusReceivedMessage` - this could be used to distinguish between peeking and receiving, but there isn't a strong use case for it.
- `ServiceBusSenderOptions` no longer derives from `ClientOptions` (`ClientOptions` is meant for HTTP options).
- `Endpoint` renamed to `FullyQualifiedNamespace` in `ProcessErrorEventArgs`.
- Throw exception if `RenewMessageLockAsync` is used with a session receiver.
- All settlement methods now are based on lock token (`CompleteAsync` has an overload that takes an `IEnumerable` of lock tokens). `RenewMessageLockAsync `has both a lock token and `ServiceBusReceivedMessage` overload.