### PR TITLE
[Event Hubs Client] Event Processor Client Tests and Logging

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
@@ -46,13 +46,13 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// <param name="accountName">The Storage account name corresponding to the associated container client.</param>
         /// <param name="name">The name of the associated container client.</param>
         ///
-        [Event(1, Level = EventLevel.Informational, Message = "BlobsCheckpointStore created. AccountName: '{0}'; ContainerName: '{1}'.")]
+        [Event(20, Level = EventLevel.Verbose, Message = "{0} created. AccountName: '{1}'; ContainerName: '{2}'.")]
         public virtual void BlobsCheckpointStoreCreated(string accountName,
                                                         string name)
         {
             if (IsEnabled())
             {
-                WriteEvent(1, accountName ?? string.Empty, name ?? string.Empty);
+                WriteEvent(20, nameof(BlobsCheckpointStore), accountName ?? string.Empty, name ?? string.Empty);
             }
         }
 
@@ -64,14 +64,14 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// <param name="eventHubName">The name of the specific Event Hub the ownership are associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the ownership are associated with.</param>
         ///
-        [Event(2, Level = EventLevel.Informational, Message = "ListOwnershipAsync started. FullyQualifiedNamespace: '{0}'; EventHubName: '{1}'; ConsumerGroup: '{2}'.")]
-        public virtual void ListOwnershipAsyncStart(string fullyQualifiedNamespace,
-                                                    string eventHubName,
-                                                    string consumerGroup)
+        [Event(21, Level = EventLevel.Informational, Message = "Starting to list ownership for FullyQualifiedNamespace: '{0}'; EventHubName: '{1}'; ConsumerGroup: '{2}'.")]
+        public virtual void ListOwnershipStart(string fullyQualifiedNamespace,
+                                               string eventHubName,
+                                               string consumerGroup)
         {
             if (IsEnabled())
             {
-                WriteEvent(2, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty);
+                WriteEvent(21, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty);
             }
         }
 
@@ -84,15 +84,15 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// <param name="consumerGroup">The name of the consumer group the ownership are associated with.</param>
         /// <param name="ownershipCount">The amount of ownership received from the storage service.</param>
         ///
-        [Event(3, Level = EventLevel.Informational, Message = "ListOwnershipAsync completed. FullyQualifiedNamespace: '{0}'; EventHubName: '{1}'; ConsumerGroup: '{2}'; OwnershipCount: '{3}'.")]
-        public virtual void ListOwnershipAsyncComplete(string fullyQualifiedNamespace,
-                                                       string eventHubName,
-                                                       string consumerGroup,
-                                                       int ownershipCount)
+        [Event(22, Level = EventLevel.Informational, Message = "Completed listing ownership for FullyQualifiedNamespace: '{0}'; EventHubName: '{1}'; ConsumerGroup: '{2}'.  There were {3} ownership entries were found.")]
+        public virtual void ListOwnershipComplete(string fullyQualifiedNamespace,
+                                                  string eventHubName,
+                                                  string consumerGroup,
+                                                  int ownershipCount)
         {
             if (IsEnabled())
             {
-                WriteEvent(3, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, ownershipCount);
+                WriteEvent(22, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, ownershipCount);
             }
         }
 
@@ -105,51 +105,134 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// <param name="consumerGroup">The name of the consumer group the ownership are associated with.</param>
         /// <param name="errorMessage">The message for the exception that occurred.</param>
         ///
-        [Event(4, Level = EventLevel.Error, Message = "ListOwnershipAsync error. FullyQualifiedNamespace: '{0}'; EventHubName: '{1}'; ConsumerGroup: '{2}'; ErrorMessage: '{3}'.")]
-        public virtual void ListOwnershipAsyncError(string fullyQualifiedNamespace,
-                                                    string eventHubName,
-                                                    string consumerGroup,
-                                                    string errorMessage)
+        [Event(23, Level = EventLevel.Error, Message = "An exception occurred when listing ownership for FullyQualifiedNamespace: '{0}'; EventHubName: '{1}'; ConsumerGroup: '{2}'; ErrorMessage: '{3}'.")]
+        public virtual void ListOwnershipError(string fullyQualifiedNamespace,
+                                               string eventHubName,
+                                               string consumerGroup,
+                                               string errorMessage)
         {
             if (IsEnabled())
             {
-                WriteEvent(4, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty);
+                WriteEvent(23, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty);
             }
         }
 
         /// <summary>
-        ///   Indicates that the ownership of a partition could not be claimed.
+        ///   Indicates that an attempt to claim a partition ownership has started.
         /// </summary>
         ///
-        /// <param name="partitionId">The identifier of the partition whose ownership could not be claimed.</param>
-        /// <param name="ownerIdentifier">The identifier of the processor that attempted to claim the ownership.</param>
-        /// <param name="errorMessage">An error message containing a better explanation of why the claim attempt has failed.</param>
+        /// <param name="partitionId">The identifier of the partition being claimed.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the ownership is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership is associated with.</param>
+        /// <param name="ownerIdentifier">The identifier of the processor that attempted to claim the ownership for.</param>
         ///
