### PR TITLE
Change keyHeader to name in AzureKeyCredentialPolicy 

### DIFF
--- a/sdk/core/Azure.Core/src/Shared/AzureKeyCredentialPolicy.cs
+++ b/sdk/core/Azure.Core/src/Shared/AzureKeyCredentialPolicy.cs
@@ -7,27 +7,27 @@ namespace Azure.Core
 {
     internal class AzureKeyCredentialPolicy : HttpPipelineSynchronousPolicy
     {
-        private readonly string _keyHeader;
+        private readonly string _name;
         private readonly AzureKeyCredential _credential;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureKeyCredentialPolicy"/> class.
         /// </summary>
         /// <param name="credential">The <see cref="AzureKeyCredential"/> used to authenticate requests.</param>
-        /// <param name="keyHeader">The name of the API key header used for signing requests.</param>
-        public AzureKeyCredentialPolicy(AzureKeyCredential credential, string keyHeader)
+        /// <param name="name">The name of the key header used for the credential.</param>
+        public AzureKeyCredentialPolicy(AzureKeyCredential credential, string name)
         {
             Argument.AssertNotNull(credential, nameof(credential));
-            Argument.AssertNotNullOrEmpty(keyHeader, nameof(keyHeader));
+            Argument.AssertNotNullOrEmpty(name, nameof(name));
             _credential = credential;
-            _keyHeader = keyHeader;
+            _name = name;
         }
 
         /// <inheritdoc/>
         public override void OnSendingRequest(HttpMessage message)
         {
             base.OnSendingRequest(message);
-            message.Request.Headers.SetValue(_keyHeader, _credential.Key);
+            message.Request.Headers.SetValue(_name, _credential.Key);
         }
     }
 }


### PR DESCRIPTION
Following [Johan's recommendation](https://github.com/Azure/azure-sdk-for-python/pull/10509#discussion_r398744760) and maintaining consistency across languages, changing `keyHeader` to `name`