### PR TITLE
Including developer credential types in DefaultAzureCredential

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
 ## 1.2.0-preview.2 (Unreleased)
-
+- Updating `DefaultAzureCredential` to enable authenticating through Visual Studio
+- Updating `DefaultAzureCredential` to enable authentication through Visual Studio Code
 
 ## 1.2.0-preview.1
 

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Release History
 
-## 1.2.0-preview.2 (Unreleased)
-- Updating `DefaultAzureCredential` to enable authenticating through Visual Studio
-- Updating `DefaultAzureCredential` to enable authentication through Visual Studio Code
+## 1.2.0-preview.2
+- Updates `DefaultAzureCredential` to enable authenticating through Visual Studio
+- Updates `DefaultAzureCredential` to enable authentication through Visual Studio Code
 
 ## 1.2.0-preview.1
 

--- a/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
+++ b/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
@@ -57,10 +57,14 @@ namespace Azure.Identity
         public bool ExcludeInteractiveBrowserCredential { get { throw null; } set { } }
         public bool ExcludeManagedIdentityCredential { get { throw null; } set { } }
         public bool ExcludeSharedTokenCacheCredential { get { throw null; } set { } }
+        public bool ExcludeVisualStudioCodeCredential { get { throw null; } set { } }
+        public bool ExcludeVisualStudioCredential { get { throw null; } set { } }
         public string InteractiveBrowserTenantId { get { throw null; } set { } }
         public string ManagedIdentityClientId { get { throw null; } set { } }
         public string SharedTokenCacheTenantId { get { throw null; } set { } }
         public string SharedTokenCacheUsername { get { throw null; } set { } }
+        public string VisualStudioCodeTenantId { get { throw null; } set { } }
+        public string VisualStudioTenantId { get { throw null; } set { } }
     }
     public partial class DeviceCodeCredential : Azure.Core.TokenCredential
     {

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredential.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredential.cs
@@ -169,7 +169,7 @@ namespace Azure.Identity
             }
 
             int i = 0;
-            TokenCredential[] chain = new TokenCredential[5];
+            TokenCredential[] chain = new TokenCredential[7];
 
             if (!options.ExcludeEnvironmentCredential)
             {
@@ -184,6 +184,16 @@ namespace Azure.Identity
             if (!options.ExcludeSharedTokenCacheCredential)
             {
                 chain[i++] = factory.CreateSharedTokenCacheCredential(options.SharedTokenCacheTenantId, options.SharedTokenCacheUsername);
+            }
+
+            if (!options.ExcludeVisualStudioCredential)
+            {
+                chain[i++] = factory.CreateVisualStudioCredential(options.VisualStudioTenantId);
+            }
+
+            if (!options.ExcludeVisualStudioCodeCredential)
+            {
+                chain[i++] = factory.CreateVisualStudioCodeCredential(options.VisualStudioCodeTenantId);
             }
 
             if (!options.ExcludeAzureCliCredential)

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -38,5 +38,15 @@ namespace Azure.Identity
         {
             return new AzureCliCredential(Pipeline, new AzureCliCredentialClient());
         }
+
+        public virtual TokenCredential CreateVisualStudioCredential(string tenantId)
+        {
+            return new VisualStudioCredential(tenantId, Pipeline, default, default);
+        }
+
+        public virtual TokenCredential CreateVisualStudioCodeCredential(string tenantId)
+        {
+            return new VisualStudioCodeCredential(tenantId, Pipeline, default, default);
+        }
     }
 }

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialOptions.cs
@@ -28,6 +28,20 @@ namespace Azure.Identity
         public string SharedTokenCacheTenantId { get; set; } = EnvironmentVariables.TenantId;
 
         /// <summary>
+        /// The tenant id of the user to authenticate, in the case the <see cref="DefaultAzureCredential"/> authenticates through, the
+        /// <see cref="VisualStudioCredential"/>. The default is null and will authenticate users to their default tenant.
+        /// The value can also be set by setting the environment variable AZURE_TENANT_ID.
+        /// </summary>
+        public string VisualStudioTenantId { get; set; } = EnvironmentVariables.TenantId;
+
+        /// <summary>
+        /// The tenant id of the user to authenticate, in the case the <see cref="DefaultAzureCredential"/> authenticates through, the
+        /// <see cref="VisualStudioCodeCredential"/>. The default is null and will authenticate users to their default tenant.
+        /// The value can also be set by setting the environment variable AZURE_TENANT_ID.
+        /// </summary>
+        public string VisualStudioCodeTenantId { get; set; } = EnvironmentVariables.TenantId;
+
+        /// <summary>
         /// Specifies the preferred authentication account to be retrieved from the shared token cache for single sign on authentication with
         /// development tools. In the case multiple accounts are found in the shared token.
         /// </summary>
@@ -70,5 +84,16 @@ namespace Azure.Identity
         /// Specifies whether the <see cref="AzureCliCredential"/> will be excluded from the <see cref="DefaultAzureCredential"/> authentication flow.
         /// </summary>
         public bool ExcludeAzureCliCredential { get; set; } = false;
+
+        /// <summary>
+        /// Specifies whether the <see cref="VisualStudioCredential"/> will be excluded from the <see cref="DefaultAzureCredential"/> authentication flow.
+        /// </summary>
+        public bool ExcludeVisualStudioCredential { get; set; } = false;
+
+
+        /// <summary>
+        /// Specifies whether the <see cref="VisualStudioCodeCredential"/> will be excluded from the <see cref="DefaultAzureCredential"/> authentication flow.
+        /// </summary>
+        public bool ExcludeVisualStudioCodeCredential { get; set; } = false;
     }
 }