-        [Event(5, Level = EventLevel.Informational, Message = "ClaimOwnershipAsync ownership is not claimable. PartitionId: '{0}'; OwnerIdentifier: '{1}'. {2}")]
+        [Event(24, Level = EventLevel.Informational, Message = "Starting to claim ownership of partition: `{0}` of FullyQualifiedNamespace: '{1}'; EventHubName: '{2}'; ConsumerGroup: '{3}' for the owner '{4}'.")]
+        public virtual void ClaimOwnershipStart(string partitionId,
+                                                string fullyQualifiedNamespace,
+                                                string eventHubName,
+                                                string consumerGroup,
+                                                string ownerIdentifier)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(24, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, ownerIdentifier ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an attempt to retrieve claim partition ownership has completed.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition being claimed.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the ownership is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership is associated with.</param>
+        /// <param name="ownerIdentifier">The identifier of the processor that attempted to claim the ownership for.</param>
+        ///
+        [Event(25, Level = EventLevel.Informational, Message = "Completed the attempt to claim ownership of partition: `{0}` of FullyQualifiedNamespace: '{1}'; EventHubName: '{2}'; ConsumerGroup: '{3}' for the owner '{4}'.")]
+        public virtual void ClaimOwnershipComplete(string partitionId,
+                                                   string fullyQualifiedNamespace,
+                                                   string eventHubName,
+                                                   string consumerGroup,
+                                                   string ownerIdentifier)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(25, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, ownerIdentifier ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an exception was encountered while attempting to retrieve claim partition ownership.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition being claimed.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the ownership is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership is associated with.</param>
+        /// <param name="ownerIdentifier">The identifier of the processor that attempted to claim the ownership for.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
+        ///
+        [Event(26, Level = EventLevel.Error, Message = "An exception occurred when claiming ownership of partition: `{0}` of FullyQualifiedNamespace: '{1}'; EventHubName: '{2}'; ConsumerGroup: '{3}' for the owner '{4}'.  ErrorMessage: '{5}'.")]
+        public virtual void ClaimOwnershipError(string partitionId,
+                                                string fullyQualifiedNamespace,
+                                                string eventHubName,
+                                                string consumerGroup,
+                                                string ownerIdentifier,
+                                                string errorMessage)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(26, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, ownerIdentifier ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that ownership was unable to be claimed.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition being claimed.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the ownership is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership is associated with.</param>
+        /// <param name="ownerIdentifier">The identifier of the processor that attempted to claim the ownership for.</param>
+        /// <param name="message">The message for the failure.</param>
+        ///
+        [Event(27, Level = EventLevel.Informational, Message = "Unable to claim ownership of partition: `{0}` of FullyQualifiedNamespace: '{1}'; EventHubName: '{2}'; ConsumerGroup: '{3}' for the owner '{4}'.  Message: '{5}'.")]
         public virtual void OwnershipNotClaimable(string partitionId,
+                                                  string fullyQualifiedNamespace,
+                                                  string eventHubName,
+                                                  string consumerGroup,
                                                   string ownerIdentifier,
-                                                  string errorMessage = null)
+                                                  string message)
         {
             if (IsEnabled())
             {
-                WriteEvent(5, partitionId ?? string.Empty, ownerIdentifier ?? string.Empty, errorMessage ?? string.Empty);
+                WriteEvent(27, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, ownerIdentifier ?? string.Empty, message ?? string.Empty);
             }
         }
 
         /// <summary>
-        ///   Indicates that the ownership of a partition has been claimed.
+        ///   Indicates that ownership was successfully claimed.
         /// </summary>
         ///
-        /// <param name="partitionId">The identifier of the partition whose ownership has been claimed.</param>
-        /// <param name="ownerIdentifier">The identifier of the processor that claimed the ownership.</param>
+        /// <param name="partitionId">The identifier of the partition being claimed.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the ownership is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership is associated with.</param>
+        /// <param name="ownerIdentifier">The identifier of the processor that attempted to claim the ownership for.</param>
         ///
-        [Event(6, Level = EventLevel.Informational, Message = "ClaimOwnershipAsync ownership claimed. PartitionId: '{0}'; OwnerIdentifier: '{1}'.")]
+        [Event(28, Level = EventLevel.Informational, Message = "Successfully claimed ownership of partition: `{0}` of FullyQualifiedNamespace: '{1}'; EventHubName: '{2}'; ConsumerGroup: '{3}' for the owner '{4}'.")]
         public virtual void OwnershipClaimed(string partitionId,
+                                             string fullyQualifiedNamespace,
+                                             string eventHubName,
+                                             string consumerGroup,
                                              string ownerIdentifier)
         {
             if (IsEnabled())
             {
-                WriteEvent(6, partitionId ?? string.Empty, ownerIdentifier ?? string.Empty);
+                WriteEvent(28, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, ownerIdentifier ?? string.Empty);
             }
         }
 
@@ -161,14 +244,14 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoints are associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoints are associated with.</param>
         ///
-        [Event(7, Level = EventLevel.Informational, Message = "ListCheckpointsAsync started. FullyQualifiedNamespace: '{0}'; EventHubName: '{1}'; ConsumerGroup: '{2}'.")]
-        public virtual void ListCheckpointsAsyncStart(string fullyQualifiedNamespace,
-                                                      string eventHubName,
-                                                      string consumerGroup)
+        [Event(29, Level = EventLevel.Informational, Message = "Starting to list checkpoints for FullyQualifiedNamespace: '{0}'; EventHubName: '{1}'; ConsumerGroup: '{2}'.")]
+        public virtual void ListCheckpointsStart(string fullyQualifiedNamespace,
+                                                 string eventHubName,
+                                                 string consumerGroup)
         {
             if (IsEnabled())
             {
-                WriteEvent(7, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty);
+                WriteEvent(29, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty);
             }
         }
 
@@ -181,30 +264,78 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// <param name="consumerGroup">The name of the consumer group the checkpoints are associated with.</param>
         /// <param name="checkpointCount">The amount of checkpoints received from the storage service.</param>
         ///
-        [Event(8, Level = EventLevel.Informational, Message = "ListCheckpointsAsync completed. FullyQualifiedNamespace: '{0}'; EventHubName: '{1}'; ConsumerGroup: '{2}'; CheckpointCount: '{3}'.")]
-        public virtual void ListCheckpointsAsyncComplete(string fullyQualifiedNamespace,
-                                                         string eventHubName,
-                                                         string consumerGroup,
-                                                         int checkpointCount)
+        [Event(30, Level = EventLevel.Informational, Message = "Completed listing checkpoints for FullyQualifiedNamespace: '{0}'; EventHubName: '{1}'; ConsumerGroup: '{2}'.  There were '{3}' checkpoints found.")]
+        public virtual void ListCheckpointsComplete(string fullyQualifiedNamespace,
+                                                    string eventHubName,
+                                                    string consumerGroup,
+                                                    int checkpointCount)
         {
             if (IsEnabled())
             {
-                WriteEvent(8, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, checkpointCount);
+                WriteEvent(30, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, checkpointCount);
             }
         }
 
         /// <summary>
-        ///   Indicates that a partition being processed had its checkpoint updated.
+        ///   Indicates that an unhandled exception was encountered while retrieving a list of checkpoints.
         /// </summary>
         ///
-        /// <param name="partitionId">The identifier of the partition whose checkpoint has been updated.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoints are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the checkpoints are associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership are associated with.</param>
+        /// <param name="errorMessage">The message for the exception that occurred.</param>
         ///
-        [Event(9, Level = EventLevel.Informational, Message = "UpdateCheckpointAsync updated checkpoint. PartitionId: '{0}'.")]
-        public virtual void CheckpointUpdated(string partitionId)
+        [Event(31, Level = EventLevel.Error, Message = "An exception occurred when listing checkpoints for FullyQualifiedNamespace: '{0}'; EventHubName: '{1}'; ConsumerGroup: '{2}'; ErrorMessage: '{3}'.")]
+        public virtual void ListCheckpointsError(string fullyQualifiedNamespace,
+                                                 string eventHubName,
+                                                 string consumerGroup,
+                                                 string errorMessage)
         {
             if (IsEnabled())
             {
-                WriteEvent(9, partitionId ?? string.Empty);
+                WriteEvent(31, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an attempt to create/update a checkpoint has started.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition being checkpointed.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoint is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
+        ///
+        [Event(32, Level = EventLevel.Informational, Message = "Starting to create/update a checkpoint for partition: `{0}` of FullyQualifiedNamespace: '{1}'; EventHubName: '{2}'; ConsumerGroup: '{3}'.")]
+        public virtual void UpdateCheckpointStart(string partitionId,
+                                                  string fullyQualifiedNamespace,
+                                                  string eventHubName,
+                                                  string consumerGroup)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(32, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty);
+            }
+        }
+
+        /// <summary>
+        ///   Indicates that an attempt to update a checkpoint has completed.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition being checkpointed.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoint is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
+        ///
+        [Event(33, Level = EventLevel.Informational, Message = "Completed the attempt to create/update a checkpoint for partition: `{0}` of FullyQualifiedNamespace: '{1}'; EventHubName: '{2}'; ConsumerGroup: '{3}'.")]
+        public virtual void  UpdateCheckpointComplete(string partitionId,
+                                                      string fullyQualifiedNamespace,
+                                                      string eventHubName,
+                                                      string consumerGroup)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(33, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty);
             }
         }
 
@@ -212,16 +343,22 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         ///   Indicates that an unhandled exception was encountered while updating a checkpoint.
         /// </summary>
         ///
-        /// <param name="partitionId">The identifier of the partition whose checkpoint update failed.</param>
+        /// <param name="partitionId">The identifier of the partition being checkpointed.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoint is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="errorMessage">The message for the exception that occurred.</param>
         ///
-        [Event(10, Level = EventLevel.Error, Message = "UpdateCheckpointAsync checkpoint could not be updated. PartitionId: '{0}'; ErrorMessage: '{1}'.")]
-        public virtual void CheckpointUpdateError(string partitionId,
-                                                  string errorMessage = null)
+        [Event(34, Level = EventLevel.Error, Message = "An exception occurred when creating/updating a checkpoint for  partition: `{0}` of FullyQualifiedNamespace: '{1}'; EventHubName: '{2}'; ConsumerGroup: '{3}'.  ErrorMessage: '{4}'.")]
+        public virtual void  UpdateCheckpointError(string partitionId,
+                                                   string fullyQualifiedNamespace,
+                                                   string eventHubName,
+                                                   string consumerGroup,
+                                                   string errorMessage)
         {
             if (IsEnabled())
             {
-                WriteEvent(10, partitionId ?? string.Empty, errorMessage ?? string.Empty);
+                WriteEvent(34, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, errorMessage ?? string.Empty);
             }
         }
 
@@ -229,20 +366,20 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         ///   Indicates that invalid checkpoint data was found during an attempt to retrieve a list of checkpoints.
         /// </summary>
         ///
+        /// <param name="partitionId">The identifier of the partition the data is associated with.</param>
         /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the data is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
         /// <param name="eventHubName">The name of the specific Event Hub the data is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the data is associated with.</param>
-        /// <param name="partitionId">The identifier of the partition the data is associated with.</param>
         ///
-        [Event(11, Level = EventLevel.Error, Message = "Invalid checkpoint data found when listing checkpoints; this checkpoint is not valid and will be ignored.  FullyQualifiedNamespace: '{0}'; EventHubName: '{1}'; ConsumerGroup: '{2}'; PartitionId: '{3}'.")]
-        public virtual void InvalidCheckpointFound(string fullyQualifiedNamespace,
+        [Event(35, Level = EventLevel.Informational, Message = "An invalid checkpoint was found for partition: '{0}' of FullyQualifiedNamespace: '{1}'; EventHubName: '{2}'; ConsumerGroup: '{3}'.  This checkpoint is not valid and will be ignored.")]
+        public virtual void InvalidCheckpointFound(string partitionId,
+                                                   string fullyQualifiedNamespace,
                                                    string eventHubName,
-                                                   string consumerGroup,
-                                                   string partitionId)
+                                                   string consumerGroup)
         {
             if (IsEnabled())
             {
-                WriteEvent(11, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty, partitionId ?? string.Empty);
+                WriteEvent(35, partitionId ?? string.Empty, fullyQualifiedNamespace ?? string.Empty, eventHubName ?? string.Empty, consumerGroup ?? string.Empty);
             }
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Storage/BlobsCheckpointStore.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Storage/BlobsCheckpointStore.cs
@@ -91,8 +91,9 @@ namespace Azure.Messaging.EventHubs.Processor
                                                                                                      string consumerGroup,
                                                                                                      CancellationToken cancellationToken)
         {
-            Logger.ListOwnershipAsyncStart(fullyQualifiedNamespace, eventHubName, consumerGroup);
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+            Logger.ListOwnershipStart(fullyQualifiedNamespace, eventHubName, consumerGroup);
+
             List<EventProcessorPartitionOwnership> result = null;
 
             try
@@ -130,12 +131,12 @@ namespace Azure.Messaging.EventHubs.Processor
             }
             catch (RequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.ContainerNotFound)
             {
-                Logger.ListOwnershipAsyncError(fullyQualifiedNamespace, eventHubName, consumerGroup, ex.ToString());
+                Logger.ListOwnershipError(fullyQualifiedNamespace, eventHubName, consumerGroup, ex.ToString());
                 throw new RequestFailedException(Resources.BlobsResourceDoesNotExist);
             }
             finally
             {
-                Logger.ListOwnershipAsyncComplete(fullyQualifiedNamespace, eventHubName, consumerGroup, result?.Count ?? 0);
+                Logger.ListOwnershipComplete(fullyQualifiedNamespace, eventHubName, consumerGroup, result?.Count ?? 0);
             }
         }
 
@@ -161,6 +162,7 @@ namespace Azure.Messaging.EventHubs.Processor
 
             foreach (EventProcessorPartitionOwnership ownership in partitionOwnership)
             {
+                Logger.ClaimOwnershipStart(ownership.PartitionId, ownership.FullyQualifiedNamespace, ownership.EventHubName, ownership.ConsumerGroup, ownership.OwnerIdentifier);
                 metadata[BlobMetadataKey.OwnerIdentifier] = ownership.OwnerIdentifier;
 
                 var blobRequestConditions = new BlobRequestConditions();
@@ -191,7 +193,7 @@ namespace Azure.Messaging.EventHubs.Processor
                                 // A blob could have just been created by another Event Processor that claimed ownership of this
                                 // partition.  In this case, there's no point in retrying because we don't have the correct ETag.
 
-                                Logger.OwnershipNotClaimable(ownership.PartitionId, ownership.OwnerIdentifier);
+                                Logger.OwnershipNotClaimable(ownership.PartitionId, ownership.FullyQualifiedNamespace, ownership.EventHubName, ownership.ConsumerGroup, ownership.OwnerIdentifier, ex.Message);
                                 return null;
                             }
                         };
@@ -230,16 +232,25 @@ namespace Azure.Messaging.EventHubs.Processor
                     }
 
                     claimedOwnership.Add(ownership);
-
-                    Logger.OwnershipClaimed(ownership.PartitionId, ownership.OwnerIdentifier);
+                    Logger.OwnershipClaimed(ownership.PartitionId, ownership.FullyQualifiedNamespace, ownership.EventHubName, ownership.ConsumerGroup, ownership.OwnerIdentifier);
                 }
                 catch (RequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.ConditionNotMet)
                 {
-                    Logger.OwnershipNotClaimable(ownership.PartitionId, ownership.OwnerIdentifier, ex.ToString());
+                    Logger.OwnershipNotClaimable(ownership.PartitionId, ownership.FullyQualifiedNamespace, ownership.EventHubName, ownership.ConsumerGroup, ownership.OwnerIdentifier, ex.ToString());
                 }
                 catch (RequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.ContainerNotFound || ex.ErrorCode == BlobErrorCode.BlobNotFound)
                 {
+                    Logger.ClaimOwnershipError(ownership.PartitionId, ownership.FullyQualifiedNamespace, ownership.EventHubName, ownership.ConsumerGroup, ownership.OwnerIdentifier, ex.Message);
                     throw new RequestFailedException(Resources.BlobsResourceDoesNotExist);
+                }
+                catch (Exception ex)
+                {
+                    Logger.ClaimOwnershipError(ownership.PartitionId, ownership.FullyQualifiedNamespace, ownership.EventHubName, ownership.ConsumerGroup, ownership.OwnerIdentifier, ex.Message);
+                    throw;
+                }
+                finally
+                {
+                    Logger.ClaimOwnershipComplete(ownership.PartitionId, ownership.FullyQualifiedNamespace, ownership.EventHubName, ownership.ConsumerGroup, ownership.OwnerIdentifier);
                 }
             }
 
