### PR TITLE
Add mock support for the Text Analytics client

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 - Refactor common properties from `DetectLanguageInput` and `TextDocumentInput` into it's own type `TextAnalyticsInput`.
+- Mock support for the Text Analytics client with respective samples.
 
 ## 1.0.0-preview.3 (2020-03-10)
 ### Breaking changes

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -1,5 +1,5 @@
 # Azure Cognitive Services Text Analytics client library for .NET
-Azure Cognitive Services Text Analytics is a cloud service that provides advanced natural language processing over raw text, and includes six main functions: 
+Azure Cognitive Services Text Analytics is a cloud service that provides advanced natural language processing over raw text, and includes the following main functions: 
 * Language Detection
 * Sentiment Analysis
 * Key Phrase Extraction
@@ -304,6 +304,7 @@ Samples are provided for each main functional area, and for each area, samples a
 - [Extract Key Phrases][extract_key_phrases_sample]
 - [Recognize Entities][recognize_entities_sample]
 - [Recognize Linked Entities][recognize_linked_entities_sample]
+- [Create a mock client][mock_client_sample] for testing using the [Moq][moq] library.
 
 ## Contributing
 See the [CONTRIBUTING.md][contributing] for details on building, testing, and contributing to this library.
@@ -349,11 +350,13 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 [extract_key_phrases_sample]: samples/Sample3_ExtractKeyPhrases.md
 [recognize_entities_sample]: samples/Sample4_RecognizeEntities.md
 [recognize_linked_entities_sample]: samples/Sample6_RecognizeLinkedEntities.md
+[mock_client_sample]: samples/Sample_MockClient.md
 
 [azure_cli]: https://docs.microsoft.com/cli/azure
 [azure_sub]: https://azure.microsoft.com/free/
 [nuget]: https://www.nuget.org/
 [azure_portal]: https://portal.azure.com
+[moq]: https://github.com/Moq/moq4/
 
 [cla]: https://cla.microsoft.com
 [code_of_conduct]: https://opensource.microsoft.com/codeofconduct/

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/README.md
@@ -10,14 +10,14 @@ description: Samples for the Azure.AI.TextAnalytics client library
 ---
 
 # Azure Text Analytics client SDK Samples
-Azure Cognitive Services Text Analytics is a cloud service that provides advanced natural language processing over raw text, and includes six main functions: 
+Azure Cognitive Services Text Analytics is a cloud service that provides advanced natural language processing over raw text, and includes the following main functions: 
 * Language Detection
 * Sentiment Analysis
 * Key Phrase Extraction
 * Named Entity Recognition
 * Linked Entity Recognition
 
-You can find samples for each of this main functions below.
+You can find samples for each of this main functions below, as well as a sample on how to create a mock client for testing purposes.
 To get started you'll need a Text Analytics endpoint and credentials. See Text Analytics Client Library [Readme][README] for more information and instructions.
 
 - [Detect Language](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample1_DetectLanguage.md)
@@ -25,5 +25,6 @@ To get started you'll need a Text Analytics endpoint and credentials. See Text A
 - [Extract Key Phrases](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample3_ExtractKeyPhrases.md)
 - [Recognize Entities](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample4_RecognizeEntities.md)
 - [Recognize Linked Entities](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md)
+- [Mock client](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample_MockClient.md)
 
 [README]: https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/textanalytics/Azure.AI.TextAnalytics/README.md

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample_MockClient.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample_MockClient.md
@@ -2,8 +2,25 @@
 
 This sample illustrates how to use [Moq][moq] to create a unit test that mocks the response from a `TextAnalyticsClient` method. For more examples of mocking, see [Moq samples][moq_samples].
 
+## Define method that uses TextAnalyticsClient
+To show the usage of mocks, define a method that will be tested with mocked objects. For this case, we are going to create a method that will verify if a document is writen in Spanish.
+
+```C# Snippet:MethodToTest
+private static async Task<bool> IsSpanishAsync(string document, TextAnalyticsClient client, CancellationToken cancellationToken)
+{
+    while (!cancellationToken.IsCancellationRequested)
+    {
+        DetectedLanguage language = await client.DetectLanguageAsync(document);
+        return language.Iso6391Name == "es";
+    }
+
+    cancellationToken.ThrowIfCancellationRequested();
+    return false;
+}
+```
+
 ## Create and setup mocks
-For this test, create a mock for the `TextAnalyticsClient` and `Response`.
+To start, create a mock for the `TextAnalyticsClient` and `Response`.
 
 ```C# Snippet:CreateMocks
 var mockResponse = new Mock<Response>();
@@ -20,14 +37,12 @@ mockClient.Setup(c => c.DetectLanguageAsync("Este documento está en español.",
 ```
 
 ## Use mocks
