### PR TITLE
Don't checkpoint start of stream offset.

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/PartitionContext.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/PartitionContext.cs
@@ -123,6 +123,12 @@ namespace Microsoft.Azure.EventHubs.Processor
             Checkpoint capturedCheckpoint;
             lock(this.ThisLock)
             {
+                // Don't checkpoint for start of stream so that we can still respect initial offset provider.
+                if (this.Offset == "-1")
+                {
+                    return Task.CompletedTask;
+                }
+
                 capturedCheckpoint = new Checkpoint(this.PartitionId, this.Offset, this.SequenceNumber);
             }
 


### PR DESCRIPTION
Don't checkpoint if there is no event received. Checkpointing w/o any event received still creates the checkpoint with offset "-1" and this result in initial offset provider ignored if lease moves to another host.

The issue is discovered while one of the customers attempted to to upgrade their cluster UD by UD with a brand new storage account.