### PR TITLE
Extend storage timeout for init store calls.

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/AzureStorageCheckpointLeaseManager.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/AzureStorageCheckpointLeaseManager.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.EventHubs.Processor
         TimeSpan leaseDuration;
         TimeSpan leaseRenewInterval;
 
-        static readonly TimeSpan storageMaximumExecutionTime = TimeSpan.FromMinutes(2);
+        static readonly TimeSpan storageMaximumExecutionTime = TimeSpan.FromMinutes(1);
         readonly CloudStorageAccount cloudStorageAccount;
         readonly string leaseContainerName;
         readonly string storageBlobPrefix;
@@ -166,12 +166,12 @@ namespace Microsoft.Azure.EventHubs.Processor
 
         public Task<bool> LeaseStoreExistsAsync()
         {
-            return this.eventHubContainer.ExistsAsync(this.defaultRequestOptions, this.operationContext);
+            return this.eventHubContainer.ExistsAsync(null, this.operationContext);
         }
 
         public Task<bool> CreateLeaseStoreIfNotExistsAsync()
         {
-            return this.eventHubContainer.CreateIfNotExistsAsync(this.defaultRequestOptions, this.operationContext);
+            return this.eventHubContainer.CreateIfNotExistsAsync(null, this.operationContext);
         }
 
         public async Task<bool> DeleteLeaseStoreAsync()


### PR DESCRIPTION
Init store code path does not need to run with small storage timeout.