### PR TITLE
[FormRecognizer] Specify IFormatProvider when casting to string

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ExtractedField.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ExtractedField.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace Azure.AI.FormRecognizer.Models
@@ -78,10 +79,8 @@ namespace Azure.AI.FormRecognizer.Models
             // "#/readResults/3/lines/7/words/12"
             string[] segments = reference.Split('/');
 
-#pragma warning disable CA1305 // Specify IFormatProvider
-            var lineIndex = int.Parse(segments[4]);
-            var wordIndex = int.Parse(segments[6]);
-#pragma warning restore CA1305 // Specify IFormatProvider
+            var lineIndex = int.Parse(segments[4], CultureInfo.InvariantCulture);
+            var wordIndex = int.Parse(segments[6], CultureInfo.InvariantCulture);
 
             // TODO: Support case where text reference is lines only, without word segment
             // https://github.com/Azure/azure-sdk-for-net/issues/10364

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ExtractedForm.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ExtractedForm.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 
 namespace Azure.AI.FormRecognizer.Models
@@ -91,11 +92,7 @@ namespace Azure.AI.FormRecognizer.Models
 
         private void SetLearnedFormType(int? clusterId)
         {
-            // TODO: Provide IFormatProvider
-            // https://github.com/Azure/azure-sdk-for-net/issues/10376
-#pragma warning disable CA1305 // Specify IFormatProvider
-            string formId = clusterId?.ToString();
-#pragma warning restore CA1305 // Specify IFormatProvider
+            string formId = clusterId?.ToString(CultureInfo.InvariantCulture);
 
             if (formId != null)
             {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ExtractedReceipt.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ExtractedReceipt.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 
 namespace Azure.AI.FormRecognizer.Models
@@ -179,12 +180,8 @@ namespace Azure.AI.FormRecognizer.Models
                 // https://github.com/Azure/azure-sdk-for-net/issues/10361
                 dateTimeOffsetValue = value.Type switch
                 {
-                    // TODO: Unsuppress
-                    // https://github.com/Azure/azure-sdk-for-net/issues/10376
-#pragma warning disable CA1305 // Specify IFormatProvider
-                    FieldValueType.Date => DateTimeOffset.Parse(value.ValueDate),
-                    FieldValueType.Time => DateTimeOffset.Parse(value.ValueTime),
-#pragma warning restore CA1305 // Specify IFormatProvider
+                    FieldValueType.Date => DateTimeOffset.Parse(value.ValueDate, CultureInfo.InvariantCulture),
+                    FieldValueType.Time => DateTimeOffset.Parse(value.ValueTime, CultureInfo.InvariantCulture),
                     _ => throw new InvalidOperationException($"The value type {value.Type} was expected to be a Date or Time")
                 };
             }


### PR DESCRIPTION
Fixes #10376

Applying `InvariantCulture` when parsing to/from string.