### PR TITLE
ForwardTo should not error on 260 character name fixes #11009

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/SubscriptionDescription.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/SubscriptionDescription.cs
@@ -184,7 +184,16 @@ namespace Microsoft.Azure.ServiceBus.Management
                     return;
                 }
 
-                EntityNameHelper.CheckValidQueueName(value, nameof(ForwardTo));
+                string testValue = value;
+
+                if (Uri.TryCreate(value, UriKind.Absolute, out Uri uriValue))
+                {
+                    testValue = uriValue.PathAndQuery;
+                }
+
+                testValue = testValue.TrimStart('/');
+
+                EntityNameHelper.CheckValidQueueName(testValue, nameof(ForwardTo));
                 if (this.topicPath.Equals(value, StringComparison.CurrentCultureIgnoreCase))
                 {
                     throw new InvalidOperationException("Entity cannot have auto-forwarding policy to itself");

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Management/SubscriptionDescriptionTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Management/SubscriptionDescriptionTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Linq;
+using Microsoft.Azure.ServiceBus.Management;
+using Xunit;
+using Microsoft.Azure.ServiceBus.UnitTests;
+
+public class SubscriptionDescriptionTests
+{        
+    [Theory]
+    [InlineData("sb://fakepath/", 261)]
+    [InlineData("", 261)]
+    [DisplayTestMethodName]
+    public void ForwardToThrowsArgumentOutOfRangeException(string baseUrl, int lengthOfName)  
+    {
+        var longName = string.Join(string.Empty, Enumerable.Repeat('a', lengthOfName));
+        var sub = new SubscriptionDescription("sb://fakeservicebus", "Fake SubscriptionName");
+        
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => sub.ForwardTo = $"{baseUrl}{longName}");
+
+        Assert.StartsWith($"Entity path '{longName}' exceeds the '260' character limit.", ex.Message);
+        Assert.Equal($"ForwardTo", ex.ParamName);
+    }
+
+    [Theory]
+    [InlineData("sb://fakepath/", 260)]
+    [InlineData("sb://fakepath//", 260)]
+    [InlineData("", 260)]
+    [InlineData("/", 260)]
+    [InlineData("//", 260)]
+    [DisplayTestMethodName]
+    public void ForwardToAllowsMaxLengthMinusBaseUrl(string baseUrl, int lengthOfName)  
+    {
+        var longName = string.Join(string.Empty, Enumerable.Repeat('a', lengthOfName));
+        var sub = new SubscriptionDescription("sb://fakeservicebus", "Fake SubscriptionName");
+        sub.ForwardTo = $"{baseUrl}{longName}";
+        Assert.Equal($"{baseUrl}{longName}", sub.ForwardTo);
+    }
+}


### PR DESCRIPTION
ForwardTo validation should exclude the baseUrl which may be set
directly, or via the NormalizeForwardToAddress method in
SubscriptionDescriptionExtensions