--- a/sdk/identity/Azure.Identity/src/VisualStudioCodeCredential.cs
+++ b/sdk/identity/Azure.Identity/src/VisualStudioCodeCredential.cs
@@ -33,12 +33,7 @@ namespace Azure.Identity
         protected VisualStudioCodeCredential() : this(default, default) {}
 
         /// <inheritdoc />
-        public VisualStudioCodeCredential(string tenantId, TokenCredentialOptions options) : this(tenantId, options, default, default) {}
-
-        internal VisualStudioCodeCredential(string tenantId, TokenCredentialOptions options, IFileSystemService fileSystem, IVisualStudioCodeAdapter vscAdapter)
-            : this(tenantId, CredentialPipeline.GetInstance(options), fileSystem, vscAdapter)
-        {
-        }
+        public VisualStudioCodeCredential(string tenantId, TokenCredentialOptions options) : this(tenantId, CredentialPipeline.GetInstance(options), default, default) {}
 
         internal VisualStudioCodeCredential(string tenantId, CredentialPipeline pipeline, IFileSystemService fileSystem, IVisualStudioCodeAdapter vscAdapter)
             : this(tenantId, pipeline, pipeline.CreateMsalPublicClient(ClientId), fileSystem, vscAdapter)

--- a/sdk/identity/Azure.Identity/src/VisualStudioCredential.cs
+++ b/sdk/identity/Azure.Identity/src/VisualStudioCredential.cs
@@ -37,12 +37,7 @@ namespace Azure.Identity
         protected VisualStudioCredential() : this(default, default) {}
 
         /// <inheritdoc />
-        internal VisualStudioCredential(string tenantId, TokenCredentialOptions options) : this(tenantId, options, default, default) {}
-
-        internal VisualStudioCredential(string tenantId, TokenCredentialOptions options, IFileSystemService fileSystem, IProcessService processService)
-            : this(tenantId, CredentialPipeline.GetInstance(options), fileSystem, processService)
-        {
-        }
+        internal VisualStudioCredential(string tenantId, TokenCredentialOptions options) : this(tenantId, CredentialPipeline.GetInstance(options), default, default) {}
 
         internal VisualStudioCredential(string tenantId, CredentialPipeline pipeline, IFileSystemService fileSystem, IProcessService processService)
         {

--- a/sdk/identity/Azure.Identity/src/VisualStudioCredential.cs
+++ b/sdk/identity/Azure.Identity/src/VisualStudioCredential.cs
@@ -40,9 +40,14 @@ namespace Azure.Identity
         internal VisualStudioCredential(string tenantId, TokenCredentialOptions options) : this(tenantId, options, default, default) {}
 
         internal VisualStudioCredential(string tenantId, TokenCredentialOptions options, IFileSystemService fileSystem, IProcessService processService)
+            : this(tenantId, CredentialPipeline.GetInstance(options), fileSystem, processService)
+        {
+        }
+
+        internal VisualStudioCredential(string tenantId, CredentialPipeline pipeline, IFileSystemService fileSystem, IProcessService processService)
         {
             _tenantId = tenantId;
-            _pipeline = CredentialPipeline.GetInstance(options);
+            _pipeline = pipeline ?? CredentialPipeline.GetInstance(null);
             _fileSystem = fileSystem ?? FileSystemService.Default;
             _processService = processService ?? ProcessService.Default;
         }

--- a/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialTests.cs
@@ -26,12 +26,14 @@ namespace Azure.Identity.Tests
             TokenCredential[] sources = cred._sources();
 
             Assert.NotNull(sources);
-            Assert.AreEqual(sources.Length, 5);
+            Assert.AreEqual(sources.Length, 7);
             Assert.IsInstanceOf(typeof(EnvironmentCredential), sources[0]);
             Assert.IsInstanceOf(typeof(ManagedIdentityCredential), sources[1]);
             Assert.IsInstanceOf(typeof(SharedTokenCacheCredential), sources[2]);
-            Assert.IsInstanceOf(typeof(AzureCliCredential), sources[3]);
-            Assert.IsNull(sources[4]);
+            Assert.IsInstanceOf(typeof(VisualStudioCredential), sources[3]);
+            Assert.IsInstanceOf(typeof(VisualStudioCodeCredential), sources[4]);
+            Assert.IsInstanceOf(typeof(AzureCliCredential), sources[5]);
+            Assert.IsNull(sources[6]);
         }
 
         [Test]
@@ -42,19 +44,21 @@ namespace Azure.Identity.Tests
             TokenCredential[] sources = cred._sources();
 
             Assert.NotNull(sources);
-            Assert.AreEqual(sources.Length, 5);
+            Assert.AreEqual(sources.Length, 7);
             Assert.IsInstanceOf(typeof(EnvironmentCredential), sources[0]);
             Assert.IsInstanceOf(typeof(ManagedIdentityCredential), sources[1]);
             Assert.IsInstanceOf(typeof(SharedTokenCacheCredential), sources[2]);
