### PR TITLE
Fix environment variable

### DIFF
--- a/sdk/identity/Azure.Identity/src/EnvironmentVariables.cs
+++ b/sdk/identity/Azure.Identity/src/EnvironmentVariables.cs
@@ -21,5 +21,6 @@ namespace Azure.Identity
 
         public static string ProgramFilesX86 => Environment.GetEnvironmentVariable("ProgramFiles(x86)");
         public static string ProgramFiles => Environment.GetEnvironmentVariable("ProgramFiles");
+        public static string AuthorityHost => Environment.GetEnvironmentVariable("AZURE_AUTHORITY_HOST");
     }
 }

--- a/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
@@ -21,7 +21,12 @@ namespace Azure.Identity
         /// </summary>
         public TokenCredentialOptions()
         {
-            AuthorityHost = KnownAuthorityHosts.AzureCloud;
+
+            string environmentAuthorityHost = EnvironmentVariables.AuthorityHost;
+
+            Uri authorityHostUri = string.IsNullOrEmpty(environmentAuthorityHost) ? KnownAuthorityHosts.AzureCloud : new Uri(environmentAuthorityHost);
+
+            AuthorityHost = authorityHostUri;
         }
     }
 }

--- a/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
@@ -21,9 +21,7 @@ namespace Azure.Identity
         /// </summary>
         public TokenCredentialOptions()
         {
-            string environmentAuthorityHost = EnvironmentVariables.AuthorityHost;
-
-            Uri authorityHostUri = string.IsNullOrEmpty(environmentAuthorityHost) ? KnownAuthorityHosts.AzureCloud : new Uri(environmentAuthorityHost);
+            Uri authorityHostUri = string.IsNullOrEmpty(EnvironmentVariables.AuthorityHost) ? KnownAuthorityHosts.AzureCloud : new Uri(EnvironmentVariables.AuthorityHost);
 
             AuthorityHost = authorityHostUri;
         }

--- a/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
@@ -21,7 +21,6 @@ namespace Azure.Identity
         /// </summary>
         public TokenCredentialOptions()
         {
-
             string environmentAuthorityHost = EnvironmentVariables.AuthorityHost;
 
             Uri authorityHostUri = string.IsNullOrEmpty(environmentAuthorityHost) ? KnownAuthorityHosts.AzureCloud : new Uri(environmentAuthorityHost);


### PR DESCRIPTION
Added EnvVar AuthorityHost to EnvironmentVariables.cs.
TokenCredentialOptions has an AuthorityHost property.
This will be modified to support EnvVar override with EnvironmentVariables.AuthorityHost.
Azure/azure-sdk-for-java/issues/5967
