### PR TITLE
Update DotNet release to call tools from eng common directory

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -67,7 +67,7 @@ stages:
                         Get-ChildItem $(Pipeline.Workspace)/${{artifact.safeName}}
                       displayName: Stage artifacts
                       timeoutInMinutes: 5
-                    - template: eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+                    - template: ../../../common/pipelines/templates/steps/create-tags-and-git-release.yml
                       parameters:
                         ArtifactLocation: $(Pipeline.Workspace)/${{artifact.safeName}}
                         PackageRepository: Nuget
@@ -156,7 +156,7 @@ stages:
                           Get-ChildItem -Recurse $(Pipeline.Workspace)/${{artifact.safeName}}
                         workingDirectory: $(Pipeline.Workspace)
                         displayName: Output Visible Artifacts
-                      - template: eng/common/pipelines/templates/steps/publish-blobs.yml
+                      - template: ../../../common/pipelines/templates/steps/publish-blobs.yml
                         parameters:
                           FolderForUpload: '$(Pipeline.Workspace)/${{artifact.safeName}}'
                           BlobSASKey: '$(azure-sdk-docs-prod-sas)'
@@ -183,7 +183,7 @@ stages:
                       - pwsh: |
                           eng/Update-PkgVersion.ps1 -ServiceDirectory '${{parameters.ServiceDirectory}}' -PackageName '${{artifact.name}}' -PackageDirName '${{artifact.directoryName}}'
                         displayName: Increment package version
-                      - template: eng/common/pipelines/templates/steps/create-pull-request.yml
+                      - template: ../../../common/pipelines/templates/steps/create-pull-request.yml
                         parameters:
                           RepoName: azure-sdk-for-net
                           PRBranchName: increment-package-version-${{ parameters.ServiceDirectory }}-$(Build.BuildId)

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -67,7 +67,7 @@ stages:
                         Get-ChildItem $(Pipeline.Workspace)/${{artifact.safeName}}
                       displayName: Stage artifacts
                       timeoutInMinutes: 5
-                    - template: eng/pipelines/templates/steps/create-tags-and-git-release.yml@azure-sdk-tools
+                    - template: ../../../common/pipelines/create-tags-and-git-release.yml
                       parameters:
                         ArtifactLocation: $(Pipeline.Workspace)/${{artifact.safeName}}
                         PackageRepository: Nuget
@@ -143,7 +143,7 @@ stages:
                 runOnce:
                   deploy:
                     steps:
-                      - checkout: azure-sdk-tools
+                      - checkout: self
                       - pwsh: |
                           New-Item -Type Directory -Name ${{artifact.safeName}} -Path $(Pipeline.Workspace)
                           New-Item -Type Directory -Name packages -Path $(Pipeline.Workspace)/${{artifact.safeName}}
@@ -156,14 +156,14 @@ stages:
                           Get-ChildItem -Recurse $(Pipeline.Workspace)/${{artifact.safeName}}
                         workingDirectory: $(Pipeline.Workspace)
                         displayName: Output Visible Artifacts
-                      - template: eng/pipelines/templates/steps/publish-blobs.yml@azure-sdk-tools
+                      - template: ../../../common/pipelines/publish-blobs.yml
                         parameters:
                           FolderForUpload: '$(Pipeline.Workspace)/${{artifact.safeName}}'
                           BlobSASKey: '$(azure-sdk-docs-prod-sas)'
                           BlobName: '$(azure-sdk-docs-prod-blob-name)'
                           TargetLanguage: 'dotnet'
                           # we override the regular script path because we have cloned the build tools repo as a separate artifact.
-                          ScriptPath: 'scripts/powershell/copy-docs-to-blobstorage.ps1'
+                          ScriptPath: 'eng/common/scripts/copy-docs-to-blobstorage.ps1'
 
           - ${{if ne(artifact.options.skipUpdatePackageVersion, 'true')}}:
             - deployment: UpdatePackageVersion
@@ -184,7 +184,7 @@ stages:
                           eng/Update-PkgVersion.ps1 -ServiceDirectory '${{parameters.ServiceDirectory}}' -PackageName '${{artifact.name}}' -PackageDirName '${{artifact.directoryName}}'
                         displayName: Increment package version
                       - template: tools/clone-buildtools/clone-buildtools.yml@azure-sdk-build-tools
-                      - template: eng/pipelines/templates/steps/create-pull-request.yml@azure-sdk-tools
+                      - template: ../../../common/pipelines/create-pull-request.yml
                         parameters:
                           RepoName: azure-sdk-for-net
                           PRBranchName: increment-package-version-${{ parameters.ServiceDirectory }}-$(Build.BuildId)

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -67,7 +67,7 @@ stages:
                         Get-ChildItem $(Pipeline.Workspace)/${{artifact.safeName}}
                       displayName: Stage artifacts
                       timeoutInMinutes: 5
