### PR TITLE
Change MaxParallel for Search tests

### DIFF
--- a/sdk/search/tests.yml
+++ b/sdk/search/tests.yml
@@ -10,6 +10,7 @@ resources:
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
   parameters:
+    ServiceDirectory: search
+    MaxParallel: 2
     EnvVars:
       AZURE_SEARCH_TEST_MODE: Live
-    ServiceDirectory: search


### PR DESCRIPTION
Live tests still failed even with the error about creating too many resources for the free tier. I think it was a combination of running live tests on my machine failing because of a concurrency issue in the test framework, me having run it multiple times (and my resource group isn't flag for deletion, so those instances stay around), as well as too many parallel runs on the server. I'm going to try 2 parallel runs initially. I'm worried that, as we add more tests and with the 20s+ per test wait for index stabilization, we'll run up against max run times or overlapping with other languages' test runs.

@chidozieononiwu are we allowed to increase the timeout for "net - search - tests"?

/cc @tg-msft @chidozieononiwu @brjohnstmsft 