-            Assert.IsInstanceOf(typeof(AzureCliCredential), sources[3]);
+            Assert.IsInstanceOf(typeof(VisualStudioCredential), sources[3]);
+            Assert.IsInstanceOf(typeof(VisualStudioCodeCredential), sources[4]);
+            Assert.IsInstanceOf(typeof(AzureCliCredential), sources[5]);
 
             if (includeInteractive)
             {
-                Assert.IsInstanceOf(typeof(InteractiveBrowserCredential), sources[4]);
+                Assert.IsInstanceOf(typeof(InteractiveBrowserCredential), sources[6]);
             }
             else
             {
-                Assert.IsNull(sources[4]);
+                Assert.IsNull(sources[6]);
             }
         }
 
@@ -63,28 +67,44 @@ namespace Azure.Identity.Tests
         {
             string expClientId = Guid.NewGuid().ToString();
             string expUsername = Guid.NewGuid().ToString();
-            string expTenantId = Guid.NewGuid().ToString();
+            string expCacheTenantId = Guid.NewGuid().ToString();
+            string expBrowserTenantId = Guid.NewGuid().ToString();
+            string expVsTenantId = Guid.NewGuid().ToString();
+            string expCodeTenantId = Guid.NewGuid().ToString();
             string actClientId = null;
             string actUsername = null;
-            string actTenantId = null;
+            string actCacheTenantId = null;
+            string actBrowserTenantId = null;
+            string actVsTenantId = null;
+            string actCodeTenantId = null;
 
             var credFactory = new MockDefaultAzureCredentialFactory(CredentialPipeline.GetInstance(null));
 
             credFactory.OnCreateManagedIdentityCredential = (clientId, _) => actClientId = clientId;
-            credFactory.OnCreateSharedTokenCacheCredential = (tenantId, username, _) => { actTenantId = tenantId; actUsername = username; };
+            credFactory.OnCreateSharedTokenCacheCredential = (tenantId, username, _) => { actCacheTenantId = tenantId; actUsername = username; };
+            credFactory.OnCreateInteractiveBrowserCredential = (tenantId, _) => { actBrowserTenantId = tenantId; };
+            credFactory.OnCreateVisualStudioCredential = (tenantId, _) => { actVsTenantId = tenantId; };
+            credFactory.OnCreateVisualStudioCodeCredential = (tenantId, _) => { actCodeTenantId = tenantId; };
 
             var options = new DefaultAzureCredentialOptions
             {
                 ManagedIdentityClientId = expClientId,
                 SharedTokenCacheUsername = expUsername,
-                SharedTokenCacheTenantId = expTenantId
+                SharedTokenCacheTenantId = expCacheTenantId,
+                VisualStudioTenantId = expVsTenantId,
+                VisualStudioCodeTenantId = expCodeTenantId,
+                InteractiveBrowserTenantId = expBrowserTenantId,
+                ExcludeInteractiveBrowserCredential = false
             };
 
             var cred = new DefaultAzureCredential(credFactory, options);
 
             Assert.AreEqual(expClientId, actClientId);
             Assert.AreEqual(expUsername, actUsername);
-            Assert.AreEqual(expTenantId, actTenantId);
+            Assert.AreEqual(expCacheTenantId, actCacheTenantId);
+            Assert.AreEqual(expBrowserTenantId, actBrowserTenantId);
+            Assert.AreEqual(expVsTenantId, actVsTenantId);
+            Assert.AreEqual(expCodeTenantId, actCodeTenantId);
         }
 
         [Test]
@@ -97,6 +117,8 @@ namespace Azure.Identity.Tests
             bool onCreateSharedCalled = false;
             bool onCreatedManagedCalled = false;
             bool onCreateInteractiveCalled = false;
+            bool onCreateVsCalled = false;
+            bool onCreateVsCodeCalled = false;
 
             using (new TestEnvVar("AZURE_CLIENT_ID", expClientId))
             using (new TestEnvVar("AZURE_USERNAME", expUsername))
@@ -123,11 +145,24 @@ namespace Azure.Identity.Tests
                     Assert.AreEqual(expTenantId, tenantId);
                 };
 
+                credFactory.OnCreateVisualStudioCredential = (tenantId, _) =>
+                {
+                    onCreateVsCalled = true;
+                    Assert.AreEqual(expTenantId, tenantId);
+                };
+
+                credFactory.OnCreateVisualStudioCodeCredential = (tenantId, _) =>
+                {
+                    onCreateVsCodeCalled = true;
+                    Assert.AreEqual(expTenantId, tenantId);
+                };
                 var options = new DefaultAzureCredentialOptions
                 {
                     ExcludeEnvironmentCredential = true,
                     ExcludeManagedIdentityCredential = false,
                     ExcludeSharedTokenCacheCredential = false,
+                    ExcludeVisualStudioCredential = false,
+                    ExcludeVisualStudioCodeCredential = false,
                     ExcludeAzureCliCredential = true,
                     ExcludeInteractiveBrowserCredential = false
                 };
@@ -137,11 +172,19 @@ namespace Azure.Identity.Tests
                 Assert.IsTrue(onCreateSharedCalled);
                 Assert.IsTrue(onCreatedManagedCalled);
                 Assert.IsTrue(onCreateInteractiveCalled);
+                Assert.IsTrue(onCreateVsCalled);
+                Assert.IsTrue(onCreateVsCodeCalled);
             }
         }
 
         [Test]