-Now, to validate the detected language of the document without making a network call, use `TextAnalyticsClient` mock.
+Now, to validate if the document is in Spanish without making a network call, use `TextAnalyticsClient` mock.
 
 ```C# Snippet:UseMocks
 TextAnalyticsClient client = mockClient.Object;
-DetectedLanguage language = await client.DetectLanguageAsync("Este documento está en español.");
-Assert.AreEqual("Spanish", language.Name);
-Assert.AreEqual("es", language.Iso6391Name);
-Assert.AreEqual(1.00, language.Score);
+bool result = await IsSpanishAsync("Este documento está en español.", client, default);
+Assert.IsTrue(result);
 ```
 
 [moq]: https://github.com/Moq/moq4/

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample_MockClient.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample_MockClient.md
@@ -1,0 +1,34 @@
+# Mock a client for testing using the Moq library
+
+This sample illustrates how to use [Moq][moq] to create a unit test that mocks the response from a `TextAnalyticsClient` method. For more examples of mocking, see [Moq samples][moq_samples].
+
+## Create and setup mocks
+For this test, create a mock for the `TextAnalyticsClient` and `Response`.
+
+```C# Snippet:CreateMocks
+var mockResponse = new Mock<Response>();
+var mockClient = new Mock<TextAnalyticsClient>();
+```
+
+Then, set up the client methods that will be executed. In this case, we will call the `DetectLanguageAsync` method.
+
+```C# Snippet:SetupMocks
+Response<DetectedLanguage> response = Response.FromValue(TextAnalyticsModelFactory.DetectedLanguage("Spanish", "es", 1.00), mockResponse.Object);
+
+mockClient.Setup(c => c.DetectLanguageAsync("Este documento está en español.", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+    .Returns(Task.FromResult(response));
+```
+
+## Use mocks
+Now, to validate the detected language of the document without making a network call, use `TextAnalyticsClient` mock.
+
+```C# Snippet:UseMocks
+TextAnalyticsClient client = mockClient.Object;
+DetectedLanguage language = await client.DetectLanguageAsync("Este documento está en español.");
+Assert.AreEqual("Spanish", language.Name);
+Assert.AreEqual("es", language.Iso6391Name);
+Assert.AreEqual(1.00, language.Score);
+```
+
+[moq]: https://github.com/Moq/moq4/
+[moq_samples]: (https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/SampleMoq.cs)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsModelFactory.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsModelFactory.cs
@@ -1,0 +1,340 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.AI.TextAnalytics
+{
+    /// <summary>
+    /// Model factory that enables mocking for the Text Analytics library.
+    /// </summary>
+    public static class TextAnalyticsModelFactory
+    {
+        #region Common
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.TextDocumentStatistics"/> for mocking purposes.
+        /// </summary>
+        /// <param name="grahemeCount">Sets the <see cref="TextDocumentStatistics.GraphemeCount"/> property.</param>
+        /// <param name="transactionCount">Sets the <see cref="TextDocumentStatistics.TransactionCount"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.TextDocumentStatistics"/> for mocking purposes.</returns>
+        public static TextDocumentStatistics TextDocumentStatistics(int grahemeCount, int transactionCount)
+        {
+            return new TextDocumentStatistics(grahemeCount, transactionCount);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.TextDocumentBatchStatistics"/> for mocking purposes.
+        /// </summary>
+        /// <param name="documentCount">Sets the <see cref="TextDocumentBatchStatistics.DocumentCount"/> property.</param>
+        /// <param name="validDocumentCount">Sets the <see cref="TextDocumentBatchStatistics.ValidDocumentCount"/> property.</param>
+        /// <param name="invalidDocumentCount">Sets the <see cref="TextDocumentBatchStatistics.InvalidDocumentCount"/> property.</param>
+        /// <param name="transactionCount">Sets the <see cref="TextDocumentBatchStatistics.TransactionCount"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.TextDocumentBatchStatistics"/> for mocking purposes.</returns>
+        public static TextDocumentBatchStatistics TextDocumentBatchStatistics(int documentCount, int validDocumentCount, int invalidDocumentCount, long transactionCount)
+        {
+            return new TextDocumentBatchStatistics(documentCount, validDocumentCount, invalidDocumentCount, transactionCount);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.TextAnalyticsError"/> for mocking purposes.
+        /// </summary>
+        /// <param name="code">Sets the <see cref="TextAnalyticsError.Code"/> property.</param>
+        /// <param name="message">Sets the <see cref="TextAnalyticsError.Message"/> property.</param>
+        /// <param name="target">Sets the <see cref="TextAnalyticsError.Target"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.TextAnalyticsError"/> for mocking purposes.</returns>
+        public static TextAnalyticsError TextAnalyticsError(string code, string message, string target = default)
+        {
+            return new TextAnalyticsError(code, message, target);
+        }
+
+        #endregion Common
+
+        #region Analyze Sentiment
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.SentimentConfidenceScores"/> for mocking purposes.
+        /// </summary>
+        /// <param name="positiveScore">Sets the <see cref="SentimentConfidenceScores.Positive"/> property.</param>
+        /// <param name="neutralScore">Sets the <see cref="SentimentConfidenceScores.Neutral"/> property.</param>
+        /// <param name="negativeScore">Sets the <see cref="SentimentConfidenceScores.Negative"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.SentimentConfidenceScores"/> for mocking purposes.</returns>
+        public static SentimentConfidenceScores SentimentConfidenceScores(double positiveScore, double neutralScore, double negativeScore)
+        {
+            return new SentimentConfidenceScores(positiveScore, neutralScore, negativeScore);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.DocumentSentiment"/> for mocking purposes.
+        /// </summary>
+        /// <param name="sentiment">Sets the <see cref="DocumentSentiment.Sentiment"/> property.</param>
+        /// <param name="positiveScore">Sets the <see cref="SentimentConfidenceScores.Positive"/> property.</param>
+        /// <param name="neutralScore">Sets the <see cref="SentimentConfidenceScores.Neutral"/> property.</param>
+        /// <param name="negativeScore">Sets the <see cref="SentimentConfidenceScores.Negative"/> property.</param>
+        /// <param name="sentenceSentiments">Sets the <see cref="DocumentSentiment.Sentences"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.DocumentSentiment"/> for mocking purposes.</returns>
+        public static DocumentSentiment DocumentSentiment(TextSentiment sentiment, double positiveScore, double neutralScore, double negativeScore, List<SentenceSentiment> sentenceSentiments)
+        {
+            return new DocumentSentiment(sentiment, positiveScore, neutralScore, negativeScore, sentenceSentiments);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.SentenceSentiment"/> for mocking purposes.
+        /// </summary>
+        /// <param name="sentiment">Sets the <see cref="SentenceSentiment.Sentiment"/> property.</param>
+        /// <param name="positiveScore">Sets the <see cref="SentimentConfidenceScores.Positive"/> property.</param>
+        /// <param name="neutralScore">Sets the <see cref="SentimentConfidenceScores.Neutral"/> property.</param>
+        /// <param name="negativeScore">Sets the <see cref="SentimentConfidenceScores.Negative"/> property.</param>
+        /// <param name="offset">Sets the <see cref="SentenceSentiment.GraphemeOffset"/> property.</param>
+        /// <param name="length">Sets the <see cref="SentenceSentiment.GraphemeLength"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.SentenceSentiment"/> for mocking purposes.</returns>
+        public static SentenceSentiment SentenceSentiment(TextSentiment sentiment, double positiveScore, double neutralScore, double negativeScore, int offset, int length)
+        {
+            return new SentenceSentiment(sentiment, positiveScore, neutralScore, negativeScore, offset, length);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.AnalyzeSentimentResult"/> for mocking purposes.
+        /// </summary>
+        /// <param name="id">Sets the <see cref="TextAnalyticsResult.Id"/> property.</param>
+        /// <param name="statistics">Sets the <see cref="TextAnalyticsResult.Statistics"/> property.</param>
+        /// <param name="documentSentiment">Sets the <see cref="AnalyzeSentimentResult.DocumentSentiment"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.AnalyzeSentimentResult"/> for mocking purposes.</returns>
+        public static AnalyzeSentimentResult AnalyzeSentimentResult(string id, TextDocumentStatistics statistics, DocumentSentiment documentSentiment)
+        {
+            return new AnalyzeSentimentResult(id, statistics, documentSentiment);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.AnalyzeSentimentResult"/> for mocking purposes.
+        /// </summary>
+        /// <param name="id">Sets the <see cref="TextAnalyticsResult.Id"/> property.</param>
+        /// <param name="error">Sets the <see cref="TextAnalyticsResult.Error"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.AnalyzeSentimentResult"/> for mocking purposes.</returns>
+        public static AnalyzeSentimentResult AnalyzeSentimentResult(string id, TextAnalyticsError error)
+        {
+            return new AnalyzeSentimentResult(id, error);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.AnalyzeSentimentResultCollection"/> for mocking purposes.
+        /// </summary>
+        /// <param name="list">Sets the collection of <see cref="TextAnalytics.AnalyzeSentimentResult"/>.</param>
+        /// <param name="statistics">Sets the <see cref="AnalyzeSentimentResultCollection.Statistics"/> property.</param>
+        /// <param name="modelVersion">Sets the <see cref="AnalyzeSentimentResultCollection.ModelVersion"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.AnalyzeSentimentResultCollection"/> for mocking purposes.</returns>
+        public static AnalyzeSentimentResultCollection AnalyzeSentimentResultCollection(IList<AnalyzeSentimentResult> list, TextDocumentBatchStatistics statistics, string modelVersion)
+        {
+            return new AnalyzeSentimentResultCollection(list, statistics, modelVersion);
+        }
+
+        #endregion Analyze Sentiment
+
+        #region Detect Language
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.DetectedLanguage"/> for mocking purposes.
+        /// </summary>
+        /// <param name="name">Sets the <see cref="DetectedLanguage.Name"/> property.</param>
+        /// <param name="iso6391Name">Sets the <see cref="DetectedLanguage.Iso6391Name"/> property.</param>
+        /// <param name="score">Sets the <see cref="DetectedLanguage.Score"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.DetectedLanguage"/> for mocking purposes.</returns>
+        public static DetectedLanguage DetectedLanguage(string name, string iso6391Name, double score)
+        {
+            return new DetectedLanguage(name, iso6391Name, score);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.DetectLanguageResult"/> for mocking purposes.
+        /// </summary>
+        /// <param name="id">Sets the <see cref="TextAnalyticsResult.Id"/> property.</param>
+        /// <param name="statistics">Sets the <see cref="TextAnalyticsResult.Statistics"/> property.</param>
+        /// <param name="detectedLanguage">Sets the <see cref="TextAnalytics.DetectedLanguage"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.DetectLanguageResult"/> for mocking purposes.</returns>
+        public static DetectLanguageResult DetectLanguageResult(string id, TextDocumentStatistics statistics, DetectedLanguage detectedLanguage)
+        {
+            return new DetectLanguageResult(id, statistics, detectedLanguage);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.DetectLanguageResult"/> for mocking purposes.
+        /// </summary>
+        /// <param name="id">Sets the <see cref="TextAnalyticsResult.Id"/> property.</param>
+        /// <param name="error">Sets the <see cref="TextAnalyticsResult.Error"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.DetectLanguageResult"/> for mocking purposes.</returns>
+        public static DetectLanguageResult DetectLanguageResult(string id, TextAnalyticsError error)
+        {
+            return new DetectLanguageResult(id, error);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.DetectLanguageResultCollection"/> for mocking purposes.
+        /// </summary>
+        /// <param name="list">Sets the collection of <see cref="TextAnalytics.DetectLanguageResult"/>.</param>
+        /// <param name="statistics">Sets the <see cref="DetectLanguageResultCollection.Statistics"/> property.</param>
+        /// <param name="modelVersion">Sets the <see cref="DetectLanguageResultCollection.ModelVersion"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.DetectLanguageResultCollection"/> for mocking purposes.</returns>
+        public static DetectLanguageResultCollection DetectLanguageResultCollection(IList<DetectLanguageResult> list, TextDocumentBatchStatistics statistics, string modelVersion)
+        {
+            return new DetectLanguageResultCollection(list, statistics, modelVersion);
+        }
+
+        #endregion Detect Language
+
+        #region Recognize Entities
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.CategorizedEntity"/> for mocking purposes.
+        /// </summary>
+        /// <param name="text">Sets the <see cref="CategorizedEntity.Text"/> property.</param>
+        /// <param name="category">Sets the <see cref="CategorizedEntity.Category"/> property.</param>
+        /// <param name="subCategory">Sets the <see cref="CategorizedEntity.SubCategory"/> property.</param>
+        /// <param name="offset">Sets the <see cref="CategorizedEntity.GraphemeOffset"/> property.</param>
+        /// <param name="length">Sets the <see cref="CategorizedEntity.GraphemeLength"/> property.</param>
+        /// <param name="score">Sets the <see cref="CategorizedEntity.ConfidenceScore"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.CategorizedEntity"/> for mocking purposes.</returns>
+        public static CategorizedEntity CategorizedEntity(string text, string category, string subCategory, int offset, int length, double score)
+        {
+            return new CategorizedEntity(text, category, subCategory, offset, length, score);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.RecognizeEntitiesResult"/> for mocking purposes.
+        /// </summary>
+        /// <param name="id">Sets the <see cref="TextAnalyticsResult.Id"/> property.</param>
+        /// <param name="statistics">Sets the <see cref="TextAnalyticsResult.Statistics"/> property.</param>
+        /// <param name="entities">Sets the collection of <see cref="TextAnalytics.CategorizedEntity"/>.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.RecognizeEntitiesResult"/> for mocking purposes.</returns>
+        public static RecognizeEntitiesResult RecognizeEntitiesResult(string id, TextDocumentStatistics statistics, IList<CategorizedEntity> entities)
+        {
+            return new RecognizeEntitiesResult(id, statistics, entities);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.RecognizeEntitiesResult"/> for mocking purposes.
+        /// </summary>
+        /// <param name="id">Sets the <see cref="TextAnalyticsResult.Id"/> property.</param>
+        /// <param name="error">Sets the <see cref="TextAnalyticsResult.Error"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.RecognizeEntitiesResult"/> for mocking purposes.</returns>
+        public static RecognizeEntitiesResult RecognizeEntitiesResult(string id, TextAnalyticsError error)
+        {
+            return new RecognizeEntitiesResult(id, error);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.RecognizeEntitiesResultCollection"/> for mocking purposes.
+        /// </summary>
+        /// <param name="list">Sets the collection of <see cref="TextAnalytics.RecognizeEntitiesResult"/>.</param>
+        /// <param name="statistics">Sets the <see cref="RecognizeEntitiesResultCollection.Statistics"/> property.</param>
+        /// <param name="modelVersion">Sets the <see cref="RecognizeEntitiesResultCollection.ModelVersion"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.RecognizeEntitiesResultCollection"/> for mocking purposes.</returns>
+        public static RecognizeEntitiesResultCollection RecognizeEntitiesResultCollection(IList<RecognizeEntitiesResult> list, TextDocumentBatchStatistics statistics, string modelVersion)
+        {
+            return new RecognizeEntitiesResultCollection(list, statistics, modelVersion);
+        }
+
+        #endregion Recognize Entities
+
+        #region Extract KeyPhrase
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.ExtractKeyPhrasesResult"/> for mocking purposes.
+        /// </summary>
+        /// <param name="id">Sets the <see cref="TextAnalyticsResult.Id"/> property.</param>
+        /// <param name="statistics">Sets the <see cref="TextAnalyticsResult.Statistics"/> property.</param>
+        /// <param name="keyPhrases">Sets the <see cref="ExtractKeyPhrasesResult.KeyPhrases"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.ExtractKeyPhrasesResult"/> for mocking purposes.</returns>
+        public static ExtractKeyPhrasesResult ExtractKeyPhrasesResult(string id, TextDocumentStatistics statistics, IList<string> keyPhrases)
+        {
+            return new ExtractKeyPhrasesResult(id, statistics, keyPhrases);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.ExtractKeyPhrasesResult"/> for mocking purposes.
+        /// </summary>
+        /// <param name="id">Sets the <see cref="TextAnalyticsResult.Id"/> property.</param>
+        /// <param name="error">Sets the <see cref="TextAnalyticsResult.Error"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.ExtractKeyPhrasesResult"/> for mocking purposes.</returns>
+        public static ExtractKeyPhrasesResult ExtractKeyPhrasesResult(string id, TextAnalyticsError error)
+        {
+            return new ExtractKeyPhrasesResult(id, error);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.ExtractKeyPhrasesResultCollection"/> for mocking purposes.
+        /// </summary>
+        /// <param name="list">Sets the collection of <see cref="TextAnalytics.ExtractKeyPhrasesResult"/>.</param>
+        /// <param name="statistics">Sets the <see cref="ExtractKeyPhrasesResultCollection.Statistics"/> property.</param>
+        /// <param name="modelVersion">Sets the <see cref="ExtractKeyPhrasesResultCollection.ModelVersion"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.ExtractKeyPhrasesResultCollection"/> for mocking purposes.</returns>
+        public static ExtractKeyPhrasesResultCollection ExtractKeyPhrasesResultCollection(IList<ExtractKeyPhrasesResult> list, TextDocumentBatchStatistics statistics, string modelVersion)
+        {
+            return new ExtractKeyPhrasesResultCollection(list, statistics, modelVersion);
+        }
+
+        #endregion Extract KeyPhrase
+
+        #region Linked Entities
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.LinkedEntity"/> for mocking purposes.
+        /// </summary>
+        /// <param name="name">Sets the <see cref="LinkedEntity.Name"/> property.</param>
+        /// <param name="dataSourceEntityId">Sets the <see cref="LinkedEntity.DataSourceEntityId"/> property.</param>
+        /// <param name="language">Sets the <see cref="LinkedEntity.Language"/> property.</param>
+        /// <param name="dataSource">Sets the <see cref="LinkedEntity.DataSource"/> property.</param>
+        /// <param name="url">Sets the <see cref="LinkedEntity.Url"/> property.</param>
+        /// <param name="matches">Sets the <see cref="LinkedEntity.Matches"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.LinkedEntity"/> for mocking purposes.</returns>
+        public static LinkedEntity LinkedEntity(string name, string dataSourceEntityId, string language, string dataSource, Uri url, IEnumerable<LinkedEntityMatch> matches)
+        {
+            return new LinkedEntity(name, dataSourceEntityId, language, dataSource, url, matches);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.LinkedEntityMatch"/> for mocking purposes.
+        /// </summary>
+        /// <param name="text">Sets the <see cref="LinkedEntityMatch.Text"/> property.</param>
+        /// <param name="score">Sets the <see cref="LinkedEntityMatch.ConfidenceScore"/> property.</param>
+        /// <param name="offset">Sets the <see cref="LinkedEntityMatch.GraphemeOffset"/> property.</param>
+        /// <param name="length">Sets the <see cref="LinkedEntityMatch.GraphemeLength"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.LinkedEntityMatch"/> for mocking purposes.</returns>
+        public static LinkedEntityMatch LinkedEntityMatch(string text, double score, int offset, int length)
+        {
+            return new LinkedEntityMatch(text, score, offset, length);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.RecognizeLinkedEntitiesResult"/> for mocking purposes.
+        /// </summary>
+        /// <param name="id">Sets the <see cref="TextAnalyticsResult.Id"/> property.</param>
+        /// <param name="statistics">Sets the <see cref="TextAnalyticsResult.Statistics"/> property.</param>
+        /// <param name="linkedEntities">Sets the collection of <see cref="TextAnalytics.LinkedEntity"/>.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.RecognizeLinkedEntitiesResult"/> for mocking purposes.</returns>
+        public static RecognizeLinkedEntitiesResult RecognizeLinkedEntitiesResult(string id, TextDocumentStatistics statistics, IList<LinkedEntity> linkedEntities)
+        {
+            return new RecognizeLinkedEntitiesResult(id, statistics, linkedEntities);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.RecognizeLinkedEntitiesResult"/> for mocking purposes.
+        /// </summary>
+        /// <param name="id">Sets the <see cref="TextAnalyticsResult.Id"/> property.</param>
+        /// <param name="error">Sets the <see cref="TextAnalyticsResult.Error"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.RecognizeLinkedEntitiesResult"/> for mocking purposes.</returns>
+        public static RecognizeLinkedEntitiesResult RecognizeLinkedEntitiesResult(string id, TextAnalyticsError error)
+        {
+            return new RecognizeLinkedEntitiesResult(id, error);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.RecognizeLinkedEntitiesResultCollection"/> for mocking purposes.
+        /// </summary>
+        /// <param name="list">Sets the collection of <see cref="TextAnalytics.RecognizeLinkedEntitiesResult"/>.</param>
+        /// <param name="statistics">Sets the <see cref="RecognizeLinkedEntitiesResultCollection.Statistics"/> property.</param>
+        /// <param name="modelVersion">Sets the <see cref="RecognizeLinkedEntitiesResultCollection.ModelVersion"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.RecognizeLinkedEntitiesResultCollection"/> for mocking purposes.</returns>
+        public static RecognizeLinkedEntitiesResultCollection RecognizeLinkedEntitiesResultCollection(IList<RecognizeLinkedEntitiesResult> list, TextDocumentBatchStatistics statistics, string modelVersion)
+        {
+            return new RecognizeLinkedEntitiesResultCollection(list, statistics, modelVersion);
+        }
+
+        #endregion Linked Entities
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsModelFactory.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsModelFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Azure.AI.TextAnalytics
@@ -123,9 +124,9 @@ namespace Azure.AI.TextAnalytics
         /// <param name="statistics">Sets the <see cref="AnalyzeSentimentResultCollection.Statistics"/> property.</param>
         /// <param name="modelVersion">Sets the <see cref="AnalyzeSentimentResultCollection.ModelVersion"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.AnalyzeSentimentResultCollection"/> for mocking purposes.</returns>
-        public static AnalyzeSentimentResultCollection AnalyzeSentimentResultCollection(IList<AnalyzeSentimentResult> list, TextDocumentBatchStatistics statistics, string modelVersion)
+        public static AnalyzeSentimentResultCollection AnalyzeSentimentResultCollection(IEnumerable<AnalyzeSentimentResult> list, TextDocumentBatchStatistics statistics, string modelVersion)
         {
-            return new AnalyzeSentimentResultCollection(list, statistics, modelVersion);
+            return new AnalyzeSentimentResultCollection(list.ToList(), statistics, modelVersion);
         }
 
         #endregion Analyze Sentiment
@@ -173,9 +174,9 @@ namespace Azure.AI.TextAnalytics
         /// <param name="statistics">Sets the <see cref="DetectLanguageResultCollection.Statistics"/> property.</param>
         /// <param name="modelVersion">Sets the <see cref="DetectLanguageResultCollection.ModelVersion"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.DetectLanguageResultCollection"/> for mocking purposes.</returns>
-        public static DetectLanguageResultCollection DetectLanguageResultCollection(IList<DetectLanguageResult> list, TextDocumentBatchStatistics statistics, string modelVersion)
+        public static DetectLanguageResultCollection DetectLanguageResultCollection(IEnumerable<DetectLanguageResult> list, TextDocumentBatchStatistics statistics, string modelVersion)
         {
-            return new DetectLanguageResultCollection(list, statistics, modelVersion);
+            return new DetectLanguageResultCollection(list.ToList(), statistics, modelVersion);
         }
 
         #endregion Detect Language
@@ -226,9 +227,9 @@ namespace Azure.AI.TextAnalytics
         /// <param name="statistics">Sets the <see cref="RecognizeEntitiesResultCollection.Statistics"/> property.</param>
         /// <param name="modelVersion">Sets the <see cref="RecognizeEntitiesResultCollection.ModelVersion"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.RecognizeEntitiesResultCollection"/> for mocking purposes.</returns>
-        public static RecognizeEntitiesResultCollection RecognizeEntitiesResultCollection(IList<RecognizeEntitiesResult> list, TextDocumentBatchStatistics statistics, string modelVersion)
+        public static RecognizeEntitiesResultCollection RecognizeEntitiesResultCollection(IEnumerable<RecognizeEntitiesResult> list, TextDocumentBatchStatistics statistics, string modelVersion)
         {
-            return new RecognizeEntitiesResultCollection(list, statistics, modelVersion);
+            return new RecognizeEntitiesResultCollection(list.ToList(), statistics, modelVersion);
         }
 
         #endregion Recognize Entities
@@ -264,9 +265,9 @@ namespace Azure.AI.TextAnalytics
         /// <param name="statistics">Sets the <see cref="ExtractKeyPhrasesResultCollection.Statistics"/> property.</param>
         /// <param name="modelVersion">Sets the <see cref="ExtractKeyPhrasesResultCollection.ModelVersion"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.ExtractKeyPhrasesResultCollection"/> for mocking purposes.</returns>
-        public static ExtractKeyPhrasesResultCollection ExtractKeyPhrasesResultCollection(IList<ExtractKeyPhrasesResult> list, TextDocumentBatchStatistics statistics, string modelVersion)
+        public static ExtractKeyPhrasesResultCollection ExtractKeyPhrasesResultCollection(IEnumerable<ExtractKeyPhrasesResult> list, TextDocumentBatchStatistics statistics, string modelVersion)
         {
-            return new ExtractKeyPhrasesResultCollection(list, statistics, modelVersion);
+            return new ExtractKeyPhrasesResultCollection(list.ToList(), statistics, modelVersion);
         }
 
         #endregion Extract KeyPhrase
@@ -330,9 +331,9 @@ namespace Azure.AI.TextAnalytics
         /// <param name="statistics">Sets the <see cref="RecognizeLinkedEntitiesResultCollection.Statistics"/> property.</param>
         /// <param name="modelVersion">Sets the <see cref="RecognizeLinkedEntitiesResultCollection.ModelVersion"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.RecognizeLinkedEntitiesResultCollection"/> for mocking purposes.</returns>
-        public static RecognizeLinkedEntitiesResultCollection RecognizeLinkedEntitiesResultCollection(IList<RecognizeLinkedEntitiesResult> list, TextDocumentBatchStatistics statistics, string modelVersion)
+        public static RecognizeLinkedEntitiesResultCollection RecognizeLinkedEntitiesResultCollection(IEnumerable<RecognizeLinkedEntitiesResult> list, TextDocumentBatchStatistics statistics, string modelVersion)
         {
-            return new RecognizeLinkedEntitiesResultCollection(list, statistics, modelVersion);
+            return new RecognizeLinkedEntitiesResultCollection(list.ToList(), statistics, modelVersion);
         }
 
         #endregion Linked Entities

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/SampleMoq.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/SampleMoq.cs
@@ -30,12 +30,24 @@ namespace Azure.AI.TextAnalytics.Samples
 
             #region Snippet:UseMocks
             TextAnalyticsClient client = mockClient.Object;
-            DetectedLanguage language = await client.DetectLanguageAsync("Este documento está en español.");
-            Assert.AreEqual("Spanish", language.Name);
-            Assert.AreEqual("es", language.Iso6391Name);
-            Assert.AreEqual(1.00, language.Score);
+            bool result = await IsSpanishAsync("Este documento está en español.", client, default);
+            Assert.IsTrue(result);
             #endregion
         }
+
+        #region Snippet:MethodToTest
+        private static async Task<bool> IsSpanishAsync(string document, TextAnalyticsClient client, CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                DetectedLanguage language = await client.DetectLanguageAsync(document);
+                return language.Iso6391Name == "es";
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            return false;
+        }
+        #endregion Snippet:MethodToTest
 
         [Test]
         public async Task DetectLanguageBatchAsync()

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/SampleMoq.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/SampleMoq.cs
@@ -1,0 +1,154 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core.Testing;
+using Moq;
+using NUnit.Framework;
+
+namespace Azure.AI.TextAnalytics.Samples
+{
+    [LiveOnly]
+    public class SampleMoq
+    {
+        [Test]
+        public async Task DetectLanguageAsync()
+        {
+            #region Snippet:CreateMocks
+            var mockResponse = new Mock<Response>();
+            var mockClient = new Mock<TextAnalyticsClient>();
+            #endregion
+
+            #region Snippet:SetupMocks
+            Response<DetectedLanguage> response = Response.FromValue(TextAnalyticsModelFactory.DetectedLanguage("Spanish", "es", 1.00), mockResponse.Object);
+
+            mockClient.Setup(c => c.DetectLanguageAsync("Este documento está en español.", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(response));
+            #endregion
+
+            #region Snippet:UseMocks
+            TextAnalyticsClient client = mockClient.Object;
+            DetectedLanguage language = await client.DetectLanguageAsync("Este documento está en español.");
+            Assert.AreEqual("Spanish", language.Name);
+            Assert.AreEqual("es", language.Iso6391Name);
+            Assert.AreEqual(1.00, language.Score);
+            #endregion
+        }
+
+        [Test]
+        public async Task DetectLanguageBatchAsync()
+        {
+            var mockResponse = new Mock<Response>();
+            var mockClient = new Mock<TextAnalyticsClient>();
+            var documents = new List<string>
+            {
+                "Hello world",
+                "Bonjour tout le monde",
+            };
+
+            var languages = new List<DetectLanguageResult>
+            {
+                TextAnalyticsModelFactory.DetectLanguageResult("0", default, TextAnalyticsModelFactory.DetectedLanguage("English", "en", 1.00)),
+                TextAnalyticsModelFactory.DetectLanguageResult("1", default, TextAnalyticsModelFactory.DetectedLanguage("French", "fr", 1.00)),
+            };
+
+            Response<DetectLanguageResultCollection> response = Response.FromValue(TextAnalyticsModelFactory.DetectLanguageResultCollection(languages, default, default), mockResponse.Object);
+
+            mockClient.Setup(c => c.DetectLanguageBatchAsync(documents, It.IsAny<string>(), It.IsAny<TextAnalyticsRequestOptions>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(response));
+
+            TextAnalyticsClient client = mockClient.Object;
+            DetectLanguageResultCollection results = await client.DetectLanguageBatchAsync(documents);
+
+            int i = 0;
+            foreach (DetectLanguageResult result in results)
+            {
+                Assert.AreEqual(languages[i].Id, results[i].Id);
+                Assert.AreEqual(languages[i].PrimaryLanguage.Name, results[i].PrimaryLanguage.Name);
+                Assert.AreEqual(languages[i].PrimaryLanguage.Iso6391Name, results[i].PrimaryLanguage.Iso6391Name);
+                Assert.AreEqual(languages[i].PrimaryLanguage.Score, results[i].PrimaryLanguage.Score);
+                i++;
+            }
+        }
+
+        [Test]
+        public async Task DetectLanguageBatchWithStatisticsAsync()
+        {
+            var mockResponse = new Mock<Response>();
+            var mockClient = new Mock<TextAnalyticsClient>();
+            var documents = new List<string>
+            {
+                "Hello world",
+                "Bonjour tout le monde",
+            };
+
+            TextDocumentStatistics language1Stats = TextAnalyticsModelFactory.TextDocumentStatistics(11, 1);
+            TextDocumentStatistics language2Stats = TextAnalyticsModelFactory.TextDocumentStatistics(21, 1);
+
+            var languages = new List<DetectLanguageResult>
+            {
+                TextAnalyticsModelFactory.DetectLanguageResult("0", language1Stats, default),
+                TextAnalyticsModelFactory.DetectLanguageResult("1", language2Stats, default),
+            };
+
+            TextDocumentBatchStatistics docStats = TextAnalyticsModelFactory.TextDocumentBatchStatistics(2, 2, 0, 2);
+
+            Response<DetectLanguageResultCollection> response = Response.FromValue(TextAnalyticsModelFactory.DetectLanguageResultCollection(languages, docStats, default), mockResponse.Object);
+
+            mockClient.Setup(c => c.DetectLanguageBatchAsync(documents, It.IsAny<string>(), It.IsAny<TextAnalyticsRequestOptions>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(response));
+
+            TextAnalyticsClient client = mockClient.Object;
+            DetectLanguageResultCollection results = await client.DetectLanguageBatchAsync(documents);
+
+            //language1
+            Assert.AreEqual(languages[0].Id, results[0].Id);
+            Assert.AreEqual(languages[0].Statistics.GraphemeCount, results[0].Statistics.GraphemeCount);
+            Assert.AreEqual(languages[0].Statistics.TransactionCount, results[0].Statistics.TransactionCount);
+
+            //language2
+            Assert.AreEqual(languages[1].Id, results[1].Id);
+            Assert.AreEqual(languages[1].Statistics.GraphemeCount, results[1].Statistics.GraphemeCount);
+            Assert.AreEqual(languages[1].Statistics.TransactionCount, results[1].Statistics.TransactionCount);
+
+            //Transaction Stats
+            Assert.AreEqual(docStats.DocumentCount, results.Statistics.DocumentCount);
+            Assert.AreEqual(docStats.ValidDocumentCount, results.Statistics.ValidDocumentCount);
+            Assert.AreEqual(docStats.InvalidDocumentCount, results.Statistics.InvalidDocumentCount);
+            Assert.AreEqual(docStats.TransactionCount, results.Statistics.TransactionCount);
+        }
+
+        [Test]
+        public async Task DetectLanguageBatchWithErrorAsync()
+        {
+            var mockResponse = new Mock<Response>();
+            var mockClient = new Mock<TextAnalyticsClient>();
+            var documents = new List<string>
+            {
+                "Hello world",
+                "",
+            };
+
+            TextAnalyticsError error = TextAnalyticsModelFactory.TextAnalyticsError("InvalidDocument", "Document text is empty.");
+
+            var languages = new List<DetectLanguageResult>
+            {
+                TextAnalyticsModelFactory.DetectLanguageResult("0", default, TextAnalyticsModelFactory.DetectedLanguage("English", "en", 1.00)),
+                TextAnalyticsModelFactory.DetectLanguageResult("1", error),
+            };
+
+            Response<DetectLanguageResultCollection> response = Response.FromValue(TextAnalyticsModelFactory.DetectLanguageResultCollection(languages, default, default), mockResponse.Object);
+
+            mockClient.Setup(c => c.DetectLanguageBatchAsync(documents, It.IsAny<string>(), It.IsAny<TextAnalyticsRequestOptions>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(response));
+
+            TextAnalyticsClient client = mockClient.Object;
+            DetectLanguageResultCollection results = await client.DetectLanguageBatchAsync(documents);
+
+            Assert.AreEqual(languages[1].Id, results[1].Id);
+            Assert.IsTrue(results[1].HasError);
+        }
+    }
+}


### PR DESCRIPTION
- New `TextAnalyticsModelFactory`
- Sample test using moq
- Sample doc for mocking the `TextAnalyticsClient`

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/8710 and https://github.com/Azure/azure-sdk-for-net/issues/10444