### PR TITLE
[Event Hubs Client] Event Processor<T> Reading Last Event Properties

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.Constructor.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.Constructor.cs
@@ -33,9 +33,9 @@ namespace Azure.Messaging.EventHubs.Tests
             var connectionStringNoHub = "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123";
             var credential = Mock.Of<TokenCredential>();
 
-            yield return new object[] { new ProcessorConstructorMock(99, "consumerGroup", connectionString), "connection string with default options" };
-            yield return new object[] { new ProcessorConstructorMock(99, "consumerGroup", connectionStringNoHub, "hub", default), "connection string with default options" };
-            yield return new object[] { new ProcessorConstructorMock(99, "consumerGroup", "namespace", "hub", credential, default(EventProcessorOptions)), "namespace with explicit null options" };
+            yield return new object[] { new MinimalProcessorMock(99, "consumerGroup", connectionString), "connection string with default options" };
+            yield return new object[] { new MinimalProcessorMock(99, "consumerGroup", connectionStringNoHub, "hub", default), "connection string with default options" };
+            yield return new object[] { new MinimalProcessorMock(99, "consumerGroup", "namespace", "hub", credential, default(EventProcessorOptions)), "namespace with explicit null options" };
         }
 
         /// <summary>
@@ -50,8 +50,8 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase(0)]
         public void ConstructorValidatesTheEventBatchMaximumCount(int constructorArgument)
         {
-            Assert.That(() => new ProcessorConstructorMock(constructorArgument, "dummyGroup", "dummyConnection", new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The connection string constructor should validate the maximum batch size.");
-            Assert.That(() => new ProcessorConstructorMock(constructorArgument, "dummyGroup", "dummyNamespace", "dummyEventHub", Mock.Of<TokenCredential>(), new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The namespace constructor should validate the maximum batch size.");
+            Assert.That(() => new MinimalProcessorMock(constructorArgument, "dummyGroup", "dummyConnection", new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The connection string constructor should validate the maximum batch size.");
+            Assert.That(() => new MinimalProcessorMock(constructorArgument, "dummyGroup", "dummyNamespace", "dummyEventHub", Mock.Of<TokenCredential>(), new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The namespace constructor should validate the maximum batch size.");
         }
 
         /// <summary>
@@ -64,8 +64,8 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorValidatesTheConsumerGroup(string constructorArgument)
         {
-            Assert.That(() => new ProcessorConstructorMock(1, constructorArgument, "dummyConnection", new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The connection string constructor should validate the consumer group.");
-            Assert.That(() => new ProcessorConstructorMock(1, constructorArgument, "dummyNamespace", "dummyEventHub", Mock.Of<TokenCredential>(), new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The namespace constructor should validate the consumer group.");
+            Assert.That(() => new MinimalProcessorMock(1, constructorArgument, "dummyConnection", new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The connection string constructor should validate the consumer group.");
+            Assert.That(() => new MinimalProcessorMock(1, constructorArgument, "dummyNamespace", "dummyEventHub", Mock.Of<TokenCredential>(), new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The namespace constructor should validate the consumer group.");
         }
 
         /// <summary>
@@ -78,8 +78,8 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorValidatesTheConnectionString(string connectionString)
         {
-            Assert.That(() => new ProcessorConstructorMock(1, EventHubConsumerClient.DefaultConsumerGroupName, connectionString), Throws.InstanceOf<ArgumentException>(), "The constructor without options should ensure a connection string.");
-            Assert.That(() => new ProcessorConstructorMock(1, EventHubConsumerClient.DefaultConsumerGroupName, connectionString, "dummy", new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The constructor with options should ensure a connection string.");
+            Assert.That(() => new MinimalProcessorMock(1, EventHubConsumerClient.DefaultConsumerGroupName, connectionString), Throws.InstanceOf<ArgumentException>(), "The constructor without options should ensure a connection string.");
+            Assert.That(() => new MinimalProcessorMock(1, EventHubConsumerClient.DefaultConsumerGroupName, connectionString, "dummy", new EventProcessorOptions()), Throws.InstanceOf<ArgumentException>(), "The constructor with options should ensure a connection string.");
         }
 
         /// <summary>
@@ -93,7 +93,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("sb://namespace.place.com")]
         public void ConstructorValidatesTheNamespace(string constructorArgument)
         {
-            Assert.That(() => new ProcessorConstructorMock(1, EventHubConsumerClient.DefaultConsumerGroupName, constructorArgument, "dummy", Mock.Of<TokenCredential>()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new MinimalProcessorMock(1, EventHubConsumerClient.DefaultConsumerGroupName, constructorArgument, "dummy", Mock.Of<TokenCredential>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorValidatesTheEventHub(string constructorArgument)
         {
-            Assert.That(() => new ProcessorConstructorMock(100, EventHubConsumerClient.DefaultConsumerGroupName, "namespace", constructorArgument, Mock.Of<TokenCredential>()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new MinimalProcessorMock(100, EventHubConsumerClient.DefaultConsumerGroupName, "namespace", constructorArgument, Mock.Of<TokenCredential>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -117,7 +117,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorValidatesTheCredential()
         {
-            Assert.That(() => new ProcessorConstructorMock(5, EventHubConsumerClient.DefaultConsumerGroupName, "namespace", "hubName", default(TokenCredential)), Throws.ArgumentNullException);
+            Assert.That(() => new MinimalProcessorMock(5, EventHubConsumerClient.DefaultConsumerGroupName, "namespace", "hubName", default(TokenCredential)), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         [Test]
         [TestCaseSource(nameof(ConstructorCreatesDefaultOptionsCases))]
-        public void ConstructorCreatesDefaultOptions(ProcessorConstructorMock eventProcessor,
+        public void ConstructorCreatesDefaultOptions(MinimalProcessorMock eventProcessor,
                                                      string constructorDescription)
         {
             var defaultOptions = new EventProcessorOptions();
@@ -152,7 +152,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 ConnectionOptions = new EventHubConnectionOptions { TransportType = expectedTransportType }
             };
 
-            var eventProcessor = new ProcessorConstructorMock(1, "consumerGroup", "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub", options);
+            var eventProcessor = new MinimalProcessorMock(1, "consumerGroup", "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub", options);
 
             // Simply retrieving the options from an inner connection won't be enough to prove the processor clones
             // its connection options because the cloning step also happens in the EventHubConnection constructor.
@@ -181,7 +181,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 ConnectionOptions = new EventHubConnectionOptions { TransportType = expectedTransportType }
             };
 
-            var eventProcessor = new ProcessorConstructorMock(11, "consumerGroup", "namespace", "hub", Mock.Of<TokenCredential>(), options);
+            var eventProcessor = new MinimalProcessorMock(11, "consumerGroup", "namespace", "hub", Mock.Of<TokenCredential>(), options);
 
             // Simply retrieving the options from an inner connection won't be enough to prove the processor clones
             // its connection options because the cloning step also happens in the EventHubConnection constructor.
@@ -207,7 +207,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 Identifier = Guid.NewGuid().ToString()
             };
 
-            var eventProcessor = new ProcessorConstructorMock(72, "consumerGroup", "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub", options);
+            var eventProcessor = new MinimalProcessorMock(72, "consumerGroup", "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub", options);
 
             Assert.That(eventProcessor.Identifier, Is.Not.Null);
             Assert.That(eventProcessor.Identifier, Is.EqualTo(options.Identifier));
@@ -226,7 +226,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 Identifier = Guid.NewGuid().ToString()
             };
 
-            var eventProcessor = new ProcessorConstructorMock(65, "consumerGroup", "namespace", "hub", Mock.Of<TokenCredential>(), options);
+            var eventProcessor = new MinimalProcessorMock(65, "consumerGroup", "namespace", "hub", Mock.Of<TokenCredential>(), options);
 
             Assert.That(eventProcessor.Identifier, Is.Not.Null);
             Assert.That(eventProcessor.Identifier, Is.EqualTo(options.Identifier));
@@ -247,7 +247,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 Identifier = identifier
             };
 
-            var eventProcessor = new ProcessorConstructorMock(34, "consumerGroup", "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub", options);
+            var eventProcessor = new MinimalProcessorMock(34, "consumerGroup", "Endpoint=sb://somehost.com;SharedAccessKeyName=ABC;SharedAccessKey=123;EntityPath=somehub", options);
 
             Assert.That(eventProcessor.Identifier, Is.Not.Null);
             Assert.That(eventProcessor.Identifier, Is.Not.Empty);
@@ -268,7 +268,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 Identifier = identifier
             };
 
-            var eventProcessor = new ProcessorConstructorMock(665, "consumerGroup", "namespace", "hub", Mock.Of<TokenCredential>(), options);
+            var eventProcessor = new MinimalProcessorMock(665, "consumerGroup", "namespace", "hub", Mock.Of<TokenCredential>(), options);
 
             Assert.That(eventProcessor.Identifier, Is.Not.Null);
             Assert.That(eventProcessor.Identifier, Is.Not.Empty);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.Infrastructure.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.Infrastructure.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
+using Azure.Messaging.EventHubs.Consumer;
 using Azure.Messaging.EventHubs.Primitives;
 using Moq;
 using Moq.Protected;
@@ -25,6 +26,123 @@ namespace Azure.Messaging.EventHubs.Tests
     ///
     public partial class EventProcessorTests
     {
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}" />
+        ///   background processing loop.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ReadLastEnqueuedEventPropertiesReadsPropertiesWhenThePartitionIsOwned()
+        {
+            using var processorCancellation = new CancellationTokenSource();
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var partitionId = "27";
+            var partitionIds = new[] { "0", partitionId };
+            var ownedPartitions = new List<string>();
+            var lastEventProperties = new LastEnqueuedEventProperties(1234, 9876, DateTimeOffset.Parse("2015-10-27T00:00:00Z"), DateTimeOffset.Parse("2012-03-04T08:30:00Z"));
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var options = new EventProcessorOptions { LoadBalancingUpdateInterval = TimeSpan.FromMinutes(5), TrackLastEnqueuedEventProperties = true };
+            var mockLoadBalancer = new Mock<PartitionLoadBalancer>();
+            var mockConnection = new Mock<EventHubConnection>();
+            var mockProcessor = new Mock<MinimalProcessorMock>(65, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options, mockLoadBalancer.Object) { CallBase = true };
+
+            mockLoadBalancer
+                .SetupGet(processor => processor.OwnedPartitionIds)
+                .Returns(ownedPartitions);
+
+            mockLoadBalancer
+                .Setup(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))
+                .Callback(() =>
+                {
+                    GetActivePartitionProcessors(mockProcessor.Object).TryAdd(
+                        partitionId,
+                        new EventProcessor<EventProcessorPartition>.PartitionProcessor(Task.Delay(Timeout.Infinite, processorCancellation.Token), new EventProcessorPartition { PartitionId = partitionId }, () => lastEventProperties, processorCancellation)
+                    );
+
+                    ownedPartitions.Add(partitionId);
+                    completionSource.TrySetResult(true);
+                })
+                .Returns(() => default);
+
+            mockConnection
+                .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partitionIds);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection.Object);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
+                .Returns(Mock.Of<SettableTransportConsumer>());
+
+            await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
+            Assert.That(mockProcessor.Object.Status, Is.EqualTo(EventProcessorStatus.Running), "The processor should not fault if a load balancing cycle fails.");
+
+            await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+            Assert.That(mockProcessor.Object.InvokeReadLastEnqueuedEventProperties(partitionId), Is.EqualTo(lastEventProperties), "The last enqueued properties should have been returned.");
+
+            await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token).IgnoreExceptions();
+            cancellationSource.Cancel();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}" />
+        ///   background processing loop.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ReadLastEnqueuedEventPropertiesThrowsWhenThePartitionIsNotOwned()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+
+            var partitionId = "27";
+            var partitionIds = new[] { "0", partitionId };
+            var lastEventProperties = new LastEnqueuedEventProperties(1234, 9876, DateTimeOffset.Parse("2015-10-27T00:00:00Z"), DateTimeOffset.Parse("2012-03-04T08:30:00Z"));
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var options = new EventProcessorOptions { LoadBalancingUpdateInterval = TimeSpan.FromMinutes(5), TrackLastEnqueuedEventProperties = true };
+            var mockLoadBalancer = new Mock<PartitionLoadBalancer>();
+            var mockConnection = new Mock<EventHubConnection>();
+            var mockProcessor = new Mock<MinimalProcessorMock>(65, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), options, mockLoadBalancer.Object) { CallBase = true };
+
+            mockLoadBalancer
+                .SetupGet(processor => processor.OwnedPartitionIds)
+                .Returns(Array.Empty<string>());
+
+            mockLoadBalancer
+                .Setup(lb => lb.RunLoadBalancingAsync(partitionIds, It.IsAny<CancellationToken>()))
+                .Returns(() => default)
+                .Callback(() => completionSource.TrySetResult(true));
+
+            mockConnection
+                .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(partitionIds);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection.Object);
+
+            mockProcessor
+                .Setup(processor => processor.CreateConsumer(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EventPosition>(), It.IsAny<EventHubConnection>(), It.IsAny<EventProcessorOptions>()))
+                .Returns(Mock.Of<SettableTransportConsumer>());
+
+            await mockProcessor.Object.StartProcessingAsync(cancellationSource.Token);
+            Assert.That(mockProcessor.Object.Status, Is.EqualTo(EventProcessorStatus.Running), "The processor should not fault if a load balancing cycle fails.");
+
+            await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+            Assert.That(() => mockProcessor.Object.InvokeReadLastEnqueuedEventProperties(partitionId), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed), "The last enqueued properties cannot be read for an unowned partition.");
+
+            await mockProcessor.Object.StopProcessingAsync(cancellationSource.Token).IgnoreExceptions();
+            cancellationSource.Cancel();
+        }
+
         /// <summary>
         ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.ToString" />
         ///   method.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
+using Azure.Messaging.EventHubs.Consumer;
 using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Primitives;
 using NUnit.Framework;
@@ -109,26 +110,35 @@ namespace Azure.Messaging.EventHubs.Tests
         ///   functionality.
         /// </summary>
         ///
-        public class ProcessorConstructorMock : EventProcessor<EventProcessorPartition>
+        public class MinimalProcessorMock : EventProcessor<EventProcessorPartition>
         {
-            public ProcessorConstructorMock(int eventBatchMaximumCount,
-                                            string consumerGroup,
-                                            string connectionString,
-                                            EventProcessorOptions options = default) : base(eventBatchMaximumCount, consumerGroup, connectionString, options) { }
+            public MinimalProcessorMock(int eventBatchMaximumCount,
+                                        string consumerGroup,
+                                        string connectionString,
+                                        EventProcessorOptions options = default) : base(eventBatchMaximumCount, consumerGroup, connectionString, options) { }
 
-            public ProcessorConstructorMock(int eventBatchMaximumCount,
-                                            string consumerGroup,
-                                            string connectionString,
-                                            string eventHubName,
-                                            EventProcessorOptions options = default) : base(eventBatchMaximumCount, consumerGroup, connectionString, eventHubName, options) { }
+            public MinimalProcessorMock(int eventBatchMaximumCount,
+                                        string consumerGroup,
+                                        string connectionString,
+                                        string eventHubName,
+                                        EventProcessorOptions options = default) : base(eventBatchMaximumCount, consumerGroup, connectionString, eventHubName, options) { }
 
-            public ProcessorConstructorMock(int eventBatchMaximumCount,
-                                            string consumerGroup,
-                                            string fullyQualifiedNamespace,
-                                            string eventHubName,
-                                            TokenCredential credential,
-                                            EventProcessorOptions options = default) : base(eventBatchMaximumCount, consumerGroup, fullyQualifiedNamespace, eventHubName, credential, options) { }
+            public MinimalProcessorMock(int eventBatchMaximumCount,
+                                        string consumerGroup,
+                                        string fullyQualifiedNamespace,
+                                        string eventHubName,
+                                        TokenCredential credential,
+                                        EventProcessorOptions options = default) : base(eventBatchMaximumCount, consumerGroup, fullyQualifiedNamespace, eventHubName, credential, options) { }
 
+            internal MinimalProcessorMock(int eventBatchMaximumCount,
+                                          string consumerGroup,
+                                          string fullyQualifiedNamespace,
+                                          string eventHubName,
+                                          TokenCredential credential,
+                                          EventProcessorOptions options,
+                                          PartitionLoadBalancer loadBalancer) : base(eventBatchMaximumCount, consumerGroup, fullyQualifiedNamespace, eventHubName, credential, options, loadBalancer) { }
+
+            public LastEnqueuedEventProperties InvokeReadLastEnqueuedEventProperties(string partitionId) => ReadLastEnqueuedEventProperties(partitionId);
             protected override Task<IEnumerable<EventProcessorPartitionOwnership>> ClaimOwnershipAsync(IEnumerable<EventProcessorPartitionOwnership> desiredOwnership, CancellationToken cancellationToken) => throw new NotImplementedException();
             protected override Task<IEnumerable<EventProcessorCheckpoint>> ListCheckpointsAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
             protected override Task<IEnumerable<EventProcessorPartitionOwnership>> ListOwnershipAsync(CancellationToken cancellationToken) => throw new NotImplementedException();


### PR DESCRIPTION
# Summary

The focus of these changes is to implement the means for a processor to read the last enqueued event properties for a given partition.

# Last Upstream Rebase

Wednesday, March 25, 1:44pm (EDT)

# References and Related Issues 

- [.NET Event Hubs Client: Event Processor<T> Proposal](https://gist.github.com/jsquire/1f4a1e72fc02871f443ce365222d40f6)
- [Implement the Event Processor Base](https://github.com/Azure/azure-sdk-for-net/issues/9324) (#9324)