### PR TITLE
[Event Hubs Client] Miscellaneous Minor Improvements

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -468,7 +468,7 @@ namespace Azure.Messaging.EventHubs
         {
             Argument.AssertNotNull(checkpointStore, nameof(checkpointStore));
             Argument.AssertNotNullOrEmpty(consumerGroup, nameof(consumerGroup));
-            Argument.AssertNotNullOrEmpty(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace));
+            Argument.AssertWellFormedEventHubsNamespace(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace));
             Argument.AssertNotNullOrEmpty(eventHubName, nameof(eventHubName));
             Argument.AssertNotNull(credential, nameof(credential));
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientTests.cs
@@ -111,6 +111,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         [TestCase(null)]
         [TestCase("")]
+        [TestCase("http://namspace.servciebus.windows.com")]
         public void ConstructorValidatesTheNamespace(string constructorArgument)
         {
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Core/Argument.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Core/Argument.cs
@@ -124,11 +124,34 @@ namespace Azure.Core
         /// <param name="wasClosed"><c>true</c> if the target instance has been closed; otherwise, <c>false</c>.</param>
         /// <param name="targetName">The name of the target instance that is being verified.</param>
         ///
+        /// <exception cref="EventHubsException"><paramref name="wasClosed"/> is <c>true</c>.</exception>
+        ///
         public static void AssertNotClosed(bool wasClosed, string targetName)
         {
             if (wasClosed)
             {
                 throw new EventHubsException(targetName, string.Format(CultureInfo.CurrentCulture, Resources.ClosedInstanceCannotPerformOperation, targetName), EventHubsException.FailureReason.ClientClosed);
+            }
+        }
+
+        /// <summary>
+        ///   Ensures that an argument's value is a well-formed Event Hubs fully qualified namespace value,
+        ///   throwing a <see cref="ArgumentException" /> if that invariant is not met.
+        /// </summary>
+        ///
+        /// <param name="argumentValue">The argument value.</param>
+        /// <param name="argumentName">Name of the argument.</param>
+        ///
+        ///
+        /// <exception cref="ArgumentException"><paramref name="argumentValue"/> is not a well-formed Event Hubs fully qualified namespace.</exception>
+        ///
+        public static void AssertWellFormedEventHubsNamespace(string argumentValue, string argumentName)
+        {
+            argumentValue ??= string.Empty;
+
+            if (Uri.CheckHostName(argumentValue) == UriHostNameType.Unknown)
+            {
+                throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, Resources.InvalidFullyQualifiedNamespace, argumentValue), argumentName);
             }
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
@@ -243,6 +243,17 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to The value '{0}' is not a well-formed Event Hubs fully qualified namespace..
+        /// </summary>
+        internal static string InvalidFullyQualifiedNamespace
+        {
+            get
+            {
+                return ResourceManager.GetString("InvalidFullyQualifiedNamespace", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to An invalid message body was encountered.  Either the body was null or an incorrect type. Expected: {0}.
         /// </summary>
         internal static string InvalidMessageBody

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
@@ -270,4 +270,7 @@
   <data name="DeveloperCodeExceptionMessageMask" xml:space="preserve">
     <value>[Developer Code Exception] : {0}.</value>
   </data>
+  <data name="InvalidFullyQualifiedNamespace" xml:space="preserve">
+    <value>The value '{0}' is not a well-formed Event Hubs fully qualified namespace.</value>
+  </data>
 </root>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubScope.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Consumer;
 using Microsoft.Azure.Management.EventHub;
 using Microsoft.Azure.Management.EventHub.Models;
 using Microsoft.Azure.Management.ResourceManager;
@@ -269,6 +270,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     })
                 ).ConfigureAwait(false);
 
+                groups.Insert(0, EventHubConsumerClient.DefaultConsumerGroupName);
                 return new EventHubScope(eventHub.Name, groups, shouldRemoveEventHubAtScopeCompletion: true);
             }
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Core/ArgumentTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Core/ArgumentTests.cs
@@ -197,5 +197,39 @@ namespace Azure.Messaging.EventHubs.Tests
             var target = "test";
             Assert.That(() => Argument.AssertNotClosed(true, target), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed).And.Message.Contains(target));
         }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="Argument.AssertWellFormedFullyQualifiedNamespace" /> method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("sb://myhub.servicebus.windows")]
