### PR TITLE
[Event Hubs Client] Collection of Minor Enhancements and Fixes

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -327,12 +327,15 @@ namespace Azure.Messaging.EventHubs
         /// <param name="connectionString">The connection string to use for connecting to the Event Hubs namespace; it is expected that the Event Hub name and the shared key properties are contained in this connection string.</param>
         ///
         /// <remarks>
-        ///   If the connection string is copied from the Event Hubs namespace, it will likely not contain the name of the desired Event Hub,
+        ///   <para>The container associated with the <paramref name="checkpointStore" /> is expected to exist; the <see cref="EventProcessorClient" />
+        ///   does not assume the ability to manage the storage account and is safe to run without permission to manage the storage account.</para>
+        ///
+        ///   <para>If the connection string is copied from the Event Hubs namespace, it will likely not contain the name of the desired Event Hub,
         ///   which is needed.  In this case, the name can be added manually by adding ";EntityPath=[[ EVENT HUB NAME ]]" to the end of the
         ///   connection string.  For example, ";EntityPath=telemetry-hub".
         ///
         ///   If you have defined a shared access policy directly on the Event Hub itself, then copying the connection string from that
-        ///   Event Hub will result in a connection string that contains the name.
+        ///   Event Hub will result in a connection string that contains the name.</para>
         /// </remarks>
         ///
         /// <seealso href="https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string"/>
@@ -353,12 +356,15 @@ namespace Azure.Messaging.EventHubs
         /// <param name="clientOptions">The set of options to use for this processor.</param>
         ///
         /// <remarks>
-        ///   If the connection string is copied from the Event Hubs namespace, it will likely not contain the name of the desired Event Hub,
+        ///   <para>The container associated with the <paramref name="checkpointStore" /> is expected to exist; the <see cref="EventProcessorClient" />
+        ///   does not assume the ability to manage the storage account and is safe to run without permission to manage the storage account.</para>
+        ///
+        ///   <para>If the connection string is copied from the Event Hubs namespace, it will likely not contain the name of the desired Event Hub,
         ///   which is needed.  In this case, the name can be added manually by adding ";EntityPath=[[ EVENT HUB NAME ]]" to the end of the
         ///   connection string.  For example, ";EntityPath=telemetry-hub".
         ///
         ///   If you have defined a shared access policy directly on the Event Hub itself, then copying the connection string from that
-        ///   Event Hub will result in a connection string that contains the name.
+        ///   Event Hub will result in a connection string that contains the name.</para>
         /// </remarks>
         ///
         /// <seealso href="https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string"/>
@@ -380,9 +386,12 @@ namespace Azure.Messaging.EventHubs
         /// <param name="eventHubName">The name of the specific Event Hub to associate the processor with.</param>
         ///
         /// <remarks>
-        ///   If the connection string is copied from the Event Hub itself, it will contain the name of the desired Event Hub,
+        ///   <para>The container associated with the <paramref name="checkpointStore" /> is expected to exist; the <see cref="EventProcessorClient" />
+        ///   does not assume the ability to manage the storage account and is safe to run without permission to manage the storage account.</para>
+        ///
+        ///   <para>If the connection string is copied from the Event Hub itself, it will contain the name of the desired Event Hub,
         ///   and can be used directly without passing the <paramref name="eventHubName" />.  The name of the Event Hub should be
-        ///   passed only once, either as part of the connection string or separately.
+        ///   passed only once, either as part of the connection string or separately.</para>
         /// </remarks>
         ///
         /// <seealso href="https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string"/>
@@ -405,9 +414,12 @@ namespace Azure.Messaging.EventHubs
         /// <param name="clientOptions">The set of options to use for this processor.</param>
         ///
         /// <remarks>
-        ///   If the connection string is copied from the Event Hub itself, it will contain the name of the desired Event Hub,
+        ///   <para>The container associated with the <paramref name="checkpointStore" /> is expected to exist; the <see cref="EventProcessorClient" />
+        ///   does not assume the ability to manage the storage account and is safe to run without permission to manage the storage account.</para>
+        ///
+        ///   <para>If the connection string is copied from the Event Hub itself, it will contain the name of the desired Event Hub,
         ///   and can be used directly without passing the <paramref name="eventHubName" />.  The name of the Event Hub should be
-        ///   passed only once, either as part of the connection string or separately.
+        ///   passed only once, either as part of the connection string or separately.</para>
         /// </remarks>
         ///
         /// <seealso href="https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string"/>
