### PR TITLE
[EventHubs] Handle errors not tied to a partition

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/EventProcessorClient.cs
@@ -831,7 +831,7 @@ namespace Azure.Messaging.EventHubs
                                                              string operationDescription,
                                                              CancellationToken cancellationToken)
         {
-            var eventArgs = new ProcessErrorEventArgs(partition.PartitionId, operationDescription, exception, cancellationToken);
+            var eventArgs = new ProcessErrorEventArgs(partition?.PartitionId, operationDescription, exception, cancellationToken);
             await _processErrorAsync(eventArgs).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
`EventProcessor{TPartition}` passes a `null` partition object when
calling OnProcessingErrorAsync if the error is not tied to a specific
partition. We were not correctly handling this case. We should be
creating an `ProcessErrorEventArgs` with a `null` Partition ID in this
case, but instead we would crash.

This issue was introduced as part of the refactoring effort to make
`EventProcessorClient` inherit from `EventProcessor`.