### PR TITLE
[Event Hubs Client] Event Processor<T> Partition Processor

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -739,7 +739,7 @@ namespace Azure.Messaging.EventHubs
                 {
                     var attributes = new Dictionary<string, string>()
                     {
-                        { DiagnosticProperty.EnqueuedTimeAttribute, partitionEvent.Data.EnqueuedTime.ToUnixTimeSeconds().ToString() }
+                        { DiagnosticProperty.EnqueuedTimeAttribute, partitionEvent.Data.EnqueuedTime.ToUnixTimeMilliseconds().ToString() }
                     };
 
                     diagnosticScope.AddLink(diagnosticId, attributes);

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
@@ -259,7 +259,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             var expectedTags = new List<KeyValuePair<string, string>>()
             {
-                new KeyValuePair<string, string>(DiagnosticProperty.EnqueuedTimeAttribute, enqueuedTime.ToUnixTimeSeconds().ToString())
+                new KeyValuePair<string, string>(DiagnosticProperty.EnqueuedTimeAttribute, enqueuedTime.ToUnixTimeMilliseconds().ToString())
             };
 
             Assert.That(linkedActivity.Tags, Is.EquivalentTo(expectedTags));

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
@@ -44,8 +44,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
             yield return new object[] { new EventProcessorClient(Mock.Of<BlobContainerClient>(), "consumerGroup", connectionString), "connection string with default options" };
             yield return new object[] { new EventProcessorClient(Mock.Of<BlobContainerClient>(), "consumerGroup", connectionString, default(EventProcessorClientOptions)), "connection string with explicit null options" };
-            yield return new object[] { new EventProcessorClient(Mock.Of<BlobContainerClient>(), "consumerGroup", connectionStringNoHub, "hub"), "connection string with default options" };
-            yield return new object[] { new EventProcessorClient(Mock.Of<BlobContainerClient>(), "consumerGroup", connectionStringNoHub, "hub", default(EventProcessorClientOptions)), "connection string with explicit null options" };
+            yield return new object[] { new EventProcessorClient(Mock.Of<BlobContainerClient>(), "consumerGroup", connectionStringNoHub, "hub"), "connection string and event hub name with default options" };
+            yield return new object[] { new EventProcessorClient(Mock.Of<BlobContainerClient>(), "consumerGroup", connectionStringNoHub, "hub", default(EventProcessorClientOptions)), "connection string and event hub name with explicit null options" };
             yield return new object[] { new EventProcessorClient(Mock.Of<BlobContainerClient>(), "consumerGroup", "namespace", "hub", credential.Object), "namespace with default options" };
             yield return new object[] { new EventProcessorClient(Mock.Of<BlobContainerClient>(), "consumerGroup", "namespace", "hub", credential.Object, default(EventProcessorClientOptions)), "namespace with explicit null options" };
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
@@ -100,9 +100,9 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to The Event Hub client responsible for this information.
+        ///   Looks up a localized string similar to The Event Hub client responsible for this information is not available.
         /// </summary>
-        internal static string ClientNeededForThisInformation
+        internal static string ClientNeededForThisInformationNotAvailable
         {
             get
             {
@@ -162,6 +162,28 @@ namespace Azure.Messaging.EventHubs
             get
             {
                 return ResourceManager.GetString("CouldNotCreateLink", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to An error was encountered while executing custom code, such as in an event handler..
+        /// </summary>
+        internal static string DeveloperCodeError
+        {
+            get
+            {
+                return ResourceManager.GetString("DeveloperCodeError", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to [Developer Code Exception] : {0}..
+        /// </summary>
+        internal static string DeveloperCodeExceptionMessageMask
+        {
+            get
+            {
+                return ResourceManager.GetString("DeveloperCodeExceptionMessageMask", resourceCulture);
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
@@ -220,7 +220,7 @@
     <value>{0} has already been closed and cannot perform the requested operation.</value>
   </data>
   <data name="TrackLastEnqueuedEventPropertiesNotSet" xml:space="preserve">
-    <value>This information is only available when TrackLastEnqueuedEventProperties is set on the Event Hub consumer options.</value>
+    <value>This information is only available when TrackLastEnqueuedEventProperties is set as part of the options.</value>
   </data>
   <data name="CannotStartEventProcessorWithoutHandler" xml:space="preserve">
     <value>Cannot begin processing without {0} handler set.</value>
@@ -229,7 +229,7 @@
     <value>The event processor is already running and needs to be stopped in order to perform this operation.</value>
   </data>
   <data name="ClientNeededForThisInformation" xml:space="preserve">
-    <value>The Event Hub client responsible for this information</value>
+    <value>The Event Hub client responsible for this information is not available.</value>
   </data>
   <data name="BlobsResourceDoesNotExist" xml:space="preserve">
     <value>The Azure Storage Blobs container or blob used by the Event Processor Client does not exist.</value>
@@ -263,5 +263,11 @@
   </data>
   <data name="CannotReadLastEnqueuedEventPropertiesWithoutEvent" xml:space="preserve">
     <value>The last enqueued event properties cannot be read when an event is not available.</value>
+  </data>
+  <data name="DeveloperCodeError" xml:space="preserve">
+    <value>An error was encountered while executing custom code, such as in an event handler.</value>
+  </data>
+  <data name="DeveloperCodeExceptionMessageMask" xml:space="preserve">
+    <value>[Developer Code Exception] : {0}.</value>
   </data>
 </root>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -180,7 +180,6 @@ namespace Azure.Messaging.EventHubs.Consumer
         private int _dummyPrimitive;
         public static Azure.Messaging.EventHubs.Consumer.EventPosition Earliest { get { throw null; } }
         public static Azure.Messaging.EventHubs.Consumer.EventPosition Latest { get { throw null; } }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public bool Equals(Azure.Messaging.EventHubs.Consumer.EventPosition other) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
@@ -189,19 +188,28 @@ namespace Azure.Messaging.EventHubs.Consumer
         public static Azure.Messaging.EventHubs.Consumer.EventPosition FromSequenceNumber(long sequenceNumber, bool isInclusive = true) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
-        public static bool operator ==(Azure.Messaging.EventHubs.Consumer.EventPosition first, Azure.Messaging.EventHubs.Consumer.EventPosition second) { throw null; }
-        public static bool operator !=(Azure.Messaging.EventHubs.Consumer.EventPosition first, Azure.Messaging.EventHubs.Consumer.EventPosition second) { throw null; }
+        public static bool operator ==(Azure.Messaging.EventHubs.Consumer.EventPosition left, Azure.Messaging.EventHubs.Consumer.EventPosition right) { throw null; }
+        public static bool operator !=(Azure.Messaging.EventHubs.Consumer.EventPosition left, Azure.Messaging.EventHubs.Consumer.EventPosition right) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string ToString() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public partial struct LastEnqueuedEventProperties
+    public partial struct LastEnqueuedEventProperties : System.IEquatable<Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties>
     {
         public LastEnqueuedEventProperties(long? lastSequenceNumber, long? lastOffset, System.DateTimeOffset? lastEnqueuedTime, System.DateTimeOffset? lastReceivedTime) { throw null; }
         public System.DateTimeOffset? EnqueuedTime { get { throw null; } }
         public System.DateTimeOffset? LastReceivedTime { get { throw null; } }
         public long? Offset { get { throw null; } }
         public long? SequenceNumber { get { throw null; } }
+        public bool Equals(Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties other) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties left, Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties right) { throw null; }
+        public static bool operator !=(Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties left, Azure.Messaging.EventHubs.Consumer.LastEnqueuedEventProperties right) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override string ToString() { throw null; }
     }
     public partial class PartitionContext
     {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
@@ -185,11 +185,11 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// <param name="maximumWaitTime">The maximum amount of time to wait to build up the requested message count for the batch; if not specified, the per-try timeout specified by the retry policy will be used.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
-        /// <returns>The batch of <see cref="EventData" /> from the Event Hub partition this consumer is associated with.  If no events are present, an empty enumerable is returned.</returns>
+        /// <returns>The batch of <see cref="EventData" /> from the Event Hub partition this consumer is associated with.  If no events are present, an empty set is returned.</returns>
         ///
-        public override async Task<IEnumerable<EventData>> ReceiveAsync(int maximumMessageCount,
-                                                                        TimeSpan? maximumWaitTime,
-                                                                        CancellationToken cancellationToken)
+        public override async Task<IReadOnlyList<EventData>> ReceiveAsync(int maximumMessageCount,
+                                                                          TimeSpan? maximumWaitTime,
+                                                                          CancellationToken cancellationToken)
         {
             Argument.AssertNotClosed(_closed, nameof(AmqpConsumer));
             Argument.AssertAtLeast(maximumMessageCount, 1, nameof(maximumMessageCount));
@@ -262,7 +262,7 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                         // No events were available.
 
-                        return Enumerable.Empty<EventData>();
+                        return new List<EventData>(0);
                     }
                     catch (EventHubsException ex) when (ex.Reason == EventHubsException.FailureReason.ServiceTimeout)
                     {
@@ -270,7 +270,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                         // amount of time to wait for events, a timeout isn't considered an error condition,
                         // rather a sign that no events were available in the requested period.
 
-                        return Enumerable.Empty<EventData>();
+                        return new List<EventData>(0);
                     }
                     catch (Exception ex)
                     {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
@@ -845,7 +845,7 @@ namespace Azure.Messaging.EventHubs.Consumer
             {
                 var failedAttemptCount = 0;
                 var writtenItems = 0;
-                var receivedItems = default(IEnumerable<EventData>);
+                var receivedItems = default(IReadOnlyList<EventData>);
                 var retryDelay = default(TimeSpan?);
                 var activeException = default(Exception);
 
@@ -859,7 +859,6 @@ namespace Azure.Messaging.EventHubs.Consumer
                         if (receivedItems == default)
                         {
                             receivedItems = await transportConsumer.ReceiveAsync(BackgroundPublishReceiveBatchSize, BackgroundPublishingWaitTime, cancellationToken).ConfigureAwait(false);
-                            receivedItems = (receivedItems as IList<EventData>) ?? receivedItems.ToList();
                         }
 
                         foreach (EventData item in receivedItems)
@@ -920,10 +919,10 @@ namespace Azure.Messaging.EventHubs.Consumer
 
                             if ((receivedItems != default) && (writtenItems > 0))
                             {
-                                receivedItems = receivedItems.Skip(writtenItems);
+                                receivedItems = receivedItems.Skip(writtenItems).ToList();
                             }
 
-                            await Task.Delay(retryDelay.Value).ConfigureAwait(false);
+                            await Task.Delay(retryDelay.Value, cancellationToken).ConfigureAwait(false);
                             activeException = null;
                         }
                         else

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventPosition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventPosition.cs
@@ -131,7 +131,6 @@ namespace Azure.Messaging.EventHubs.Consumer
         ///
         /// <returns><c>true</c> if the specified <see cref="EventPosition" /> is equal to this instance; otherwise, <c>false</c>.</returns>
         ///
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public bool Equals(EventPosition other)
         {
             return (Offset == other.Offset)
@@ -208,24 +207,24 @@ namespace Azure.Messaging.EventHubs.Consumer
         ///   Determines whether the specified <see cref="EventPosition" /> instances are equal to each other.
         /// </summary>
         ///
-        /// <param name="first">The first <see cref="EventPosition" /> to consider.</param>
-        /// <param name="second">The second <see cref="EventPosition" /> to consider.</param>
+        /// <param name="left">The first <see cref="EventPosition" /> to consider.</param>
+        /// <param name="right">The second <see cref="EventPosition" /> to consider.</param>
         ///
         /// <returns><c>true</c> if the two specified <see cref="EventPosition" /> instances are equal; otherwise, <c>false</c>.</returns>
         ///
-        public static bool operator ==(EventPosition first,
-                                       EventPosition second) => first.Equals(second);
+        public static bool operator ==(EventPosition left,
+                                       EventPosition right) => left.Equals(right);
 
         /// <summary>
         ///   Determines whether the specified <see cref="EventPosition" /> instances are not equal to each other.
         /// </summary>
         ///
-        /// <param name="first">The first <see cref="EventPosition" /> to consider.</param>
-        /// <param name="second">The second <see cref="EventPosition" /> to consider.</param>
+        /// <param name="left">The first <see cref="EventPosition" /> to consider.</param>
+        /// <param name="right">The second <see cref="EventPosition" /> to consider.</param>
         ///
         /// <returns><c>true</c> if the two specified <see cref="EventPosition" /> instances are not equal; otherwise, <c>false</c>.</returns>
         ///
-        public static bool operator !=(EventPosition first,
-                                       EventPosition second) => (!first.Equals(second));
+        public static bool operator !=(EventPosition left,
+                                       EventPosition right) => (!left.Equals(right));
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/LastEnqueuedEventProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/LastEnqueuedEventProperties.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
+using System.ComponentModel;
+using Azure.Core;
 
 namespace Azure.Messaging.EventHubs.Consumer
 {
@@ -9,7 +11,7 @@ namespace Azure.Messaging.EventHubs.Consumer
     ///   A set of information about the enqueued state of a partition, as observed by the consumer.
     /// </summary>
     ///
-    public struct LastEnqueuedEventProperties
+    public struct LastEnqueuedEventProperties : IEquatable<LastEnqueuedEventProperties>
     {
         /// <summary>
         ///   The sequence number of the last observed event to be enqueued in the partition.
@@ -68,5 +70,88 @@ namespace Azure.Messaging.EventHubs.Consumer
                  sourceEvent?.LastPartitionPropertiesRetrievalTime)
         {
         }
+
+        /// <summary>
+        ///   Determines whether the specified <see cref="LastEnqueuedEventProperties" /> is equal to this instance.
+        /// </summary>
+        ///
+        /// <param name="other">The <see cref="LastEnqueuedEventProperties" /> to compare with this instance.</param>
+        ///
+        /// <returns><c>true</c> if the specified <see cref="LastEnqueuedEventProperties" /> is equal to this instance; otherwise, <c>false</c>.</returns>
+        ///
+        public bool Equals(LastEnqueuedEventProperties other)
+        {
+            return (Offset == other.Offset)
+                && (SequenceNumber == other.SequenceNumber)
+                && (EnqueuedTime == other.EnqueuedTime)
+                && (LastReceivedTime == other.LastReceivedTime);
+        }
+
+        /// <summary>
+        ///   Determines whether the specified <see cref="System.Object" /> is equal to this instance.
+        /// </summary>
+        ///
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+        ///
+        /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) =>
+            obj switch
+            {
+                LastEnqueuedEventProperties other => Equals(other),
+                _ => false
+            };
+
+        /// <summary>
+        ///   Returns a hash code for this instance.
+        /// </summary>
+        ///
+        /// <returns>A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode()
+        {
+            var hashCode = new HashCodeBuilder();
+            hashCode.Add(Offset);
+            hashCode.Add(SequenceNumber);
+            hashCode.Add(EnqueuedTime);
+            hashCode.Add(LastReceivedTime);
+
+            return hashCode.ToHashCode();
+        }
+
+        /// <summary>
+        ///   Converts the instance to string representation.
+        /// </summary>
+        ///
+        /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override string ToString() => base.ToString();
+
+        /// <summary>
+        ///   Determines whether the specified <see cref="LastEnqueuedEventProperties" /> instances are equal to each other.
+        /// </summary>
+        ///
+        /// <param name="left">The first <see cref="LastEnqueuedEventProperties" /> to consider.</param>
+        /// <param name="right">The second <see cref="LastEnqueuedEventProperties" /> to consider.</param>
+        ///
+        /// <returns><c>true</c> if the two specified <see cref="LastEnqueuedEventProperties" /> instances are equal; otherwise, <c>false</c>.</returns>
+        ///
+        public static bool operator ==(LastEnqueuedEventProperties left,
+                                       LastEnqueuedEventProperties right) => left.Equals(right);
+
+        /// <summary>
+        ///   Determines whether the specified <see cref="LastEnqueuedEventProperties" /> instances are not equal to each other.
+        /// </summary>
+        ///
+        /// <param name="left">The first <see cref="LastEnqueuedEventProperties" /> to consider.</param>
+        /// <param name="right">The second <see cref="LastEnqueuedEventProperties" /> to consider.</param>
+        ///
+        /// <returns><c>true</c> if the two specified <see cref="LastEnqueuedEventProperties" /> instances are not equal; otherwise, <c>false</c>.</returns>
+        ///
+        public static bool operator !=(LastEnqueuedEventProperties left,
+                                       LastEnqueuedEventProperties right) => (!left.Equals(right));
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/PartitionContext.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/PartitionContext.cs
@@ -53,7 +53,7 @@ namespace Azure.Messaging.EventHubs.Consumer
                 // If the consumer instance was not available, treat it as a closed instance for
                 // messaging consistency.
 
-                Argument.AssertNotClosed(true, Resources.ClientNeededForThisInformation);
+                Argument.AssertNotClosed(true, Resources.ClientNeededForThisInformationNotAvailable);
             }
 
             return new LastEnqueuedEventProperties(consumer.LastReceivedEvent);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/DeveloperCodeException.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/DeveloperCodeException.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Messaging.EventHubs
+{
+    /// <summary>
+    ///   Serves an marker for an exception occurring within developer-provided code, such as
+    ///   event handlers.  Such exceptions are typically intended to be explicitly not handled by
+    ///   the infrastructure of the various Event Hubs types.
+    /// </summary>
+    ///
+    /// <seealso cref="System.Exception" />
+    ///
+    internal class DeveloperCodeException : Exception
+    {
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="DeveloperCodeException"/> class.
+        /// </summary>
+        ///
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+        ///
+        public DeveloperCodeException(Exception innerException) : base(Resources.DeveloperCodeError, innerException)
+        {
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportConsumer.cs
@@ -49,9 +49,9 @@ namespace Azure.Messaging.EventHubs.Core
         ///
         /// <returns>The batch of <see cref="EventData" /> from the Event Hub partition this consumer is associated with.  If no events are present, an empty enumerable is returned.</returns>
         ///
-        public abstract Task<IEnumerable<EventData>> ReceiveAsync(int maximumMessageCount,
-                                                                  TimeSpan? maximumWaitTime,
-                                                                  CancellationToken cancellationToken);
+        public abstract Task<IReadOnlyList<EventData>> ReceiveAsync(int maximumMessageCount,
+                                                                    TimeSpan? maximumWaitTime,
+                                                                    CancellationToken cancellationToken);
 
         /// <summary>
         ///   Closes the connection to the transport producer instance.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -691,14 +691,188 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="errorMessage">The message for the exception that occurred.</param>
         ///
         [Event(36, Level = EventLevel.Error, Message = "An exception occurred during partition processing or load balancing for processor instance with identifier '{0}' for Event Hub: {1} and Consumer Group: {2}.  Error Message: '{3}'")]
-        public virtual void EventProcessingTaskError(string identifier,
-                                                     string eventHubName,
-                                                     string consumerGroup,
-                                                     string errorMessage)
+        public virtual void EventProcessorTaskError(string identifier,
+                                                    string eventHubName,
+                                                    string consumerGroup,
+                                                    string errorMessage)
         {
             if (IsEnabled())
             {
                 WriteEvent(36, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an <see cref="EventProcessor{TPartition}" /> instance has taken ownership of a partition and is beginning to process it.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the Event Hub partition whose processing is starting.</param>
+        /// <param name="identifier">A unique name used to identify the event processor.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        ///
+        [Event(37, Level = EventLevel.Verbose, Message = "Starting to process partition '{0}' using processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}.")]
+        public virtual void EventProcessorPartitionProcessingStart(string partitionId,
+                                                                   string identifier,
+                                                                   string eventHubName,
+                                                                   string consumerGroup)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(37, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an <see cref="EventProcessor{TPartition}" /> instance has experienced an exception while starting processing for a partition.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the Event Hub partition whose processing is starting.</param>
+        /// <param name="identifier">A unique name used to identify the event processor.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(38, Level = EventLevel.Error, Message = "An exception occurred while starting to process partition '{0}' using processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}.  Error Message: '{4}'")]
+        public virtual void EventProcessorPartitionProcessingStartError(string partitionId,
+                                                                        string identifier,
+                                                                        string eventHubName,
+                                                                        string consumerGroup,
+                                                                        string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(38, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an <see cref="EventProcessor{TPartition}" /> instance has taken ownership of a partition and is actively processing it.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the Event Hub partition whose processing is starting.</param>
+        /// <param name="identifier">A unique name used to identify the event processor.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        ///
+        [Event(39, Level = EventLevel.Verbose, Message = "Completed starting to process partition '{0}' using processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}.")]
+        public virtual void EventProcessorPartitionProcessingStartComplete(string partitionId,
+                                                                           string identifier,
+                                                                           string eventHubName,
+                                                                           string consumerGroup)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(39, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an <see cref="EventProcessor{TPartition}" /> instance has lost ownership of a partition and is beginning to stop processing it.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the Event Hub partition whose processing is stopping.</param>
+        /// <param name="identifier">A unique name used to identify the event processor.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        ///
+        [Event(40, Level = EventLevel.Verbose, Message = "Stopping processing for partition '{0}' by processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}.")]
+        public virtual void EventProcessorPartitionProcessingStop(string partitionId,
+                                                                  string identifier,
+                                                                  string eventHubName,
+                                                                  string consumerGroup)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(40, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an <see cref="EventProcessor{TPartition}" /> instance has experienced an exception while stopping processing for a partition.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the Event Hub partition whose processing is stopping.</param>
+        /// <param name="identifier">A unique name used to identify the event processor.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(41, Level = EventLevel.Error, Message = "An exception occurred while stopping processing for partition '{0}' by processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}.  Error Message: '{4}'")]
+        public virtual void EventProcessorPartitionProcessingStopError(string partitionId,
+                                                                       string identifier,
+                                                                       string eventHubName,
+                                                                       string consumerGroup,
+                                                                       string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(41, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an <see cref="EventProcessor{TPartition}" /> instance has finished stopping processing for a partition, and it is now no longer running.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the Event Hub partition whose processing is stopping.</param>
+        /// <param name="identifier">A unique name used to identify the event processor.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        ///
+        [Event(42, Level = EventLevel.Verbose, Message = "Completed stopping processing for partition '{0}' by processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}.")]
+        public virtual void EventProcessorPartitionProcessingStopComplete(string partitionId,
+                                                                          string identifier,
+                                                                          string eventHubName,
+                                                                          string consumerGroup)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(42, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an <see cref="EventProcessor{TPartition}" /> instance has experienced an exception while processing events for a partition.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the Event Hub partition whose processing is taking place.</param>
+        /// <param name="identifier">A unique name used to identify the event processor.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(43, Level = EventLevel.Error, Message = "An exception occurred while processing events for partition '{0}' by processor instance with identifier '{1}' for Event Hub: {2} and Consumer Group: {3}.  Error Message: '{4}'")]
+        public virtual void EventProcessorPartitionProcessingError(string partitionId,
+                                                                   string identifier,
+                                                                   string eventHubName,
+                                                                   string consumerGroup,
+                                                                   string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(43, partitionId ?? string.Empty, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an <see cref="EventProcessor{TPartition}" /> instance has experienced an exception while performing load balancing.
+        /// </summary>
+        ///
+        /// <param name="identifier">A unique name used to identify the event processor.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the processor is associated with.</param>
+        /// <param name="consumerGroup">The name of the consumer group that the processor is associated with.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(44, Level = EventLevel.Error, Message = "An exception occurred while performing load balancing for the processor instance with identifier '{0}' for Event Hub: {1} and Consumer Group: {2}.  Error Message: '{3}'")]
+        public virtual void EventProcessorLoadBalancingError(string identifier,
+                                                             string eventHubName,
+                                                             string consumerGroup,
+                                                             string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(44, identifier ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty);
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -90,7 +90,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <remarks>
         ///   This property is only populated for events received from the Event Hubs service. If this
-        ///   EventData was not recived from the Event Hubs service, the value is <see cref="long.MinValue"/>.
+        ///   EventData was not received from the Event Hubs service, the value is <see cref="long.MinValue"/>.
         /// </remarks>
         ///
         public long SequenceNumber { get; }
@@ -101,7 +101,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <remarks>
         ///   This property is only populated for events received from the Event Hubs service. If this
-        ///   EventData was not recived from the Event Hubs service, the value is <see cref="long.MinValue"/>.
+        ///   EventData was not received from the Event Hubs service, the value is <see cref="long.MinValue"/>.
         /// </remarks>
         ///
         public long Offset { get; }
@@ -112,7 +112,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <remarks>
         ///   This property is only populated for events received from the Event Hubs service. If this
-        ///   EventData was not recived from the Event Hubs service, the value <c>default(DateTimeOffset)</c>.
+        ///   EventData was not received from the Event Hubs service, the value <c>default(DateTimeOffset)</c>.
         /// </remarks>
         ///
         public DateTimeOffset EnqueuedTime { get; }
@@ -199,7 +199,7 @@ namespace Azure.Messaging.EventHubs
         /// <param name="lastPartitionSequenceNumber">The sequence number that was last enqueued into the Event Hub partition.</param>
         /// <param name="lastPartitionOffset">The offset that was last enqueued into the Event Hub partition.</param>
         /// <param name="lastPartitionEnqueuedTime">The date and time, in UTC, of the event that was last enqueued into the Event Hub partition.</param>
-        /// <param name="lastPartitionPropertiesRetrievalTime">The date and time, in UTC, that the last event information for the Event Hub partition was retrieved from the serivce.</param>
+        /// <param name="lastPartitionPropertiesRetrievalTime">The date and time, in UTC, that the last event information for the Event Hub partition was retrieved from the service.</param>
         ///
         internal EventData(ReadOnlyMemory<byte> eventBody,
                            IDictionary<string, object> properties = null,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor{TPartition}.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor{TPartition}.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Threading;
@@ -29,6 +30,9 @@ namespace Azure.Messaging.EventHubs.Primitives
     ///
     public abstract class EventProcessor<TPartition> where TPartition : EventProcessorPartition, new()
     {
+        /// <summary>The maximum number of failed consumers to allow when processing a partition; failed consumers are those which have been unable to receive and process events.</summary>
+        private const int MaximumFailedConsumerCount = 1;
+
         /// <summary>The primitive for synchronizing access when starting and stopping the processor.</summary>
         private readonly SemaphoreSlim ProcessorRunningSync = new SemaphoreSlim(1, 1);
 
@@ -407,6 +411,261 @@ namespace Azure.Messaging.EventHubs.Primitives
             new PartitionLoadBalancer(storageManager, identifier, consumerGroup, fullyQualifiedNamespace, eventHubName, ownershipExpiration);
 
         /// <summary>
+        ///   Creates the infrastructure for tracking the processing of a partition and begins processing the
+        ///   partition in the background until cancellation is requested.
+        /// </summary>
+        ///
+        /// <param name="partition">The Event Hub partition whose processing should be started.</param>
+        /// <param name="startingPosition">The position within the event stream that processing should begin.</param>
+        /// <param name="cancellationSource">A <see cref="CancellationTokenSource"/> instance to signal the request to cancel the operation.</param>
+        ///
+        /// <returns>The <see cref="PartitionProcessor" /> encapsulating the processing task, its cancellation token, and associated state.</returns>
+        ///
+        /// <remarks>
+        ///   This method makes liberal use of class methods and state in addition to the received parameters.
+        /// </remarks>
+        ///
+        internal virtual PartitionProcessor CreatePartitionProcessor(TPartition partition,
+                                                                     EventPosition startingPosition,
+                                                                     CancellationTokenSource cancellationSource)
+        {
+            cancellationSource.Token.ThrowIfCancellationRequested<TaskCanceledException>();
+            var consumer = default(TransportConsumer);
+
+            // If the tracking of the last enqueued event properties was requested, then read the
+            // properties from the active consumer, which can change during processing in the event of
+            // error scenarios.
+
+            LastEnqueuedEventProperties readLastEnquedEventInformation()
+            {
+                if (!Options.TrackLastEnqueuedEventProperties)
+                {
+                    throw new InvalidOperationException(Resources.TrackLastEnqueuedEventPropertiesNotSet);
+                }
+
+                // This is not an expected scenario; the guard exists to prevent a race condition that is
+                // unlikely, but possible, when partition processing is being stopped or consumer creation
+                // outright failed.
+
+                if ((consumer == null) || (consumer.IsClosed))
+                {
+                    throw new InvalidOperationException(Resources.ClientNeededForThisInformationNotAvailable);
+                }
+
+                return new LastEnqueuedEventProperties(consumer.LastReceivedEvent);
+            }
+
+            // Define the routine to handle processing for the partition.
+
+            async Task performProcessing()
+            {
+                var connection = CreateConnection();
+                await using var connectionAwaiter = connection.ConfigureAwait(false);
+
+                var retryPolicy = Options.RetryOptions.ToRetryPolicy();
+                var retryDelay = default(TimeSpan?);
+                var capturedException = default(Exception);
+                var eventBatch = default(IReadOnlyList<EventData>);
+                var lastEvent = default(EventData);
+                var failedAttemptCount = 0;
+                var failedConsumerCount = 0;
+
+                // Continue processing the partition until cancellation is signaled or until the count of failed consumers is too great.
+                // Consumers which been consistently unable to receive and process events will be considered invalid and abandoned for a new consumer.
+
+                while ((!cancellationSource.IsCancellationRequested) && (failedConsumerCount <= MaximumFailedConsumerCount))
+                {
+                    try
+                    {
+                        consumer = CreateConsumer(ConsumerGroup, partition.PartitionId, startingPosition, connection, Options);
+
+                        // Allow the core dispatching loop to apply an additional set of retries over any provided by the consumer
+                        // itself, as a processor should be as resilient as possible and retain partition ownership if processing is
+                        // able to make forward progress.  If the retries are exhausted or a non-retriable exception occurs, the
+                        // consumer will be considered invalid and potentially refreshed.
+
+                        while (!cancellationSource.IsCancellationRequested)
+                        {
+                            try
+                            {
+                                eventBatch = await consumer.ReceiveAsync(EventBatchMaximumCount, Options.MaximumWaitTime, cancellationSource.Token).ConfigureAwait(false);
+                                await ProcessEventBatchAsync(partition, eventBatch, Options.MaximumWaitTime.HasValue, cancellationSource.Token).ConfigureAwait(false);
+
+                                // If the batch was successfully processed, capture the last event as the current starting position, in the
+                                // event that the consumer becomes invalid and needs to be replaced.
+
+                                lastEvent = eventBatch?.LastOrDefault();
+
+                                if ((lastEvent != null) && (lastEvent.Offset != long.MinValue))
+                                {
+                                    startingPosition = EventPosition.FromOffset(lastEvent.Offset, false);
+                                }
+
+                                // If event batches are successfully processed, then the need for forward progress is
+                                // satisfied, and the failure counts should reset.
+
+                                failedAttemptCount = 0;
+                                failedConsumerCount = 0;
+                            }
+                            catch (TaskCanceledException) when (cancellationSource.IsCancellationRequested)
+                            {
+                                // Do not log; this is an expected scenario when partition processing is asked to stop.
+
+                                throw;
+                            }
+                            catch (Exception ex) when (!(ex is DeveloperCodeException))
+                            {
+                                // The error handler is invoked as a fire-and-forget task; the processor does not assume responsibility
+                                // for observing or surfacing exceptions that may occur in the handler.
+
+                                _ = OnProcessingErrorAsync(ex, partition, Resources.OperationReadEvents, CancellationToken.None);
+
+                                Logger.EventProcessorPartitionProcessingError(partition.PartitionId, Identifier, EventHubName, ConsumerGroup, ex.Message);
+                                retryDelay = retryPolicy.CalculateRetryDelay(ex, ++failedAttemptCount);
+
+                                if (!retryDelay.HasValue)
+                                {
+                                    // If the exception should not be retried, then allow it to pass to the outer loop; this is intended
+                                    // to prevent being stuck in a corrupt state where the consumer is unable to read events.
+
+                                    throw;
+                                }
+
+                                await Task.Delay(retryDelay.Value, cancellationSource.Token).ConfigureAwait(false);
+                            }
+                        }
+                    }
+                    catch (OperationCanceledException ex)
+                    {
+                        throw new TaskCanceledException(ex.Message, ex);
+                    }
+                    catch (DeveloperCodeException ex)
+                    {
+                        // Record that an exception was observed in developer-provided code, but consider it fatal and take no further
+                        // steps to handle or dispatch it.
+
+                        var message = string.Format(CultureInfo.InvariantCulture, Resources.DeveloperCodeExceptionMessageMask, ex.InnerException.Message);
+                        Logger.EventProcessorPartitionProcessingError(partition.PartitionId, Identifier, EventHubName, ConsumerGroup, message);
+
+                        ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                    }
+                    catch (Exception ex) when
+                        (ex is TaskCanceledException
+                        || ex is OutOfMemoryException
+                        || ex is StackOverflowException
+                        || ex is ThreadAbortException)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        ++failedConsumerCount;
+                        capturedException = ex;
+                    }
+                    finally
+                    {
+                        try
+                        {
+                            if (consumer != null)
+                            {
+                                await consumer.CloseAsync(CancellationToken.None).ConfigureAwait(false);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.EventProcessorPartitionProcessingError(partition.PartitionId, Identifier, EventHubName, ConsumerGroup, ex.Message);
+
+                            // Do not bubble the exception, as the consumer is being refreshed; failure to close this consumer is non-fatal.
+                        }
+                    }
+                }
+
+                // If there was an exception captured, then surface it.  Otherwise signal that cancellation took place.
+
+                if (capturedException != null)
+                {
+                    ExceptionDispatchInfo.Capture(capturedException).Throw();
+                }
+
+                throw new TaskCanceledException();
+            }
+
+            // Start processing in the background and return the processor
+            // metadata.
+
+            return new PartitionProcessor
+            (
+                Task.Run(performProcessing, cancellationSource.Token),
+                readLastEnquedEventInformation,
+                cancellationSource
+            );
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to process a batch of events.
+        /// </summary>
+        ///
+        /// <param name="partition">The Event Hub partition whose processing should be started.</param>
+        /// <param name="eventBatch">The batch of events to process.</param>
+        /// <param name="dispatchEmptyBatches"><c>true</c> if empty batches should be dispatched to the handler; otherwise, <c>false</c>.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the processing.</param>
+        ///
+        internal virtual async Task ProcessEventBatchAsync(TPartition partition,
+                                                           IReadOnlyList<EventData> eventBatch,
+                                                           bool dispatchEmptyBatches,
+                                                           CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+
+            // If there were no events in the batch and empty batches should not be emitted,
+            // take no further action.
+
+            if (((eventBatch == null) || (eventBatch.Count <= 0)) && (!dispatchEmptyBatches))
+            {
+                return;
+            }
+
+            // Create the diagnostics scope used for distributed tracing and instrument the events in the batch.
+
+            using var diagnosticScope = EventDataInstrumentation.ScopeFactory.CreateScope(DiagnosticProperty.EventProcessorProcessingActivityName);
+            diagnosticScope.AddAttribute(DiagnosticProperty.KindAttribute, DiagnosticProperty.ConsumerKind);
+            diagnosticScope.AddAttribute(DiagnosticProperty.EventHubAttribute, EventHubName);
+            diagnosticScope.AddAttribute(DiagnosticProperty.EndpointAttribute, FullyQualifiedNamespace);
+
+            if ((diagnosticScope.IsEnabled) && (eventBatch.Any()))
+            {
+                foreach (var eventData in eventBatch)
+                {
+                    if (EventDataInstrumentation.TryExtractDiagnosticId(eventData, out string diagnosticId))
+                    {
+                        var attributes = new Dictionary<string, string>(1)
+                        {
+                            { DiagnosticProperty.EnqueuedTimeAttribute, eventData.EnqueuedTime.ToUnixTimeMilliseconds().ToString() }
+                        };
+
+                        diagnosticScope.AddLink(diagnosticId, attributes);
+                    }
+                }
+            }
+
+            diagnosticScope.Start();
+
+            // Dispatch the batch to the handler for processing.  Exceptions in the handler code are intended to be
+            // unhandled by the processor; explicitly signal that the exception was observed in developer-provided
+            // code.
+
+            try
+            {
+                await OnProcessingEventBatchAsync(eventBatch, partition, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                diagnosticScope.Failed(ex);
+                throw new DeveloperCodeException(ex);
+            }
+        }
+
+        /// <summary>
         ///   Produces a list of the available checkpoints for the Event Hub and consumer group associated with the
         ///   event processor instance, so that processing for a given set of partitions can be properly initialized.
         /// </summary>
@@ -699,7 +958,7 @@ namespace Azure.Messaging.EventHubs.Primitives
                 }
                 catch (Exception ex)
                 {
-                    Logger.EventProcessingTaskError(Identifier, EventHubName, ConsumerGroup, ex.Message);
+                    Logger.EventProcessorTaskError(Identifier, EventHubName, ConsumerGroup, ex.Message);
                     processingException = ex;
                 }
 
@@ -768,6 +1027,21 @@ namespace Azure.Messaging.EventHubs.Primitives
         {
             CreateConnection();
             await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   Begin processing the requested partition in the background and update tracking state
+        ///   so that processing can be stopped.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the Event Hub partition whose processing should be started.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        internal async virtual Task StartProcessingPartitionAsync(string partitionId,
+                                                                  CancellationToken cancellationToken)
+        {
+            await Task.Delay(1).ConfigureAwait(false);
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -870,7 +1144,7 @@ namespace Azure.Messaging.EventHubs.Primitives
         ///   of a partition.
         /// </summary>
         ///
-        private class PartitionProcessor
+        internal class PartitionProcessor
         {
             /// <summary>The task that is performing the processing.</summary>
             public readonly Task ProcessingTask;
@@ -878,15 +1152,20 @@ namespace Azure.Messaging.EventHubs.Primitives
             /// <summary>The source token that can be used to cancel the processing for the associated <see cref="ProcessingTask" />.</summary>
             public readonly CancellationTokenSource CancellationSource;
 
+            /// <summary>A function that can be used to read the information about the last enqueued event of the partition.</summary>
+            public readonly Func<LastEnqueuedEventProperties> ReadLastEnqueuedEventProperties;
+
             /// <summary>
             ///   Initializes a new instance of the <see cref="PartitionProcessor"/> class.
             /// </summary>
             ///
             /// <param name="processingTask">The task that is performing the processing.</param>
+            /// <param name="readLastEnqueuedEventProperties">A function that can be used to read the information about the last enqueued event of the partition.</param>
             /// <param name="cancellationSource">he source token that can be used to cancel the processing.</param>
             ///
             public PartitionProcessor(Task processingTask,
-                                      CancellationTokenSource cancellationSource) => (ProcessingTask, CancellationSource) = (processingTask, cancellationSource);
+                                      Func<LastEnqueuedEventProperties> readLastEnqueuedEventProperties,
+                                      CancellationTokenSource cancellationSource) => (ProcessingTask, ReadLastEnqueuedEventProperties, CancellationSource) = (processingTask, readLastEnqueuedEventProperties, cancellationSource);
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
@@ -1136,7 +1136,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedReceiveCalls = (maximumRetries + 1);
             var receiveCalls = 0;
 
-            Func<int, TimeSpan?, IEnumerable<EventData>> receiveCallback = (_max, _time) =>
+            Func<int, TimeSpan?, IReadOnlyList<EventData>> receiveCallback = (_max, _time) =>
             {
                 ++receiveCalls;
                 throw exception;
@@ -1181,7 +1181,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var receiveCalls = 0;
 
-            Func<int, TimeSpan?, IEnumerable<EventData>> receiveCallback = (_max, _time) =>
+            Func<int, TimeSpan?, IReadOnlyList<EventData>> receiveCallback = (_max, _time) =>
             {
                 ++receiveCalls;
                 throw exception;
@@ -1944,7 +1944,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var receiveCalls = 0;
 
-            Func<int, TimeSpan?, IEnumerable<EventData>> receiveCallback = (_max, _time) =>
+            Func<int, TimeSpan?, IReadOnlyList<EventData>> receiveCallback = (_max, _time) =>
             {
                 ++receiveCalls;
                 throw exception;
@@ -1990,7 +1990,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var receiveCalls = 0;
 
-            Func<int, TimeSpan?, IEnumerable<EventData>> receiveCallback = (_max, _time) =>
+            Func<int, TimeSpan?, IReadOnlyList<EventData>> receiveCallback = (_max, _time) =>
             {
                 ++receiveCalls;
                 throw exception;
@@ -2269,12 +2269,12 @@ namespace Azure.Messaging.EventHubs.Tests
                 set => base.LastReceivedEvent = value;
             }
 
-            public override Task<IEnumerable<EventData>> ReceiveAsync(int maximumMessageCount,
-                                                                      TimeSpan? maximumWaitTime,
-                                                                      CancellationToken cancellationToken)
+            public override Task<IReadOnlyList<EventData>> ReceiveAsync(int maximumMessageCount,
+                                                                        TimeSpan? maximumWaitTime,
+                                                                        CancellationToken cancellationToken)
             {
                 ReceiveCalledWith = (maximumMessageCount, maximumWaitTime);
-                return Task.FromResult(Enumerable.Empty<EventData>());
+                return Task.FromResult((IReadOnlyList<EventData>)new List<EventData>(0));
             }
 
             public override Task CloseAsync(CancellationToken cancellationToken)
@@ -2310,7 +2310,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 }
             }
 
-            public override async Task<IEnumerable<EventData>> ReceiveAsync(int maximumMessageCount, TimeSpan? maximumWaitTime, CancellationToken cancellationToken)
+            public override async Task<IReadOnlyList<EventData>> ReceiveAsync(int maximumMessageCount, TimeSpan? maximumWaitTime, CancellationToken cancellationToken)
             {
                 var stopWatch = Stopwatch.StartNew();
                 PublishDelayCallback?.Invoke();
@@ -2321,8 +2321,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     // Delay execution in this path to prevent a tight loop, starving other Tasks.
 
                     await Task.Delay(100).ConfigureAwait(false);
-
-                    return Enumerable.Empty<EventData>();
+                    return new List<EventData>(0);
                 }
 
                 var index = PublishIndex;
@@ -2334,9 +2333,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
                 LastMaximumMessageCount = maximumMessageCount;
                 PublishIndex = (index + maximumMessageCount);
-                var source = EventsToPublish.Skip(index).Take(maximumMessageCount).ToList();
 
-                return (IEnumerable<EventData>)source;
+                return EventsToPublish.Skip(index).Take(maximumMessageCount).ToList();
             }
 
             public override Task CloseAsync(CancellationToken cancellationToken) => Task.CompletedTask;
@@ -2349,9 +2347,9 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         private class ReceiveCallbackTransportConsumerMock : TransportConsumer
         {
-            public Func<int, TimeSpan?, IEnumerable<EventData>> ReceiveCallback = (_max, _wait) => Enumerable.Empty<EventData>();
+            public Func<int, TimeSpan?, IReadOnlyList<EventData>> ReceiveCallback = (_max, _wait) => new List<EventData>(0);
 
-            public ReceiveCallbackTransportConsumerMock(Func<int, TimeSpan?, IEnumerable<EventData>> receiveCallback = null) : base()
+            public ReceiveCallbackTransportConsumerMock(Func<int, TimeSpan?, IReadOnlyList<EventData>> receiveCallback = null) : base()
             {
                 if (receiveCallback != null)
                 {
@@ -2359,9 +2357,9 @@ namespace Azure.Messaging.EventHubs.Tests
                 }
             }
 
-            public override Task<IEnumerable<EventData>> ReceiveAsync(int maximumMessageCount, TimeSpan? maximumWaitTime, CancellationToken cancellationToken)
+            public override Task<IReadOnlyList<EventData>> ReceiveAsync(int maximumMessageCount, TimeSpan? maximumWaitTime, CancellationToken cancellationToken)
             {
-                IEnumerable<EventData> results = ReceiveCallback(maximumMessageCount, maximumWaitTime);
+                var results = ReceiveCallback(maximumMessageCount, maximumWaitTime);
                 return Task.FromResult(results);
             }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventPositionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventPositionTests.cs
@@ -21,23 +21,6 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public void AnInstanceIsEqualToItself()
-        {
-            var first = EventPosition.FromOffset(12);
-            var second = first;
-
-            Assert.That(first.Equals((object)second), Is.True, "The default Equals comparison is incorrect.");
-            Assert.That(first.Equals(second), Is.True, "The IEquatable comparison is incorrect.");
-            Assert.That((first == second), Is.True, "The == operator comparison is incorrect.");
-            Assert.That((first != second), Is.False, "The != operator comparison is incorrect.");
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the <see cref="EventPosition "/>
-        ///   equality.
-        /// </summary>
-        ///
-        [Test]
         public void EarliestAndLatestAreNotEqual()
         {
             var first = EventPosition.Earliest;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/LastEnqueuedEventPropertiesTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/LastEnqueuedEventPropertiesTests.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Messaging.EventHubs.Consumer;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="LastEnqueuedEventProperties" />
+    ///   struct.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class LastEnqueuedEventPropertiesTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the <see cref="LastEnqueuedEventProperties "/>
+        ///   equality.
+        /// </summary>
+        ///
+        [Test]
+        public void TheSameValuesAreEqual()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var first = new LastEnqueuedEventProperties(lastSequenceNumber: 123, lastOffset: 887, lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
+            var second = new LastEnqueuedEventProperties(lastSequenceNumber: 123, lastOffset: 887, lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
+
+            Assert.That(first.Equals((object)second), Is.True, "The default Equals comparison is incorrect.");
+            Assert.That(first.Equals(second), Is.True, "The IEquatable comparison is incorrect.");
+            Assert.That((first == second), Is.True, "The == operator comparison is incorrect.");
+            Assert.That((first != second), Is.False, "The != operator comparison is incorrect.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="LastEnqueuedEventProperties "/>
+        ///   equality.
+        /// </summary>
+        ///
+        [Test]
+        public void DifferentOffsetsAreNotEqual()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var first = new LastEnqueuedEventProperties(lastSequenceNumber: 123, lastOffset: 999, lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
+            var second = new LastEnqueuedEventProperties(lastSequenceNumber: 123, lastOffset: 888, lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
+
+            Assert.That(first.Equals((object)second), Is.False, "The default Equals comparison is incorrect.");
+            Assert.That(first.Equals(second), Is.False, "The IEquatable comparison is incorrect.");
+            Assert.That((first == second), Is.False, "The == operator comparison is incorrect.");
+            Assert.That((first != second), Is.True, "The != operator comparison is incorrect.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="LastEnqueuedEventProperties "/>
+        ///   equality.
+        /// </summary>
+        ///
+        [Test]
+        public void DifferentEnqueueTimesAreNotEqual()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var first = new LastEnqueuedEventProperties(lastSequenceNumber: 123, lastOffset: 887, lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
+            var second = new LastEnqueuedEventProperties(lastSequenceNumber: 123, lastOffset: 887, lastEnqueuedTime: DateTimeOffset.Parse("1974-12-09T21:30:00Z"), lastReceivedTime: now);
+
+            Assert.That(first.Equals((object)second), Is.False, "The default Equals comparison is incorrect.");
+            Assert.That(first.Equals(second), Is.False, "The IEquatable comparison is incorrect.");
+            Assert.That((first == second), Is.False, "The == operator comparison is incorrect.");
+            Assert.That((first != second), Is.True, "The != operator comparison is incorrect.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="LastEnqueuedEventProperties "/>
+        ///   equality.
+        /// </summary>
+        ///
+        [Test]
+        public void DifferentSequenceNumbersAreNotEqual()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var first = new LastEnqueuedEventProperties(lastSequenceNumber: 333, lastOffset: 887, lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
+            var second = new LastEnqueuedEventProperties(lastSequenceNumber: 444, lastOffset: 887, lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
+
+            Assert.That(first.Equals((object)second), Is.False, "The default Equals comparison is incorrect.");
+            Assert.That(first.Equals(second), Is.False, "The IEquatable comparison is incorrect.");
+            Assert.That((first == second), Is.False, "The == operator comparison is incorrect.");
+            Assert.That((first != second), Is.True, "The != operator comparison is incorrect.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="LastEnqueuedEventProperties "/>
+        ///   equality.
+        /// </summary>
+        ///
+        [Test]
+        public void DifferentLastReceiveTimesAreNotEqual()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var first = new LastEnqueuedEventProperties(lastSequenceNumber: 123, lastOffset: 887, lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
+            var second = new LastEnqueuedEventProperties(lastSequenceNumber: 123, lastOffset: 887, lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now.AddHours(1));
+
+            Assert.That(first.Equals((object)second), Is.False, "The default Equals comparison is incorrect.");
+            Assert.That(first.Equals(second), Is.False, "The IEquatable comparison is incorrect.");
+            Assert.That((first == second), Is.False, "The == operator comparison is incorrect.");
+            Assert.That((first != second), Is.True, "The != operator comparison is incorrect.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="LastEnqueuedEventProperties.GetHashCode "/>
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void GetHashCodeReturnsDifferentValuesForDifferentMembers()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var first = new LastEnqueuedEventProperties(lastSequenceNumber: 333, lastOffset: 888, lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
+            var second = new LastEnqueuedEventProperties(lastSequenceNumber: 555, lastOffset: 777, lastEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastReceivedTime: now);
+
+            Assert.That(first.GetHashCode(), Is.Not.EqualTo(second.GetHashCode()));
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/PartitionContextTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/PartitionContextTests.cs
@@ -133,7 +133,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 LastReceivedEvent = lastEvent;
             }
 
-            public override Task<IEnumerable<EventData>> ReceiveAsync(int maximumMessageCount, TimeSpan? maximumWaitTime, CancellationToken cancellationToken) => throw new NotImplementedException();
+            public override Task<IReadOnlyList<EventData>> ReceiveAsync(int maximumMessageCount, TimeSpan? maximumWaitTime, CancellationToken cancellationToken) => throw new NotImplementedException();
             public override Task CloseAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.cs
@@ -3,11 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Messaging.EventHubs.Consumer;
+using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Diagnostics;
 using Azure.Messaging.EventHubs.Primitives;
 using Moq;
@@ -24,6 +26,9 @@ namespace Azure.Messaging.EventHubs.Tests
     [TestFixture]
     public class EventProcessorTests
     {
+        /// <summary>An empty event batch to use for mocking.</summary>
+        private readonly IReadOnlyList<EventData> EmptyBatch = new List<EventData>(0);
+
         /// <summary>
         ///   Provides test cases for the constructor tests.
         /// </summary>
@@ -34,9 +39,9 @@ namespace Azure.Messaging.EventHubs.Tests
             var connectionStringNoHub = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123";
             var credential = Mock.Of<TokenCredential>();
 
-            yield return new object[] { new BasicProcessorMock(99, "consumerGroup", connectionString), "connection string with default options" };
-            yield return new object[] { new BasicProcessorMock(99, "consumerGroup", connectionStringNoHub, "hub", default), "connection string with default options" };
-            yield return new object[] { new BasicProcessorMock(99, "consumerGroup", "namespace", "hub", credential, default(EventProcessorOptions)), "namespace with explicit null options" };
+            yield return new object[] { new ProcessorConstructorMock(99, "consumerGroup", connectionString), "connection string with default options" };
+            yield return new object[] { new ProcessorConstructorMock(99, "consumerGroup", connectionStringNoHub, "hub", default), "connection string with default options" };
+            yield return new object[] { new ProcessorConstructorMock(99, "consumerGroup", "namespace", "hub", credential, default(EventProcessorOptions)), "namespace with explicit null options" };
         }
 
         /// <summary>
@@ -51,8 +56,8 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase(0)]
         public void ConstructorValidatesTheEventBatchMaximumCount(int constructorArgument)
         {
-            Assert.That(() => new BasicProcessorMock(constructorArgument, "dummyGroup", "dummyConnection", new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The connection string constructor should validate the maximum batch size.");
-            Assert.That(() => new BasicProcessorMock(constructorArgument, "dummyGroup", "dummyNamespace", "dummyEventHub", Mock.Of<TokenCredential>(), new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The namespace constructor should validate the maximum batch size.");
+            Assert.That(() => new ProcessorConstructorMock(constructorArgument, "dummyGroup", "dummyConnection", new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The connection string constructor should validate the maximum batch size.");
+            Assert.That(() => new ProcessorConstructorMock(constructorArgument, "dummyGroup", "dummyNamespace", "dummyEventHub", Mock.Of<TokenCredential>(), new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The namespace constructor should validate the maximum batch size.");
         }
 
         /// <summary>
@@ -65,8 +70,8 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorValidatesTheConsumerGroup(string constructorArgument)
         {
-            Assert.That(() => new BasicProcessorMock(1, constructorArgument, "dummyConnection", new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The connection string constructor should validate the consumer group.");
-            Assert.That(() => new BasicProcessorMock(1, constructorArgument, "dummyNamespace", "dummyEventHub", Mock.Of<TokenCredential>(), new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The namespace constructor should validate the consumer group.");
+            Assert.That(() => new ProcessorConstructorMock(1, constructorArgument, "dummyConnection", new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The connection string constructor should validate the consumer group.");
+            Assert.That(() => new ProcessorConstructorMock(1, constructorArgument, "dummyNamespace", "dummyEventHub", Mock.Of<TokenCredential>(), new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The namespace constructor should validate the consumer group.");
         }
 
         /// <summary>
@@ -79,8 +84,8 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorValidatesTheConnectionString(string connectionString)
         {
-            Assert.That(() => new BasicProcessorMock(1, EventHubConsumerClient.DefaultConsumerGroupName, connectionString), Throws.InstanceOf<ArgumentException>(), "The constructor without options should ensure a connection string.");
-            Assert.That(() => new BasicProcessorMock(1, EventHubConsumerClient.DefaultConsumerGroupName, connectionString, "dummy", new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The constructor with options should ensure a connection string.");
+            Assert.That(() => new ProcessorConstructorMock(1, EventHubConsumerClient.DefaultConsumerGroupName, connectionString), Throws.InstanceOf<ArgumentException>(), "The constructor without options should ensure a connection string.");
+            Assert.That(() => new ProcessorConstructorMock(1, EventHubConsumerClient.DefaultConsumerGroupName, connectionString, "dummy", new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The constructor with options should ensure a connection string.");
         }
 
         /// <summary>
@@ -93,7 +98,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorValidatesTheNamespace(string constructorArgument)
         {
-            Assert.That(() => new BasicProcessorMock(1, EventHubConsumerClient.DefaultConsumerGroupName, constructorArgument, "dummy", Mock.Of<TokenCredential>()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new ProcessorConstructorMock(1, EventHubConsumerClient.DefaultConsumerGroupName, constructorArgument, "dummy", Mock.Of<TokenCredential>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -106,7 +111,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorValidatesTheEventHub(string constructorArgument)
         {
-            Assert.That(() => new BasicProcessorMock(100, EventHubConsumerClient.DefaultConsumerGroupName, "namespace", constructorArgument, Mock.Of<TokenCredential>()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new ProcessorConstructorMock(100, EventHubConsumerClient.DefaultConsumerGroupName, "namespace", constructorArgument, Mock.Of<TokenCredential>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -117,7 +122,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorValidatesTheCredential()
         {
-            Assert.That(() => new BasicProcessorMock(5, EventHubConsumerClient.DefaultConsumerGroupName, "namespace", "hubName", default(TokenCredential)), Throws.ArgumentNullException);
+            Assert.That(() => new ProcessorConstructorMock(5, EventHubConsumerClient.DefaultConsumerGroupName, "namespace", "hubName", default(TokenCredential)), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -127,7 +132,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         [Test]
         [TestCaseSource(nameof(ConstructorCreatesDefaultOptionsCases))]
-        public void ConstructorCreatesDefaultOptions(BasicProcessorMock eventProcessor,
+        public void ConstructorCreatesDefaultOptions(ProcessorConstructorMock eventProcessor,
                                                      string constructorDescription)
         {
             var defaultOptions = new EventProcessorOptions();
@@ -152,7 +157,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 ConnectionOptions = new EventHubConnectionOptions { TransportType = expectedTransportType }
             };
 
-            var eventProcessor = new BasicProcessorMock(1, "consumerGroup", "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub", options);
+            var eventProcessor = new ProcessorConstructorMock(1, "consumerGroup", "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub", options);
 
             // Simply retrieving the options from an inner connection won't be enough to prove the processor clones
             // its connection options because the cloning step also happens in the EventHubConnection constructor.
@@ -181,7 +186,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 ConnectionOptions = new EventHubConnectionOptions { TransportType = expectedTransportType }
             };
 
-            var eventProcessor = new BasicProcessorMock(11, "consumerGroup", "namespace", "hub", Mock.Of<TokenCredential>(), options);
+            var eventProcessor = new ProcessorConstructorMock(11, "consumerGroup", "namespace", "hub", Mock.Of<TokenCredential>(), options);
 
             // Simply retrieving the options from an inner connection won't be enough to prove the processor clones
             // its connection options because the cloning step also happens in the EventHubConnection constructor.
@@ -207,7 +212,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 Identifier = Guid.NewGuid().ToString()
             };
 
-            var eventProcessor = new BasicProcessorMock(72, "consumerGroup", "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub", options);
+            var eventProcessor = new ProcessorConstructorMock(72, "consumerGroup", "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub", options);
 
             Assert.That(eventProcessor.Identifier, Is.Not.Null);
             Assert.That(eventProcessor.Identifier, Is.EqualTo(options.Identifier));
@@ -226,7 +231,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 Identifier = Guid.NewGuid().ToString()
             };
 
-            var eventProcessor = new BasicProcessorMock(65, "consumerGroup", "namespace", "hub", Mock.Of<TokenCredential>(), options);
+            var eventProcessor = new ProcessorConstructorMock(65, "consumerGroup", "namespace", "hub", Mock.Of<TokenCredential>(), options);
 
             Assert.That(eventProcessor.Identifier, Is.Not.Null);
             Assert.That(eventProcessor.Identifier, Is.EqualTo(options.Identifier));
@@ -247,7 +252,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 Identifier = identifier
             };
 
-            var eventProcessor = new BasicProcessorMock(34, "consumerGroup", "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub", options);
+            var eventProcessor = new ProcessorConstructorMock(34, "consumerGroup", "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub", options);
 
             Assert.That(eventProcessor.Identifier, Is.Not.Null);
             Assert.That(eventProcessor.Identifier, Is.Not.Empty);
@@ -268,7 +273,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 Identifier = identifier
             };
 
-            var eventProcessor = new BasicProcessorMock(665, "consumerGroup", "namespace", "hub", Mock.Of<TokenCredential>(), options);
+            var eventProcessor = new ProcessorConstructorMock(665, "consumerGroup", "namespace", "hub", Mock.Of<TokenCredential>(), options);
 
             Assert.That(eventProcessor.Identifier, Is.Not.Null);
             Assert.That(eventProcessor.Identifier, Is.Not.Empty);
@@ -282,7 +287,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         [TestCase(true)]
         [TestCase(false)]
-        public void StartProcessingRespectsACanceledToken(bool async)
+        public void StartProcessingRespectsACancelledToken(bool async)
         {
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();
@@ -525,7 +530,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         [TestCase(true)]
         [TestCase(false)]
-        public void StopProcessingRespectsACanceledToken(bool async)
+        public void StopProcessingRespectsACancelledToken(bool async)
         {
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();
@@ -929,7 +934,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 Times.Once);
 
             mockEventSource
-               .Verify(log => log.EventProcessingTaskError(
+               .Verify(log => log.EventProcessorTaskError(
                    mockProcessor.Object.Identifier,
                    mockProcessor.Object.EventHubName,
                    mockProcessor.Object.ConsumerGroup,
@@ -941,6 +946,1289 @@ namespace Azure.Messaging.EventHubs.Tests
                     mockProcessor.Object.Identifier,
                     mockProcessor.Object.EventHubName,
                     mockProcessor.Object.ConsumerGroup),
+                Times.Once);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.ProcessEventBatchAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void ProcessEventBatchAsyncHonorsTheCancellationToken()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.Cancel();
+
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+            Assert.That(() => mockProcessor.Object.ProcessEventBatchAsync(new EventProcessorPartition(), EmptyBatch, true, cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.ProcessEventBatchAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ProcessEventBatchAsyncDelegatesToTheHandlerWhenTheBatchHasEvents()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var eventBatch = new[] { new EventData(Array.Empty<byte>()), new EventData(Array.Empty<byte>()) };
+            var partition = new EventProcessorPartition { PartitionId = "123" };
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(67, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+
+            await mockProcessor.Object.ProcessEventBatchAsync(partition, eventBatch, false, cancellationSource.Token);
+
+            mockProcessor
+                .Protected()
+                .Verify("OnProcessingEventBatchAsync", Times.Once(), eventBatch, partition, cancellationSource.Token);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.ProcessEventBatchAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ProcessEventBatchAsyncDelegatesToTheHandlerWhenEmptyBatchesAreToBeDispatched()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var partition = new EventProcessorPartition { PartitionId = "123" };
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(67, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+
+            await mockProcessor.Object.ProcessEventBatchAsync(partition, EmptyBatch, true, cancellationSource.Token);
+
+            mockProcessor
+                .Protected()
+                .Verify("OnProcessingEventBatchAsync", Times.Once(), EmptyBatch, partition, cancellationSource.Token);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.ProcessEventBatchAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ProcessEventBatchAsyncDoesNotInvokeTheHandlerWhenEmptyBatchesShouldNotBeDispatched()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var partition = new EventProcessorPartition { PartitionId = "123" };
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(67, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+
+            await mockProcessor.Object.ProcessEventBatchAsync(partition, EmptyBatch, false, cancellationSource.Token);
+
+            mockProcessor
+                .Protected()
+                .Verify("OnProcessingEventBatchAsync", Times.Never(), EmptyBatch, partition, cancellationSource.Token);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.ProcessEventBatchAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void ProcessEventBatchAsyncWrapsErrors()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var partition = new EventProcessorPartition { PartitionId = "123" };
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(67, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+
+            mockProcessor
+                .Protected()
+                .Setup("OnProcessingEventBatchAsync", EmptyBatch, partition, cancellationSource.Token)
+                .Throws(new MissingFieldException());
+
+            Assert.That(async () => await mockProcessor.Object.ProcessEventBatchAsync(partition, EmptyBatch, true, cancellationSource.Token), Throws.InstanceOf<DeveloperCodeException>().And.Message.EqualTo(Resources.DeveloperCodeError));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CreatePartitionProcessorHonorsTheCancellationToken()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.Cancel();
+
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+            Assert.That(() => mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), EventPosition.Earliest, cancellationSource), Throws.InstanceOf<TaskCanceledException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CreatePartitionProcessorPreservesTheCancellationSource()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = Mock.Of<TransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(mockConsumer);
+
+           var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), EventPosition.Earliest, cancellationSource);
+           Assert.That(partitionProcessor.CancellationSource, Is.SameAs(cancellationSource));
+
+           cancellationSource.Cancel();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CreatePartitionProcessorDoesNotAllowReadingLastEventPropertiesWithNoOption()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false };
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = Mock.Of<TransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(mockConsumer);
+
+           var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), EventPosition.Earliest, cancellationSource);
+           Assert.That(() => partitionProcessor.ReadLastEnqueuedEventProperties(), Throws.InstanceOf<InvalidOperationException>().And.Message.EqualTo(Resources.TrackLastEnqueuedEventPropertiesNotSet));
+
+           cancellationSource.Cancel();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CreatePartitionProcessorDoesNotAllowReadingLastEventPropertiesWithNoConsumer()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = true };
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(default(TransportConsumer));
+
+           var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), EventPosition.Earliest, cancellationSource);
+           Assert.That(() => partitionProcessor.ReadLastEnqueuedEventProperties(), Throws.InstanceOf<InvalidOperationException>().And.Message.EqualTo(Resources.ClientNeededForThisInformationNotAvailable));
+
+           cancellationSource.Cancel();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreatePartitionProcessorCanReadLastEventProperties()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = true };
+            var lastEvent = new EventData(Array.Empty<byte>(), lastPartitionSequenceNumber: 123, lastPartitionOffset: 887, lastPartitionEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastPartitionPropertiesRetrievalTime: DateTimeOffset.Parse("2021-03-04T08:30:00Z"));
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = new Mock<SettableTransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            mockConsumer.Object.SetLastEvent(lastEvent);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(mockConsumer.Object)
+                .Callback(() => completionSource.TrySetResult(true));
+
+           var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), EventPosition.Earliest, cancellationSource);
+
+           await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+           Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+           cancellationSource.Cancel();
+
+           var lastEventProperties = partitionProcessor.ReadLastEnqueuedEventProperties();
+           Assert.That(lastEventProperties, Is.EqualTo(new LastEnqueuedEventProperties(lastEvent)));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreatePartitionProcessorCanReadLastEventPropertiesWhenTheConsumerIsReplaced()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = true, RetryOptions = retryOptions };
+            var lastEvent = new EventData(Array.Empty<byte>(), lastPartitionSequenceNumber: 123, lastPartitionOffset: 887, lastPartitionEnqueuedTime: DateTimeOffset.Parse("2015-10-27T12:00:00Z"), lastPartitionPropertiesRetrievalTime: DateTimeOffset.Parse("2021-03-04T08:30:00Z"));
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = new Mock<SettableTransportConsumer>();
+            var badMockConsumer = new Mock<SettableTransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            mockConsumer.Object.SetLastEvent(lastEvent);
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(EmptyBatch);
+
+            badMockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .Throws(new DllNotFoundException());
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(badMockConsumer.Object)
+                .Returns(() =>
+                {
+                    completionSource.TrySetResult(true);
+                    return mockConsumer.Object;
+                });
+
+           var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), EventPosition.Earliest, cancellationSource);
+
+           await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+           Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+           cancellationSource.Cancel();
+
+           var lastEventProperties = partitionProcessor.ReadLastEnqueuedEventProperties();
+           Assert.That(lastEventProperties, Is.EqualTo(new LastEnqueuedEventProperties(lastEvent)));
+
+            mockProcessor
+                .Verify(processor => processor.CreateConsumer(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<EventPosition>(),
+                    mockConnection,
+                    It.IsAny<EventProcessorOptions>()),
+                Times.AtLeast(2));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreatePartitionProcessorStartsTheProcessingTask()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var partition = new EventProcessorPartition { PartitionId = "99" };
+            var position = EventPosition.FromOffset(12);
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false };
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = new Mock<SettableTransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<EventData> { new EventData(Array.Empty<byte>()), new EventData(Array.Empty<byte>()) })
+                .Callback(() => completionSource.TrySetResult(true));
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(mockConsumer.Object);
+
+            mockProcessor
+                .Setup(processor => processor.ProcessEventBatchAsync(partition, It.IsAny<IReadOnlyList<EventData>>(), It.IsAny<bool>(), cancellationSource.Token))
+                .Returns(Task.CompletedTask);
+
+           var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, position, cancellationSource);
+
+           await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+           Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+           Assert.That(partitionProcessor.ProcessingTask, Is.Not.Null, "There should be a processing task present.");
+           Assert.That(partitionProcessor.ProcessingTask.IsCompleted, Is.False, "The processing task should not be completed.");
+
+           mockConsumer
+                .Verify(consumer => consumer.ReceiveAsync(
+                    It.IsAny<int>(),
+                    It.IsAny<TimeSpan?>(),
+                    It.IsAny<CancellationToken>()),
+                 Times.AtLeastOnce);
+
+           cancellationSource.Cancel();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreatePartitionProcessorProcessingTaskRespectsCancellation()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var partition = new EventProcessorPartition { PartitionId = "99" };
+            var position = EventPosition.FromOffset(12);
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false };
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = new Mock<SettableTransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<EventData> { new EventData(Array.Empty<byte>()), new EventData(Array.Empty<byte>()) })
+                .Callback(() => completionSource.TrySetResult(true));
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(mockConsumer.Object);
+
+           mockProcessor
+                .Setup(processor => processor.ProcessEventBatchAsync(partition, It.IsAny<IReadOnlyList<EventData>>(), It.IsAny<bool>(), cancellationSource.Token))
+                .Returns(Task.CompletedTask);
+
+           var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, position, cancellationSource);
+
+           await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+           Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+           Assert.That(partitionProcessor.ProcessingTask, Is.Not.Null, "There should be a processing task present.");
+           Assert.That(partitionProcessor.ProcessingTask.IsCompleted, Is.False, "The processing task should not be completed.");
+
+           cancellationSource.Cancel();
+           Assert.That(async () => await partitionProcessor.ProcessingTask, Throws.InstanceOf<TaskCanceledException>(), "The processing task should honor a cancellation request.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreatePartitionProcessorProcessingTaskDispatchesEvents()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var partition = new EventProcessorPartition { PartitionId = "99" };
+            var position = EventPosition.FromOffset(12);
+            var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = new Mock<SettableTransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<EventData> { new EventData(Array.Empty<byte>()), new EventData(Array.Empty<byte>()) });
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(mockConsumer.Object);
+
+           mockProcessor
+                .Setup(processor => processor.ProcessEventBatchAsync(partition, It.IsAny<IReadOnlyList<EventData>>(), It.IsAny<bool>(), cancellationSource.Token))
+                .Returns(Task.CompletedTask)
+                .Callback(() => completionSource.TrySetResult(true));
+
+           var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, position, cancellationSource);
+
+           await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+           Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+           mockProcessor
+                .Verify(processor => processor.ProcessEventBatchAsync(
+                    partition,
+                    It.IsAny<IReadOnlyList<EventData>>(),
+                    It.IsAny<bool>(),
+                    cancellationSource.Token),
+                Times.AtLeastOnce);
+
+           cancellationSource.Cancel();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreatePartitionProcessorProcessingTaskDispatchesExceptions()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var expectedException = new DivideByZeroException();
+            var partition = new EventProcessorPartition { PartitionId = "99" };
+            var position = EventPosition.FromOffset(12);
+            var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
+            var receiveCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var errorCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = new Mock<SettableTransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .Callback(() => receiveCompletion.TrySetResult(true))
+                .Throws(expectedException);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(mockConsumer.Object)
+                .Returns(Mock.Of<TransportConsumer>());
+
+           mockProcessor
+                .Setup(processor => processor.ProcessEventBatchAsync(partition, It.IsAny<IReadOnlyList<EventData>>(), It.IsAny<bool>(), cancellationSource.Token))
+                .Returns(Task.CompletedTask);
+
+            mockProcessor
+               .Protected()
+               .Setup<Task>("OnProcessingErrorAsync", expectedException, ItExpr.IsAny<EventProcessorPartition>(), ItExpr.IsAny<string>(), ItExpr.IsAny<CancellationToken>())
+               .Callback(() => errorCompletion.TrySetResult(true))
+               .Returns(Task.CompletedTask);
+
+           var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, position, cancellationSource);
+           var completionSources = Task.WhenAll(receiveCompletion.Task, errorCompletion.Task);
+
+           await Task.WhenAny(completionSources, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+           Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+           mockProcessor
+               .Protected()
+               .Verify("OnProcessingErrorAsync", Times.Once(),
+                    expectedException,
+                    partition,
+                    Resources.OperationReadEvents,
+                    CancellationToken.None);
+
+           cancellationSource.Cancel();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreatePartitionProcessorProcessingTaskLogsExceptions()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var expectedException = new DivideByZeroException("OMG FAIL!");
+            var partition = new EventProcessorPartition { PartitionId = "99" };
+            var position = EventPosition.FromOffset(12);
+            var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
+            var receiveCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var errorCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockLogger = new Mock<EventHubsEventSource>();
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = new Mock<SettableTransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .Callback(() => receiveCompletion.TrySetResult(true))
+                .Throws(expectedException);
+
+            mockProcessor.Object.Logger = mockLogger.Object;
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(mockConsumer.Object)
+                .Returns(Mock.Of<TransportConsumer>());
+
+           mockProcessor
+                .Setup(processor => processor.ProcessEventBatchAsync(partition, It.IsAny<IReadOnlyList<EventData>>(), It.IsAny<bool>(), cancellationSource.Token))
+                .Returns(Task.CompletedTask);
+
+            mockLogger
+               .Setup(log => log.EventProcessorPartitionProcessingError(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+               .Callback(() => errorCompletion.TrySetResult(true));
+
+           var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, position, cancellationSource);
+           var completionSources = Task.WhenAll(receiveCompletion.Task, errorCompletion.Task);
+
+           await Task.WhenAny(completionSources, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+           Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+            mockLogger
+               .Verify(log => log.EventProcessorPartitionProcessingError(
+                   partition.PartitionId,
+                   mockProcessor.Object.Identifier,
+                   mockProcessor.Object.EventHubName,
+                   mockProcessor.Object.ConsumerGroup,
+                   expectedException.Message),
+                Times.Once);
+
+           cancellationSource.Cancel();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreatePartitionProcessorProcessingTaskSurfacesExceptions()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var expectedException = new DivideByZeroException("I'm special!");
+            var partition = new EventProcessorPartition { PartitionId = "99" };
+            var position = EventPosition.FromOffset(12);
+            var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
+            var receiveCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var errorCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = new Mock<SettableTransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .Callback(() => receiveCompletion.TrySetResult(true))
+                .Throws(expectedException);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(mockConsumer.Object)
+                .Returns(Mock.Of<TransportConsumer>());
+
+           mockProcessor
+                .Setup(processor => processor.ProcessEventBatchAsync(partition, It.IsAny<IReadOnlyList<EventData>>(), It.IsAny<bool>(), cancellationSource.Token))
+                .Returns(Task.CompletedTask);
+
+            mockProcessor
+               .Protected()
+               .Setup<Task>("OnProcessingErrorAsync", expectedException, ItExpr.IsAny<EventProcessorPartition>(), ItExpr.IsAny<string>(), ItExpr.IsAny<CancellationToken>())
+               .Callback(() => errorCompletion.TrySetResult(true))
+               .Returns(Task.CompletedTask);
+
+           var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, position, cancellationSource);
+           var completionSources = Task.WhenAll(receiveCompletion.Task, errorCompletion.Task);
+
+           await Task.WhenAny(completionSources, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+           Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+           cancellationSource.Cancel();
+           Assert.That(async () => await partitionProcessor.ProcessingTask, Throws.TypeOf(expectedException.GetType()).And.EqualTo(expectedException), "The exception should have been surfaced by the task.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreatePartitionProcessorProcessingTaskDoesNotDispatchDeveloperCodeExceptions()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var expectedException = new DeveloperCodeException(new DivideByZeroException());
+            var partition = new EventProcessorPartition { PartitionId = "99" };
+            var position = EventPosition.FromOffset(12);
+            var retryOptions = new EventHubsRetryOptions { MaximumRetries = 1, MaximumDelay = TimeSpan.FromMilliseconds(5) };
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = new Mock<SettableTransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<EventData> { new EventData(Array.Empty<byte>()), new EventData(Array.Empty<byte>()) });
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(mockConsumer.Object);
+
+           mockProcessor
+                .Setup(processor => processor.ProcessEventBatchAsync(partition, It.IsAny<IReadOnlyList<EventData>>(), It.IsAny<bool>(), cancellationSource.Token))
+                .Callback(() => completionSource.TrySetResult(true))
+                .Throws(expectedException);
+
+           var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, position, cancellationSource);
+
+           await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+           Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+           // Allow for a small delay because error processing is a background task, just to give it time to trigger.
+
+           await Task.Delay(250);
+
+           mockProcessor
+               .Protected()
+               .Verify("OnProcessingErrorAsync", Times.Never(),
+                    expectedException,
+                    partition,
+                    ItExpr.IsAny<string>(),
+                    ItExpr.IsAny<CancellationToken>());
+
+           cancellationSource.Cancel();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreatePartitionProcessorProcessingTaskLogsDeveloperCodeExceptions()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var expectedException = new DeveloperCodeException(new DivideByZeroException("Yay, I'm on the inside!"));
+            var partition = new EventProcessorPartition { PartitionId = "99" };
+            var position = EventPosition.FromOffset(12);
+            var retryOptions = new EventHubsRetryOptions { MaximumRetries = 1, MaximumDelay = TimeSpan.FromMilliseconds(5) };
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockLogger = new Mock<EventHubsEventSource>();
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = new Mock<SettableTransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<EventData> { new EventData(Array.Empty<byte>()), new EventData(Array.Empty<byte>()) });
+
+            mockProcessor.Object.Logger = mockLogger.Object;
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(mockConsumer.Object);
+
+           mockProcessor
+                .Setup(processor => processor.ProcessEventBatchAsync(partition, It.IsAny<IReadOnlyList<EventData>>(), It.IsAny<bool>(), cancellationSource.Token))
+                .Callback(() => completionSource.TrySetResult(true))
+                .Throws(expectedException);
+
+           var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, position, cancellationSource);
+
+           await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+           Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+           // Allow for a small delay because error processing is a background task, just to give it time to trigger.
+
+           await Task.Delay(250);
+
+           mockLogger
+               .Verify(log => log.EventProcessorPartitionProcessingError(
+                   partition.PartitionId,
+                   mockProcessor.Object.Identifier,
+                   mockProcessor.Object.EventHubName,
+                   mockProcessor.Object.ConsumerGroup,
+                   It.Is<string>(value => value.Contains(expectedException.InnerException.Message))),
+                Times.Once);
+
+           cancellationSource.Cancel();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreatePartitionProcessorProcessingTaskSurfacesDeveloperCodeExceptions()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var expectedException = new InvalidOperationException("BOOM!");
+            var developerException = new DeveloperCodeException(expectedException);
+            var partition = new EventProcessorPartition { PartitionId = "99" };
+            var position = EventPosition.FromOffset(12);
+            var retryOptions = new EventHubsRetryOptions { MaximumRetries = 1, MaximumDelay = TimeSpan.FromMilliseconds(5) };
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = new Mock<SettableTransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<EventData> { new EventData(Array.Empty<byte>()), new EventData(Array.Empty<byte>()) });
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(mockConsumer.Object);
+
+           mockProcessor
+                .Setup(processor => processor.ProcessEventBatchAsync(partition, It.IsAny<IReadOnlyList<EventData>>(), It.IsAny<bool>(), cancellationSource.Token))
+                .Callback(() => completionSource.TrySetResult(true))
+                .Throws(developerException);
+
+           var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, position, cancellationSource);
+
+           await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+           Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+           cancellationSource.Cancel();
+           Assert.That(async () => await partitionProcessor.ProcessingTask, Throws.TypeOf(expectedException.GetType()).And.EqualTo(expectedException), "The inner exception should have been surfaced by the task.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreatePartitionProcessorProcessingTaskHonorsTheRetryPolicy()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var expectedException = new EventHubsException(true, "frank", "BOOM!", EventHubsException.FailureReason.GeneralError);
+            var partition = new EventProcessorPartition { PartitionId = "99" };
+            var position = EventPosition.FromOffset(12);
+            var retryOptions = new EventHubsRetryOptions { MaximumRetries = 2, MaximumDelay = TimeSpan.FromMilliseconds(15) };
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = new Mock<SettableTransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .Throws(expectedException);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(mockConsumer.Object)
+                .Returns(() =>
+                {
+                    completionSource.TrySetResult(true);
+                    return Mock.Of<TransportConsumer>();
+                });
+
+           mockProcessor
+                .Setup(processor => processor.ProcessEventBatchAsync(partition, It.IsAny<IReadOnlyList<EventData>>(), It.IsAny<bool>(), cancellationSource.Token))
+                .Returns(Task.CompletedTask);
+
+           var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, position, cancellationSource);
+
+           await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+           Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+           mockConsumer
+                .Verify(consumer => consumer.ReceiveAsync(
+                    It.IsAny<int>(),
+                    It.IsAny<TimeSpan?>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Exactly(retryOptions.MaximumRetries + 1));
+
+           cancellationSource.Cancel();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreatePartitionProcessorProcessingTaskReplacesTheConsumerOnFailure()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = new Mock<SettableTransportConsumer>();
+            var badMockConsumer = new Mock<SettableTransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(EmptyBatch);
+
+            badMockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .Throws(new DllNotFoundException());
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(badMockConsumer.Object)
+                .Returns(() =>
+                {
+                    completionSource.TrySetResult(true);
+                    return mockConsumer.Object;
+                });
+
+           var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), EventPosition.Earliest, cancellationSource);
+
+           await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+           Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+           cancellationSource.Cancel();
+
+            mockProcessor
+                .Verify(processor => processor.CreateConsumer(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<EventPosition>(),
+                    mockConnection,
+                    It.IsAny<EventProcessorOptions>()),
+                Times.AtLeast(2));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreatePartitionProcessorProcessingTaskStartsTheConsumerAtTheCorrectEventWhenReplaced()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
+            var partition = new EventProcessorPartition { PartitionId = "4" };
+            var lastEventBatch = new List<EventData> { new EventData(Array.Empty<byte>()), new EventData(Array.Empty<byte>(), offset: 9987) };
+            var initialStartingPosition = EventPosition.FromSequenceNumber(332);
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = new Mock<SettableTransportConsumer>();
+            var badMockConsumer = new Mock<SettableTransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(EmptyBatch);
+
+            badMockConsumer
+                .SetupSequence(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<EventData> { new EventData(Array.Empty<byte>()) })
+                .ReturnsAsync(lastEventBatch)
+                .Throws(new DllNotFoundException());
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(badMockConsumer.Object)
+                .Returns(() =>
+                {
+                    completionSource.TrySetResult(true);
+                    return mockConsumer.Object;
+                });
+
+           var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, initialStartingPosition, cancellationSource);
+
+           await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+           Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+           cancellationSource.Cancel();
+
+            mockProcessor
+                .Verify(processor => processor.CreateConsumer(
+                    mockProcessor.Object.ConsumerGroup,
+                    partition.PartitionId,
+                    initialStartingPosition,
+                    mockConnection,
+                    It.IsAny<EventProcessorOptions>()),
+                Times.Once);
+
+            mockProcessor
+                .Verify(processor => processor.CreateConsumer(
+                    mockProcessor.Object.ConsumerGroup,
+                    partition.PartitionId,
+                    EventPosition.FromOffset(lastEventBatch.Last().Offset, false),
+                    mockConnection,
+                    It.IsAny<EventProcessorOptions>()),
+                Times.Once);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreatePartitionProcessorProcessingTaskDoesNotReplaceTheConsumerOnFatalExceptions()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var expectedException = new StackOverflowException("We be overflowing!");
+            var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = new Mock<SettableTransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .Throws(expectedException);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(mockConsumer.Object)
+                .Callback(() => completionSource.TrySetResult(true));
+
+           var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), EventPosition.Earliest, cancellationSource);
+
+           await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+           Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+           cancellationSource.Cancel();
+           Assert.That(async () => await partitionProcessor.ProcessingTask, Throws.TypeOf(expectedException.GetType()).And.EqualTo(expectedException), "The exception should have been surfaced by the task.");
+
+            mockProcessor
+                .Verify(processor => processor.CreateConsumer(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<EventPosition>(),
+                    mockConnection,
+                    It.IsAny<EventProcessorOptions>()),
+                Times.Once);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreatePartitionProcessorProcessingTaskWrapsAnOperationCanceledExceptionAndConsidersItFatal()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var expectedException = new OperationCanceledException("STAHP!");
+            var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = new Mock<SettableTransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .Throws(expectedException);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(mockConsumer.Object)
+                .Callback(() => completionSource.TrySetResult(true));
+
+           var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), EventPosition.Earliest, cancellationSource);
+
+           await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+           Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+           cancellationSource.Cancel();
+           Assert.That(async () => await partitionProcessor.ProcessingTask, Throws.InstanceOf<TaskCanceledException>().And.InnerException.EqualTo(expectedException), "The wrapped exception should have been surfaced by the task.");
+
+            mockProcessor
+                .Verify(processor => processor.CreateConsumer(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<EventPosition>(),
+                    mockConnection,
+                    It.IsAny<EventProcessorOptions>()),
+                Times.Once);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreatePartitionProcessorProcessingTaskDoesNotReplaceTheConsumerWhenCancellationRequested()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = new Mock<SettableTransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(EmptyBatch)
+                .Callback(() =>
+                {
+                    completionSource.TrySetResult(true);
+                });
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(mockConsumer.Object);
+
+           var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), EventPosition.Earliest, cancellationSource);
+
+           await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+           Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+           cancellationSource.Cancel();
+           Assert.That(async () => await partitionProcessor.ProcessingTask, Throws.InstanceOf<TaskCanceledException>(), "The cancellation should have been surfaced by the task.");
+
+            mockProcessor
+                .Verify(processor => processor.CreateConsumer(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<EventPosition>(),
+                    mockConnection,
+                    It.IsAny<EventProcessorOptions>()),
+                Times.Once);
+
+            mockConsumer
+                .Verify(consumer => consumer.ReceiveAsync(
+                    It.IsAny<int>(),
+                    It.IsAny<TimeSpan?>(),
+                    It.IsAny<CancellationToken>()),
+                Times.AtLeastOnce);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreatePartitionProcessorProcessingTaskClosesTheConsumerWhenItIsReplaced()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = new Mock<SettableTransportConsumer>();
+            var badMockConsumer = new Mock<SettableTransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(EmptyBatch);
+
+            badMockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .Throws(new DllNotFoundException());
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(badMockConsumer.Object)
+                .Returns(() =>
+                {
+                    completionSource.TrySetResult(true);
+                    return mockConsumer.Object;
+                });
+
+           var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(new EventProcessorPartition(), EventPosition.Earliest, cancellationSource);
+
+           await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+           Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+           cancellationSource.Cancel();
+
+            mockProcessor
+                .Verify(processor => processor.CreateConsumer(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<EventPosition>(),
+                    mockConnection,
+                    It.IsAny<EventProcessorOptions>()),
+                Times.AtLeast(2));
+
+            badMockConsumer
+                .Verify(consumer => consumer.CloseAsync(CancellationToken.None),
+                Times.Once);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.CreatePartitionProcessor" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreatePartitionProcessorProcessingLogsWhenAnExceptionOccursClosingTheConsumer()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var expectedException = new DataMisalignedException("This is bad and you should feel bad.");
+            var partition = new EventProcessorPartition { PartitionId = "omgno" };
+            var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };
+            var options = new EventProcessorOptions { TrackLastEnqueuedEventProperties = false, RetryOptions = retryOptions };
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var mockLogger = new Mock<EventHubsEventSource>();
+            var mockConnection = Mock.Of<EventHubConnection>();
+            var mockConsumer = new Mock<SettableTransportConsumer>();
+            var badMockConsumer = new Mock<SettableTransportConsumer>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(5, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options) { CallBase = true };
+
+            mockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(EmptyBatch);
+
+            badMockConsumer
+                .Setup(consumer => consumer.ReceiveAsync(It.IsAny<int>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+                .Throws(new DllNotFoundException());
+
+            badMockConsumer
+                .Setup(consumer => consumer.CloseAsync(It.IsAny<CancellationToken>()))
+                .Throws(expectedException);
+
+            mockProcessor.Object.Logger = mockLogger.Object;
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection);
+
+            mockProcessor
+                .SetupSequence(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), mockConnection, It.IsAny<EventProcessorOptions>()))
+                .Returns(badMockConsumer.Object)
+                .Returns(() =>
+                {
+                    completionSource.TrySetResult(true);
+                    return mockConsumer.Object;
+                });
+
+           var partitionProcessor = mockProcessor.Object.CreatePartitionProcessor(partition, EventPosition.Earliest, cancellationSource);
+
+           await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+           Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+           cancellationSource.Cancel();
+
+           badMockConsumer
+                .Verify(consumer => consumer.CloseAsync(CancellationToken.None),
+                Times.Once);
+
+           mockLogger
+               .Verify(log => log.EventProcessorPartitionProcessingError(
+                   partition.PartitionId,
+                   mockProcessor.Object.Identifier,
+                   mockProcessor.Object.EventHubName,
+                   mockProcessor.Object.ConsumerGroup,
+                   expectedException.Message),
                 Times.Once);
         }
 
@@ -1085,31 +2373,43 @@ namespace Azure.Messaging.EventHubs.Tests
         ///   functionality.
         /// </summary>
         ///
-        public class BasicProcessorMock : EventProcessor<EventProcessorPartition>
+        public class ProcessorConstructorMock : EventProcessor<EventProcessorPartition>
         {
-            public BasicProcessorMock(int eventBatchMaximumCount,
-                                      string consumerGroup,
-                                      string connectionString,
-                                      EventProcessorOptions options = default) : base(eventBatchMaximumCount, consumerGroup, connectionString, options) { }
+            public ProcessorConstructorMock(int eventBatchMaximumCount,
+                                            string consumerGroup,
+                                            string connectionString,
+                                            EventProcessorOptions options = default) : base(eventBatchMaximumCount, consumerGroup, connectionString, options) { }
 
-            public BasicProcessorMock(int eventBatchMaximumCount,
-                                      string consumerGroup,
-                                      string connectionString,
-                                      string eventHubName,
-                                      EventProcessorOptions options = default) : base(eventBatchMaximumCount, consumerGroup, connectionString, eventHubName, options) { }
+            public ProcessorConstructorMock(int eventBatchMaximumCount,
+                                            string consumerGroup,
+                                            string connectionString,
+                                            string eventHubName,
+                                            EventProcessorOptions options = default) : base(eventBatchMaximumCount, consumerGroup, connectionString, eventHubName, options) { }
 
-            public BasicProcessorMock(int eventBatchMaximumCount,
-                                      string consumerGroup,
-                                      string fullyQualifiedNamespace,
-                                      string eventHubName,
-                                      TokenCredential credential,
-                                      EventProcessorOptions options = default) : base(eventBatchMaximumCount, consumerGroup, fullyQualifiedNamespace, eventHubName, credential, options) { }
+            public ProcessorConstructorMock(int eventBatchMaximumCount,
+                                            string consumerGroup,
+                                            string fullyQualifiedNamespace,
+                                            string eventHubName,
+                                            TokenCredential credential,
+                                            EventProcessorOptions options = default) : base(eventBatchMaximumCount, consumerGroup, fullyQualifiedNamespace, eventHubName, credential, options) { }
 
             protected override Task<IEnumerable<EventProcessorPartitionOwnership>> ClaimOwnershipAsync(IEnumerable<EventProcessorPartitionOwnership> desiredOwnership, CancellationToken cancellationToken) => throw new NotImplementedException();
             protected override Task<IEnumerable<EventProcessorCheckpoint>> ListCheckpointsAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
             protected override Task<IEnumerable<EventProcessorPartitionOwnership>> ListOwnershipAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
             protected override Task OnProcessingErrorAsync(Exception exception, EventProcessorPartition partition, string operationDescription, CancellationToken cancellationToken) => throw new NotImplementedException();
             protected override Task OnProcessingEventBatchAsync(IEnumerable<EventData> events, EventProcessorPartition partition, CancellationToken cancellationToken) => throw new NotImplementedException();
+        }
+
+        /// <summary>
+        ///   A shim for the transport consumer, allowing setting of base class
+        ///   protected properties.
+        /// </summary>
+        ///
+        internal class SettableTransportConsumer : TransportConsumer
+        {
+            public void SetLastEvent(EventData lastEvent) => LastReceivedEvent = lastEvent;
+            public override Task CloseAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
+            public override Task<IReadOnlyList<EventData>> ReceiveAsync(int maximumMessageCount, TimeSpan? maximumWaitTime, CancellationToken cancellationToken) => throw new NotImplementedException();
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Properties/AssemblyInfo.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Properties/AssemblyInfo.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Runtime.CompilerServices;
 using NUnit.Framework;
 
 [assembly: Parallelizable(ParallelScope.All)]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]


### PR DESCRIPTION
# Summary

The focus of these changes is to implement the partition processor flow responsible for ensuring resilience and error handling while reading from the Event Hubs service and dispatching to the developer-provided code for event processing and error handling.

**Note:** The design to which these changes belong has been reviewed and approved by the SDK architecture board and by the language architect. Marking with the corresponding tag for tracking purposes.

Key goals for these changes are:

  - Attempt to be resilient while processing and avoid partition ownership changing if we are able to make forward progress.  
_(the more a partition's ownership changes, the more likely processing throughput will drop)_

  - Ensure that errors within the event processor infrastructure and flow are surfaced to the error handler in a fire-and-forget manner.

  - Explicitly do not attempt to handle or surface exceptions in developer-provided code; these should be logged but should otherwise be treated as fatal.
    _(the processor lacks the necessary insight and context into the host application to make an informed decision about the impact of these exceptions.  Developers are expected to account for exception handling within their handler code.)_

  - Guard against dispatching empty event batches to handler code unless the option for a maximum wait time was specified; the underlying consumer will continue to spin based on the per-try timeout.

  - Instrument events being dispatched for processing for use with the distributed tracing ecosystem.  
  _(tests pending)_

  - Allow for the last enqueued event properties for a partition to be read if the associated option was set; this should be supported even when the underlying
    transport consumer for reading events from the service changes during processing, which is an expected resilience mechanism.

Orthogonal, but riding along is also a tweak to the data capture of enqueued times for diagnostics, as discussed in: #10324

# Last Upstream Rebase

Friday, March 13, 2:26pm (EST)

# References and Related Issues 

- [.NET Event Hubs Client: Event Processor<T> Proposal](https://gist.github.com/jsquire/1f4a1e72fc02871f443ce365222d40f6)
- [Implement the Event Processor Base](https://github.com/Azure/azure-sdk-for-net/issues/9324) (#9324)