### PR TITLE
[Event Hubs Client] Event Processor and Blob Checkpoint Store Test Cleanup

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
@@ -44,15 +44,15 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         /// </summary>
         ///
         /// <param name="accountName">The Storage account name corresponding to the associated container client.</param>
-        /// <param name="name">The name of the associated container client.</param>
+        /// <param name="containerName">The name of the associated container client.</param>
         ///
         [Event(20, Level = EventLevel.Verbose, Message = "{0} created. AccountName: '{1}'; ContainerName: '{2}'.")]
         public virtual void BlobsCheckpointStoreCreated(string accountName,
-                                                        string name)
+                                                        string containerName)
         {
             if (IsEnabled())
             {
-                WriteEvent(20, nameof(BlobsCheckpointStore), accountName ?? string.Empty, name ?? string.Empty);
+                WriteEvent(20, nameof(BlobsCheckpointStore), accountName ?? string.Empty, containerName ?? string.Empty);
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Storage/BlobsCheckpointStore.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Storage/BlobsCheckpointStore.cs
@@ -131,7 +131,7 @@ namespace Azure.Messaging.EventHubs.Processor
             }
             catch (RequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.ContainerNotFound)
             {
-                Logger.ListOwnershipError(fullyQualifiedNamespace, eventHubName, consumerGroup, ex.ToString());
+                Logger.ListOwnershipError(fullyQualifiedNamespace, eventHubName, consumerGroup, ex.Message);
                 throw new RequestFailedException(Resources.BlobsResourceDoesNotExist);
             }
             finally

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/CheckpointStore/BlobsCheckpointStoreTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/CheckpointStore/BlobsCheckpointStoreTests.cs
@@ -118,9 +118,9 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             var mockLog = new Mock<BlobEventStoreEventSource>();
             target.Logger = mockLog.Object;
 
-            Assert.ThrowsAsync<RequestFailedException>(async () => await target.ListOwnershipAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, new CancellationToken()));
+            Assert.That(async () => await target.ListOwnershipAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, new CancellationToken()), Throws.InstanceOf<RequestFailedException>());
 
-            mockLog.Verify(m => m.ListOwnershipError(FullyQualifiedNamespace, EventHubName, ConsumerGroup, It.Is<string>(e => e.Contains("RequestFailedException"))));
+            mockLog.Verify(m => m.ListOwnershipError(FullyQualifiedNamespace, EventHubName, ConsumerGroup, ex.Message));
         }
 
         /// <summary>
@@ -311,7 +311,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             var mockLog = new Mock<BlobEventStoreEventSource>();
             target.Logger = mockLog.Object;
 
-            Assert.ThrowsAsync<RequestFailedException>(async () => await target.ClaimOwnershipAsync(partitionOwnership, new CancellationToken()));
+            Assert.That(async () => await target.ClaimOwnershipAsync(partitionOwnership, new CancellationToken()), Throws.InstanceOf<RequestFailedException>());
         }
 
         /// <summary>
@@ -490,7 +490,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             var mockLog = new Mock<BlobEventStoreEventSource>();
             target.Logger = mockLog.Object;
 
-            Assert.ThrowsAsync<RequestFailedException>(async () => await target.ListCheckpointsAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, new CancellationToken()));
+            Assert.That(async () => await target.ListCheckpointsAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, new CancellationToken()), Throws.InstanceOf<RequestFailedException>());
             mockLog.Verify(m => m.ListCheckpointsError(FullyQualifiedNamespace, EventHubName, ConsumerGroup, ex.Message));
         }
 
@@ -574,9 +574,9 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             var mockLog = new Mock<BlobEventStoreEventSource>();
             target.Logger = mockLog.Object;
 
-            Assert.ThrowsAsync<RequestFailedException>(async () => await target.UpdateCheckpointAsync(checkpoint, new EventData(Array.Empty<byte>()), new CancellationToken()));
+            Assert.That(async () => await target.UpdateCheckpointAsync(checkpoint, new EventData(Array.Empty<byte>()), new CancellationToken()), Throws.InstanceOf<RequestFailedException>());
 
-            mockLog.Verify(m => m.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, It.Is<string>(s => s.Contains(BlobErrorCode.ContainerNotFound.ToString()))));
+            mockLog.Verify(m => m.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, ex.Message));
         }
 
         /// <summary>

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -10,6 +10,6 @@ resources:
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
   parameters:
-    MaxParallel: 6
+    MaxParallel: 2
     ServiceDirectory: eventhub
     TimeoutInMinutes: 120


### PR DESCRIPTION
# Summary

The focus of these changes is to address some deferred feedback provided for the `EventProcessorClient` and `BlobsCheckpointStore` tests.

The maximum value for parallel execution of tests has also been lowered, as Azure is under heavier load than normal and we're seeing an elevated set of timeout failures during nightly runs.

# Last Upstream Rebase

Thursday, April 2, 5:16pm (EDT)

# References and Related Issues 

- [.NET Event Hubs Client: Event Processor<T> Proposal](https://gist.github.com/jsquire/1f4a1e72fc02871f443ce365222d40f6)
- [Update the Event Processor Client to Derive From Event Processor<T>](https://github.com/Azure/azure-sdk-for-net/issues/10843) (#10843)