### PR TITLE
[Event Hubs Client] Ignore Diagnostics Tests

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
@@ -34,6 +34,8 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </remarks>
     ///
     [NonParallelizable]
+    [TestFixture]
+    [Ignore("Tests intermittently failing in CI; Investigation needed")]
     public class DiagnosticsTests
     {
         /// <summary>The name of the diagnostics source being tested.</summary>


### PR DESCRIPTION
# Summary

The focus of these changes is to ignore the diagnostics tests which have been intermittently failing during CI.  These will be investigated and fixed in a
pending PR.

# Last Upstream Rebase

Friday, March 27, 9:48am (EDT)

