### PR TITLE
DOC: .Net Core SDK sendAsync warning for partition entities when batching

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/ISenderClient.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/ISenderClient.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.ServiceBus.Core
 
         /// <summary>
         /// Sends a list of messages to Service Bus.
+        /// When called on partitioned entities, messages meant for different partitions cannot be batched together.
         /// </summary>
         Task SendAsync(IList<Message> messageList);
 

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/MessageSender.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/MessageSender.cs
@@ -239,6 +239,7 @@ namespace Microsoft.Azure.ServiceBus.Core
 
         /// <summary>
         /// Sends a list of messages to the entity as described by <see cref="Path"/>.
+        /// When called on partitioned entities, messages meant for different partitions cannot be batched together.
         /// </summary>
         public async Task SendAsync(IList<Message> messageList)
         {

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/QueueClient.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/QueueClient.cs
@@ -341,6 +341,7 @@ namespace Microsoft.Azure.ServiceBus
 
         /// <summary>
         /// Sends a list of messages to Service Bus.
+        /// When called on partitioned entities, messages meant for different partitions cannot be batched together.
         /// </summary>
         public Task SendAsync(IList<Message> messageList)
         {

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/TopicClient.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/TopicClient.cs
@@ -177,6 +177,7 @@ namespace Microsoft.Azure.ServiceBus
 
         /// <summary>
         /// Sends a list of messages to Service Bus.
+        /// When called on partitioned entities, messages meant for different partitions cannot be batched together.
         /// </summary>
         public Task SendAsync(IList<Message> messageList)
         {


### PR DESCRIPTION
Add documentation change for sendAsync on a batch of messages