### PR TITLE
Smoke Tests use dynamic resource allocation

### DIFF
--- a/common/SmokeTests/SmokeTest/test-resources.json
+++ b/common/SmokeTests/SmokeTest/test-resources.json
@@ -3,7 +3,8 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "location": {
-            "type": "string"
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]"
         },
         "baseName": {
             "type": "string"

--- a/common/SmokeTests/SmokeTest/test-resources.json
+++ b/common/SmokeTests/SmokeTest/test-resources.json
@@ -1,0 +1,309 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "location": {
+            "type": "string"
+        },
+        "baseName": {
+            "type": "string"
+        },
+        "testApplicationId": {
+            "type": "string"
+        },
+        "testApplicationSecret": {
+            "type": "string"
+        },
+        "testApplicationOid": {
+            "type": "string"
+        },
+        "tenantId": {
+            "type": "string"
+        },
+        "storageEndpointSuffix": {
+            "type": "string"
+        },
+        "authorityHost": {
+            "type": "string"
+        }
+    },
+    "variables": {
+        "keyVaultName": "[format('kv-smk-{0}', parameters('baseName'))]",
+        "eventHubNamespaceName": "[format('eh-smoke-{0}', parameters('baseName'))]",
+        "eventHubName": "myeventhub",
+        "eventHubAuthorizationRuleName": "RootManageSharedAccessKey",
+        "storageAccountName": "[format('stsmoke{0}', parameters('baseName'))]",
+        "cosmosDbAccountName": "[format('co-smoke-{0}', parameters('baseName'))]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts",
+            "apiVersion": "2019-12-12",
+            "name": "[variables('cosmosDbAccountName')]",
+            "location": "[parameters('location')]",
+            "tags": {
+                "defaultExperience": "Core (SQL)"
+            },
+            "kind": "GlobalDocumentDB",
+            "properties": {
+                "enableAutomaticFailover": false,
+                "enableMultipleWriteLocations": false,
+                "isVirtualNetworkFilterEnabled": false,
+                "virtualNetworkRules": [],
+                "disableKeyBasedMetadataWriteAccess": false,
+                "databaseAccountOfferType": "Standard",
+                "consistencyPolicy": {
+                    "defaultConsistencyLevel": "Session",
+                    "maxIntervalInSeconds": 5,
+                    "maxStalenessPrefix": 100
+                },
+                "locations": [
+                    {
+                        "locationName": "[parameters('location')]",
+                        "provisioningState": "Succeeded",
+                        "failoverPriority": 0,
+                        "isZoneRedundant": false
+                    }
+                ],
+                "capabilities": []
+            }
+        },
+        {
+            "type": "Microsoft.EventHub/namespaces",
+            "apiVersion": "2018-01-01-preview",
+            "name": "[variables('eventHubNamespaceName')]",
+            "location": "[parameters('location')]",
+            "sku": {
+                "name": "Basic",
+                "tier": "Basic",
+                "capacity": 1
+            },
+            "properties": {
+                "zoneRedundant": false,
+                "isAutoInflateEnabled": false,
+                "maximumThroughputUnits": 0,
+                "kafkaEnabled": false
+            }
+        },
+        {
+            "type": "Microsoft.KeyVault/vaults",
+            "apiVersion": "2016-10-01",
+            "name": "[variables('keyVaultName')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "sku": {
+                    "family": "A",
+                    "name": "standard"
+                },
+                "tenantId": "[parameters('tenantId')]",
+                "accessPolicies": [
+                    {
+                        "tenantId": "[parameters('tenantId')]",
+                        "objectId": "[parameters('testApplicationOid')]",
+                        "permissions": {
+                            "keys": [
+                                "backup",
+                                "create",
+                                "decrypt",
+                                "delete",
+                                "encrypt",
+                                "get",
+                                "import",
+                                "list",
+                                "purge",
+                                "recover",
+                                "restore",
+                                "sign",
+                                "unwrapKey",
+                                "update",
+                                "verify",
+                                "wrapKey"
+                            ],
+                            "secrets": [
+                                "backup",
+                                "delete",
+                                "get",
+                                "list",
+                                "purge",
+                                "recover",
+                                "restore",
+                                "set"
+                            ],
+                            "certificates": [
+                                "backup",
+                                "create",
+                                "delete",
+                                "deleteissuers",
+                                "get",
+                                "getissuers",
+                                "import",
+                                "list",
+                                "listissuers",
+                                "managecontacts",
+                                "manageissuers",
+                                "purge",
+                                "recover",
+                                "restore",
+                                "setissuers",
+                                "update"
+                            ]
+                        }
+                    }
+                ],
+                "enabledForDeployment": false,
+                "enabledForDiskEncryption": false,
+                "enabledForTemplateDeployment": false
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "apiVersion": "2019-06-01",
+            "name": "[variables('storageAccountName')]",
+            "location": "[parameters('location')]",
+            "sku": {
+                "name": "Standard_RAGRS",
+                "tier": "Standard"
+            },
+            "kind": "StorageV2",
+            "properties": {
+                "networkAcls": {
+                    "bypass": "AzureServices",
+                    "virtualNetworkRules": [],
+                    "ipRules": [],
+                    "defaultAction": "Allow"
+                },
+                "supportsHttpsTrafficOnly": true,
+                "encryption": {
+                    "services": {
+                        "file": {
+                            "keyType": "Account",
+                            "enabled": true
+                        },
+                        "blob": {
+                            "keyType": "Account",
+                            "enabled": true
+                        }
+                    },
+                    "keySource": "Microsoft.Storage"
+                },
+                "accessTier": "Hot"
+            }
+        },
+        {
+            "type": "Microsoft.EventHub/namespaces/AuthorizationRules",
+            "apiVersion": "2017-04-01",
+            "name": "[format('{0}/{1}', variables('eventHubNamespaceName'), variables('eventHubAuthorizationRuleName'))]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.EventHub/namespaces', variables('eventHubNamespaceName'))]"
+            ],
+            "properties": {
+                "rights": [
+                    "Listen",
+                    "Manage",
+                    "Send"
+                ]
+            }
+        },
+        {
+            "type": "Microsoft.EventHub/namespaces/eventhubs",
+            "apiVersion": "2017-04-01",
+            "name": "[format('{0}/{1}', variables('eventHubNamespaceName'), variables('eventHubName'))]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.EventHub/namespaces', variables('eventHubNamespaceName'))]"
+            ],
+            "properties": {
+                "messageRetentionInDays": 1,
+                "partitionCount": 2,
+                "status": "Active"
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/blobServices",
+            "apiVersion": "2019-06-01",
+            "name": "[concat(variables('storageAccountName'), '/default')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+            ],
+            "sku": {
+                "name": "Standard_RAGRS"
+            },
+            "properties": {
+                "cors": {
+                    "corsRules": []
+                },
+                "deleteRetentionPolicy": {
+                    "enabled": false
+                }
+            }
+        },
+        {
+            "type": "Microsoft.EventHub/namespaces/eventhubs/authorizationRules",
+            "apiVersion": "2017-04-01",
+            "name": "[concat(variables('eventHubNamespaceName'), '/myeventhub/Test')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.EventHub/namespaces/eventhubs', variables('eventHubNamespaceName'), 'myeventhub')]",
+                "[resourceId('Microsoft.EventHub/namespaces', variables('eventHubNamespaceName'))]"
+            ],
+            "properties": {
+                "rights": [
+                    "Manage",
+                    "Listen",
+                    "Send"
+                ]
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+            "apiVersion": "2019-06-01",
+            "name": "[concat(variables('storageAccountName'), '/default/mycontainer')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/blobServices', variables('storageAccountName'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+            ],
+            "properties": {
+                "publicAccess": "None"
+            }
+        }
+    ],
+    "outputs": {
+        "AZURE_TENANT_ID": {
+            "type": "string",
+            "value": "[parameters('tenantId')]"
+        },
+        "AZURE_CLIENT_ID": {
+            "type": "string",
+            "value": "[parameters('testApplicationId')]"
+        },
+        "AZURE_CLIENT_SECRET": {
+            "type": "string",
+            "value": "[parameters('testApplicationSecret')]"
+        },
+        "AZURE_AUTHORITY_HOST": {
+            "type": "string",
+            "value": "[parameters('authorityHost')]"
+        },
+        "KEY_VAULT_URI": {
+            "type": "string",
+            "value": "[reference(variables('keyVaultName')).vaultUri]"
+        },
+        "EVENT_HUBS_CONNECTION_STRING": {
+            "type": "string",
+            "value": "[listKeys(resourceId('Microsoft.EventHub/namespaces/eventhubs/authorizationRules', variables('eventHubNamespaceName'),  variables('eventHubName'), 'Test'), '2017-04-01').primaryConnectionString]"
+        },
+        "BLOB_CONNECTION_STRING": {
+            "type": "string",
+            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2019-06-01').keys[0].value, ';EndpointSuffix=', parameters('storageEndpointSuffix'))]"
+        },
+        "COSMOS_AUTH_KEY": {
+            "type": "string",
+            "value": "[listKeys(variables('cosmosDbAccountName'), '2019-12-12').primaryMasterKey]"
+        },
+        "COSMOS_URI": {
+            "type": "string",
+            "value": "[reference(variables('cosmosDbAccountName')).documentEndpoint]"
+        }
+    }
+}

