### PR TITLE
Allow remote swagger readme.md inputs

### DIFF
--- a/eng/CodeGeneration.targets
+++ b/eng/CodeGeneration.targets
@@ -8,6 +8,10 @@
     <_DefaultInputName Condition="Exists('$(MSBuildProjectDirectory)/autorest.md')">$(MSBuildProjectDirectory)/autorest.md</_DefaultInputName>
     <AutorestInput Condition="'$(AutorestInput)' == ''">$(_DefaultInputName)</AutorestInput>
     <AutorestConfiguration Condition="'$(AutorestConfiguration)' == '' AND '$(AutorestInput)' != '$(_DefaultInputName)'">$(_DefaultInputName)</AutorestConfiguration>
+    <!--
+      Allows passing additional AutoRest command line arguments, for example to run in interactive mode 
+      use the following command line: dotnet msbuild /t:GenerateCode /p:AutorestAdditionalParameters="--interactive"
+    -->
     <AutorestAdditionalParameters></AutorestAdditionalParameters>
     <_SharedCodeDirectory>$(MSBuildThisFileDirectory)../sdk/core/Azure.Core/src/Shared/</_SharedCodeDirectory>
     <_AutoRestSharedCodeDirectory>$(_SharedCodeDirectory)Autorest/</_AutoRestSharedCodeDirectory>

--- a/eng/CodeGeneration.targets
+++ b/eng/CodeGeneration.targets
@@ -5,8 +5,8 @@
     <_AutoRestCoreVersion>3.0.6257</_AutoRestCoreVersion>
     <_AutoRestCSharpVersion>https://github.com/Azure/autorest.csharp/releases/download/3.0.0-dev.20200325.2/autorest-csharp-v3-3.0.0-dev.20200325.2.tgz</_AutoRestCSharpVersion>
     <_SupportsCodeGeneration Condition="'$(IsClientLibrary)' == 'true'">true</_SupportsCodeGeneration>
-    <_DefaultInputName>$(MSBuildProjectDirectory)/autorest.md</_DefaultInputName>
-    <AutorestInput Condition="'$(AutorestInput)' == '' AND Exists('$(_DefaultInputName)')">$(_DefaultInputName)</AutorestInput>
+    <_DefaultInputName Condition="Exists('$(_DefaultInputName)')">$(MSBuildProjectDirectory)/autorest.md</_DefaultInputName>
+    <AutorestInput Condition="'$(AutorestInput)' == ''">$(_DefaultInputName)</AutorestInput>
     <AutorestConfiguration Condition="'$(AutorestConfiguration)' == '' AND '$(AutorestInput)' != '$(_DefaultInputName)'">$(_DefaultInputName)</AutorestConfiguration>
     <AutorestAdditionalParameters></AutorestAdditionalParameters>
     <_SharedCodeDirectory>$(MSBuildThisFileDirectory)../sdk/core/Azure.Core/src/Shared/</_SharedCodeDirectory>
@@ -17,8 +17,11 @@
   </PropertyGroup>
 
   <Target Name="GenerateCode" Condition="'$(_GenerateCode)' == 'true'" >
+    <PropertyGroup>
+      <_RequireConfigurationArgument Condition="'$(AutorestConfiguration)' != ''">--require=$(AutorestConfiguration)</_RequireConfigurationArgument>
+    </PropertyGroup>
     <RemoveDir Directories="$(MSBuildProjectDirectory)/Generated"/>
-    <Exec Command="npx autorest@$(_AutoRestVersion) --version=$(_AutoRestCoreVersion) $(AutorestInput) --require=$(AutorestConfiguration) $(AutorestAdditionalParameters) --use=$(_AutoRestCSharpVersion) --output-folder=$(MSBuildProjectDirectory) --title=$(RootNamespace) --namespace=$(RootNamespace) --shared-source-folder=$(_SharedCodeDirectory) --verbose" />
+    <Exec Command="npx autorest@$(_AutoRestVersion) --version=$(_AutoRestCoreVersion) $(AutorestInput) $(_RequireConfigurationArgument) $(AutorestAdditionalParameters) --use=$(_AutoRestCSharpVersion) --output-folder=$(MSBuildProjectDirectory) --title=$(RootNamespace) --namespace=$(RootNamespace) --shared-source-folder=$(_SharedCodeDirectory) --verbose" />
   </Target>
 
   <ItemGroup Condition="'$(_GenerateCode)' == 'true'">

