### PR TITLE
[Event Hubs Client] Event Processor Release Preparation

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -12,12 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Remove the project reference and restore the package reference when the next version of the Event Hubs core is published. -->
-    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj" />
-    <!--
-    <PackageReference Include="Azure.Messaging.EventHubs" />
-    -->
-
+    <PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.1.0-preview.1" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 5.1.0-preview.2 (Unreleased)
+
+Changes will be detailed prior to release
+
 ## 5.1.0-preview.1
 
 ### Acknowledgments

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This client library allows for both publishing and consuming events using Azure Event Hubs. For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>5.1.0-preview.1</Version>
+    <Version>5.1.0-preview.2</Version>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;AMQP;IoT;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <EnableFxCopAnalyzers>false</EnableFxCopAnalyzers>


### PR DESCRIPTION
# Summary

The focus of these changes is to prepare v5.1.0-preview.1 of the Event Processor package for release, and to record the release of the Event Hubs core package.

# Last Upstream Rebase

Monday, April 6, 1:40pm (EDT)