--- a/eng/pipelines/smoke-tests.yml
+++ b/eng/pipelines/smoke-tests.yml
@@ -6,38 +6,62 @@ jobs:
 
     strategy:
       matrix:
-        Linux (Public):
+        Linux (AzureCloud):
           OSName: "Linux"
           OSVmImage: "ubuntu-16.04"
           TestTargetFramework: netcoreapp2.1
-          CloudType: public
-        Windows_NetCoreApp (Public):
+          CloudType: AzureCloud
+          ArmTemplateParameters: $(azureCloudArmParameters)
+        Windows_NetCoreApp (AzureCloud):
           OSName: "Windows"
           OSVmImage: "windows-2019"
           TestTargetFramework: netcoreapp2.1
-          CloudType: public
-        Windows_NetFramework (Public):
+          CloudType: AzureCloud
+          ArmTemplateParameters: $(azureCloudArmParameters)
+        Windows_NetFramework (AzureCloud):
           OSName: "Windows"
           OSVmImage: "windows-2019"
           TestTargetFramework: net461
-          CloudType: public
-        MacOs (Public):
+          CloudType: AzureCloud
+          ArmTemplateParameters: $(azureCloudArmParameters)
+        MacOs (AzureCloud):
           OSName: "MacOS"
           OSVmImage: "macOS-10.15"
           TestTargetFramework: netcoreapp2.1