-        public void ValidateCtorWithExcludeOptions([Values(true, false)]bool excludeEnvironmentCredential, [Values(true, false)]bool excludeManagedIdentityCredential, [Values(true, false)]bool excludeSharedTokenCacheCredential, [Values(true, false)]bool excludeCliCredential, [Values(true, false)]bool excludeInteractiveBrowserCredential)
+        public void ValidateCtorWithExcludeOptions([Values(true, false)]bool excludeEnvironmentCredential,
+                                                   [Values(true, false)]bool excludeManagedIdentityCredential,
+                                                   [Values(true, false)]bool excludeSharedTokenCacheCredential,
+                                                   [Values(true, false)]bool excludeVisualStudioCredential,
+                                                   [Values(true, false)]bool excludeVisualStudioCodeCredential,
+                                                   [Values(true, false)]bool excludeCliCredential,
+                                                   [Values(true, false)]bool excludeInteractiveBrowserCredential)
         {
             var credFactory = new MockDefaultAzureCredentialFactory(CredentialPipeline.GetInstance(null));
 
@@ -150,10 +193,14 @@ namespace Azure.Identity.Tests
             bool sharedTokenCacheCredentialIncluded = false;
             bool cliCredentialIncluded = false;
             bool interactiveBrowserCredentialIncluded = false;
+            bool visualStudioCredentialIncluded = false;
+            bool visualStudioCodeCredentialIncluded = false;
 
             credFactory.OnCreateEnvironmentCredential = (_) => environmentCredentialIncluded = true;
             credFactory.OnCreateAzureCliCredential = (_) => cliCredentialIncluded = true;
             credFactory.OnCreateInteractiveBrowserCredential = (tenantId, _) => interactiveBrowserCredentialIncluded = true;
+            credFactory.OnCreateVisualStudioCredential = (tenantId, _) => visualStudioCredentialIncluded = true;
+            credFactory.OnCreateVisualStudioCodeCredential = (tenantId, _) => visualStudioCodeCredentialIncluded = true;
             credFactory.OnCreateManagedIdentityCredential = (clientId, _) =>
             {
                 managedIdentityCredentialIncluded = true;
@@ -169,10 +216,12 @@ namespace Azure.Identity.Tests
                 ExcludeManagedIdentityCredential = excludeManagedIdentityCredential,
                 ExcludeSharedTokenCacheCredential = excludeSharedTokenCacheCredential,
                 ExcludeAzureCliCredential = excludeCliCredential,
-                ExcludeInteractiveBrowserCredential = excludeInteractiveBrowserCredential
+                ExcludeInteractiveBrowserCredential = excludeInteractiveBrowserCredential,
+                ExcludeVisualStudioCredential = excludeVisualStudioCredential,
+                ExcludeVisualStudioCodeCredential = excludeVisualStudioCodeCredential
             };
 
-            if (excludeEnvironmentCredential && excludeManagedIdentityCredential && excludeSharedTokenCacheCredential && excludeCliCredential && excludeInteractiveBrowserCredential)
+            if (excludeEnvironmentCredential && excludeManagedIdentityCredential && excludeSharedTokenCacheCredential && excludeVisualStudioCredential && excludeVisualStudioCodeCredential && excludeCliCredential && excludeInteractiveBrowserCredential)
             {
                 Assert.Throws<ArgumentException>(() => new DefaultAzureCredential(options));
             }
@@ -185,13 +234,21 @@ namespace Azure.Identity.Tests
                 Assert.AreEqual(!excludeSharedTokenCacheCredential, sharedTokenCacheCredentialIncluded);
                 Assert.AreEqual(!excludeCliCredential, cliCredentialIncluded);
                 Assert.AreEqual(!excludeInteractiveBrowserCredential, interactiveBrowserCredentialIncluded);
+                Assert.AreEqual(!excludeVisualStudioCredential, visualStudioCredentialIncluded);
+                Assert.AreEqual(!excludeVisualStudioCodeCredential, visualStudioCodeCredentialIncluded);
             }
         }
 
         [Test]
-        public void ValidateAllUnavailable([Values(true, false)]bool excludeEnvironmentCredential, [Values(true, false)]bool excludeManagedIdentityCredential, [Values(true, false)]bool excludeSharedTokenCacheCredential, [Values(true, false)]bool excludeCliCredential, [Values(true, false)]bool excludeInteractiveBrowserCredential)
+        public void ValidateAllUnavailable([Values(true, false)]bool excludeEnvironmentCredential,
+                                           [Values(true, false)]bool excludeManagedIdentityCredential,
+                                           [Values(true, false)]bool excludeSharedTokenCacheCredential,
+                                           [Values(true, false)]bool excludeVisualStudioCredential,
+                                           [Values(true, false)]bool excludeVisualStudioCodeCredential,
+                                           [Values(true, false)]bool excludeCliCredential,
+                                           [Values(true, false)]bool excludeInteractiveBrowserCredential)
         {
-            if (excludeEnvironmentCredential && excludeManagedIdentityCredential && excludeSharedTokenCacheCredential && excludeCliCredential && excludeInteractiveBrowserCredential)
+            if (excludeEnvironmentCredential && excludeManagedIdentityCredential && excludeSharedTokenCacheCredential && excludeVisualStudioCredential && excludeVisualStudioCodeCredential && excludeCliCredential && excludeInteractiveBrowserCredential)
             {
                 Assert.Pass();
             }
@@ -218,12 +275,22 @@ namespace Azure.Identity.Tests
             {
                 ((MockTokenCredential)c).TokenFactory = (context, cancel) => { throw new CredentialUnavailableException("CliCredential Unavailable"); };
             };
+            credFactory.OnCreateVisualStudioCredential = (_, c) =>
+            {
+                ((MockTokenCredential)c).TokenFactory = (context, cancel) => { throw new CredentialUnavailableException("VisualStudioCredential Unavailable"); };
+            };
+            credFactory.OnCreateVisualStudioCodeCredential = (_, c) =>
+            {
+                ((MockTokenCredential)c).TokenFactory = (context, cancel) => { throw new CredentialUnavailableException("VisualStudioCodeCredential Unavailable"); };
+            };
 
             var options = new DefaultAzureCredentialOptions
             {
                 ExcludeEnvironmentCredential = excludeEnvironmentCredential,
                 ExcludeManagedIdentityCredential = excludeManagedIdentityCredential,
                 ExcludeSharedTokenCacheCredential = excludeSharedTokenCacheCredential,
+                ExcludeVisualStudioCredential = excludeVisualStudioCredential,
+                ExcludeVisualStudioCodeCredential = excludeVisualStudioCodeCredential,
                 ExcludeAzureCliCredential = excludeCliCredential,
                 ExcludeInteractiveBrowserCredential = excludeInteractiveBrowserCredential
             };
@@ -252,10 +319,18 @@ namespace Azure.Identity.Tests
             {
                 Assert.True(ex.Message.Contains("InteractiveBrowserCredential Unavailable"));
             }
+            if (!excludeVisualStudioCredential)
+            {
+                Assert.True(ex.Message.Contains("VisualStudioCredential Unavailable"));
+            }
+            if (!excludeVisualStudioCodeCredential)
+            {
+                Assert.True(ex.Message.Contains("VisualStudioCodeCredential Unavailable"));
+            }
         }
 
         [Test]
