### PR TITLE
[Event Hubs Client] Test Determinism Tweaks

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
@@ -34,6 +34,7 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </remarks>
     ///
     [NonParallelizable]
+    [TestFixture]
     public class DiagnosticsTests
     {
         /// <summary>The name of the diagnostics source being tested.</summary>
@@ -375,16 +376,18 @@ namespace Azure.Messaging.EventHubs.Tests
                 new KeyValuePair<string, string>(DiagnosticProperty.EndpointAttribute, fullyQualifiedNamespace)
             };
 
+            var scopes = listener.Scopes.ToList();
+
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
-            Assert.That(listener.Scopes.Select(scope => scope.Name), Has.All.EqualTo(DiagnosticProperty.EventProcessorProcessingActivityName), "The processing scopes should have the correct name.");
+            Assert.That(scopes.Select(scope => scope.Name), Has.All.EqualTo(DiagnosticProperty.EventProcessorProcessingActivityName), "The processing scopes should have the correct name.");
 
             for (var index = 0; index < eventBatch.Count; ++index)
             {
                 var targetId = (++diagnosticId).ToString();
-                Assert.That(listener.Scopes.SelectMany(scope => scope.Links), Has.One.EqualTo(targetId), $"There should have been a link for the diagnostic identifier: { targetId }");
+                Assert.That(scopes.SelectMany(scope => scope.Links), Has.One.EqualTo(targetId), $"There should have been a link for the diagnostic identifier: { targetId }");
             }
 
-            foreach (var scope in listener.Scopes)
+            foreach (var scope in scopes)
             {
                 Assert.That(expectedTags, Is.SubsetOf(scope.Activity.Tags.ToList()));
             }
@@ -429,7 +432,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 new KeyValuePair<string, string>(DiagnosticProperty.EnqueuedTimeAttribute, enqueuedTime.ToUnixTimeMilliseconds().ToString())
             };
 
-            Assert.That(linkedActivity.Tags, Is.EquivalentTo(expectedTags), "The activity should have been tagged appropriately.");
+            var tags = linkedActivity.Tags.ToList();
+            Assert.That(tags, Is.EquivalentTo(expectedTags), "The activity should have been tagged appropriately.");
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.cs
@@ -154,8 +154,8 @@ namespace Azure.Messaging.EventHubs.Tests
         internal class SettableTransportConsumer : TransportConsumer
         {
             public void SetLastEvent(EventData lastEvent) => LastReceivedEvent = lastEvent;
-            public override Task CloseAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
-            public override Task<IReadOnlyList<EventData>> ReceiveAsync(int maximumMessageCount, TimeSpan? maximumWaitTime, CancellationToken cancellationToken) => throw new NotImplementedException();
+            public override Task CloseAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public override Task<IReadOnlyList<EventData>> ReceiveAsync(int maximumMessageCount, TimeSpan? maximumWaitTime, CancellationToken cancellationToken) => Task.FromResult<IReadOnlyList<EventData>>(new List<EventData>(0));
         }
     }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to address some non-deterministic behavior within the tests that was causing intermittent failures in CI, often with cascading failures within the diagnostics tests.

# Last Upstream Rebase

Friday, March 27, 1:14pm (EDT)

