### PR TITLE
Add EnvVar AuthorityHost

### DIFF
--- a/sdk/identity/Azure.Identity/src/EnvironmentVariables.cs
+++ b/sdk/identity/Azure.Identity/src/EnvironmentVariables.cs
@@ -21,5 +21,6 @@ namespace Azure.Identity
 
         public static string ProgramFilesX86 => Environment.GetEnvironmentVariable("ProgramFiles(x86)");
         public static string ProgramFiles => Environment.GetEnvironmentVariable("ProgramFiles");
+        public static string AuthorityHost => Environment.GetEnvironmentVariable("AZURE_AUTHORITY_HOST");
     }
 }

--- a/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
@@ -21,7 +21,12 @@ namespace Azure.Identity
         /// </summary>
         public TokenCredentialOptions()
         {
-            AuthorityHost = KnownAuthorityHosts.AzureCloud;
+
+            string environmentAuthorityHost = EnvironmentVariables.AuthorityHost;
+
+            Uri authorityHostUri = string.IsNullOrEmpty(environmentAuthorityHost) ? KnownAuthorityHosts.AzureCloud : new Uri(environmentAuthorityHost);
+
+            AuthorityHost = authorityHostUri;
         }
     }
 }

--- a/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
@@ -21,9 +21,7 @@ namespace Azure.Identity
         /// </summary>
         public TokenCredentialOptions()
         {
-            string environmentAuthorityHost = EnvironmentVariables.AuthorityHost;
-
-            Uri authorityHostUri = string.IsNullOrEmpty(environmentAuthorityHost) ? KnownAuthorityHosts.AzureCloud : new Uri(environmentAuthorityHost);
+            Uri authorityHostUri = string.IsNullOrEmpty(EnvironmentVariables.AuthorityHost) ? KnownAuthorityHosts.AzureCloud : new Uri(EnvironmentVariables.AuthorityHost);
 
             AuthorityHost = authorityHostUri;
         }

--- a/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
@@ -11,18 +11,14 @@ namespace Azure.Identity
     /// </summary>
     public class TokenCredentialOptions : ClientOptions
     {
+        private Uri _authorityHost;
         /// <summary>
         /// The host of the Azure Active Directory authority. The default is https://login.microsoftonline.com/. For well known authority hosts for Azure cloud instances see <see cref="KnownAuthorityHosts"/>.
         /// </summary>
-        public Uri AuthorityHost { get; set; }
-
-        /// <summary>
-        /// Creates an instance of <see cref="TokenCredentialOptions"/> with default settings.
-        /// </summary>
-        public TokenCredentialOptions()
+        public Uri AuthorityHost
         {
-            Uri authorityHostUri = string.IsNullOrEmpty(EnvironmentVariables.AuthorityHost) ? KnownAuthorityHosts.AzureCloud : new Uri(EnvironmentVariables.AuthorityHost);
-            AuthorityHost = authorityHostUri;
+            get { return _authorityHost ?? (EnvironmentVariables.AuthorityHost != null ? new Uri(EnvironmentVariables.AuthorityHost) : KnownAuthorityHosts.AzureCloud); }
+            set { _authorityHost = value; }
         }
     }
 }

--- a/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
@@ -21,7 +21,6 @@ namespace Azure.Identity
         /// </summary>
         public TokenCredentialOptions()
         {
-
             string environmentAuthorityHost = EnvironmentVariables.AuthorityHost;
 
             Uri authorityHostUri = string.IsNullOrEmpty(environmentAuthorityHost) ? KnownAuthorityHosts.AzureCloud : new Uri(environmentAuthorityHost);

--- a/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
@@ -22,7 +22,6 @@ namespace Azure.Identity
         public TokenCredentialOptions()
         {
             Uri authorityHostUri = string.IsNullOrEmpty(EnvironmentVariables.AuthorityHost) ? KnownAuthorityHosts.AzureCloud : new Uri(EnvironmentVariables.AuthorityHost);
-
             AuthorityHost = authorityHostUri;
         }
     }