-        public void ValidateUnhandledException([Values(0, 1, 2, 3, 4)]int exPossition)
+        public void ValidateUnhandledException([Values(0, 1, 2, 3, 4, 5, 6)]int exPossition)
         {
             var credFactory = new MockDefaultAzureCredentialFactory(CredentialPipeline.GetInstance(null));
 
@@ -301,11 +376,39 @@ namespace Azure.Identity.Tests
                     }
                 };
             };
-            credFactory.OnCreateAzureCliCredential = (c) =>
+            credFactory.OnCreateVisualStudioCredential = (_, c) =>
             {
                 ((MockTokenCredential)c).TokenFactory = (context, cancel) =>
                 {
                     if (exPossition > 3)
+                    {
+                        throw new CredentialUnavailableException("VisualStudioCredential Unavailable");
+                    }
+                    else
+                    {
+                        throw new MockClientException("VisualStudioCredential unhandled exception");
+                    }
+                };
+            };
+            credFactory.OnCreateVisualStudioCodeCredential = (_, c) =>
+            {
+                ((MockTokenCredential)c).TokenFactory = (context, cancel) =>
+                {
+                    if (exPossition > 4)
+                    {
+                        throw new CredentialUnavailableException("VisualStudioCodeCredential Unavailable");
+                    }
+                    else
+                    {
+                        throw new MockClientException("VisualStudioCodeCredential unhandled exception");
+                    }
+                };
+            };
+            credFactory.OnCreateAzureCliCredential = (c) =>
+            {
+                ((MockTokenCredential)c).TokenFactory = (context, cancel) =>
+                {
+                    if (exPossition > 5)
                     {
                         throw new CredentialUnavailableException("CliCredential Unavailable");
                     }
@@ -348,9 +451,15 @@ namespace Azure.Identity.Tests
                     Assert.AreEqual(ex.InnerException.Message, "SharedTokenCacheCredential unhandled exception");
                     break;
                 case 3:
-                    Assert.AreEqual(ex.InnerException.Message, "CliCredential unhandled exception");
+                    Assert.AreEqual(ex.InnerException.Message, "VisualStudioCredential unhandled exception");
                     break;
                 case 4:
+                    Assert.AreEqual(ex.InnerException.Message, "VisualStudioCodeCredential unhandled exception");
+                    break;
+                case 5:
+                    Assert.AreEqual(ex.InnerException.Message, "CliCredential unhandled exception");
+                    break;
+                case 6:
                     Assert.AreEqual(ex.InnerException.Message, "InteractiveBrowserCredential unhandled exception");
                     break;
                 default:
@@ -360,7 +469,7 @@ namespace Azure.Identity.Tests
         }
 
         [Test]
-        public async Task ValidateSelectedCredentialCaching([Values(typeof(EnvironmentCredential), typeof(ManagedIdentityCredential), typeof(SharedTokenCacheCredential), typeof(AzureCliCredential), typeof(InteractiveBrowserCredential))]Type availableCredential)
+        public async Task ValidateSelectedCredentialCaching([Values(typeof(EnvironmentCredential), typeof(ManagedIdentityCredential), typeof(SharedTokenCacheCredential), typeof(VisualStudioCredential), typeof(VisualStudioCodeCredential), typeof(AzureCliCredential), typeof(InteractiveBrowserCredential))]Type availableCredential)
         {
             var expToken = new AccessToken(Guid.NewGuid().ToString(), DateTimeOffset.MaxValue);
 
@@ -411,6 +520,24 @@ namespace Azure.Identity.Tests
                     calledCredentials.Add(typeof(InteractiveBrowserCredential));
 
                     return (availableCredential == typeof(InteractiveBrowserCredential)) ? expToken : throw new CredentialUnavailableException("Unavailable");
+                };
+            };
+            credFactory.OnCreateVisualStudioCredential = (_, c) =>
+            {
+                ((MockTokenCredential)c).TokenFactory = (context, cancel) =>
+                {
+                    calledCredentials.Add(typeof(VisualStudioCredential));
+
+                    return (availableCredential == typeof(VisualStudioCredential)) ? expToken : throw new CredentialUnavailableException("Unavailable");
+                };
+            };
+            credFactory.OnCreateVisualStudioCodeCredential = (_, c) =>
+            {
+                ((MockTokenCredential)c).TokenFactory = (context, cancel) =>
+                {
+                    calledCredentials.Add(typeof(VisualStudioCodeCredential));
+
+                    return (availableCredential == typeof(VisualStudioCodeCredential)) ? expToken : throw new CredentialUnavailableException("Unavailable");
                 };
             };
 

