### PR TITLE
Support HTTP Proxy for Services.AppAuthentication and ADAL

### DIFF
--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/AzureServiceTokenProviderTests.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/AzureServiceTokenProviderTests.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Services.AppAuthentication.TestCommon;
+using Microsoft.Azure.Services.AppAuthentication.Unit.Tests.Mocks;
 using Xunit;
 
 namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
@@ -312,6 +313,28 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         public void RemainMockable()
         {
             MockUtil.AssertPublicMethodsAreVirtual<AzureServiceTokenProvider>();
+        }
+
+        /// <summary>
+        /// Injects an HTTP factory.
+        /// </summary>
+        [Fact]
+        public void InjectHttpFactory()
+        {
+            var factory = new MockHttpClientFactory();
+            var provider = new AzureServiceTokenProvider(httpClientFactory: factory);
+            //todo: How to assert that the factory is passed into the underlying?
+        }
+
+        /// <summary>
+        /// Side load an HTTP factory.
+        /// </summary>
+        [Fact]
+        public void SideLoadHttpFactory()
+        {
+            AzureServiceTokenProvider.HttpClientFactory = new MockHttpClientFactory();
+            var provider = new AzureServiceTokenProvider();
+            //todo: How to assert that the factory is passed into the underlying?
         }
     }
 }

--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/AzureServiceTokenProviderTests.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/AzureServiceTokenProviderTests.cs
@@ -267,7 +267,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         }
 
         /// <summary>
-        /// If token could not be aquired through any of the specified providers, an exception should be thrown
+        /// If token could not be acquired through any of the specified providers, an exception should be thrown
         /// </summary>
         [Fact]
         public void DiscoveryTestBothFail()
@@ -319,22 +319,37 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         /// Injects an HTTP factory.
         /// </summary>
         [Fact]
-        public void InjectHttpFactory()
+        public async Task InjectHttpFactory()
         {
             var factory = new MockHttpClientFactory();
-            var provider = new AzureServiceTokenProvider(httpClientFactory: factory);
-            //todo: How to assert that the factory is passed into the underlying?
+
+            // create a client secret token provider
+            var azureServiceTokenProvider = new AzureServiceTokenProvider(Constants.ClientSecretConnString, Constants.AzureAdInstance, factory);
+
+            // trying to use the provider should fail because the http factory isn't implemented. We can verify it was used though.
+            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() =>
+                azureServiceTokenProvider.GetAccessTokenAsync(Constants.GraphResourceId, Constants.TenantId));
+
+            Assert.EndsWith(MockHttpClientFactory.ExceptionMessage, exception.Message);
         }
 
         /// <summary>
         /// Side load an HTTP factory.
         /// </summary>
         [Fact]
-        public void SideLoadHttpFactory()
+        public async Task SideLoadHttpFactory()
         {
-            AzureServiceTokenProvider.HttpClientFactory = new MockHttpClientFactory();
-            var provider = new AzureServiceTokenProvider();
-            //todo: How to assert that the factory is passed into the underlying?
+            MockHttpClientFactory factory = new MockHttpClientFactory();
+
+            // create a client secret token provider
+            AzureServiceTokenProvider.HttpClientFactory = factory;
+            var azureServiceTokenProvider = new AzureServiceTokenProvider(Constants.ClientSecretConnString, Constants.AzureAdInstance);
+
+            // trying to use the provider should fail because the http factory isn't implemented. We can verify it was used though.
+            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() =>
+                azureServiceTokenProvider.GetAccessTokenAsync(Constants.GraphResourceId, Constants.TenantId));
+
+            Assert.EndsWith(MockHttpClientFactory.ExceptionMessage, exception.Message);
         }
     }
 }

