### PR TITLE
[Event Hubs Client] Test Fixes

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventPosition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventPosition.cs
@@ -180,7 +180,16 @@ namespace Azure.Messaging.EventHubs.Consumer
         /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
         ///
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override string ToString() => base.ToString();
+        public override string ToString() =>
+            this switch
+            {
+                EventPosition _ when (Offset == StartOfStreamOffset) => nameof(Earliest),
+                EventPosition _ when (Offset == EndOfStreamOffset) => nameof(Latest),
+                EventPosition _ when (!string.IsNullOrEmpty(Offset)) => $"Offset: [{ Offset }] | Inclusive: [{ IsInclusive }]",
+                EventPosition _ when (SequenceNumber.HasValue) => $"Sequence Number: [{ SequenceNumber }] | Inclusive: [{ IsInclusive }]",
+                EventPosition _ when (EnqueuedTime.HasValue) => $"Enqueued: [{ EnqueuedTime }]",
+                _ => base.ToString()
+            };
 
         /// <summary>
         ///   Corresponds to the event in the partition at the provided offset.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/LastEnqueuedEventProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/LastEnqueuedEventProperties.cs
@@ -128,7 +128,7 @@ namespace Azure.Messaging.EventHubs.Consumer
         /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
         ///
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override string ToString() => base.ToString();
+        public override string ToString() => $"Sequence: [{ SequenceNumber }] | Offset: [{ Offset }] | Enqueued: [{ EnqueuedTime }] | Last Received: [{ LastReceivedTime }]";
 
         /// <summary>
         ///   Determines whether the specified <see cref="LastEnqueuedEventProperties" /> instances are equal to each other.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventPositionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventPositionTests.cs
@@ -200,5 +200,27 @@ namespace Azure.Messaging.EventHubs.Tests
 
             Assert.That(first.GetHashCode(), Is.Not.EqualTo(second.GetHashCode()));
         }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventPosition.ToString "/>
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void ToStringReflectsTheState()
+        {
+            var inclusive = true;
+            var offset = 123;
+            var sequence = 778;
+            var enqueued = DateTimeOffset.Now.AddHours(1);
+
+            Assert.That(EventPosition.Earliest.ToString(), Contains.Substring(nameof(EventPosition.Earliest)), "Earliest should be represented.");
+            Assert.That(EventPosition.Latest.ToString(), Contains.Substring(nameof(EventPosition.Latest)), "Latest should be represented.");
+            Assert.That(EventPosition.FromOffset(offset).ToString(), Contains.Substring($"[{ offset }]"), "The offset should be represented.");
+            Assert.That(EventPosition.FromSequenceNumber(sequence).ToString(), Contains.Substring($"[{ sequence }]"), "The sequence should be represented.");
+            Assert.That(EventPosition.FromEnqueuedTime(enqueued).ToString(), Contains.Substring($"[{ enqueued }]"), "The enqueued time should be represented.");
+            Assert.That(EventPosition.FromOffset(offset, inclusive).ToString(), Contains.Substring($"[{ inclusive }]"), "The inclusive flag should be represented for the offset.");
+            Assert.That(EventPosition.FromSequenceNumber(sequence, inclusive).ToString(), Contains.Substring($"[{ inclusive }]"), "The inclusive flag should be represented for the sequence number.");
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/LastEnqueuedEventPropertiesTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/LastEnqueuedEventPropertiesTests.cs
@@ -119,5 +119,26 @@ namespace Azure.Messaging.EventHubs.Tests
 
             Assert.That(first.GetHashCode(), Is.Not.EqualTo(second.GetHashCode()));
         }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="LastEnqueuedEventProperties.ToString "/>
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void ToStringReflectsTheState()
+        {
+            var offset = 123;
+            var sequence = 778;
+            var enqueued = DateTimeOffset.Now.AddHours(1);
+            var received = DateTimeOffset.Now.AddHours(7);
+            var properties = new LastEnqueuedEventProperties(sequence, offset, enqueued, received);
+            var toStringValue = properties.ToString();
+
+            Assert.That(toStringValue, Contains.Substring($"[{ offset }]"), "The offset should be represented.");
+            Assert.That(toStringValue, Contains.Substring($"[{ sequence }]"), "The sequence number should be represented.");
+            Assert.That(toStringValue, Contains.Substring($"[{ enqueued }]"), "The enqueued time should be represented.");
+            Assert.That(toStringValue, Contains.Substring($"[{ received }]"), "The received time should be represented.");
+        }
     }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to fix a race condition that is believed to have been the root cause of the non-deterministic behavior in CI runs. _([example](https://dev.azure.com/azure-sdk/public/_build/results?buildId=300767&view=ms.vss-test-web.build-test-results-tab&runId=9593236&resultId=102638&paneView=debug))_  

Riding along are enhancements to the string version of the `EventPosition` and `LastEnqueuedEventProperties` types, which are treated as opaque values and offered little insight for failed equality checks or the structural composition.

# Last Upstream Rebase

Tuesday, March 17, 10:26am (EST)