### PR TITLE
Clobber older Az versions and log verbosely

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -60,7 +60,7 @@ jobs:
           version: "$(DotNetCoreSDKVersion)"
 
       # TODO: Remove when eng/New-TestResources.ps1 bootstraps the Az module (https://github.com/Azure/azure-sdk-for-net/issues/9130).
-      - pwsh: Install-Module -Name Az -Scope CurrentUser -Force
+      - pwsh: Install-Module -Name Az -Scope CurrentUser -AllowClobber -Force -Verbose
         displayName: "Install Azure PowerShell module"
 
         # Chomp the string literal to more easily read and update the New-TestResources parameters.


### PR DESCRIPTION
This will fix the live test runs for Windows platforms for regression testing.