--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/Mocks/MockHttpClientFactory.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/Mocks/MockHttpClientFactory.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Net.Http;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+
+namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests.Mocks
+{
+    internal class MockHttpClientFactory : IHttpClientFactory
+    {
+        public HttpClient GetHttpClient()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/Mocks/MockHttpClientFactory.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/Mocks/MockHttpClientFactory.cs
@@ -6,9 +6,11 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests.Mocks
 {
     internal class MockHttpClientFactory : IHttpClientFactory
     {
+        public const string ExceptionMessage = "MockHttpClientFactory.GetHttpClient";
+
         public HttpClient GetHttpClient()
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException(ExceptionMessage);
         }
     }
 }

--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProvider.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProvider.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
 
         /// <summary>
         /// If a connection string was specified, or discovery of provider has already happened (in which case _selectedAccessTokenProvider would have been set),
-        /// Use the approproate access token provider. 
+        /// Use the appropriate access token provider. 
         /// </summary>
         /// <returns></returns>
         private List<NonInteractiveAzureServiceTokenProviderBase> GetTokenProviders()

--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProvider.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
 
 namespace Microsoft.Azure.Services.AppAuthentication
 {
@@ -37,6 +38,12 @@ namespace Microsoft.Azure.Services.AppAuthentication
         public delegate Task<string> TokenCallback(string authority, string resource, string scope);
 
         /// <summary>
+        /// HTTP client factory to support HTTP proxy in ADAL
+        /// Implemented as a static so that client apps can gain proxy support without having to wait for intermediate packages to support it.
+        /// </summary>
+        public static IHttpClientFactory HttpClientFactory { get; set; }
+
+        /// <summary>
         /// Property to get authentication callback to be used with KeyVaultClient.  
         /// </summary>
         /// <example>
@@ -62,7 +69,8 @@ namespace Microsoft.Azure.Services.AppAuthentication
         /// </summary>
         /// <param name="connectionString">Connection string to specify which option to use to get the token.</param>
         /// <param name="azureAdInstance">Specify a value for clouds other than the Public Cloud.</param>
-        public AzureServiceTokenProvider(string connectionString = default(string), string azureAdInstance = "https://login.microsoftonline.com/")
+        /// <param name="httpClientFactory">Passed to ADAL to allow proxied connections. Takes precedence over the static <see cref="HttpClientFactory"/> property</param>
+        public AzureServiceTokenProvider(string connectionString = default(string), string azureAdInstance = "https://login.microsoftonline.com/", IHttpClientFactory httpClientFactory = null)
         {
             if (string.IsNullOrEmpty(azureAdInstance))
             {
@@ -82,10 +90,12 @@ namespace Microsoft.Azure.Services.AppAuthentication
                 connectionString = EnvironmentHelper.GetEnvironmentVariable("AzureServicesAuthConnectionString");
             }
 
+            // injection is nicer than static backdoor.
+            var factory = httpClientFactory ?? HttpClientFactory;
+
             if (!string.IsNullOrWhiteSpace(connectionString))
             {
-                _selectedAccessTokenProvider = AzureServiceTokenProviderFactory.Create(connectionString, azureAdInstance);
-
+                _selectedAccessTokenProvider = AzureServiceTokenProviderFactory.Create(connectionString, azureAdInstance, factory);
                 _connectionString = connectionString;
             }
             else
@@ -96,7 +106,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
                     new VisualStudioAccessTokenProvider(new ProcessManager()),
                     new AzureCliAccessTokenProvider(new ProcessManager()),
 #if FullNetFx
-                    new WindowsAuthenticationAzureServiceTokenProvider(new AdalAuthenticationContext(), azureAdInstance)
+                    new WindowsAuthenticationAzureServiceTokenProvider(new AdalAuthenticationContext(factory), azureAdInstance)
 #endif
                 };
             }


### PR DESCRIPTION
This PR allows HTTP proxies to be properly supported via the IHttpClientFactory interface (https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/wiki/Providing-an-HttpClient).

The manner for passing this interface into AzureServiceTokenProvider is either by constructor parameter (so that upstream libraries can play nice) or via static property AzureServiceTokenProvider.HttpClientFactory (so that upstream clients can get proxy support without waiting for upstream libraries). This solves the outstanding issues with #4404

i.e. my client application behind a web proxy can now get a secret from KeyVault using a certificate for service principal authentication.

Rebases/replaces #6451