--- a/sdk/identity/Azure.Identity/tests/Mock/MockDefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/tests/Mock/MockDefaultAzureCredentialFactory.cs
@@ -17,6 +17,8 @@ namespace Azure.Identity.Tests.Mock
         public Action<string, TokenCredential> OnCreateManagedIdentityCredential { get; set; }
         public Action<string, string, TokenCredential> OnCreateSharedTokenCacheCredential { get; set; }
         public Action<string, TokenCredential> OnCreateInteractiveBrowserCredential { get; set; }
+        public Action<string, TokenCredential> OnCreateVisualStudioCredential { get; set; }
+        public Action<string, TokenCredential> OnCreateVisualStudioCodeCredential { get; set; }
 
         public override TokenCredential CreateEnvironmentCredential()
         {
@@ -59,6 +61,24 @@ namespace Azure.Identity.Tests.Mock
             TokenCredential cred = new MockTokenCredential();
 
             OnCreateInteractiveBrowserCredential?.Invoke(tenantId, cred);
+
+            return cred;
+        }
+
+        public override TokenCredential CreateVisualStudioCredential(string tenantId)
+        {
+            TokenCredential cred = new MockTokenCredential();
+
+            OnCreateVisualStudioCredential?.Invoke(tenantId, cred);
+
+            return cred;
+        }
+
+        public override TokenCredential CreateVisualStudioCodeCredential(string tenantId)
+        {
+            TokenCredential cred = new MockTokenCredential();
+
+            OnCreateVisualStudioCodeCredential?.Invoke(tenantId, cred);
 
             return cred;
         }

--- a/sdk/identity/Azure.Identity/tests/VisualStudioCodeCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/VisualStudioCodeCredentialLiveTests.cs
@@ -42,7 +42,7 @@ namespace Azure.Identity.Tests
             using IDisposable fixture = await CreateRefreshTokenFixtureAsync(tenantId, cloudName);
 
             TokenCredentialOptions options = Recording.InstrumentClientOptions(new TokenCredentialOptions());
-            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(tenantId, options, fileSystem, default));
+            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(tenantId, CredentialPipeline.GetInstance(options), fileSystem, default));
             AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new[] {".default"}), CancellationToken.None);
             Assert.IsNotNull(token.Token);
         }
@@ -56,7 +56,7 @@ namespace Azure.Identity.Tests
             var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", refreshToken);
 
             TokenCredentialOptions options = Recording.InstrumentClientOptions(new TokenCredentialOptions());
-            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(tenantId, options, fileSystemService, vscAdapter));
+            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(tenantId, CredentialPipeline.GetInstance(options), fileSystemService, vscAdapter));
             AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new[] {".default"}), CancellationToken.None);
             Assert.IsNotNull(token.Token);
         }
@@ -70,7 +70,7 @@ namespace Azure.Identity.Tests
             var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", refreshToken);
 
             TokenCredentialOptions options = Recording.InstrumentClientOptions(new TokenCredentialOptions());
-            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(tenantId, options, fileSystemService, vscAdapter));
+            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(tenantId, CredentialPipeline.GetInstance(options), fileSystemService, vscAdapter));
             AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new[] {".default"}), CancellationToken.None);
             Assert.IsNotNull(token.Token);
         }
@@ -85,7 +85,7 @@ namespace Azure.Identity.Tests
             var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", refreshToken);
 
             TokenCredentialOptions options = Recording.InstrumentClientOptions(new TokenCredentialOptions());
-            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(default, options, fileSystemService, vscAdapter));
+            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(default, CredentialPipeline.GetInstance(options), fileSystemService, vscAdapter));
 
             AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new[] {".default"}), CancellationToken.None);
             Assert.IsNotNull(token.Token);
@@ -102,7 +102,7 @@ namespace Azure.Identity.Tests
             using IDisposable fixture = await CreateRefreshTokenFixtureAsync(tenantId, cloudName);
 
             TokenCredentialOptions options = Recording.InstrumentClientOptions(new TokenCredentialOptions());
-            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(Guid.NewGuid().ToString(), options, fileSystemService, default));
+            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(Guid.NewGuid().ToString(), CredentialPipeline.GetInstance(options), fileSystemService, default));
 
             AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(new[] {".default"}), CancellationToken.None);
             Assert.IsNotNull(token.Token);
@@ -116,7 +116,7 @@ namespace Azure.Identity.Tests
             var fileSystem = CreateTestFileSystemService();
 
             TokenCredentialOptions options = Recording.InstrumentClientOptions(new TokenCredentialOptions());
-            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(tenantId, options, fileSystem, vscAdapter));
+            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(tenantId, CredentialPipeline.GetInstance(options), fileSystem, vscAdapter));
 
             Assert.CatchAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {".default"}), CancellationToken.None));
         }