-                    - template: ../../../common/pipelines/create-tags-and-git-release.yml
+                    - template: eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
                       parameters:
                         ArtifactLocation: $(Pipeline.Workspace)/${{artifact.safeName}}
                         PackageRepository: Nuget
@@ -156,7 +156,7 @@ stages:
                           Get-ChildItem -Recurse $(Pipeline.Workspace)/${{artifact.safeName}}
                         workingDirectory: $(Pipeline.Workspace)
                         displayName: Output Visible Artifacts
-                      - template: ../../../common/pipelines/publish-blobs.yml
+                      - template: eng/common/pipelines/templates/steps/publish-blobs.yml
                         parameters:
                           FolderForUpload: '$(Pipeline.Workspace)/${{artifact.safeName}}'
                           BlobSASKey: '$(azure-sdk-docs-prod-sas)'
@@ -183,14 +183,12 @@ stages:
                       - pwsh: |
                           eng/Update-PkgVersion.ps1 -ServiceDirectory '${{parameters.ServiceDirectory}}' -PackageName '${{artifact.name}}' -PackageDirName '${{artifact.directoryName}}'
                         displayName: Increment package version
-                      - template: tools/clone-buildtools/clone-buildtools.yml@azure-sdk-build-tools
-                      - template: ../../../common/pipelines/create-pull-request.yml
+                      - template: eng/common/pipelines/templates/steps/create-pull-request.yml
                         parameters:
                           RepoName: azure-sdk-for-net
                           PRBranchName: increment-package-version-${{ parameters.ServiceDirectory }}-$(Build.BuildId)
                           CommitMsg: "Increment package version after release of ${{ artifact.name }}"
                           PRTitle: "Increment version for ${{ parameters.ServiceDirectory }} releases"
-                          BuildToolsPath: $(AzureSDKBuildToolsPath)
 
   - stage: Integration
     dependsOn: Signing

--- a/sdk/template/Azure.Template/CHANGELOG.md
+++ b/sdk/template/Azure.Template/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 1.0.2-preview.10 (2020-03-23)
+- Test release pipeline
+
 ## 1.0.2-preview.9 (2020-03-17)
 - Test release pipeline
 

--- a/sdk/template/Azure.Template/CHANGELOG.md
+++ b/sdk/template/Azure.Template/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release History
 
-## 1.0.2-preview.9 (Unreleased)
+## 1.0.2-preview.9 (2020-03-17)
+- Test release pipeline
 
 ## 1.0.2-preview.8 (2020-03-10)
 - Testing out release pipeline

--- a/sdk/template/Azure.Template/CHANGELOG.md
+++ b/sdk/template/Azure.Template/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 1.0.2-preview.11 (2020-03-23)
+- Test release pipeline
+
 ## 1.0.2-preview.10 (2020-03-23)
 - Test release pipeline
 

--- a/sdk/template/Azure.Template/src/Azure.Template.csproj
+++ b/sdk/template/Azure.Template/src/Azure.Template.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is a template project to demonstrate how to create a package that uses code generation as well as use for testing our build and release pipelines</Description>
     <AssemblyTitle>Azure SDK Template</AssemblyTitle>
-    <Version>1.0.2-preview.9</Version>
+    <Version>1.0.2-preview.10</Version>
     <PackageTags>Azure Template</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <EnableApiCompat>false</EnableApiCompat>

--- a/sdk/template/Azure.Template/src/Azure.Template.csproj
+++ b/sdk/template/Azure.Template/src/Azure.Template.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is a template project to demonstrate how to create a package that uses code generation as well as use for testing our build and release pipelines</Description>
     <AssemblyTitle>Azure SDK Template</AssemblyTitle>
-    <Version>1.0.2-preview.10</Version>
+    <Version>1.0.2-preview.11</Version>
     <PackageTags>Azure Template</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <EnableApiCompat>false</EnableApiCompat>


### PR DESCRIPTION
This PR depends on [this](https://github.com/Azure/azure-sdk-tools/pull/439)
Release stage will now use the following tools from `eng/common` directory

- create-pull-request.yml
- create-tags-and-git-release.yml
- publish-blobs.yml
- copy-docs-to-blobstorage.ps1

Tested with release of [Azure.Template.1.0.2-preview.9](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=310359&view=results) and verified doc publish step [here](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=313084&view=results)