-          CloudType: public
-        Windows_NetCoreApp (Gov):
+          CloudType: AzureCloud
+          ArmTemplateParameters: $(azureCloudArmParameters)
+        Windows_NetCoreApp (AzureUSGovernment):
           OSName: "Windows"
           OSVmImage: "windows-2019"
           TestTargetFramework: netcoreapp2.1
-          CloudType: gov
-        Windows_NetFramework (Gov):
+          CloudType: AzureUSGovernment
+          ArmTemplateParameters: $(azureUSGovernmentArmParameters)
+        Windows_NetFramework (AzureUSGovernment):
           OSName: "Windows"
           OSVmImage: "windows-2019"
           TestTargetFramework: net461
-          CloudType: gov
+          CloudType: AzureUSGovernment
+          ArmTemplateParameters: $(azureUSGovernmentArmParameters)
+        Windows_NetCoreApp (AzureChinaCloud):
+          OSName: "Windows"
+          OSVmImage: "windows-2019"
+          TestTargetFramework: netcoreapp2.1
+          CloudType: AzureChinaCloud
+          ArmTemplateParameters: $(azureChinaCloudArmParameters)
+        Windows_NetFramework (AzureChinaCloud):
+          OSName: "Windows"
+          OSVmImage: "windows-2019"
+          TestTargetFramework: net461
+          CloudType: AzureChinaCloud
+          ArmTemplateParameters: $(azureChinaCloudArmParameters)
+
     pool:
       vmImage: $(OSVmImage)
+
+    variables:
+      azureCloudArmParameters: "@{ storageEndpointSuffix = 'core.windows.net'; authorityHost = 'https://login.microsoftonline.com'; }"
+      azureUSGovernmentArmParameters: "@{ storageEndpointSuffix = 'core.usgovcloudapi.net'; authorityHost = 'https://login.microsoftonline.us/'; }"
+      azureChinaCloudArmParameters: "@{ storageEndpointSuffix = 'core.chinacloudapi.cn'; authorityHost = 'https://login.chinacloudapi.cn'; }"
 
     steps:
       - task: DotNetCoreInstaller@2
@@ -70,43 +94,10 @@ jobs:
       - template: ../common/TestResources/deploy-test-resources.yml
         parameters:
           ServiceDirectory: '$(Build.SourcesDirectory)/common/SmokeTests/'
