### PR TITLE
[Event Hubs Client] Ignore Flaky Test

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.PartitionProcessing.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.PartitionProcessing.cs
@@ -180,6 +180,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        [Ignore("Intermittent failures in CI; investigation required.")]
         public async Task CreatePartitionProcessorReadsEmptyLastEventPropertiesWithNoOption()
         {
             using var cancellationSource = new CancellationTokenSource();


### PR DESCRIPTION
# Summary

The focus of these changes is to ignore a test that has been unstable in CI until it can be investigated and fixed.

# Last Upstream Rebase

Thursday, March 26, 11:08am (EDT)