@@ -129,7 +129,7 @@ namespace Azure.Identity.Tests
             var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", "{}");
 
             TokenCredentialOptions options = Recording.InstrumentClientOptions(new TokenCredentialOptions());
-            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(tenantId, options, fileSystemService, vscAdapter));
+            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(tenantId, CredentialPipeline.GetInstance(options), fileSystemService, vscAdapter));
 
             Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {".default"}), CancellationToken.None));
         }
@@ -142,7 +142,7 @@ namespace Azure.Identity.Tests
             var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", Guid.NewGuid().ToString());
 
             TokenCredentialOptions options = Recording.InstrumentClientOptions(new TokenCredentialOptions());
-            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(tenantId, options, fileSystemService, vscAdapter));
+            VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(tenantId, CredentialPipeline.GetInstance(options), fileSystemService, vscAdapter));
 
             Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] {".default"}), CancellationToken.None));
         }

--- a/sdk/identity/Azure.Identity/tests/VisualStudioCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/VisualStudioCredentialTests.cs
@@ -24,7 +24,7 @@ namespace Azure.Identity.Tests
             var fileSystem = CreateTestFileSystem();
             var (expectedToken, expectedExpiresOn, processOutput) = CreateTestToken();
             var testProcess = new TestProcess { Output = processOutput };
-            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, new TestProcessService(testProcess)));
+            var credential = InstrumentClient(new VisualStudioCredential(default, (TokenCredentialOptions)default, fileSystem, new TestProcessService(testProcess)));
             var token = await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), CancellationToken.None);
 
             Assert.AreEqual(token.Token, expectedToken);
@@ -38,7 +38,7 @@ namespace Azure.Identity.Tests
             var (expectedToken, expectedExpiresOn, processOutput) = CreateTestToken();
             var testProcess1 = new TestProcess { Error = "Error" };
             var testProcess2 = new TestProcess { Output = processOutput };
-            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, new TestProcessService(testProcess1, testProcess2)));
+            var credential = InstrumentClient(new VisualStudioCredential(default, (TokenCredentialOptions)default, fileSystem, new TestProcessService(testProcess1, testProcess2)));
             var token = await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), CancellationToken.None);
 
             Assert.AreEqual(token.Token, expectedToken);
@@ -72,7 +72,7 @@ namespace Azure.Identity.Tests
                 }
             };
 
-            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, testProcessFactory));
+            var credential = InstrumentClient(new VisualStudioCredential(default, (TokenCredentialOptions)default, fileSystem, testProcessFactory));
             var token = await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), CancellationToken.None);
 
             Assert.AreEqual(token.Token, expectedToken);
@@ -93,7 +93,7 @@ namespace Azure.Identity.Tests
                 return false;
             };
 
-            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, new TestProcessService(testProcess)));
+            var credential = InstrumentClient(new VisualStudioCredential(default, (TokenCredentialOptions)default, fileSystem, new TestProcessService(testProcess)));
             Assert.CatchAsync<OperationCanceledException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), cts.Token));
         }
 
@@ -105,7 +105,7 @@ namespace Azure.Identity.Tests
             var testProcess = new TestProcess { Timeout = 10000 };
             testProcess.Started += (o, e) => cts.Cancel();
 
-            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, new TestProcessService(testProcess)));
+            var credential = InstrumentClient(new VisualStudioCredential(default, (TokenCredentialOptions)default, fileSystem, new TestProcessService(testProcess)));
             Assert.CatchAsync<OperationCanceledException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), cts.Token));
         }
 
@@ -117,7 +117,7 @@ namespace Azure.Identity.Tests
 
             var (_, _, processOutput) = CreateTestToken();
             var testProcess = new TestProcess { Output = processOutput };
-            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, new TestProcessService(testProcess)));
+            var credential = InstrumentClient(new VisualStudioCredential(default, (TokenCredentialOptions)default, fileSystem, new TestProcessService(testProcess)));
             Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), CancellationToken.None));
         }
 
@@ -126,7 +126,7 @@ namespace Azure.Identity.Tests
         {
             var (_, _, processOutput) = CreateTestToken();
             var testProcess = new TestProcess { Output = processOutput };
-            var credential = InstrumentClient(new VisualStudioCredential(default, default, new TestFileSystemService(), new TestProcessService(testProcess)));
+            var credential = InstrumentClient(new VisualStudioCredential(default, (TokenCredentialOptions)default, new TestFileSystemService(), new TestProcessService(testProcess)));
             Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), CancellationToken.None));
         }
 
@@ -136,7 +136,7 @@ namespace Azure.Identity.Tests
             var (_, _, processOutput) = CreateTestToken();
             var testProcess = new TestProcess { Output = processOutput };
             var fileSystem = new TestFileSystemService { ReadAllHandler = p => "{\"Some\": false}" };
-            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, new TestProcessService(testProcess)));
+            var credential = InstrumentClient(new VisualStudioCredential(default, (TokenCredentialOptions)default, fileSystem, new TestProcessService(testProcess)));
             Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), CancellationToken.None));
         }
 
@@ -145,7 +145,7 @@ namespace Azure.Identity.Tests
         {
             var testProcess = new TestProcess { Error = "Some error" };
             var fileSystem = CreateTestFileSystem();
-            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, new TestProcessService(testProcess)));
+            var credential = InstrumentClient(new VisualStudioCredential(default, (TokenCredentialOptions)default, fileSystem, new TestProcessService(testProcess)));
             Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), CancellationToken.None));
         }
 