-          TenantId: $(aad-azure-sdk-test-tenant-id)
-          TestApplicationId: $(aad-azure-sdk-test-client-id)
-          TestApplicationSecret: $(aad-azure-sdk-test-client-secret)
-          TestApplicationObjectId: $(aad-azure-sdk-test-client-oid)
-          ProvisionerApplicationId: $(provisioner-aad-id)
-          ProvisionerApplicationSecret: $(provisioner-aad-secret)
-          AdditionalParameters: "@{ storageEndpointSuffix = 'core.windows.net'; authorityHost = 'https://login.microsoftonline.com' }"
-          Condition: and(succeeded(), eq(variables['CloudType'], 'public'))
-
-      - template: ../common/TestResources/deploy-test-resources.yml
-        parameters:
-          ServiceDirectory: $(Build.SourcesDirectory)/common/SmokeTests/
-          TenantId: $(aad-azure-sdk-test-tenant-id-gov)
-          TestApplicationId: $(aad-azure-sdk-test-client-id-gov)
-          TestApplicationSecret: $(aad-azure-sdk-test-client-secret-gov)
-          TestApplicationObjectId: $(aad-azure-sdk-test-client-oid-gov)
-          ProvisionerApplicationId: $(provisioner-aad-id-gov)
-          ProvisionerApplicationSecret: $(provisioner-aad-secret-gov)
-          AdditionalParameters: "@{ storageEndpointSuffix = 'core.usgovcloudapi.net'; authorityHost = 'https://login.microsoftonline.us/' }"
-          Location: usgovvirginia
-          Environment: AzureUSGovernment
-          Condition: and(succeeded(), eq(variables['CloudType'], 'gov'))
+          CloudType: $(CloudType)
+          ArmTemplateParameters: $(ArmTemplateParameters)
 
       - pwsh: dotnet run -p .\common\SmokeTests\SmokeTest\SmokeTest.csproj --framework $(TestTargetFramework)
         displayName: "Run Smoke Tests"
 
       - template: ../common/TestResources/remove-test-resources.yml
-        parameters:
-          TenantId: $(aad-azure-sdk-test-tenant-id)
-          ProvisionerApplicationId: $(provisioner-aad-id)
-          ProvisionerApplicationSecret: $(provisioner-aad-secret)
-          Condition: eq(variables['CloudType'], 'public')
-
-      - template: ../common/TestResources/remove-test-resources.yml
-        parameters:
-          TenantId: $(aad-azure-sdk-test-tenant-id-gov)
-          ProvisionerApplicationId: $(provisioner-aad-id-gov)
-          ProvisionerApplicationSecret: $(provisioner-aad-secret-gov)
-          Environment: AzureUSGovernment
-          Condition: eq(variables['CloudType'], 'gov')

--- a/eng/pipelines/smoke-tests.yml
+++ b/eng/pipelines/smoke-tests.yml
@@ -67,46 +67,46 @@ jobs:
       - pwsh: dotnet restore ./common/SmokeTests/SmokeTest/SmokeTest.csproj
         displayName: dotnet restore
 
-      # Set secret environment variables for different clouds
-      - pwsh: |
-          $variables = @{
-            KEY_VAULT_URI='$(smoke-tests-key-vault-project-url)'
-            EVENT_HUBS_CONNECTION_STRING='$(smoke-tests-event-hubs-connection-string)'
-            BLOB_CONNECTION_STRING='$(smoke-tests-storage-connection-string)'
-            AZURE_CLIENT_SECRET='$(aad-azure-sdk-test-client-secret)'
-            AZURE_TENANT_ID='$(aad-azure-sdk-test-tenant-id)'
-            AZURE_CLIENT_ID='$(aad-azure-sdk-test-client-id)'
-            AZURE_AUTHORITY_HOST='$(aad-azure-sdk-test-authority-uri)'
-            COSMOS_AUTH_KEY='$(smoke-tests-cosmos-key)'
-            COSMOS_URI='$(smoke-tests-cosmos-endpoint)'
-          };
-          foreach ($key in $variables.Keys) {
-            Write-Host "Setting variable '$key'"
-            Write-Host "##vso[task.setvariable variable=_$key;issecret=true;]$($variables[$key])"
-            Write-Host "##vso[task.setvariable variable=$key;]$($variables[$key])"
-          }
-        displayName: Set secrets for public cloud
-        condition: and(succeeded(), eq(variables['CloudType'], 'public'))
+      - template: ../common/TestResources/deploy-test-resources.yml
+        parameters:
+          ServiceDirectory: '$(Build.SourcesDirectory)/common/SmokeTests/'
+          TenantId: $(aad-azure-sdk-test-tenant-id)
+          TestApplicationId: $(aad-azure-sdk-test-client-id)
+          TestApplicationSecret: $(aad-azure-sdk-test-client-secret)
+          TestApplicationObjectId: $(aad-azure-sdk-test-client-oid)
+          ProvisionerApplicationId: $(provisioner-aad-id)
+          ProvisionerApplicationSecret: $(provisioner-aad-secret)
+          AdditionalParameters: "@{ storageEndpointSuffix = 'core.windows.net'; authorityHost = 'https://login.microsoftonline.com' }"
+          Condition: and(succeeded(), eq(variables['CloudType'], 'public'))
 