+        [TestCase("sb://192.168.1.15")]
+        [TestCase("amqps://myhub.servicebus.windows")]
+        [TestCase("amqps://192.168.1.15")]
+        [TestCase("http://myhub.servicebus.windows")]
+        [TestCase("https://192.168.1.15")]
+        public void AssertWellFormedFullyQualifiedNamespaceEnforcesInvariants(string value)
+        {
+            Assert.That(() => Argument.AssertWellFormedEventHubsNamespace(value, nameof(value)), Throws.ArgumentException.And.Property(nameof(ArgumentException.ParamName)).EqualTo(nameof(value)));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="Argument.AssertWellFormedFullyQualifiedNamespace" /> method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase("myhub")]
+        [TestCase("myhub.servicebus.windows.com")]
+        [TestCase("myhub.servicebus.microsoft.ca")]
+        [TestCase("myhub.place.jp")]
+        [TestCase("192.168.1.12")]
+        [TestCase("2001:0000:3238:DFE1:0063:0000:0000:FEFB")]
+        public void AssertWellFormedFullyQualifiedNamespaceAllowsValidValues(string value)
+        {
+            Assert.That(() => Argument.AssertWellFormedEventHubsNamespace(value, nameof(value)), Throws.Nothing);
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -291,7 +291,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                         }
                         else if (ex is AmqpException)
                         {
-                            throw activeEx;
+                            ExceptionDispatchInfo.Capture(activeEx).Throw();
                         }
                         else
                         {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
@@ -221,7 +221,7 @@ namespace Azure.Messaging.EventHubs.Consumer
                                       EventHubConsumerClientOptions clientOptions = default)
         {
             Argument.AssertNotNullOrEmpty(consumerGroup, nameof(consumerGroup));
-            Argument.AssertNotNullOrEmpty(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace));
+            Argument.AssertWellFormedEventHubsNamespace(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace));
             Argument.AssertNotNullOrEmpty(eventHubName, nameof(eventHubName));
             Argument.AssertNotNull(credential, nameof(credential));
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnection.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnection.cs
@@ -189,7 +189,7 @@ namespace Azure.Messaging.EventHubs
                                   TokenCredential credential,
                                   EventHubConnectionOptions connectionOptions = default)
         {
-            Argument.AssertNotNullOrEmpty(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace));
+            Argument.AssertWellFormedEventHubsNamespace(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace));
             Argument.AssertNotNullOrEmpty(eventHubName, nameof(eventHubName));
             Argument.AssertNotNull(credential, nameof(credential));
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessorStatus.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessorStatus.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Messaging.EventHubs.Primitives
+{
+    /// <summary>
+    ///   Represents the state of an event processor.
+    /// </summary>
+    ///
+    internal enum EventProcessorStatus
+    {
+        /// <summary>The processor is not running and in a good state.</summary>
+        NotRunning,
+
+        /// <summary>The processor is running and actively processing events.</summary>
+        Running,
+
+        /// <summary>The processor has begun its initialization, which is still in progress.</summary>
+        Starting,
+
+        /// <summary>The processor has begun shutting down, which is still in progress.</summary>
+        Stopping,
+
+        /// <summary>The processor is not running and in a bad state; Stop must be called to reset state.</summary>
+        Faulted
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
@@ -200,7 +200,7 @@ namespace Azure.Messaging.EventHubs.Primitives
         {
             Argument.AssertNotNullOrEmpty(consumerGroup, nameof(consumerGroup));
             Argument.AssertNotNullOrEmpty(partitionId, nameof(partitionId));
-            Argument.AssertNotNullOrEmpty(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace));
+            Argument.AssertWellFormedEventHubsNamespace(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace));
             Argument.AssertNotNullOrEmpty(eventHubName, nameof(eventHubName));
             Argument.AssertNotNull(credential, nameof(credential));
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -207,8 +207,7 @@ namespace Azure.Messaging.EventHubs.Producer
                                       TokenCredential credential,
                                       EventHubProducerClientOptions clientOptions = default)
         {
-            Argument.AssertNotNullOrEmpty(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace));
-            Argument.AssertNotNullOrEmpty(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace));
+            Argument.AssertWellFormedEventHubsNamespace(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace));
             Argument.AssertNotNullOrEmpty(eventHubName, nameof(eventHubName));
             Argument.AssertNotNull(credential, nameof(credential));
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Connection/EventHubConnectionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Connection/EventHubConnectionTests.cs
@@ -38,6 +38,7 @@ namespace Azure.Messaging.EventHubs.Tests
             yield return new object[] { "FakeNamespace", null, credential.Object };
             yield return new object[] { "FakNamespace", "", credential.Object };
             yield return new object[] { "FakeNamespace", "FakePath", null };
