### PR TITLE
[Event Hubs Client] Event Processor Test Cleanup

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/TaskExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/TaskExtensions.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The set of extensions for the <see cref="Task" />
+    ///   class.
+    /// </summary>
+    ///
+    internal static class TaskExtensions
+    {
+        /// <summary>
+        ///   Completes the <paramref name="instance" /> by awaiting, ignoring any exceptions
+        ///   that may occur.
+        /// </summary>
+        ///
+        /// <param name="instance">The instance to consider.</param>
+        ///
+        public static async Task IgnoreExceptions(this Task instance)
+        {
+            try
+            {
+                await instance.ConfigureAwait(false);
+            }
+            catch
+            {
+                // Intentionally ignoring exceptions.
+            }
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/TaskExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/TaskExtensionsTests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Core;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="TaskExtensions" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class TaskExtensionsTests
+    {
+        /// <summary>
+        ///  Verifies functionality of the <see cref="TaskExtensions.IgnoreExceptions" />
+        ///  method.
+        /// </summary>
+        ///
+        public void IgnoreExceptionDoesNotSurfaceExceptions()
+        {
+            var exceptionTask = Task.Run(() => throw new DllNotFoundException());
+            Assert.That(async () => await exceptionTask.IgnoreExceptions(), Throws.Nothing);
+        }
+
+        /// <summary>
+        ///  Verifies functionality of the <see cref="TaskExtensions.IgnoreExceptions" />
+        ///  method.
+        /// </summary>
+        ///
+        public void IgnoreExceptionDoesNotInterfereWithSuccessfulTasks()
+        {
+            var successfulTask = Task.Delay(250);
+            Assert.That(async () => await successfulTask.IgnoreExceptions(), Throws.Nothing);
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.StartStop.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.StartStop.cs
@@ -88,7 +88,7 @@ namespace Azure.Messaging.EventHubs.Tests
             // Shut the processor down to ensure resource clean-up, but ignore any errors since it isn't the
             // subject of this test.
 
-            try { await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token); }  catch {}
+            await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token).IgnoreExceptions();
         }
 
         /// <summary>
@@ -149,7 +149,7 @@ namespace Azure.Messaging.EventHubs.Tests
             // Shut the processor down to ensure resource clean-up, but ignore any errors since it isn't the
             // subject of this test.
 
-            try { await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token); }  catch {}
+            await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token).IgnoreExceptions();
             cancellationSource.Cancel();
         }
 
@@ -203,7 +203,7 @@ namespace Azure.Messaging.EventHubs.Tests
             // Shut the processor down to ensure resource clean-up, but ignore any errors since it isn't the
             // subject of this test.
 
-            try { await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token); }  catch {}
+            await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token).IgnoreExceptions();
         }
 
         /// <summary>
@@ -256,7 +256,7 @@ namespace Azure.Messaging.EventHubs.Tests
             // Shut the processor down to ensure resource clean-up, but ignore any errors since it isn't the
             // subject of this test.
 
-            try { await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token); }  catch {}
+            await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token).IgnoreExceptions();
         }
 
         /// <summary>
@@ -322,7 +322,7 @@ namespace Azure.Messaging.EventHubs.Tests
             // Shut the processor down to ensure resource clean-up, but ignore any errors since it isn't the
             // subject of this test.
 
-            try { await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token); }  catch {}
+            await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token).IgnoreExceptions();
         }
 
         /// <summary>


### PR DESCRIPTION
# Summary

The focus of these changes is to perform a small bit of cleanup for the Event Processor tests, removing single-line try/catch blocks intended to ignore exceptions and replace them with an extension method for better formatting and readability.

# Last Upstream Rebase

Saturday, March 21, 1:42pm (EST)

# References and Related Issues 

- [.NET Event Hubs Client: Event Processor<T> Proposal](https://gist.github.com/jsquire/1f4a1e72fc02871f443ce365222d40f6)
- [Implement the Event Processor Base](https://github.com/Azure/azure-sdk-for-net/issues/9324) (#9324)