### PR TITLE
Do not error on 260 character name additional fix

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/EntityNameHelper.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/EntityNameHelper.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.ServiceBus
 
         internal static void CheckValidQueueName(string queueName, string paramName = "queuePath")
         {
-            CheckValidEntityName(queueName, ManagementClientConstants.QueueNameMaximumLength, true, paramName);
+            CheckValidEntityName(GetPathWithoutBaseUri(queueName), ManagementClientConstants.QueueNameMaximumLength, true, paramName);
         }
 
         internal static void CheckValidTopicName(string topicName, string paramName = "topicPath")
@@ -126,6 +126,16 @@ namespace Microsoft.Azure.ServiceBus
                     throw new ArgumentException($@"'{entityName}' contains character '{uriSchemeKey}' which is not allowed because it is reserved in the Uri scheme.", paramName);
                 }
             }
+        }
+
+        private static string GetPathWithoutBaseUri(string entityName)
+        {
+            if (Uri.TryCreate(entityName, UriKind.Absolute, out Uri uriValue))
+            {
+                entityName = uriValue.PathAndQuery;
+            }
+
+            return entityName.TrimStart('/');
         }
     }
 }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/SubscriptionDescription.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/SubscriptionDescription.cs
@@ -183,17 +183,8 @@ namespace Microsoft.Azure.ServiceBus.Management
                     this.forwardTo = value;
                     return;
                 }
-
-                string testValue = value;
-
-                if (Uri.TryCreate(value, UriKind.Absolute, out Uri uriValue))
-                {
-                    testValue = uriValue.PathAndQuery;
-                }
-
-                testValue = testValue.TrimStart('/');
-
-                EntityNameHelper.CheckValidQueueName(testValue, nameof(ForwardTo));
+                
+                EntityNameHelper.CheckValidQueueName(value, nameof(ForwardTo));
                 if (this.topicPath.Equals(value, StringComparison.CurrentCultureIgnoreCase))
                 {
                     throw new InvalidOperationException("Entity cannot have auto-forwarding policy to itself");

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Management/QueueDescriptionTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Management/QueueDescriptionTests.cs
@@ -4,7 +4,7 @@ using Microsoft.Azure.ServiceBus.Management;
 using Microsoft.Azure.ServiceBus.UnitTests;
 using Xunit;
 
-public class SubscriptionDescriptionTests
+public class QueueDescriptionTests
 {        
     [Theory]
     [InlineData("sb://fakepath/", 261)]
@@ -13,7 +13,7 @@ public class SubscriptionDescriptionTests
     public void ForwardToThrowsArgumentOutOfRangeException(string baseUrl, int lengthOfName)  
     {
         var longName = string.Join(string.Empty, Enumerable.Repeat('a', lengthOfName));
-        var sub = new SubscriptionDescription("sb://fakeservicebus", "Fake SubscriptionName");
+        var sub = new QueueDescription("Fake SubscriptionName");
         
         var ex = Assert.Throws<ArgumentOutOfRangeException>(() => sub.ForwardTo = $"{baseUrl}{longName}");
 
@@ -28,12 +28,27 @@ public class SubscriptionDescriptionTests
     public void ForwardDeadLetteredMessagesToThrowsArgumentOutOfRangeException(string baseUrl, int lengthOfName)  
     {
         var longName = string.Join(string.Empty, Enumerable.Repeat('a', lengthOfName));
-        var sub = new SubscriptionDescription("sb://fakeservicebus", "Fake SubscriptionName");
+        var sub = new QueueDescription("Fake SubscriptionName");
         
         var ex = Assert.Throws<ArgumentOutOfRangeException>(() => sub.ForwardDeadLetteredMessagesTo = $"{baseUrl}{longName}");
 
         Assert.StartsWith($"Entity path '{longName}' exceeds the '260' character limit.", ex.Message);
         Assert.Equal($"ForwardDeadLetteredMessagesTo", ex.ParamName);
+    }
+
+    [Theory]
+    [InlineData("sb://fakepath/", 261)]
+    [InlineData("", 261)]
+    [DisplayTestMethodName]
+    public void PathToThrowsArgumentOutOfRangeException(string baseUrl, int lengthOfName)  
+    {
+        var longName = string.Join(string.Empty, Enumerable.Repeat('a', lengthOfName));
+        var sub = new QueueDescription("Fake SubscriptionName");
+        
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => sub.Path = $"{baseUrl}{longName}");
+
+        Assert.StartsWith($"Entity path '{longName}' exceeds the '260' character limit.", ex.Message);
+        Assert.Equal($"Path", ex.ParamName);
     }
 
     [Theory]
@@ -44,7 +59,7 @@ public class SubscriptionDescriptionTests
     public void ForwardToAllowsMaxLengthMinusBaseUrl(string baseUrl, int lengthOfName)  
     {
         var longName = string.Join(string.Empty, Enumerable.Repeat('a', lengthOfName));
-        var sub = new SubscriptionDescription("sb://fakeservicebus", "Fake SubscriptionName");
+        var sub = new QueueDescription("Fake SubscriptionName");
         sub.ForwardTo = $"{baseUrl}{longName}";
         Assert.Equal($"{baseUrl}{longName}", sub.ForwardTo);
     }
@@ -57,8 +72,21 @@ public class SubscriptionDescriptionTests
     public void ForwardDeadLetteredMessagesToAllowsMaxLengthMinusBaseUrl(string baseUrl, int lengthOfName)  
     {
         var longName = string.Join(string.Empty, Enumerable.Repeat('a', lengthOfName));
-        var sub = new SubscriptionDescription("sb://fakeservicebus", "Fake SubscriptionName");
+        var sub = new QueueDescription("Fake SubscriptionName");
         sub.ForwardDeadLetteredMessagesTo = $"{baseUrl}{longName}";
         Assert.Equal($"{baseUrl}{longName}", sub.ForwardDeadLetteredMessagesTo);
+    }
+
+    [Theory]
+    [InlineData("sb://fakepath/", 260)]
+    [InlineData("sb://fakepath//", 260)]
+    [InlineData("", 260)]
+    [DisplayTestMethodName]
+    public void PathAllowsMaxLengthMinusBaseUrl(string baseUrl, int lengthOfName)  
+    {
+        var longName = string.Join(string.Empty, Enumerable.Repeat('a', lengthOfName));
+        var sub = new QueueDescription("Fake SubscriptionName");
+        sub.Path = $"{baseUrl}{longName}";
+        Assert.Equal($"{baseUrl}{longName}", sub.Path);
     }
 }


### PR DESCRIPTION
Per feedback on the issue, the reported issue in #11009 also impacts
the ForwardToDeadLetterMessagesTo property as well as the same fields
in QueueDescription.

- Refactor ForwardTo logic into CheckValidQueueName
- Add unit tests for ForwardDeadLetteredMessagesTo
- Add unit tests for QueueDescriptionTests

fixes #11009