@@ -262,10 +273,11 @@ namespace Azure.Messaging.EventHubs.Processor
                                                                                                string consumerGroup,
                                                                                                CancellationToken cancellationToken)
         {
-            Logger.ListCheckpointsAsyncStart(fullyQualifiedNamespace, eventHubName, consumerGroup);
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+            Logger.ListCheckpointsStart(fullyQualifiedNamespace, eventHubName, consumerGroup);
 
             var prefix = string.Format(CheckpointPrefix, fullyQualifiedNamespace.ToLowerInvariant(), eventHubName.ToLowerInvariant(), consumerGroup.ToLowerInvariant());
+            var checkpointCount = 0;
 
             Func<CancellationToken, Task<IEnumerable<EventProcessorCheckpoint>>> listCheckpointsAsync = async listCheckpointsToken =>
             {
@@ -301,11 +313,11 @@ namespace Azure.Messaging.EventHubs.Processor
                     }
                     else
                     {
-                        Logger.InvalidCheckpointFound(fullyQualifiedNamespace, eventHubName, consumerGroup, partitionId);
+                        Logger.InvalidCheckpointFound(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup);
                     }
                 }
 
-                Logger.ListCheckpointsAsyncComplete(fullyQualifiedNamespace, eventHubName, consumerGroup, checkpoints.Count);
+                checkpointCount = checkpoints.Count;
                 return checkpoints;
             };
 
@@ -315,7 +327,17 @@ namespace Azure.Messaging.EventHubs.Processor
             }
             catch (RequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.ContainerNotFound)
             {
+                Logger.ListCheckpointsError(fullyQualifiedNamespace, eventHubName, consumerGroup, ex.Message);
                 throw new RequestFailedException(Resources.BlobsResourceDoesNotExist);
+            }
+            catch (Exception ex)
+            {
+                Logger.ListCheckpointsError(fullyQualifiedNamespace, eventHubName, consumerGroup, ex.Message);
+                throw;
+            }
+            finally
+            {
+                Logger.ListCheckpointsComplete(fullyQualifiedNamespace, eventHubName, consumerGroup, checkpointCount);
             }
         }
 
@@ -334,6 +356,7 @@ namespace Azure.Messaging.EventHubs.Processor
                                                          CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+            Logger.UpdateCheckpointStart(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup);
 
             var blobName = string.Format(CheckpointPrefix + checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace.ToLowerInvariant(), checkpoint.EventHubName.ToLowerInvariant(), checkpoint.ConsumerGroup.ToLowerInvariant());
             var blobClient = ContainerClient.GetBlobClient(blobName);
@@ -353,12 +376,20 @@ namespace Azure.Messaging.EventHubs.Processor
             try
             {
                 await ApplyRetryPolicy(updateCheckpointAsync, cancellationToken).ConfigureAwait(false);
-                Logger.CheckpointUpdated(checkpoint.PartitionId);
             }
             catch (RequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.ContainerNotFound)
             {
-                Logger.CheckpointUpdateError(checkpoint.PartitionId, ex.ToString());
+                Logger.UpdateCheckpointError(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, ex.Message);
                 throw new RequestFailedException(Resources.BlobsResourceDoesNotExist);
+            }
+            catch (Exception ex)
+            {
+                Logger.UpdateCheckpointError(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, ex.Message);
+                throw;
+            }
+            finally
+            {
+                Logger.UpdateCheckpointComplete(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup);
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Azure.Messaging.EventHubs.Processor.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Azure.Messaging.EventHubs.Processor.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="System.Net.WebSockets.Client" />
     <PackageReference Include="System.ValueTuple" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/CheckpointStore/BlobsCheckpointStoreTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/CheckpointStore/BlobsCheckpointStoreTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Consumer;
 using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Primitives;
 using Azure.Messaging.EventHubs.Processor.Diagnostics;
@@ -99,8 +100,8 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             await target.ListOwnershipAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, new CancellationToken());
 
-            mockLog.Verify(m => m.ListOwnershipAsyncStart(FullyQualifiedNamespace, EventHubName, ConsumerGroup));
-            mockLog.Verify(m => m.ListOwnershipAsyncComplete(FullyQualifiedNamespace, EventHubName, ConsumerGroup, blobList.Count));
+            mockLog.Verify(m => m.ListOwnershipStart(FullyQualifiedNamespace, EventHubName, ConsumerGroup));
+            mockLog.Verify(m => m.ListOwnershipComplete(FullyQualifiedNamespace, EventHubName, ConsumerGroup, blobList.Count));
         }
 
         /// <summary>
@@ -119,7 +120,70 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             Assert.ThrowsAsync<RequestFailedException>(async () => await target.ListOwnershipAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, new CancellationToken()));
 
-            mockLog.Verify(m => m.ListOwnershipAsyncError(FullyQualifiedNamespace, EventHubName, ConsumerGroup, It.Is<string>(e => e.Contains("RequestFailedException"))));
+            mockLog.Verify(m => m.ListOwnershipError(FullyQualifiedNamespace, EventHubName, ConsumerGroup, It.Is<string>(e => e.Contains("RequestFailedException"))));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of ClaimOwnershipAsync and ensures the appropriate logging.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ClaimOwnershipLogsStartAndComplete()
+        {
+            var partitionOwnership = new List<EventProcessorPartitionOwnership>
+            {
+                new EventProcessorPartitionOwnership
+                {
+                    FullyQualifiedNamespace = FullyQualifiedNamespace,
+                    EventHubName = EventHubName,
+                    ConsumerGroup = ConsumerGroup,
+                    OwnerIdentifier = OwnershipIdentifier,
+                    PartitionId = PartitionId,
+                    LastModifiedTime = DateTime.UtcNow
+                }
+            };
+
+            var target = new BlobsCheckpointStore(new MockBlobContainerClient(),
+                                                  new BasicRetryPolicy(new EventHubsRetryOptions()));
+            var mockLog = new Mock<BlobEventStoreEventSource>();
+            target.Logger = mockLog.Object;
+
+            var result = (await target.ClaimOwnershipAsync(partitionOwnership, new CancellationToken())).ToList();
+
+            CollectionAssert.AreEquivalent(partitionOwnership, result);
+            mockLog.Verify(m => m.ClaimOwnershipStart(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, OwnershipIdentifier));
+            mockLog.Verify(m => m.ClaimOwnershipComplete(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, OwnershipIdentifier));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of ClaimOwnershipAsync and ensures the appropriate logging.
+        /// </summary>
+        ///
+        [Test]
+        public void ClaimOwnershipLogsErrors()
+        {
+            var partitionOwnership = new List<EventProcessorPartitionOwnership>
+            {
+                new EventProcessorPartitionOwnership
+                {
+                    FullyQualifiedNamespace = FullyQualifiedNamespace,
+                    EventHubName = EventHubName,
+                    ConsumerGroup = ConsumerGroup,
+                    OwnerIdentifier = OwnershipIdentifier,
+                    PartitionId = PartitionId,
+                    LastModifiedTime = DateTime.UtcNow
+                }
+            };
+
+            var expectedException = new DllNotFoundException("BOOM!");
+            var mockLog = new Mock<BlobEventStoreEventSource>();
+            var mockContainerClient = new MockBlobContainerClient() { BlobClientUploadBlobException = expectedException };
+            var target = new BlobsCheckpointStore(mockContainerClient, new BasicRetryPolicy(new EventHubsRetryOptions()));
+
+            target.Logger = mockLog.Object;
+
+            Assert.That(async () => await target.ClaimOwnershipAsync(partitionOwnership, new CancellationToken()), Throws.Exception.EqualTo(expectedException));
+            mockLog.Verify(m => m.ClaimOwnershipError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, OwnershipIdentifier, expectedException.Message));
         }
 
         /// <summary>
@@ -150,7 +214,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             var result = (await target.ClaimOwnershipAsync(partitionOwnership, new CancellationToken())).ToList();
 
             CollectionAssert.AreEquivalent(partitionOwnership, result);
-            mockLog.Verify(m => m.OwnershipClaimed(PartitionId, OwnershipIdentifier));
+            mockLog.Verify(m => m.OwnershipClaimed(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, OwnershipIdentifier));
         }
 
         /// <summary>
@@ -184,7 +248,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             var result = (await target.ClaimOwnershipAsync(partitionOwnership, new CancellationToken())).ToList();
 
             CollectionAssert.AreEquivalent(partitionOwnership, result);
-            mockLog.Verify(m => m.OwnershipClaimed(PartitionId, OwnershipIdentifier));
+            mockLog.Verify(m => m.OwnershipClaimed(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, OwnershipIdentifier));
         }
 
         /// <summary>
@@ -218,7 +282,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             var result = (await target.ClaimOwnershipAsync(partitionOwnership, new CancellationToken())).ToList();
 
             CollectionAssert.IsEmpty(result);
-            mockLog.Verify(m => m.OwnershipNotClaimable(PartitionId, OwnershipIdentifier, It.Is<string>(e => e.Contains(BlobErrorCode.ConditionNotMet.ToString()))));
+            mockLog.Verify(m => m.OwnershipNotClaimable(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, OwnershipIdentifier, It.Is<string>(e => e.Contains(BlobErrorCode.ConditionNotMet.ToString()))));
         }
 
         /// <summary>
@@ -275,8 +339,116 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             await target.ListCheckpointsAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, new CancellationToken());
 