+            yield return new object[] { "sb://fakenamspace.com", "FakePath", credential.Object };
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
@@ -2112,9 +2112,9 @@ namespace Azure.Messaging.EventHubs.Tests
                                                                       EventPosition startingPosition,
                                                                       ReadEventOptions readOptions = default,
                                                                       int expectedEventCount = int.MaxValue,
-                                                                      int consecutiveEmptyLimit = 15,
-                                                                      int consecutiveEmptyDelayThreshold = 5,
-                                                                      int consecutiveEmptyDelayMilliseconds = 250,
+                                                                      int consecutiveEmptyLimit = 20,
+                                                                      int consecutiveEmptyDelayThreshold = 8,
+                                                                      int consecutiveEmptyDelayMilliseconds = 350,
                                                                       Func<Task<bool>> iterationCallback = default,
                                                                       CancellationToken cancellationToken = default)
         {
@@ -2178,9 +2178,9 @@ namespace Azure.Messaging.EventHubs.Tests
                                                                       ReadEventOptions readOptions = default,
                                                                       bool startReadingAtFirst = true,
                                                                       int expectedEventCount = int.MaxValue,
-                                                                      int consecutiveEmptyLimit = 15,
-                                                                      int consecutiveEmptyDelayThreshold = 5,
-                                                                      int consecutiveEmptyDelayMilliseconds = 250,
+                                                                      int consecutiveEmptyLimit = 20,
+                                                                      int consecutiveEmptyDelayThreshold = 8,
+                                                                      int consecutiveEmptyDelayMilliseconds = 350,
                                                                       Func<Task<bool>> iterationCallback = default,
                                                                       CancellationToken cancellationToken = default)
         {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
@@ -86,6 +86,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         [TestCase(null)]
         [TestCase("")]
+        [TestCase("amqp://namespace.place.ext")]
         public void ConstructorValidatesTheNamespace(string constructorArgument)
         {
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverTests.cs
@@ -73,6 +73,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         [TestCase(null)]
         [TestCase("")]
+        [TestCase("amqps://namespace.windows.servicebus.net")]
         public void ConstructorValidatesTheFullyQualifiedNamespace(string fullyQualifiedNamespace)
         {
             Assert.That(() => new PartitionReceiver("cg", "pid", EventPosition.Earliest, fullyQualifiedNamespace, "eh", Mock.Of<TokenCredential>()), Throws.InstanceOf<ArgumentException>(), "The constructor should perform validation.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
@@ -44,6 +44,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         [TestCase(null)]
         [TestCase("")]
+        [TestCase("sb://test.place.com")]
         public void ConstructorValidatesTheNamespace(string constructorArgument)
         {
             var credential = new Mock<EventHubTokenCredential>(Mock.Of<TokenCredential>(), "{namespace}.servicebus.windows.net");


### PR DESCRIPTION
# Summary

These changes are intended to address several unrelated, but small areas of improvement.   Included are:

- Tweaks to test timings for consumer live tests, to improve nightly run stability

- Improve validation for the fully qualified namespace, ensuring it is well-formed.  This addresses the primary point of failure for #10576 and has been applied across all client types.

- Adds an internal `Status` member to the Event Processor as a better representation of transitional state, intended primarily to aid in debugging and test scenarios.  While there  may be value in exposing this to public or protected callers, there exists a potential to pollute or introduce breaking changes to the public API for the `EventProcessorClient` so the decision was made to keep the `internal` focus for now; should there be scenarios which warrant it, discussions can take place to increase visibility in the future.

- Fixes an incorrect re-throw of an observed exception within the AMQP consumer; the dispatcher is now used to rethrow without losing the original context.

- Includes the `$Default` consumer group in the set returned by the `EventHubScope` to live tests;  previously, this only included those which tests specifically asked for as special cases and left the default as an implied member.

# Last Upstream Rebase

Sunday, March 15, 12:31pm (EST)