### PR TITLE
Improve CODEOWNERS for Search

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,7 +33,10 @@
 /sdk/keyvault/ @schaabs @heaths
 
 /sdk/search/ @brjohnstmsft @arv100kri @bleroy @tg-msft @heaths
+/sdk/search/Microsoft.*/ @brjohnstmsft @arv100kri @bleroy
+
 /sdk/servicebus/ @nemakam @jsquire
+
 /sdk/storage/ @seanmcc-msft @amnguye @tg-msft @JoshLove-msft
 
 /sdk/textanalytics/ @annelo-msft @maririos


### PR DESCRIPTION
We want to get a better sense of who owns what. I choose this exclusive pattern because most if not all of the files in sdk/search/* the Azure SDK team owns as part of our infrastructure. Since you, @arv100kri, @bleroy, and @brjohnstmsft have expressed interest in tracking track 2 changes and are helping with the effort, I've kept all of us as track 2 owners. We can change this at any time as well.

My eventual goal is to generate a mapping of which packages Azure SDK team owns based on CODEOWNERS, so I wanted to be more appropriately specific.