-            mockLog.Verify(m => m.ListCheckpointsAsyncStart(FullyQualifiedNamespace, EventHubName, ConsumerGroup));
-            mockLog.Verify(m => m.ListCheckpointsAsyncComplete(FullyQualifiedNamespace, EventHubName, ConsumerGroup, blobList.Count));
+            mockLog.Verify(m => m.ListCheckpointsStart(FullyQualifiedNamespace, EventHubName, ConsumerGroup));
+            mockLog.Verify(m => m.ListCheckpointsComplete(FullyQualifiedNamespace, EventHubName, ConsumerGroup, blobList.Count));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of ListCheckpointsAsync and ensures the starting position is set correctly.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ListCheckpointsUsesOffsetAsTheStartingPositionWhenPresent()
+        {
+            var expectedOffset = 13;
+            var expectedStartingPosition = EventPosition.FromOffset(expectedOffset, false);
+
+            var blobList = new List<BlobItem>{
+                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/checkpoint/{Guid.NewGuid().ToString()}",
+                                           false,
+                                           BlobsModelFactory.BlobItemProperties(true, lastModified: DateTime.UtcNow, eTag: new ETag(MatchingEtag)),
+                                           "snapshot",
+                                           new Dictionary<string, string>
+                                           {
+                                               {BlobMetadataKey.OwnerIdentifier, Guid.NewGuid().ToString()},
+                                               {BlobMetadataKey.Offset, expectedOffset.ToString()},
+                                               {BlobMetadataKey.SequenceNumber, "7777"}
+                                           })
+            };
+            var target = new BlobsCheckpointStore(new MockBlobContainerClient() { Blobs = blobList }, new BasicRetryPolicy(new EventHubsRetryOptions()));
+            var checkpoints = await target.ListCheckpointsAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, new CancellationToken());
+
+            Assert.That(checkpoints, Is.Not.Null, "A set of checkpoints should have been returned.");
+            Assert.That(checkpoints.Single().StartingPosition, Is.EqualTo(expectedStartingPosition));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of ListCheckpointsAsync and ensures the starting position is set correctly.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ListCheckpointsUsesSequenceNumberAsTheStartingPositionWhenNoOffsetIsPresent()
+        {
+            var expectedSequence = 133;
+            var expectedStartingPosition = EventPosition.FromSequenceNumber(expectedSequence, false);
+
+            var blobList = new List<BlobItem>{
+                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/checkpoint/{Guid.NewGuid().ToString()}",
+                                           false,
+                                           BlobsModelFactory.BlobItemProperties(true, lastModified: DateTime.UtcNow, eTag: new ETag(MatchingEtag)),
+                                           "snapshot",
+                                           new Dictionary<string, string>
+                                           {
+                                               {BlobMetadataKey.OwnerIdentifier, Guid.NewGuid().ToString()},
+                                               {BlobMetadataKey.SequenceNumber, expectedSequence.ToString()}
+                                           })
+            };
+            var target = new BlobsCheckpointStore(new MockBlobContainerClient() { Blobs = blobList }, new BasicRetryPolicy(new EventHubsRetryOptions()));
+            var checkpoints = await target.ListCheckpointsAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, new CancellationToken());
+
+            Assert.That(checkpoints, Is.Not.Null, "A set of checkpoints should have been returned.");
+            Assert.That(checkpoints.Single().StartingPosition, Is.EqualTo(expectedStartingPosition));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of ListCheckpointsAsync and ensures the starting position is set correctly.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ListCheckpointsConsidersDataInvalidWithNoOffsetOrSequenceNumber()
+        {
+            var partitionId = "67";
+
+            var blobList = new List<BlobItem>{
+                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/checkpoint/{partitionId}",
+                                           false,
+                                           BlobsModelFactory.BlobItemProperties(true, lastModified: DateTime.UtcNow, eTag: new ETag(MatchingEtag)),
+                                           "snapshot",
+                                           new Dictionary<string, string>
+                                           {
+                                               {BlobMetadataKey.OwnerIdentifier, Guid.NewGuid().ToString()}
+                                           })
+            };
+
+            var mockLogger = new Mock<BlobEventStoreEventSource>();
+            var target = new BlobsCheckpointStore(new MockBlobContainerClient() { Blobs = blobList }, new BasicRetryPolicy(new EventHubsRetryOptions()));
+
+            target.Logger = mockLogger.Object;
+
+            var checkpoints = await target.ListCheckpointsAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, new CancellationToken());
+
+            Assert.That(checkpoints, Is.Not.Null, "A set of checkpoints should have been returned.");
+            Assert.That(checkpoints.Any(), Is.False, "No valid checkpoints should exist.");
+
+            mockLogger.Verify(log => log.InvalidCheckpointFound(partitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of ListCheckpointsAsync and ensures the appropriate events are emitted when errors occur.
+        /// </summary>
+        ///
+        [Test]
+        public void ListCheckpointsLogsErrors()
+        {
+            var expectedException = new DllNotFoundException("BOOM!");
+            var mockLog = new Mock<BlobEventStoreEventSource>();
+            var mockContainerClient = new MockBlobContainerClient() { GetBlobsAsyncException = expectedException };
+            var target = new BlobsCheckpointStore(mockContainerClient, new BasicRetryPolicy(new EventHubsRetryOptions()));
+
+            target.Logger = mockLog.Object;
+
+            Assert.That(async () => await target.ListCheckpointsAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, new CancellationToken()), Throws.Exception.EqualTo(expectedException));
+            mockLog.Verify(m => m.ListCheckpointsError(FullyQualifiedNamespace, EventHubName, ConsumerGroup, expectedException.Message));
         }
 
         /// <summary>
@@ -301,8 +473,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             target.Logger = mockLog.Object;
 
             await target.ListCheckpointsAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, new CancellationToken());
-
-            mockLog.Verify(m => m.InvalidCheckpointFound(FullyQualifiedNamespace, EventHubName, ConsumerGroup, partitionId));
+            mockLog.Verify(m => m.InvalidCheckpointFound(partitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup));
         }
 
         /// <summary>
@@ -320,6 +491,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             target.Logger = mockLog.Object;
 
             Assert.ThrowsAsync<RequestFailedException>(async () => await target.ListCheckpointsAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, new CancellationToken()));
+            mockLog.Verify(m => m.ListCheckpointsError(FullyQualifiedNamespace, EventHubName, ConsumerGroup, ex.Message));
         }
 
         /// <summary>
@@ -327,7 +499,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         /// </summary>
         ///
         [Test]
-        public async Task UpdateCheckpointLogsCheckpointUpdated()
+        public async Task UpdateCheckpointLogsStartAndComplete()
         {
             var checkpoint = new EventProcessorCheckpoint
             {
@@ -350,8 +522,35 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             target.Logger = mockLog.Object;
 
             await target.UpdateCheckpointAsync(checkpoint, new EventData(Array.Empty<byte>()), new CancellationToken());
+            mockLog.Verify(log => log.UpdateCheckpointStart(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup));
+            mockLog.Verify(log => log.UpdateCheckpointComplete(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup));
+        }
 
-            mockLog.Verify(m => m.CheckpointUpdated(PartitionId));
+        /// <summary>
+        ///   Verifies basic functionality of UpdateCheckpointAsync and ensures the appropriate logs are written
+        ///   when exceptions occur.
+        /// </summary>
+        ///
+        [Test]
+        public void UpdateCheckpointLogsErrors()
+        {
+            var checkpoint = new EventProcessorCheckpoint
+            {
+                FullyQualifiedNamespace = FullyQualifiedNamespace,
+                EventHubName = EventHubName,
+                ConsumerGroup = ConsumerGroup,
+                PartitionId = PartitionId,
+            };
+
+            var expectedException = new DllNotFoundException("BOOM!");
+            var mockLog = new Mock<BlobEventStoreEventSource>();
+            var mockContainerClient = new MockBlobContainerClient() { BlobClientUploadBlobException = expectedException };
+            var target = new BlobsCheckpointStore(mockContainerClient, new BasicRetryPolicy(new EventHubsRetryOptions()));
+
+            target.Logger = mockLog.Object;
+
+            Assert.That(async () => await target.UpdateCheckpointAsync(checkpoint, new EventData(Array.Empty<byte>()), new CancellationToken()), Throws.Exception.EqualTo(expectedException));
+            mockLog.Verify(log => log.UpdateCheckpointError(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, expectedException.Message));
         }
 
         /// <summary>
@@ -377,7 +576,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             Assert.ThrowsAsync<RequestFailedException>(async () => await target.UpdateCheckpointAsync(checkpoint, new EventData(Array.Empty<byte>()), new CancellationToken()));
 
-            mockLog.Verify(m => m.CheckpointUpdateError(PartitionId, It.Is<string>(s => s.Contains(BlobErrorCode.ContainerNotFound.ToString()))));
+            mockLog.Verify(m => m.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, It.Is<string>(s => s.Contains(BlobErrorCode.ContainerNotFound.ToString()))));
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/DiagnosticsTests.cs
@@ -49,7 +49,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockContext = new Mock<PartitionContext>("65");
             var mockLogger = new Mock<EventProcessorClientEventSource>();
-            var mockProcessor = new Mock<EventProcessorClient>(Mock.Of<StorageManager>(), "cg", "host", "hub", Mock.Of<TokenCredential>(), null);
+            var mockProcessor = new Mock<EventProcessorClient>(Mock.Of<StorageManager>(), "cg", "host", "hub", Mock.Of<TokenCredential>(), null) { CallBase = true };
 
             mockProcessor
                 .Protected()

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientLiveTests.cs
@@ -8,10 +8,15 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Identity;
 using Azure.Messaging.EventHubs.Consumer;
 using Azure.Messaging.EventHubs.Primitives;
 using Azure.Messaging.EventHubs.Processor.Tests;
 using Azure.Messaging.EventHubs.Producer;
+using Azure.Storage.Blobs;
+using Moq;
+using Moq.Protected;
 using NUnit.Framework;
 
 namespace Azure.Messaging.EventHubs.Tests
