### PR TITLE
[ACR] Fix jwt dependency. Do not require exact version (require minimum version instead)

### DIFF
--- a/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/src/Microsoft.Azure.ContainerRegistry.csproj
+++ b/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/src/Microsoft.Azure.ContainerRegistry.csproj
@@ -3,7 +3,7 @@
   	<PackageId>Microsoft.Azure.ContainerRegistry</PackageId>
     <Description>This is a client library for Azure Container Registry data plane operations. Use this library to retrieve, update and view Registry tags, blobs and manifests. </Description>
     <AssemblyTitle>Microsoft Azure Container Registry</AssemblyTitle>
-    <Version>0.10.0-preview</Version>
+    <Version>0.10.1-preview</Version>
     <PackageTags>Microsoft Azure Container Registry;Container Registry; Microsoft; Docker Registry HTTP API V2</PackageTags>
     <PackageReleaseNotes>
       * Manage Azure Container Registry repositories, tags, manifests, blobs, access tokens and refresh tokens.
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" VersionOverride="[5.1.2]" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" VersionOverride="5.1.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Can a new release be done for the ACR dataplane sdk `Microsoft.Azure.ContainerRegistry`. For some reason an exact version for the dependency `System.IdentityModel.Tokens.Jwt` was required.