--- a/eng/CodeGeneration.targets
+++ b/eng/CodeGeneration.targets
@@ -10,7 +10,7 @@
     <AutorestConfiguration Condition="'$(AutorestConfiguration)' == '' AND '$(AutorestInput)' != '$(_DefaultInputName)'">$(_DefaultInputName)</AutorestConfiguration>
     <!--
       Allows passing additional AutoRest command line arguments, for example to run in interactive mode 
-      use the following command line: dotnet msbuild /t:GenerateCode /p:AutorestAdditionalParameters="--interactive"
+      use the following command line (remove the space between minus minus): dotnet msbuild /t:GenerateCode /p:AutorestAdditionalParameters="- -interactive"
     -->
     <AutorestAdditionalParameters></AutorestAdditionalParameters>
     <_SharedCodeDirectory>$(MSBuildThisFileDirectory)../sdk/core/Azure.Core/src/Shared/</_SharedCodeDirectory>

--- a/eng/CodeGeneration.targets
+++ b/eng/CodeGeneration.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <_AutoRestVersion>https://github.com/Azure/autorest/releases/download/autorest-3.0.6207/autorest-3.0.6207.tgz</_AutoRestVersion>
     <_AutoRestCoreVersion>3.0.6257</_AutoRestCoreVersion>
-    <_AutoRestCSharpVersion>https://github.com/Azure/autorest.csharp/releases/download/3.0.0-dev.20200323.2/autorest-csharp-v3-3.0.0-dev.20200323.2.tgz</_AutoRestCSharpVersion>
+    <_AutoRestCSharpVersion>https://github.com/Azure/autorest.csharp/releases/download/3.0.0-dev.20200325.2/autorest-csharp-v3-3.0.0-dev.20200325.2.tgz</_AutoRestCSharpVersion>
     <_SupportsCodeGeneration Condition="'$(IsClientLibrary)' == 'true'">true</_SupportsCodeGeneration>
     <_DefaultInputName>$(MSBuildProjectDirectory)/autorest.md</_DefaultInputName>
     <AutorestInput Condition="'$(AutorestInput)' == '' AND Exists('$(_DefaultInputName)')">$(_DefaultInputName)</AutorestInput>

--- a/eng/CodeGeneration.targets
+++ b/eng/CodeGeneration.targets
@@ -5,7 +5,7 @@
     <_AutoRestCoreVersion>3.0.6257</_AutoRestCoreVersion>
     <_AutoRestCSharpVersion>https://github.com/Azure/autorest.csharp/releases/download/3.0.0-dev.20200325.2/autorest-csharp-v3-3.0.0-dev.20200325.2.tgz</_AutoRestCSharpVersion>
     <_SupportsCodeGeneration Condition="'$(IsClientLibrary)' == 'true'">true</_SupportsCodeGeneration>
-    <_DefaultInputName Condition="Exists('$(_DefaultInputName)')">$(MSBuildProjectDirectory)/autorest.md</_DefaultInputName>
+    <_DefaultInputName Condition="Exists('$(MSBuildProjectDirectory)/autorest.md')">$(MSBuildProjectDirectory)/autorest.md</_DefaultInputName>
     <AutorestInput Condition="'$(AutorestInput)' == ''">$(_DefaultInputName)</AutorestInput>
     <AutorestConfiguration Condition="'$(AutorestConfiguration)' == '' AND '$(AutorestInput)' != '$(_DefaultInputName)'">$(_DefaultInputName)</AutorestConfiguration>
     <AutorestAdditionalParameters></AutorestAdditionalParameters>

--- a/eng/CodeGeneration.targets
+++ b/eng/CodeGeneration.targets
@@ -3,20 +3,22 @@
   <PropertyGroup>
     <_AutoRestVersion>https://github.com/Azure/autorest/releases/download/autorest-3.0.6207/autorest-3.0.6207.tgz</_AutoRestVersion>
     <_AutoRestCoreVersion>3.0.6257</_AutoRestCoreVersion>