--- a/sdk/identity/Azure.Identity/tests/VisualStudioCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/VisualStudioCredentialTests.cs
@@ -24,7 +24,7 @@ namespace Azure.Identity.Tests
             var fileSystem = CreateTestFileSystem();
             var (expectedToken, expectedExpiresOn, processOutput) = CreateTestToken();
             var testProcess = new TestProcess { Output = processOutput };
-            var credential = InstrumentClient(new VisualStudioCredential(default, (TokenCredentialOptions)default, fileSystem, new TestProcessService(testProcess)));
+            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, new TestProcessService(testProcess)));
             var token = await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), CancellationToken.None);
 
             Assert.AreEqual(token.Token, expectedToken);
@@ -38,7 +38,7 @@ namespace Azure.Identity.Tests
             var (expectedToken, expectedExpiresOn, processOutput) = CreateTestToken();
             var testProcess1 = new TestProcess { Error = "Error" };
             var testProcess2 = new TestProcess { Output = processOutput };
-            var credential = InstrumentClient(new VisualStudioCredential(default, (TokenCredentialOptions)default, fileSystem, new TestProcessService(testProcess1, testProcess2)));
+            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, new TestProcessService(testProcess1, testProcess2)));
             var token = await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), CancellationToken.None);
 
             Assert.AreEqual(token.Token, expectedToken);
@@ -72,7 +72,7 @@ namespace Azure.Identity.Tests
                 }
             };
 
-            var credential = InstrumentClient(new VisualStudioCredential(default, (TokenCredentialOptions)default, fileSystem, testProcessFactory));
+            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, testProcessFactory));
             var token = await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), CancellationToken.None);
 
             Assert.AreEqual(token.Token, expectedToken);
@@ -93,7 +93,7 @@ namespace Azure.Identity.Tests
                 return false;
             };
 
-            var credential = InstrumentClient(new VisualStudioCredential(default, (TokenCredentialOptions)default, fileSystem, new TestProcessService(testProcess)));
+            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, new TestProcessService(testProcess)));
             Assert.CatchAsync<OperationCanceledException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), cts.Token));
         }
 
@@ -105,7 +105,7 @@ namespace Azure.Identity.Tests
             var testProcess = new TestProcess { Timeout = 10000 };
             testProcess.Started += (o, e) => cts.Cancel();
 
-            var credential = InstrumentClient(new VisualStudioCredential(default, (TokenCredentialOptions)default, fileSystem, new TestProcessService(testProcess)));
+            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, new TestProcessService(testProcess)));
             Assert.CatchAsync<OperationCanceledException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), cts.Token));
         }
 
@@ -117,7 +117,7 @@ namespace Azure.Identity.Tests
 
             var (_, _, processOutput) = CreateTestToken();
             var testProcess = new TestProcess { Output = processOutput };
-            var credential = InstrumentClient(new VisualStudioCredential(default, (TokenCredentialOptions)default, fileSystem, new TestProcessService(testProcess)));
+            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, new TestProcessService(testProcess)));
             Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), CancellationToken.None));
         }
 
@@ -126,7 +126,7 @@ namespace Azure.Identity.Tests
         {
             var (_, _, processOutput) = CreateTestToken();
             var testProcess = new TestProcess { Output = processOutput };
-            var credential = InstrumentClient(new VisualStudioCredential(default, (TokenCredentialOptions)default, new TestFileSystemService(), new TestProcessService(testProcess)));
+            var credential = InstrumentClient(new VisualStudioCredential(default, default, new TestFileSystemService(), new TestProcessService(testProcess)));
             Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), CancellationToken.None));
         }
 
@@ -136,7 +136,7 @@ namespace Azure.Identity.Tests
             var (_, _, processOutput) = CreateTestToken();
             var testProcess = new TestProcess { Output = processOutput };
             var fileSystem = new TestFileSystemService { ReadAllHandler = p => "{\"Some\": false}" };
-            var credential = InstrumentClient(new VisualStudioCredential(default, (TokenCredentialOptions)default, fileSystem, new TestProcessService(testProcess)));
+            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, new TestProcessService(testProcess)));
             Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), CancellationToken.None));
         }
 
@@ -145,7 +145,7 @@ namespace Azure.Identity.Tests
         {
             var testProcess = new TestProcess { Error = "Some error" };
             var fileSystem = CreateTestFileSystem();
-            var credential = InstrumentClient(new VisualStudioCredential(default, (TokenCredentialOptions)default, fileSystem, new TestProcessService(testProcess)));
+            var credential = InstrumentClient(new VisualStudioCredential(default, default, fileSystem, new TestProcessService(testProcess)));
             Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[]{"https://vault.azure.net/"}), CancellationToken.None));
         }
 


### PR DESCRIPTION
This PR adds the `VisualStudioCredential` and the `VisualStudioCodeCredential` to the `DefaultAzureCredential` authentication flow. Both are enabled by default, and execute after the `SharedTokenCacheCredential` and prior to the `AzureCliCredential`. After this addition the overall authentication flow of the `DefaultAzureCredential` becomes:

`EnvironmentCredential` -> `ManagedIdentityCredential` -> `SharedTokenCacheCredential` -> `VisualStudioCredential` -> `VisualStudioCodeCredential` -> `AzureCliCredential` -> `InteractiveBrowserCredential`(DisabledByDefault)

Options have also been added to `DefaultAzureCredentialOptions` to exclude either or both of the new credential types. Also you can specify the tenant you want to authenticate either credential with through the options.