### PR TITLE
[Event Hubs Client] Ignore Flaky tests

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.cs
@@ -1182,6 +1182,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        [Ignore("Intermittent CI failure; investigating")]
         public async Task CreatePartitionProcessorCanReadLastEventProperties()
         {
             using var cancellationSource = new CancellationTokenSource();
@@ -1221,6 +1222,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        [Ignore("Intermittent CI failure; investigating")]
         public async Task CreatePartitionProcessorCanReadLastEventPropertiesWhenTheConsumerIsReplaced()
         {
             using var cancellationSource = new CancellationTokenSource();


### PR DESCRIPTION
# Summary

The purpose of these changes is to suppress two tests that had intermittent failures in CI. 
_(ref: https://github.com/Azure/azure-sdk-for-net/pull/10562/checks?check_run_id=512203761)_

# Last Upstream Rebase

Tuesday, March 17, 9:17am (EST)