### PR TITLE
[Event Hubs Client] Ignore Unstable Test

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.cs
@@ -2026,6 +2026,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        [Ignore("Test unstable in CI; requires investigation")]
         public async Task CreatePartitionProcessorProcessingTaskWrapsAnOperationCanceledExceptionAndConsidersItFatal()
         {
             using var cancellationSource = new CancellationTokenSource();


### PR DESCRIPTION
# Summary

These changes ignore a test that was reported as unstable during CI runs, so that it can be investigated and fixed.

# Last Upstream Rebase

Wednesday, March 18, 9:31am (EST)