-    <_AutoRestCSharpVersion>https://github.com/Azure/autorest.csharp/releases/download/3.0.0-dev.20200325.2/autorest-csharp-v3-3.0.0-dev.20200325.2.tgz</_AutoRestCSharpVersion>
+    <_AutoRestCSharpVersion>https://github.com/Azure/autorest.csharp/releases/download/3.0.0-dev.20200323.2/autorest-csharp-v3-3.0.0-dev.20200323.2.tgz</_AutoRestCSharpVersion>
     <_SupportsCodeGeneration Condition="'$(IsClientLibrary)' == 'true'">true</_SupportsCodeGeneration>
-    <AutoRestConfiguration Condition="'$(AutoRestConfiguration)' == ''">autorest.md</AutoRestConfiguration>
-
+    <_DefaultInputName>$(MSBuildProjectDirectory)/autorest.md</_DefaultInputName>
+    <AutorestInput Condition="'$(AutorestInput)' == '' AND Exists('$(_DefaultInputName)')">$(_DefaultInputName)</AutorestInput>
+    <AutorestConfiguration Condition="'$(AutorestConfiguration)' == '' AND '$(AutorestInput)' != '$(_DefaultInputName)'">$(_DefaultInputName)</AutorestConfiguration>
+    <AutorestAdditionalParameters></AutorestAdditionalParameters>
     <_SharedCodeDirectory>$(MSBuildThisFileDirectory)../sdk/core/Azure.Core/src/Shared/</_SharedCodeDirectory>
     <_AutoRestSharedCodeDirectory>$(_SharedCodeDirectory)Autorest/</_AutoRestSharedCodeDirectory>
 
-    <_GenerateCode Condition="'$(_SupportsCodeGeneration)' == 'true' AND Exists('$(AutoRestConfiguration)')">true</_GenerateCode>
+    <_GenerateCode Condition="'$(_SupportsCodeGeneration)' == 'true' AND '$(AutorestInput)' != ''">true</_GenerateCode>
     <UsesJsonSerialization Condition="'$(UsesJsonSerialization)' == ''">true</UsesJsonSerialization>
   </PropertyGroup>
 
   <Target Name="GenerateCode" Condition="'$(_GenerateCode)' == 'true'" >
     <RemoveDir Directories="$(MSBuildProjectDirectory)/Generated"/>
-    <Exec Command="npx autorest@$(_AutoRestVersion) --version=$(_AutoRestCoreVersion) --input=$(AutoRestConfiguration) --use=$(_AutoRestCSharpVersion) --output-folder=$(MSBuildProjectDirectory) --title=$(RootNamespace) --namespace=$(RootNamespace) --shared-source-folder=$(_SharedCodeDirectory) --verbose" />
+    <Exec Command="npx autorest@$(_AutoRestVersion) --version=$(_AutoRestCoreVersion) $(AutorestInput) --require=$(AutorestConfiguration) $(AutorestAdditionalParameters) --use=$(_AutoRestCSharpVersion) --output-folder=$(MSBuildProjectDirectory) --title=$(RootNamespace) --namespace=$(RootNamespace) --shared-source-folder=$(_SharedCodeDirectory) --verbose" />
   </Target>
 
   <ItemGroup Condition="'$(_GenerateCode)' == 'true'">

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ExcludeMgmtLib Include="..\sdk\*\*.Management.*\**\*.csproj;..\sdk\*mgmt*\**\*.csproj;" />
+    <ExcludeMgmtLib Include="..\sdk\*\Microsoft.*.Management.*\**\*.csproj;..\sdk\*mgmt*\**\*.csproj;" />
     <TestProjects Include="..\sdk\$(ServiceDirectory)\**\tests\**\*.csproj" />
     <SamplesProjects Include="..\sdk\$(ServiceDirectory)\**\samples\**\*.csproj" />
     <SampleApplications Include="..\samples\**\*.csproj" />


### PR DESCRIPTION
This change allows the README.md from specs repo to be specified as the main input, local `autorest.md` would be used as an additional configuration file in that case.

Example:

```
    <AutorestInput>https://github.com/Azure/azure-rest-api-specs/blob/03c98e8708f9fdcc5aadb06df641eb73556eb123/specification/storage/resource-manager/readme.md</AutorestInput>
```

Also adds support for `AutorestAdditionalParameters` and changes tree traversal to include track 2 management libraries into the default set.