-      - pwsh: |
-          $variables = @{
-            KEY_VAULT_URI='$(smoke-tests-key-vault-project-url-gov)'
-            EVENT_HUBS_CONNECTION_STRING='$(smoke-tests-event-hubs-connection-string-gov)'
-            BLOB_CONNECTION_STRING='$(smoke-tests-storage-connection-string-gov)'
-            AZURE_CLIENT_SECRET='$(aad-azure-sdk-test-client-secret-gov)'
-            AZURE_TENANT_ID='$(aad-azure-sdk-test-tenant-id-gov)'
-            AZURE_CLIENT_ID='$(aad-azure-sdk-test-client-id-gov)'
-            AZURE_AUTHORITY_HOST='$(aad-azure-sdk-test-authority-uri-gov)'
-            COSMOS_AUTH_KEY='$(smoke-tests-cosmos-key-gov)'
-            COSMOS_URI='$(smoke-tests-cosmos-endpoint-gov)'
-          };
-          foreach ($key in $variables.Keys) {
-            Write-Host "Setting variable '$key'"
-            Write-Host "##vso[task.setvariable variable=_$key;issecret=true;]$($variables[$key])"
-            Write-Host "##vso[task.setvariable variable=$key;]$($variables[$key])"
-          }
-        displayName: Set secrets for government cloud
-        condition: and(succeeded(), eq(variables['CloudType'], 'gov'))
+      - template: ../common/TestResources/deploy-test-resources.yml
+        parameters:
+          ServiceDirectory: $(Build.SourcesDirectory)/common/SmokeTests/
+          TenantId: $(aad-azure-sdk-test-tenant-id-gov)
+          TestApplicationId: $(aad-azure-sdk-test-client-id-gov)
+          TestApplicationSecret: $(aad-azure-sdk-test-client-secret-gov)
+          TestApplicationObjectId: $(aad-azure-sdk-test-client-oid-gov)
+          ProvisionerApplicationId: $(provisioner-aad-id-gov)
+          ProvisionerApplicationSecret: $(provisioner-aad-secret-gov)
+          AdditionalParameters: "@{ storageEndpointSuffix = 'core.usgovcloudapi.net'; authorityHost = 'https://login.microsoftonline.us/' }"
+          Location: usgovvirginia
+          Environment: AzureUSGovernment
+          Condition: and(succeeded(), eq(variables['CloudType'], 'gov'))
 
       - pwsh: dotnet run -p .\common\SmokeTests\SmokeTest\SmokeTest.csproj --framework $(TestTargetFramework)
         displayName: "Run Smoke Tests"
+
+      - template: ../common/TestResources/remove-test-resources.yml
+        parameters:
+          TenantId: $(aad-azure-sdk-test-tenant-id)
+          ProvisionerApplicationId: $(provisioner-aad-id)
+          ProvisionerApplicationSecret: $(provisioner-aad-secret)
+          Condition: eq(variables['CloudType'], 'public')
+
+      - template: ../common/TestResources/remove-test-resources.yml
+        parameters:
+          TenantId: $(aad-azure-sdk-test-tenant-id-gov)
+          ProvisionerApplicationId: $(provisioner-aad-id-gov)
+          ProvisionerApplicationSecret: $(provisioner-aad-secret-gov)
+          Environment: AzureUSGovernment
+          Condition: eq(variables['CloudType'], 'gov')


### PR DESCRIPTION
Use dynamic resource allocation (from eng/common) to allocate smoke test resources.

Changes in https://github.com/Azure/azure-sdk-tools/pull/447 should merge first to supersede the set of changes in `eng/common` in this PR. 