--- a/sdk/identity/Azure.Identity/tests/TokenCredentialOptionsTests.cs
+++ b/sdk/identity/Azure.Identity/tests/TokenCredentialOptionsTests.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core.Testing;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests
+{
+    public class TokenCredentialOptionsTests : ClientTestBase
+    {
+        public TokenCredentialOptionsTests(bool isAsync) : base(isAsync)
+        {
+        }
+
+        [Test]
+        public void InvalidEnvAuthorityHost()
+        {
+            using (new TestEnvVar("AZURE_AUTHORITY_HOST", "mock-env-authority-host"))
+            {
+                TokenCredentialOptions option = new TokenCredentialOptions();
+
+                Assert.Throws<UriFormatException>(() => { Uri finalUri = option.AuthorityHost; });
+            }
+        }
+
+        [Test]
+        public void EnvAuthorityHost()
+        {
+            string envHostValue = KnownAuthorityHosts.AzureChinaCloud.ToString();
+
+            using (new TestEnvVar("AZURE_AUTHORITY_HOST", envHostValue))
+            {
+                TokenCredentialOptions option = new TokenCredentialOptions();
+                Uri finalUri = option.AuthorityHost;
+
+                Assert.AreEqual(finalUri, new Uri(envHostValue));
+            }
+        }
+
+        [Test]
+        public void CustomAuthorityHost()
+        {
+            string envHostValue = KnownAuthorityHosts.AzureGermanCloud.ToString();
+
+            using (new TestEnvVar("AZURE_AUTHORITY_HOST", envHostValue))
+            {
+                Uri customUri = KnownAuthorityHosts.AzureChinaCloud;
+
+                TokenCredentialOptions option = new TokenCredentialOptions() { AuthorityHost = customUri };
+                Uri finalUri = option.AuthorityHost;
+
+                Assert.AreNotEqual(finalUri, new Uri(envHostValue));
+                Assert.AreEqual(finalUri, customUri);
+            }
+        }
+
+        [Test]
+        public void DefaultAuthorityHost()
+        {
+            using (new TestEnvVar("AZURE_AUTHORITY_HOST", null))
+            {
+                TokenCredentialOptions option = new TokenCredentialOptions();
+
+                Assert.AreEqual(option.AuthorityHost, KnownAuthorityHosts.AzureCloud);
+            }
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/TokenCredentialOptionsTests.cs
+++ b/sdk/identity/Azure.Identity/tests/TokenCredentialOptionsTests.cs
@@ -20,7 +20,7 @@ namespace Azure.Identity.Tests
             {
                 TokenCredentialOptions option = new TokenCredentialOptions();
 
-                Assert.Throws<UriFormatException>(() => { Uri finalUri = option.AuthorityHost; });
+                Assert.Throws<UriFormatException>(() => { Uri authHost = option.AuthorityHost; });
             }
         }
 
@@ -32,9 +32,9 @@ namespace Azure.Identity.Tests
             using (new TestEnvVar("AZURE_AUTHORITY_HOST", envHostValue))
             {
                 TokenCredentialOptions option = new TokenCredentialOptions();
-                Uri finalUri = option.AuthorityHost;
+                Uri authHost = option.AuthorityHost;
 
-                Assert.AreEqual(finalUri, new Uri(envHostValue));
+                Assert.AreEqual(authHost, new Uri(envHostValue));
             }
         }
 
@@ -48,10 +48,10 @@ namespace Azure.Identity.Tests
                 Uri customUri = KnownAuthorityHosts.AzureChinaCloud;
 
                 TokenCredentialOptions option = new TokenCredentialOptions() { AuthorityHost = customUri };
-                Uri finalUri = option.AuthorityHost;
+                Uri authHost = option.AuthorityHost;
 
-                Assert.AreNotEqual(finalUri, new Uri(envHostValue));
-                Assert.AreEqual(finalUri, customUri);
+                Assert.AreNotEqual(authHost, new Uri(envHostValue));
+                Assert.AreEqual(authHost, customUri);
             }
         }
 

--- a/sdk/identity/Azure.Identity/tests/TokenCredentialOptionsTests.cs
+++ b/sdk/identity/Azure.Identity/tests/TokenCredentialOptionsTests.cs
@@ -13,6 +13,7 @@ namespace Azure.Identity.Tests
         {
         }
 
+        [NonParallelizable]
         [Test]
         public void InvalidEnvAuthorityHost()
         {
@@ -24,6 +25,7 @@ namespace Azure.Identity.Tests
             }
         }
 
+        [NonParallelizable]
         [Test]
         public void EnvAuthorityHost()
         {
@@ -38,6 +40,7 @@ namespace Azure.Identity.Tests
             }
         }
 
+        [NonParallelizable]
         [Test]
         public void CustomAuthorityHost()
         {
@@ -55,6 +58,7 @@ namespace Azure.Identity.Tests
             }
         }
 
+        [NonParallelizable]
         [Test]
         public void DefaultAuthorityHost()
         {


### PR DESCRIPTION
Added EnvVar AuthorityHost to EnvironmentVariables.cs.
TokenCredentialOptions has an AuthorityHost property.
This will be modified to support EnvVar override with EnvironmentVariables.AuthorityHost.
Azure/azure-sdk-for-java/issues/5967