@@ -31,5 +36,831 @@ namespace Azure.Messaging.EventHubs.Tests
     [Category(TestCategory.DisallowVisualStudioLiveUnitTesting)]
     public class EventProcessorClientLiveTests
     {
+        /// <summary>The name of the custom event property which holds a test-specific artificial sequence number.</summary>
+        private static readonly string CustomIdProperty = $"{ nameof(EventProcessorClientLiveTests) }::Identifier";
+
+        /// <summary>The name of the custom event property which holds a test-specific artificial sequence number.</summary>
+        private static readonly string CustomSequenceProperty = $"{ nameof(EventProcessorClientLiveTests) }::Sequence";
+
+        /// <summary>A generator for random values used within the tests.</summary>
+        private readonly Random RandomGenerator = new Random();
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventProcessorClient" /> can read a set of published events.
+        /// </summary>
+        ///
+        [Test]
+        public async Task EventsCanBeReadByOneProcessorClient()
+        {
+            // Setup the environment.
+
+            await using EventHubScope scope = await EventHubScope.CreateAsync(2);
+            var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+            // Test the scenario.
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+
+            var sentCount = 0;
+            var processCount = 0L;
+            var sourceEvents = CreateEvents(50).ToList();
+            var processedEvents = new Dictionary<string, EventData>();
+
+            // Send a set of events.
+
+            await using (var producer = new EventHubProducerClient(connectionString))
+            {
+                foreach (var batch in (await BuildBatchesAsync(sourceEvents, producer, cancellationSource.Token)))
+                {
+                    await producer.SendAsync(batch, cancellationSource.Token);
+
+                    sentCount += batch.Count;
+                    batch.Dispose();
+                }
+            }
+
+            Assert.That(sentCount, Is.EqualTo(sourceEvents.Count), "Not all of the source events were sent.");
+
+            // Attempt to read back the events.
+
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var options = new EventProcessorOptions { LoadBalancingUpdateInterval = TimeSpan.FromMilliseconds(250) };
+            var processor = CreateProcessor(scope.ConsumerGroups.First(), connectionString, options: options);
+
+            processor.ProcessErrorAsync += args =>
+            {
+                Assert.Fail($"Processor Error Surfaced: ({ args.Exception.GetType().Name })[{ args.Exception.Message }]");
+                return Task.CompletedTask;
+            };
+
+            processor.ProcessEventAsync += args =>
+            {
+                if (args.HasEvent)
+                {
+                    var eventId = args.Data.Properties[CustomIdProperty].ToString();
+
+                    // Guard against duplicates; Event Hubs has an at-least-once guarantee.
+
+                    if ((TryAdd(processedEvents, eventId, args.Data)) && (Interlocked.Increment(ref processCount) >= sentCount))
+                    {
+                        completionSource.TrySetResult(true);
+                    }
+                }
+
+                return Task.CompletedTask;
+            };
+
+            await processor.StartProcessingAsync(cancellationSource.Token);
+
+            await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+            await processor.StopProcessingAsync(cancellationSource.Token);
+            cancellationSource.Cancel();
+
+            // Validate the events that were processed.
+
+            foreach (var sourceEvent in sourceEvents)
+            {
+                var sourceId = sourceEvent.Properties[CustomIdProperty].ToString();
+
+                if (!processedEvents.TryGetValue(sourceId, out var processedEvent))
+                {
+                    Assert.Fail($"The event with custom identifier [{ sourceId }] was not processed.");
+                }
+
+                Assert.That(sourceEvent.IsEquivalentTo(processedEvent), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event.");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventProcessorClient" /> can read a set of published events.
+        /// </summary>
+        ///
+        [Test]
+        public async Task EventsCanBeReadByOneProcessorClientUsingAnIdentityCredential()
+        {
+            // Setup the environment.
+
+            await using EventHubScope scope = await EventHubScope.CreateAsync(2);
+            var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+            // Test the scenario.
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+
+            var sentCount = 0;
+            var processCount = 0L;
+            var sourceEvents = CreateEvents(50).ToList();
+            var processedEvents = new Dictionary<string, EventData>();
+
+            // Send a set of events.
+
+            await using (var producer = new EventHubProducerClient(connectionString))
+            {
+                foreach (var batch in (await BuildBatchesAsync(sourceEvents, producer, cancellationSource.Token)))
+                {
+                    await producer.SendAsync(batch, cancellationSource.Token);
+
+                    sentCount += batch.Count;
+                    batch.Dispose();
+                }
+            }
+
+            Assert.That(sentCount, Is.EqualTo(sourceEvents.Count), "Not all of the source events were sent.");
+
+            // Attempt to read back the events.
+
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var options = new EventProcessorOptions { LoadBalancingUpdateInterval = TimeSpan.FromMilliseconds(250) };
+            var processor = CreateProcessorWithIdentity(scope.ConsumerGroups.First(), scope.EventHubName, options: options);
+
+            processor.ProcessErrorAsync += args =>
+            {
+                Assert.Fail($"Processor Error Surfaced: ({ args.Exception.GetType().Name })[{ args.Exception.Message }]");
+                return Task.CompletedTask;
+            };
+
+            processor.ProcessEventAsync += args =>
+            {
+                if (args.HasEvent)
+                {
+                    var eventId = args.Data.Properties[CustomIdProperty].ToString();
+
+                    // Guard against duplicates; Event Hubs has an at-least-once guarantee.
+
+                    if ((TryAdd(processedEvents, eventId, args.Data)) && (Interlocked.Increment(ref processCount) >= sentCount))
+                    {
+                        completionSource.TrySetResult(true);
+                    }
+                }
+
+                return Task.CompletedTask;
+            };
+
+            await processor.StartProcessingAsync(cancellationSource.Token);
+
+            await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, $"The cancellation token should not have been signaled.  { processedEvents.Count } events were processed.");
+
+            await processor.StopProcessingAsync(cancellationSource.Token);
+            cancellationSource.Cancel();
+
+            // Validate the events that were processed.
+
+            foreach (var sourceEvent in sourceEvents)
+            {
+                var sourceId = sourceEvent.Properties[CustomIdProperty].ToString();
+
+                if (!processedEvents.TryGetValue(sourceId, out var processedEvent))
+                {
+                    Assert.Fail($"The event with custom identifier [{ sourceId }] was not processed.");
+                }
+
+                Assert.That(sourceEvent.IsEquivalentTo(processedEvent), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event.");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventProcessorClient" /> can read a set of published events.
+        /// </summary>
+        ///
+        [Test]
+        public async Task EventsCanBeReadByMultipleProcessorClients()
+        {
+            // Setup the environment.
+
+            await using EventHubScope scope = await EventHubScope.CreateAsync(4);
+            var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+            // Test the scenario.
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+
+            var sentCount = 0;
+            var processCount = 0L;
+            var sourceEvents = CreateEvents(500).ToList();
+            var processedEvents = new ConcurrentDictionary<string, EventData>();
+
+
+            // Send a set of events.
+
+            await using (var producer = new EventHubProducerClient(connectionString))
+            {
+                foreach (var batch in (await BuildBatchesAsync(sourceEvents, producer, cancellationSource.Token)))
+                {
+                    await producer.SendAsync(batch, cancellationSource.Token);
+
+                    sentCount += batch.Count;
+                    batch.Dispose();
+                }
+            }
+
+            Assert.That(sentCount, Is.EqualTo(sourceEvents.Count), "Not all of the source events were sent.");
+
+            // Attempt to read back the events.
+
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            // Create multiple processors using the same handlers; events may not appear in the same order, but each event
+            // should be read once.
+
+            var options = new EventProcessorOptions { LoadBalancingUpdateInterval = TimeSpan.FromMilliseconds(500) };
+
+            var processors = new[]
+            {
+                CreateProcessor(scope.ConsumerGroups.First(), connectionString, options: options),
+                CreateProcessor(scope.ConsumerGroups.First(), connectionString, options: options)
+            };
+
+            foreach (var processor in processors)
+            {
+                processor.ProcessErrorAsync += args =>
+                {
+                    Assert.Fail($"Processor Error Surfaced: ({ args.Exception.GetType().Name })[{ args.Exception.Message }]");
+                    return Task.CompletedTask;
+                };
+
+                processor.ProcessEventAsync += args =>
+                {
+                    if (args.HasEvent)
+                    {
+                        var eventId = args.Data.Properties[CustomIdProperty].ToString();
+
+                        // Guard against duplicates; Event Hubs has an at-least-once guarantee.
+
+                        if ((processedEvents.TryAdd(eventId, args.Data)) && (Interlocked.Increment(ref processCount) >= sentCount))
+                        {
+                            completionSource.TrySetResult(true);
+                        }
+                    }
+
+                    return Task.CompletedTask;
+                };
+            }
+
+            await Task.WhenAll(processors.Select(processor => processor.StartProcessingAsync(cancellationSource.Token)));
+
+            // Allow the processors to complete, while respecting the test timeout.
+
+            await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, $"The cancellation token should not have been signaled.  { processedEvents.Count } events were processed.");
+
+            await Task.WhenAll(processors.Select(processor => processor.StopProcessingAsync(cancellationSource.Token)));
+            cancellationSource.Cancel();
+
+            // Validate the events that were processed.
+
+            foreach (var sourceEvent in sourceEvents)
+            {
+                var sourceId = sourceEvent.Properties[CustomIdProperty].ToString();
+
+                if (!processedEvents.TryGetValue(sourceId, out var processedEvent))
+                {
+                    Assert.Fail($"The event with custom identifier [{ sourceId }] was not processed.");
+                }
+
+                Assert.That(sourceEvent.IsEquivalentTo(processedEvent), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event.");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventProcessorClient" /> can read a set of published events.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ProcessorClientCreatesOwnership()
+        {
+            // Setup the environment.
+
+            var partitionCount = 2;
+            var partitionIds = new HashSet<string>();
+
+            await using EventHubScope scope = await EventHubScope.CreateAsync(partitionCount);
+            var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+            // Test the scenario.
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+
+            var sentCount = 0;
+            var processCount = 0L;
+            var sourceEvents = CreateEvents(200).ToList();
+            var processedEvents = new HashSet<string>();
+
+            // Send a set of events.
+
+            await using (var producer = new EventHubProducerClient(connectionString))
+            {
+                foreach (var partition in (await producer.GetPartitionIdsAsync(cancellationSource.Token)))
+                {
+                    partitionIds.Add(partition);
+                }
+
+                foreach (var batch in (await BuildBatchesAsync(sourceEvents, producer, cancellationSource.Token)))
+                {
+                    await producer.SendAsync(batch, cancellationSource.Token);
+
+                    sentCount += batch.Count;
+                    batch.Dispose();
+                }
+            }
+
+            Assert.That(sentCount, Is.EqualTo(sourceEvents.Count), "Not all of the source events were sent.");
+
+            // Attempt to read back the events.
+
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var storageManager = new InMemoryStorageManager(_ => {});
+            var options = new EventProcessorOptions { LoadBalancingUpdateInterval = TimeSpan.FromMilliseconds(250) };
+            var processor = CreateProcessorWithIdentity(scope.ConsumerGroups.First(), scope.EventHubName, storageManager, options);
+
+            processor.ProcessErrorAsync += args =>
+            {
+                Assert.Fail($"Processor Error Surfaced: ({ args.Exception.GetType().Name })[{ args.Exception.Message }]");
+                return Task.CompletedTask;
+            };
+
+            processor.ProcessEventAsync += args =>
+            {
+                if (args.HasEvent)
+                {
+                    var eventId = args.Data.Properties[CustomIdProperty].ToString();
+
+                    // Guard against duplicates; Event Hubs has an at-least-once guarantee.
+
+                    if ((!processedEvents.Contains(eventId)) && (Interlocked.Increment(ref processCount) >= sentCount))
+                    {
+                        completionSource.TrySetResult(true);
+                    }
+                }
+
+                return Task.CompletedTask;
+            };
+
+            await processor.StartProcessingAsync(cancellationSource.Token);
+
+            await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, $"The cancellation token should not have been signaled.  { processedEvents.Count } events were processed.");
+
+            await processor.StopProcessingAsync(cancellationSource.Token);
+            cancellationSource.Cancel();
+
+            // Validate that events that were processed.
+
+            var ownership = (await storageManager.ListOwnershipAsync(TestEnvironment.FullyQualifiedNamespace, scope.EventHubName, scope.ConsumerGroups.First(), cancellationSource.Token))?.ToList();
+
+            Assert.That(ownership, Is.Not.Null, "The ownership list should have been returned.");
+            Assert.That(ownership.Count, Is.AtLeast(1), "At least one partition should have been owned.");
+
+            foreach (var partitionOwnership in ownership)
+            {
+                Assert.That(partitionIds.Contains(partitionOwnership.PartitionId), Is.True, $"The partition `{ partitionOwnership.PartitionId }` is not valid for the Event Hub.");
+                Assert.That(partitionOwnership.OwnerIdentifier, Is.Empty, "Ownership should have bee relinquished when the processor was stopped.");
+            }
+
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventProcessorClient" /> can read a set of published events.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ProcessorClientCanStartFromAnInitialPosition()
+        {
+            // Setup the environment.
+
+            await using EventHubScope scope = await EventHubScope.CreateAsync(1);
+            var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+            // Test the scenario.
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+
+            var sentCount = 0;
+            var sourceEvents = CreateEvents(20).ToList();
+            var lastSourceEvent = sourceEvents.Last();
+
+            // Send an initial set of events to populate the partition.
+
+            await using (var producer = new EventHubProducerClient(connectionString))
+            {
+                foreach (var batch in (await BuildBatchesAsync(sourceEvents, producer, cancellationSource.Token)))
+                {
+                    await producer.SendAsync(batch, cancellationSource.Token);
+
+                    sentCount += batch.Count;
+                    batch.Dispose();
+                }
+            }
+
+            Assert.That(sentCount, Is.EqualTo(sourceEvents.Count), "Not all of the source events were sent.");
+
+            // Read the initial set back, marking the offset and sequence number of the last event in the initial set.
+
+            var startingCustomSequence = 0;
+            var startingOffset = 0L;
+
+            await using (var consumer = new EventHubConsumerClient(scope.ConsumerGroups.First(), connectionString))
+            {
+                await foreach  (var partitionEvent in consumer.ReadEventsAsync(new ReadEventOptions { MaximumWaitTime = null }, cancellationSource.Token))
+                {
+                    if (partitionEvent.Data.IsEquivalentTo(lastSourceEvent))
+                    {
+                        startingCustomSequence = int.Parse(partitionEvent.Data.Properties[CustomSequenceProperty].ToString());
+                        startingOffset = partitionEvent.Data.Offset;
+
+                        break;
+                    }
+                }
+            }
+
+            // Send the second set of events to be read by the processor.
+
+            sentCount = 0;
+            sourceEvents = CreateEvents(20, (startingCustomSequence + 1)).ToList();
+
+            // Send an initial set of events to populate the partition.
+
+            await using (var producer = new EventHubProducerClient(connectionString))
+            {
+                foreach (var batch in (await BuildBatchesAsync(sourceEvents, producer, cancellationSource.Token)))
+                {
+                    await producer.SendAsync(batch, cancellationSource.Token);
+
+                    sentCount += batch.Count;
+                    batch.Dispose();
+                }
+            }
+
+            Assert.That(sentCount, Is.EqualTo(sourceEvents.Count), "Not all of the source events were sent.");
+
+            // Attempt to read back the second set of events.
+
+            var processCount = 0L;
+            var processedEvents = new Dictionary<string, EventData>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var options = new EventProcessorOptions { LoadBalancingUpdateInterval = TimeSpan.FromMilliseconds(250) };
+            var processor = CreateProcessor(scope.ConsumerGroups.First(), connectionString, options: options);
+
+            processor.PartitionInitializingAsync += args =>
+            {
+                args.DefaultStartingPosition = EventPosition.FromOffset(startingOffset, false);
+                return Task.CompletedTask;
+            };
+
+            processor.ProcessErrorAsync += args =>
+            {
+                Assert.Fail($"Processor Error Surfaced: ({ args.Exception.GetType().Name })[{ args.Exception.Message }]");
+                return Task.CompletedTask;
+            };
+
+            processor.ProcessEventAsync += args =>
+            {
+                if (args.HasEvent)
+                {
+                    var eventId = args.Data.Properties[CustomIdProperty].ToString();
+
+                    // Guard against duplicates; Event Hubs has an at-least-once guarantee.
+
+                    if ((TryAdd(processedEvents, eventId, args.Data)) && (Interlocked.Increment(ref processCount) >= sentCount))
+                    {
+                        completionSource.TrySetResult(true);
+                    }
+                }
+
+                return Task.CompletedTask;
+            };
+
+            await processor.StartProcessingAsync(cancellationSource.Token);
+
+            await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+            await processor.StopProcessingAsync(cancellationSource.Token);
+            cancellationSource.Cancel();
+
+            // Validate the events that were processed.
+
+            foreach (var sourceEvent in sourceEvents)
+            {
+                var sourceId = sourceEvent.Properties[CustomIdProperty].ToString();
+
+                if (!processedEvents.TryGetValue(sourceId, out var processedEvent))
+                {
+                    Assert.Fail($"The event with custom identifier [{ sourceId }] was not processed.");
+                }
+
+                Assert.That(sourceEvent.IsEquivalentTo(processedEvent), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event.");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventProcessorClient" /> can read a set of published events.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ProcessorClientBeginsWithTheNextEventAfterCheckpointing()
+        {
+            // Setup the environment.
+
+            await using EventHubScope scope = await EventHubScope.CreateAsync(1);
+            var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+            // Test the scenario.
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+
+            var sentCount = 0;
+            var segmentEventCount = 25;
+            var beforeCheckpointEvents = CreateEvents(segmentEventCount).ToList();
+            var afterCheckpointEvents = CreateEvents(segmentEventCount, segmentEventCount).ToList();
+            var sourceEvents = Enumerable.Concat(beforeCheckpointEvents, afterCheckpointEvents).ToList();
+            var checkpointEvent = beforeCheckpointEvents.Last();
+
+            // Send the full set of events.
+
+            await using (var producer = new EventHubProducerClient(connectionString))
+            {
+                foreach (var batch in (await BuildBatchesAsync(sourceEvents, producer, cancellationSource.Token)))
+                {
+                    await producer.SendAsync(batch, cancellationSource.Token);
+
+                    sentCount += batch.Count;
+                    batch.Dispose();
+                }
+            }
+
+            Assert.That(sentCount, Is.EqualTo(sourceEvents.Count), "Not all of the source events were sent.");
+
+            // Attempt to read back the first half of the events and checkpoint.
+
+            var processCount = 0L;
+            var processedEvents = new Dictionary<string, EventData>();
+            var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var options = new EventProcessorOptions { LoadBalancingUpdateInterval = TimeSpan.FromMilliseconds(250) };
+            var storageManager = new InMemoryStorageManager(_ => {});
+            var processor = CreateProcessor(scope.ConsumerGroups.First(), connectionString, storageManager, options);
+
+            processor.ProcessErrorAsync += args =>
+            {
+                Assert.Fail($"Processor Error Surfaced: ({ args.Exception.GetType().Name })[{ args.Exception.Message }]");
+                return Task.CompletedTask;
+            };
+
+            processor.ProcessEventAsync += async args =>
+            {
+                if (args.HasEvent)
+                {
+                    var eventId = args.Data.Properties[CustomIdProperty].ToString();
+
+                    if (args.Data.IsEquivalentTo(checkpointEvent))
+                    {
+                        await args.UpdateCheckpointAsync(cancellationSource.Token);
+                    }
+
+                    // Guard against duplicates; Event Hubs has an at-least-once guarantee.
+
+                    if ((TryAdd(processedEvents, eventId, args.Data)) && (Interlocked.Increment(ref processCount) >= segmentEventCount))
+                    {
+                        completionSource.TrySetResult(true);
+                    }
+                }
+            };
+
+            await processor.StartProcessingAsync(cancellationSource.Token);
+
+            await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+            await processor.StopProcessingAsync(cancellationSource.Token);
+
+            // Validate a checkpoint was created and that events were processed.
+
+            var checkpoints = (await storageManager.ListCheckpointsAsync(processor.FullyQualifiedNamespace, processor.EventHubName, processor.ConsumerGroup, cancellationSource.Token))?.ToList();
+            Assert.That(checkpoints, Is.Not.Null, "A checkpoint should have been created.");
+            Assert.That(checkpoints.Count, Is.EqualTo(1), "A single checkpoint should exist.");
+            Assert.That(processCount, Is.AtLeast(beforeCheckpointEvents.Count), "All events before the checkpoint should have been processed.");
+
+            // Reset state and start the processor again; it should resume from the event following the checkpoint.
+
+            processedEvents.Clear();
+
+            processCount = 0;
+            completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            await processor.StartProcessingAsync(cancellationSource.Token);
+
+            await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+            await processor.StopProcessingAsync(cancellationSource.Token);
+            cancellationSource.Cancel();
+
+            foreach (var sourceEvent in afterCheckpointEvents)
+            {
+                var sourceId = sourceEvent.Properties[CustomIdProperty].ToString();
+
+                if (!processedEvents.TryGetValue(sourceId, out var processedEvent))
+                {
+                    Assert.Fail($"The event with custom identifier [{ sourceId }] was not processed.");
+                }
+
+                Assert.That(sourceEvent.IsEquivalentTo(processedEvent), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event.");
+            }
+        }
+
+        /// <summary>
+        ///   Creates an <see cref="EventProcessorClient" /> that uses mock storage and
+        ///   a connection based on a connection string.
+        /// </summary>
+        ///
+        /// <param name="consumerGroup">The consumer group for the processor.</param>
+        /// <param name="connectionString">The connection to use for spawning connections.</param>
+        /// <param name="storageManager">The storage manager to set for the processor; if <c>default</c>, a mock storage manager will be created.</param>
+        /// <param name="options">The set of client options to pass.</param>
+        ///
+        /// <returns>The processor instance.</returns>
+        ///
+        private EventProcessorClient CreateProcessor(string consumerGroup,
+                                                     string connectionString,
+                                                     StorageManager storageManager = default,
+                                                     EventProcessorOptions options = default)
+        {
+            EventHubConnection createConnection() => new EventHubConnection(connectionString);
+
+            storageManager ??= new InMemoryStorageManager(_=> {});
+            return new TestEventProcessorClient(storageManager, consumerGroup, "fakeNamespace", "fakeEventHub", Mock.Of<TokenCredential>(), createConnection, options);
+        }
+
+        /// <summary>
+        ///   Creates an <see cref="EventProcessorClient" /> that uses mock storage and
+        ///   a connection based on an identity credential.
+        /// </summary>
+        ///
+        /// <param name="consumerGroup">The consumer group for the processor.</param>
+        /// <param name="eventHubName">The name of the Event Hub for the processor.</param>
+        /// <param name="storageManager">The storage manager to set for the processor; if <c>default</c>, a mock storage manager will be created.</param>
+        /// <param name="options">The set of client options to pass.</param>
+        ///
+        /// <returns>The processor instance.</returns>
+        ///
+        private EventProcessorClient CreateProcessorWithIdentity(string consumerGroup,
+                                                                 string eventHubName,
+                                                                 StorageManager storageManager = default,
+                                                                 EventProcessorOptions options = default)
+        {
+            var credential = new ClientSecretCredential(TestEnvironment.EventHubsTenant, TestEnvironment.EventHubsClient, TestEnvironment.EventHubsSecret);
+            EventHubConnection createConnection() => new EventHubConnection(TestEnvironment.FullyQualifiedNamespace, eventHubName, credential);
+
+            storageManager ??= new InMemoryStorageManager(_=> {});
+            return new TestEventProcessorClient(storageManager, consumerGroup, TestEnvironment.FullyQualifiedNamespace, eventHubName, credential, createConnection, options);
+        }
+
+        /// <summary>
+        ///   Creates a set of events with random data and random body size.
+        /// </summary>
+        ///
+        /// <param name="numberOfEvents">The number of events to create.</param>
+        /// <param name="startSequenceNumberingAt">The number to start the custom sequencing at.</param>
+        ///
+        /// <returns></returns>
+        ///
+        private IEnumerable<EventData> CreateEvents(int numberOfEvents,
+                                                    int startSequenceNumberingAt = 0)
+        {
+            const int minimumBodySize = 3;
+            const int maximumBodySize = 83886;
+
+            EventData currentEvent;
+
+            var currentSequence = startSequenceNumberingAt;
+
+            for (var index = 0; index < numberOfEvents; ++index)
+            {
+                var buffer = new byte[RandomGenerator.Next(minimumBodySize, maximumBodySize)];
+                RandomGenerator.NextBytes(buffer);
+
+                currentEvent = new EventData(buffer);
+                currentEvent.Properties.Add(CustomIdProperty, Guid.NewGuid().ToString());
+                currentEvent.Properties.Add(CustomSequenceProperty, currentSequence);
+
+                currentSequence++;
+                yield return currentEvent;
+            }
+        }
+
+        /// <summary>
+        ///   Builds a set of batches from the provided events.
+        /// </summary>
+        ///
+        /// <param name="events">The events to group into batches.</param>
+        /// <param name="producer">The producer to use for creating batches.</param>
+        /// <param name="batchEvents">A dictionary to which the events included in the batches should be tracked.</param>
+        /// <param name="cancellationToken">The token used to signal a cancellation request.</param>
+        ///
+        /// <returns>The set of batches needed to contain the entire set of <paramref name="events"/>.</returns>
+        ///
+        /// <remarks>
+        ///   Callers are assumed to be responsible for taking ownership of the lifespan of the returned batches, including
+        ///   their disposal.
+        ///
+        ///   This method is intended for use within the test suite only; it is not hardened for general purpose use.
+        /// </remarks>
+        ///
+        private async Task<IEnumerable<EventDataBatch>> BuildBatchesAsync(IEnumerable<EventData> events,
+                                                                          EventHubProducerClient producer,
+                                                                          CancellationToken cancellationToken)
+        {
+            EventData eventData;
+
+            var queuedEvents = new Queue<EventData>(events);
+            var batches = new List<EventDataBatch>();
+            var currentBatch = default(EventDataBatch);
+
+            while (queuedEvents.Count > 0)
+            {
+                currentBatch ??= (await producer.CreateBatchAsync(cancellationToken).ConfigureAwait(false));
+                eventData = queuedEvents.Peek();
+
+                if (!currentBatch.TryAdd(eventData))
+                {
+                    if (currentBatch.Count == 0)
+                    {
+                        throw new InvalidOperationException("There was an event too large to fit into a batch.");
+                    }
+
+                    batches.Add(currentBatch);
+                    currentBatch = default;
+                }
+                else
+                {
+                   queuedEvents.Dequeue();
+                }
+            }
+
+            if ((currentBatch != default) && (currentBatch.Count > 0))
+            {
+                batches.Add(currentBatch);
+            }
+
+            return batches;
+        }
+
+        /// <summary>
+        ///   Attempts to add an item to the <paramref name="dictionary" /> if it does not
+        ///   already exist.
+        /// </summary>
+        ///
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <typeparam name="TValue">The type of the value.</typeparam>
+        ///
+        /// <param name="dictionary">The dictionary to attempt to add the item to.</param>
+        /// <param name="key">The key to assign the item.</param>
+        /// <param name="value">The value of the item.</param>
+        ///
+        /// <returns><c>true</c> if the item was added; otherwise, <c>false</c>.</returns>
+        ///
+        private static bool TryAdd<TKey, TValue>(Dictionary<TKey, TValue> dictionary,
+                                                 TKey key,
+                                                 TValue value)
+        {
+            if (dictionary.ContainsKey(key))
+            {
+                return false;
+            }
+
+            dictionary.Add(key, value);
+            return true;
+        }
+
+        /// <summary>
+        ///   A mock <see cref="EventProcessorClient" /> used for testing purposes to override
+        ///   connection creation.
+        /// </summary>
+        ///
+        public class TestEventProcessorClient : EventProcessorClient
+        {
+            private readonly Func<EventHubConnection> InjectedConnectionFactory;
+
+            internal TestEventProcessorClient(StorageManager storageManager,
+                                              string consumerGroup,
+                                              string fullyQualifiedNamespace,
+                                              string eventHubName,
+                                              TokenCredential credential,
+                                              Func<EventHubConnection> connectionFactory,
+                                              EventProcessorOptions options) : base(storageManager, consumerGroup, fullyQualifiedNamespace, eventHubName, credential, options)
+            {
+                InjectedConnectionFactory = connectionFactory;
+            }
+
+            protected override EventHubConnection CreateConnection() => InjectedConnectionFactory();
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/InMemoryStorageManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/InMemoryStorageManager.cs
@@ -21,7 +21,7 @@ namespace Azure.Messaging.EventHubs.Tests
     ///   store the checkpoints and partition ownership to a persistent store instead.
     /// </summary>
     ///
-    internal class MockCheckPointStorage : StorageManager
+    internal class InMemoryStorageManager : StorageManager
     {
         /// <summary>The primitive for synchronizing access during ownership update.</summary>
         private readonly object _ownershipLock = new object();
@@ -50,7 +50,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         /// <param name="logger">Logs activities performed by this storage manager.</param>
         ///
-        public MockCheckPointStorage(Action<string> logger = null)
+        public InMemoryStorageManager(Action<string> logger = null)
         {
             _logger = logger;
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Azure.Messaging.EventHubs.Shared.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Azure.Messaging.EventHubs.Shared.Tests.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <Compile Include="..\src\Testing\EventDataExtensions.cs" Link="SharedSource\Testing\EventDataExtensions.cs" />
-    <Compile Include="..\src\Testing\MockCheckPointStorage.cs" Link="SharedSource\Testing\MockCheckPointStorage.cs" />
+    <Compile Include="..\src\Testing\InMemoryStorageManager.cs" Link="SharedSource\Testing\InMemoryStorageManager.cs" />
     <Compile Include="..\src\Testing\MockEventData.cs" Link="SharedSource\Testing\MockEventData.cs" />
     <Compile Include="..\src\Testing\TaskExtensions.cs" Link="SharedSource\Testing\TaskExtensions.cs" />
   </ItemGroup>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Processor/PartitionLoadBalancerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Processor/PartitionLoadBalancerTests.cs
@@ -35,7 +35,7 @@ namespace Azure.Messaging.EventHubs.Primitives.Tests
         {
             const int NumberOfPartitions = 3;
             var partitionIds = Enumerable.Range(1, NumberOfPartitions).Select(p => p.ToString()).ToArray();
-            var storageManager = new MockCheckPointStorage((s) => Console.WriteLine(s));
+            var storageManager = new InMemoryStorageManager((s) => Console.WriteLine(s));
             var loadbalancer1 = new PartitionLoadBalancer(
                 storageManager, Guid.NewGuid().ToString(), ConsumerGroup, FullyQualifiedNamespace, EventHubName, TimeSpan.FromMinutes(1));
             var loadbalancer2 = new PartitionLoadBalancer(
@@ -93,7 +93,7 @@ namespace Azure.Messaging.EventHubs.Primitives.Tests
         {
             const int NumberOfPartitions = 3;
             var partitionIds = Enumerable.Range(1, NumberOfPartitions).Select(p => p.ToString()).ToArray();
-            var storageManager = new MockCheckPointStorage((s) => Console.WriteLine(s));
+            var storageManager = new InMemoryStorageManager((s) => Console.WriteLine(s));
             var loadbalancer = new PartitionLoadBalancer(
                 storageManager, Guid.NewGuid().ToString(), ConsumerGroup, FullyQualifiedNamespace, EventHubName, TimeSpan.FromMinutes(1));
 
@@ -127,7 +127,7 @@ namespace Azure.Messaging.EventHubs.Primitives.Tests
             const int MinimumpartitionCount = 4;
             const int NumberOfPartitions = 13;
             var partitionIds = Enumerable.Range(1, NumberOfPartitions).Select(p => p.ToString()).ToArray();
-            var storageManager = new MockCheckPointStorage((s) => Console.WriteLine(s));
+            var storageManager = new InMemoryStorageManager((s) => Console.WriteLine(s));
             var loadbalancer = new PartitionLoadBalancer(
                 storageManager, Guid.NewGuid().ToString(), ConsumerGroup, FullyQualifiedNamespace, EventHubName, TimeSpan.FromMinutes(1));
 
@@ -193,7 +193,7 @@ namespace Azure.Messaging.EventHubs.Primitives.Tests
             const int MaximumpartitionCount = 5;
             const int NumberOfPartitions = 14;
             var partitionIds = Enumerable.Range(1, NumberOfPartitions).Select(p => p.ToString()).ToArray();
-            var storageManager = new MockCheckPointStorage((s) => Console.WriteLine(s));
+            var storageManager = new InMemoryStorageManager((s) => Console.WriteLine(s));
             var loadbalancer = new PartitionLoadBalancer(
                 storageManager, Guid.NewGuid().ToString(), ConsumerGroup, FullyQualifiedNamespace, EventHubName, TimeSpan.FromMinutes(1));
 
@@ -265,7 +265,7 @@ namespace Azure.Messaging.EventHubs.Primitives.Tests
             const int MaximumpartitionCount = 5;
             const int NumberOfPartitions = 12;
             var partitionIds = Enumerable.Range(1, NumberOfPartitions).Select(p => p.ToString()).ToArray();
-            var storageManager = new MockCheckPointStorage((s) => Console.WriteLine(s));
+            var storageManager = new InMemoryStorageManager((s) => Console.WriteLine(s));
             var loadbalancer = new PartitionLoadBalancer(
                 storageManager, Guid.NewGuid().ToString(), ConsumerGroup, FullyQualifiedNamespace, EventHubName, TimeSpan.FromMinutes(1));
 
@@ -335,7 +335,7 @@ namespace Azure.Messaging.EventHubs.Primitives.Tests
             const int NumberOfPartitions = 4;
             const int MinimumpartitionCount = NumberOfPartitions / 2;
             var partitionIds = Enumerable.Range(1, NumberOfPartitions).Select(p => p.ToString()).ToArray();
-            var storageManager = new MockCheckPointStorage((s) => Console.WriteLine(s));
+            var storageManager = new InMemoryStorageManager((s) => Console.WriteLine(s));
             var loadbalancer = new PartitionLoadBalancer(
                 storageManager, Guid.NewGuid().ToString(), ConsumerGroup, FullyQualifiedNamespace, EventHubName, TimeSpan.FromMinutes(1));
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Testing/InMemoryStorageManagerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Testing/InMemoryStorageManagerTests.cs
@@ -12,36 +12,36 @@ using NUnit.Framework;
 namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
-    ///   The suite of tests for the <see cref="MockCheckPointStorage" />
+    ///   The suite of tests for the <see cref="InMemoryStorageManager" />
     ///   class.
     /// </summary>
     ///
     [TestFixture]
-    public class MockCheckPointStorageTests
+    public class InMemoryStorageManagerTests
     {
         /// <summary>
-        ///   Verifies functionality of the <see cref="MockCheckPointStorage.ListOwnershipAsync" />
+        ///   Verifies functionality of the <see cref="InMemoryStorageManager.ListOwnershipAsync" />
         ///   method.
         /// </summary>
         ///
         [Test]
         public async Task ListOwnershipAsyncReturnsEmptyIEnumerableWhenThereAreNoOwnership()
         {
-            var storageManager = new MockCheckPointStorage();
+            var storageManager = new InMemoryStorageManager();
             IEnumerable<EventProcessorPartitionOwnership> ownership = await storageManager.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup");
 
             Assert.That(ownership, Is.Not.Null.And.Empty);
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="MockCheckPointStorage.ClaimOwnershipAsync" />
+        ///   Verifies functionality of the <see cref="InMemoryStorageManager.ClaimOwnershipAsync" />
         ///   method.
         /// </summary>
         ///
         [Test]
         public async Task FirstOwnershipClaimSucceeds()
         {
-            var storageManager = new MockCheckPointStorage();
+            var storageManager = new InMemoryStorageManager();
             var ownershipList = new List<EventProcessorPartitionOwnership>();
             var ownership = new EventProcessorPartitionOwnership
             {
@@ -64,7 +64,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="MockCheckPointStorage.ClaimOwnershipAsync" />
+        ///   Verifies functionality of the <see cref="InMemoryStorageManager.ClaimOwnershipAsync" />
         ///   method.
         /// </summary>
         ///
@@ -73,7 +73,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("invalidVersion")]
         public async Task OwnershipClaimFailsWhenVersionIsInvalid(string version)
         {
-            var storageManager = new MockCheckPointStorage();
+            var storageManager = new InMemoryStorageManager();
             var ownershipList = new List<EventProcessorPartitionOwnership>();
             var firstOwnership = new EventProcessorPartitionOwnership
             {
@@ -112,14 +112,14 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="MockCheckPointStorage.ClaimOwnershipAsync" />
+        ///   Verifies functionality of the <see cref="InMemoryStorageManager.ClaimOwnershipAsync" />
         ///   method.
         /// </summary>
         ///
         [Test]
         public async Task OwnershipClaimSucceedsWhenVersionsValid()
         {
-            var storageManager = new MockCheckPointStorage();
+            var storageManager = new InMemoryStorageManager();
             var ownershipList = new List<EventProcessorPartitionOwnership>();
             var firstOwnership = new EventProcessorPartitionOwnership
             {
@@ -162,14 +162,14 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="MockCheckPointStorage.ClaimOwnershipAsync" />
+        ///   Verifies functionality of the <see cref="InMemoryStorageManager.ClaimOwnershipAsync" />
         ///   method.
         /// </summary>
         ///
         [Test]
         public async Task ClaimOwnershipAsyncCanClaimMultipleOwnership()
         {
-            var storageManager = new MockCheckPointStorage();
+            var storageManager = new InMemoryStorageManager();
             var ownershipList = new List<EventProcessorPartitionOwnership>();
             var ownershipCount = 5;
 
@@ -196,14 +196,14 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="MockCheckPointStorage.ClaimOwnershipAsync" />
+        ///   Verifies functionality of the <see cref="InMemoryStorageManager.ClaimOwnershipAsync" />
         ///   method.
         /// </summary>
         ///
         [Test]
         public async Task ClaimOwnershipAsyncReturnsOnlyTheSuccessfullyClaimedOwnership()
         {
-            var storageManager = new MockCheckPointStorage();
+            var storageManager = new InMemoryStorageManager();
             var ownershipList = new List<EventProcessorPartitionOwnership>();
             var ownershipCount = 5;
 
@@ -255,14 +255,14 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="MockCheckPointStorage.ClaimOwnershipAsync" />
+        ///   Verifies functionality of the <see cref="InMemoryStorageManager.ClaimOwnershipAsync" />
         ///   method.
         /// </summary>
         ///
         [Test]
         public async Task OwnershipClaimDoesNotInterfereWithOtherConsumerGroups()
         {
-            var storageManager = new MockCheckPointStorage();
+            var storageManager = new InMemoryStorageManager();
             var ownershipList = new List<EventProcessorPartitionOwnership>();
 
             var firstOwnership = new EventProcessorPartitionOwnership
@@ -311,14 +311,14 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="MockCheckPointStorage.ClaimOwnershipAsync" />
+        ///   Verifies functionality of the <see cref="InMemoryStorageManager.ClaimOwnershipAsync" />
         ///   method.
         /// </summary>
         ///
         [Test]
         public async Task OwnershipClaimDoesNotInterfereWithOtherEventHubs()
         {
-            var storageManager = new MockCheckPointStorage();
+            var storageManager = new InMemoryStorageManager();
             var ownershipList = new List<EventProcessorPartitionOwnership>();
 
             var firstOwnership = new EventProcessorPartitionOwnership
@@ -367,14 +367,14 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="MockCheckPointStorage.ClaimOwnershipAsync" />
+        ///   Verifies functionality of the <see cref="InMemoryStorageManager.ClaimOwnershipAsync" />
         ///   method.
         /// </summary>
         ///
         [Test]
         public async Task OwnershipClaimDoesNotInterfereWithOtherNamespaces()
         {
-            var storageManager = new MockCheckPointStorage();
+            var storageManager = new InMemoryStorageManager();
             var ownershipList = new List<EventProcessorPartitionOwnership>();
 
             var firstOwnership = new EventProcessorPartitionOwnership
@@ -423,14 +423,14 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="MockCheckPointStorage.UpdateCheckpointAsync" />
+        ///   Verifies functionality of the <see cref="InMemoryStorageManager.UpdateCheckpointAsync" />
         ///   method.
         /// </summary>
         ///
         [Test]
         public async Task CheckpointUpdateDoesNotInterfereWithOtherConsumerGroups()
         {
-            var storageManager = new MockCheckPointStorage();
+            var storageManager = new InMemoryStorageManager();
 
             var mockEvent = new MockEventData(
                 eventBody: Array.Empty<byte>(),
@@ -464,14 +464,14 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="MockCheckPointStorage.UpdateCheckpointAsync" />
+        ///   Verifies functionality of the <see cref="InMemoryStorageManager.UpdateCheckpointAsync" />
         ///   method.
         /// </summary>
         ///
         [Test]
         public async Task CheckpointUpdateDoesNotInterfereWithOtherEventHubs()
         {
-            var storageManager = new MockCheckPointStorage();
+            var storageManager = new InMemoryStorageManager();
 
             var mockEvent = new MockEventData(
                 eventBody: Array.Empty<byte>(),
@@ -505,14 +505,14 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="MockCheckPointStorage.UpdateCheckpointAsync" />
+        ///   Verifies functionality of the <see cref="InMemoryStorageManager.UpdateCheckpointAsync" />
         ///   method.
         /// </summary>
         ///
         [Test]
         public async Task CheckpointUpdateDoesNotInterfereWithOtherNamespaces()
         {
-            var storageManager = new MockCheckPointStorage();
+            var storageManager = new InMemoryStorageManager();
 
             var mockEvent = new MockEventData(
                 eventBody: Array.Empty<byte>(),
@@ -546,14 +546,14 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="MockCheckPointStorage.UpdateCheckpointAsync" />
+        ///   Verifies functionality of the <see cref="InMemoryStorageManager.UpdateCheckpointAsync" />
         ///   method.
         /// </summary>
         ///
         [Test]
         public async Task CheckpointUpdateDoesNotInterfereWithOtherPartitions()
         {
-            var storageManager = new MockCheckPointStorage();
+            var storageManager = new InMemoryStorageManager();
 
             var mockEvent = new MockEventData(
                 eventBody: Array.Empty<byte>(),

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
@@ -208,7 +208,7 @@ namespace Azure.Messaging.EventHubs.Amqp
 
             try
             {
-                while (!cancellationToken.IsCancellationRequested)
+                while ((!cancellationToken.IsCancellationRequested) && (!_closed))
                 {
                     try
                     {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
@@ -212,7 +212,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                 var retryDelay = default(TimeSpan?);
                 var tryTimeout = RetryPolicy.CalculateTryTimeout(0);
 
-                while (!cancellationToken.IsCancellationRequested)
+                while ((!cancellationToken.IsCancellationRequested) && (!_closed))
                 {
                     try
                     {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/PartitionContext.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/PartitionContext.cs
@@ -32,7 +32,7 @@ namespace Azure.Messaging.EventHubs.Consumer
         ///   created with <see cref="ReadEventOptions.TrackLastEnqueuedEventProperties" /> set.
         /// </summary>
         ///
-        /// <returns>The set of properties for the last event that was enqueued to the partition.</returns>
+        /// <returns>The set of properties for the last event that was enqueued to the partition.  If no events were read or tracking was not set, the properties will be returned with default values.</returns>
         ///
         /// <remarks>
         ///   When information about the partition's last enqueued event is being tracked, each event received from the Event Hubs
@@ -42,7 +42,6 @@ namespace Azure.Messaging.EventHubs.Consumer
         /// </remarks>
         ///
         /// <exception cref="EventHubsException">Occurs when the Event Hubs client needed to read this information is no longer available.</exception>
-        /// <exception cref="InvalidOperationException">Occurs when this method is invoked without <see cref="ReadEventOptions.TrackLastEnqueuedEventProperties" /> set.</exception>
         ///
         public virtual LastEnqueuedEventProperties ReadLastEnqueuedEventProperties()
         {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor{TPartition}.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor{TPartition}.cs
@@ -693,7 +693,7 @@ namespace Azure.Messaging.EventHubs.Primitives
 
             return new PartitionProcessor
             (
-                Task.Run(performProcessing, cancellationSource.Token),
+                Task.Run(performProcessing),
                 partition,
                 readLastEnquedEventInformation,
                 cancellationSource


### PR DESCRIPTION
# Summary

The focus of these changes is to flesh out the Live test scenarios for the `EventProcessorClient` and to normalize the logging pattern used by the
Blob storage manager so that it aligns with the other event sources.

# Last Upstream Rebase

Wednesday, April 1, 7:16pm (EDT)

# References and Related Issues 

- [.NET Event Hubs Client: Event Processor<T> Proposal](https://gist.github.com/jsquire/1f4a1e72fc02871f443ce365222d40f6)
- [Update the Event Processor Client to Derive From Event Processor<T>](https://github.com/Azure/azure-sdk-for-net/issues/10843) (#10843)