### PR TITLE
Unify Environment Variable Names across tests

### DIFF
--- a/sdk/identity/Azure.Identity/tests/SessionRecords/UsernamePasswordCredentialLiveTests/AuthenticateUsernamePasswordLive.json
+++ b/sdk/identity/Azure.Identity/tests/SessionRecords/UsernamePasswordCredentialLiveTests/AuthenticateUsernamePasswordLive.json
@@ -297,8 +297,8 @@
     }
   ],
   "Variables": {
-    "IDENTITYTEST_USERNAMEPASSWORDCREDENTIAL_TENANTID": "c54fac88-3dd3-461f-a7c4-8a368e0340b3",
-    "IDENTITYTEST_USERNAMEPASSWORDCREDENTIAL_USERNAME": "tempuser2@azuresdkplayground.onmicrosoft.com",
+    "AZURE_IDENTITY_TEST_TENANTID": "c54fac88-3dd3-461f-a7c4-8a368e0340b3",
+    "AZURE_IDENTITY_TEST_USERNAME": "tempuser2@azuresdkplayground.onmicrosoft.com",
     "RandomSeed": "1640485913"
   }
 }

--- a/sdk/identity/Azure.Identity/tests/SessionRecords/UsernamePasswordCredentialLiveTests/AuthenticateUsernamePasswordLiveAsync.json
+++ b/sdk/identity/Azure.Identity/tests/SessionRecords/UsernamePasswordCredentialLiveTests/AuthenticateUsernamePasswordLiveAsync.json
@@ -189,8 +189,8 @@
     }
   ],
   "Variables": {
-    "IDENTITYTEST_USERNAMEPASSWORDCREDENTIAL_TENANTID": "c54fac88-3dd3-461f-a7c4-8a368e0340b3",
-    "IDENTITYTEST_USERNAMEPASSWORDCREDENTIAL_USERNAME": "tempuser2@azuresdkplayground.onmicrosoft.com",
+    "AZURE_IDENTITY_TEST_TENANTID": "c54fac88-3dd3-461f-a7c4-8a368e0340b3",
+    "AZURE_IDENTITY_TEST_USERNAME": "tempuser2@azuresdkplayground.onmicrosoft.com",
     "RandomSeed": "2008179389"
   }
 }

--- a/sdk/identity/Azure.Identity/tests/UsernamePasswordCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/UsernamePasswordCredentialLiveTests.cs
@@ -25,9 +25,9 @@ namespace Azure.Identity.Tests
     //   team members can use the azuresdkplayground.onmicrosoft.com tenant
     //   (c54fac88-3dd3-461f-a7c4-8a368e0340b3)
     // - Set the environment variables
-    //    IDENTITYTEST_USERNAMEPASSWORDCREDENTIAL_USERNAME
-    //    IDENTITYTEST_USERNAMEPASSWORDCREDENTIAL_PASSWORD
-    //    IDENTITYTEST_USERNAMEPASSWORDCREDENTIAL_TENANTID
+    //    AZURE_IDENTITY_TEST_USERNAME
+    //    AZURE_IDENTITY_TEST_PASSWORD
+    //    AZURE_IDENTITY_TEST_TENANTID
     //   to the corresponding values of the newly created temp account.
     // - Run the tests in "Record" mode and copy the updated recordings into the
     //   .\SessionRecords folder.
@@ -70,11 +70,9 @@ namespace Azure.Identity.Tests
         [Test]
         public async Task AuthenticateUsernamePasswordLive()
         {
-            var username = Recording.GetVariableFromEnvironment("IDENTITYTEST_USERNAMEPASSWORDCREDENTIAL_USERNAME");
-
-            var password = Environment.GetEnvironmentVariable("IDENTITYTEST_USERNAMEPASSWORDCREDENTIAL_PASSWORD") ?? "SANITIZED";
-
-            var tenantId = Recording.GetVariableFromEnvironment("IDENTITYTEST_USERNAMEPASSWORDCREDENTIAL_TENANTID");
+            var tenantId = Recording.GetVariableFromEnvironment("AZURE_IDENTITY_TEST_TENANTID");
+            var username = Recording.GetVariableFromEnvironment("AZURE_IDENTITY_TEST_USERNAME");
+            var password = Environment.GetEnvironmentVariable("AZURE_IDENTITY_TEST_PASSWORD") ?? "SANITIZED";
 
             var options = Recording.InstrumentClientOptions(new TokenCredentialOptions());
 


### PR DESCRIPTION
Required for https://github.com/Azure/azure-sdk-for-net/pull/11044 to pass