@@ -458,6 +470,11 @@ namespace Azure.Messaging.EventHubs
         /// <param name="eventHubName">The name of the specific Event Hub to associate the processor with.</param>
         /// <param name="credential">The Azure managed identity credential to use for authorization.  Access controls may be specified by the Event Hubs namespace or the requested Event Hub, depending on Azure configuration.</param>
         /// <param name="clientOptions">The set of options to use for this processor.</param>
+        ///
+        /// <remarks>
+        ///   The container associated with the <paramref name="checkpointStore" /> is expected to exist; the <see cref="EventProcessorClient" />
+        ///   does not assume the ability to manage the storage account and is safe to run without permission to manage the storage account.
+        /// </remarks>
         ///
         public EventProcessorClient(BlobContainerClient checkpointStore,
                                     string consumerGroup,

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Core/ConnectionStringParser.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Core/ConnectionStringParser.cs
@@ -12,15 +12,6 @@ namespace Azure.Messaging.EventHubs.Core
     ///
     internal static class ConnectionStringParser
     {
-        /// <summary>The character used to separate a token and its value in the connection string.</summary>
-        private const char TokenValueSeparator = '=';
-
-        /// <summary>The character used to mark the beginning of a new token/value pair in the connection string.</summary>
-        private const char TokenValuePairDelimiter = ';';
-
-        /// <summary>The formatted protocol used by an Event Hubs endpoint. </summary>
-        private const string EventHubsEndpointScheme = "sb://";
-
         /// <summary>The token that identifies the endpoint address for the Event Hubs namespace.</summary>
         private const string EndpointToken = "Endpoint";
 
@@ -32,6 +23,18 @@ namespace Azure.Messaging.EventHubs.Core
 
         /// <summary>The token that identifies the value of a shared access key.</summary>
         private const string SharedAccessKeyValueToken = "SharedAccessKey";
+
+        /// <summary>The character used to separate a token and its value in the connection string.</summary>
+        private const char TokenValueSeparator = '=';
+
+        /// <summary>The character used to mark the beginning of a new token/value pair in the connection string.</summary>
+        private const char TokenValuePairDelimiter = ';';
+
+        /// <summary>The name of the protocol used by an Event Hubs endpoint. </summary>
+        private const string EventHubsEndpointSchemeName = "sb";
+
+        /// <summary>The formatted protocol used by an Event Hubs endpoint. </summary>
+        private static readonly string EventHubsEndpointScheme = $"{ EventHubsEndpointSchemeName }{ Uri.SchemeDelimiter }";
 
         /// <summary>
         ///   Parses the specified Event Hubs connection string into its component properties.
@@ -115,8 +118,15 @@ namespace Azure.Messaging.EventHubs.Core
                     {
                         parsedValues.EndpointToken = new UriBuilder(value)
                         {
-                            Scheme = EventHubsEndpointScheme
+                            Scheme = EventHubsEndpointScheme,
+                            Port = -1
                         };
+
+                        if ((string.Compare(parsedValues.EndpointToken.Scheme, EventHubsEndpointSchemeName, StringComparison.OrdinalIgnoreCase) != 0)
+                            || (Uri.CheckHostName(parsedValues.EndpointToken.Host) == UriHostNameType.Unknown))
+                        {
+                            throw new FormatException(Resources.InvalidConnectionString);
+                        }
                     }
                     else if (string.Compare(EventHubNameToken, token, StringComparison.OrdinalIgnoreCase) == 0)
                     {

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
@@ -188,6 +188,17 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to The event batch is currently being used in communication with the Event Hubs service; events may not be added until the active operation is complete..
+        /// </summary>
+        internal static string EventBatchIsLocked
+        {
+            get
+            {
+                return ResourceManager.GetString("EventBatchIsLocked", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Could not create a reader of events for Event Hub: &apos;{0}&apos;, partition: &apos;{1}&apos;, consumer group: &apos;{2}&apos;..
         /// </summary>
         internal static string FailedToCreateReader

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
@@ -273,4 +273,7 @@
   <data name="InvalidFullyQualifiedNamespace" xml:space="preserve">
     <value>The value '{0}' is not a well-formed Event Hubs fully qualified namespace.</value>
   </data>
+  <data name="EventBatchIsLocked" xml:space="preserve">
+    <value>The event batch is currently being used in communication with the Event Hubs service; events may not be added until the active operation is complete.</value>
+  </data>
 </root>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -71,6 +71,7 @@ namespace Azure.Messaging.EventHubs
         public bool IsTransient { get { throw null; } }
         public override string Message { get { throw null; } }
         public Azure.Messaging.EventHubs.EventHubsException.FailureReason Reason { get { throw null; } }
+        public override string ToString() { throw null; }
         public enum FailureReason
         {
             GeneralError = 0,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpMessageConverter.cs
@@ -157,7 +157,6 @@ namespace Azure.Messaging.EventHubs.Amqp
         {
             Argument.AssertNotNull(response, nameof(response));
 
-
             if (!(response.ValueBody?.Value is AmqpMap responseData))
             {
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resources.InvalidMessageBody, typeof(AmqpMap).Name));
@@ -220,7 +219,6 @@ namespace Azure.Messaging.EventHubs.Amqp
         public virtual PartitionProperties CreatePartitionPropertiesFromResponse(AmqpMessage response)
         {
             Argument.AssertNotNull(response, nameof(response));
-
 
             if (!(response.ValueBody?.Value is AmqpMap responseData))
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsException.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsException.cs
@@ -177,6 +177,14 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
+        ///   Converts the instance to string representation.
+        /// </summary>
+        ///
+        /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
+        ///
+        public override string ToString() => $"{ typeof(EventHubsException).Name }({ Reason })";
+
+        /// <summary>
         ///   The set of well-known reasons for an Event Hubs operation failure that
         ///   was the cause of an exception.
         /// </summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -502,12 +502,17 @@ namespace Azure.Messaging.EventHubs.Producer
 
             try
             {
+                eventBatch.Lock();
                 await activeProducer.SendAsync(eventBatch, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
                 scope.Failed(ex);
                 throw;
+            }
+            finally
+            {
+                eventBatch.Unlock();
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Errors/EventHubsExceptionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Errors/EventHubsExceptionTests.cs
@@ -157,5 +157,23 @@ namespace Azure.Messaging.EventHubs.Tests
 
             Assert.That(knownReasons.OrderBy(item => item.ToString()), Is.EquivalentTo(reasonTestCases), "All failure reasons defined by EventHubsException in the client library should have a matching IsTransient test case.");
         }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubsException.ToString" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void ToStringValueContainsTheTypeNameAndFailureReason()
+        {
+            var message = "Test message!";
+            var namespaceValue = "the-namespace";
+            var reason = EventHubsException.FailureReason.QuotaExceeded;
+            var instance = new EventHubsException(false, namespaceValue, message, reason);
+
+            Assert.That(instance.ToString(), Is.Not.Null.And.Not.Empty, "The ToString value should be populated.");
+            Assert.That(instance.ToString(), Contains.Substring(typeof(EventHubsException).Name), "The ToString value should contain the type name.");
+            Assert.That(instance.ToString(), Contains.Substring(reason.ToString()), "The ToString value should contain the failure reason.");
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventDataBatchTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventDataBatchTests.cs
@@ -145,6 +145,27 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
+        ///   Verifies property accessors for the <see cref="EventDataBatch.TryAdd" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void TryAddRespectsTheBatchLock()
+        {
+            var mockBatch = new MockTransportBatch();
+            var batch = new EventDataBatch(mockBatch, "ns", "eh", new SendEventOptions());
+            var eventData = new EventData(new byte[] { 0x21 });
+
+            Assert.That(batch.TryAdd(new EventData(new byte[] { 0x21 })), Is.True, "The event should have been accepted before locking.");
+
+            batch.Lock();
+            Assert.That(() => batch.TryAdd(new EventData(Array.Empty<byte>())), Throws.InstanceOf<InvalidOperationException>(), "The batch should not accept events when locked.");
+
+            batch.Unlock();
+            Assert.That(batch.TryAdd(new EventData(Array.Empty<byte>())), Is.True, "The event should have been accepted after unlocking.");
+        }
+
+        /// <summary>
         ///   Retrieves the inner transport batch from an <see cref="EventDataBatch" />
         ///   using its private accessors.
         /// </summary>


### PR DESCRIPTION
# Summary

These changes focus on addressing several small fixes and enhancements that were being informally tracked.  Included are:

 - Disallowing events to be added to the `EventDataBatch` when that batch is in use by an active `Send` operation.

 - Addition of verbiage in the `EventProcesorClient` constructor documentation to clarify that the container used by Azure Blobs storage must exist _(the
   processor does not assume responsibility for creation)_

- Extending `ToString` for the `EventHubsException` to include the failure reason as part of the text.

- Allowing additional formats for the `Endpoint` token of the connection string when parsed; this addresses several common mistakes made when forming the
  string manually rather than doing copy/paste from the portal.

- Trimming some extra blank lines from the `AmqpMessageConverter`.

# Last Upstream Rebase

Friday, March 20, 4:10pm (EST)