### PR TITLE
use autorest version "V2" for mgmt sdk

### DIFF
--- a/sdk/advisor/Microsoft.Azure.Management.Advisor/src/generate.ps1
+++ b/sdk/advisor/Microsoft.Azure.Management.Advisor/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "advisor/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "advisor/resource-manager" -AutoRestVersion "v2"

--- a/sdk/alertsmanagement/Microsoft.Azure.Management.AlertsManagement/src/generate.ps1
+++ b/sdk/alertsmanagement/Microsoft.Azure.Management.AlertsManagement/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "alertsmanagement/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "alertsmanagement/resource-manager" -AutoRestVersion "v2"

--- a/sdk/apimanagement/Microsoft.Azure.Management.ApiManagement/src/generate.ps1
+++ b/sdk/apimanagement/Microsoft.Azure.Management.ApiManagement/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "apimanagement/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "apimanagement/resource-manager" -AutoRestVersion "v2"

--- a/sdk/appplatform/Microsoft.Azure.Management.AppPlatform/src/generate.ps1
+++ b/sdk/appplatform/Microsoft.Azure.Management.AppPlatform/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "appplatform/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "appplatform/resource-manager" -AutoRestVersion "v2"

--- a/sdk/attestation/Microsoft.Azure.Management.Attestation/src/generate.ps1
+++ b/sdk/attestation/Microsoft.Azure.Management.Attestation/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "attestation/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "attestation/resource-manager" -AutoRestVersion "v2"

--- a/sdk/authorization/Microsoft.Azure.Management.Authorization/src/generate.ps1
+++ b/sdk/authorization/Microsoft.Azure.Management.Authorization/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "authorization/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "authorization/resource-manager" -AutoRestVersion "v2"

--- a/sdk/automation/Microsoft.Azure.Management.Automation/src/generate.ps1
+++ b/sdk/automation/Microsoft.Azure.Management.Automation/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "automation/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "automation/resource-manager" -AutoRestVersion "v2"

--- a/sdk/azurestack/Microsoft.AzureStack.Management.AzureBridge.Admin/src/generate.ps1
+++ b/sdk/azurestack/Microsoft.AzureStack.Management.AzureBridge.Admin/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/azurebridge" -AutoRestVersion "latest" -SdkRootDirectory $PSScriptRoot
+Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/azurebridge" -AutoRestVersion "v2" -SdkRootDirectory $PSScriptRoot

--- a/sdk/azurestack/Microsoft.AzureStack.Management.Backup.Admin/src/generate.ps1
+++ b/sdk/azurestack/Microsoft.AzureStack.Management.Backup.Admin/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/backup" -AutoRestVersion "latest" -SdkRootDirectory $PSScriptRoot
+Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/backup" -AutoRestVersion "v2" -SdkRootDirectory $PSScriptRoot

--- a/sdk/azurestack/Microsoft.AzureStack.Management.Commerce.Admin/src/generate.ps1
+++ b/sdk/azurestack/Microsoft.AzureStack.Management.Commerce.Admin/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/commerce" -AutoRestVersion "latest" -SdkRootDirectory $PSScriptRoot
+Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/commerce" -AutoRestVersion "v2" -SdkRootDirectory $PSScriptRoot

--- a/sdk/azurestack/Microsoft.AzureStack.Management.Compute.Admin/src/generate.ps1
+++ b/sdk/azurestack/Microsoft.AzureStack.Management.Compute.Admin/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/compute" -AutoRestVersion "latest" -SdkRootDirectory "$PSScriptRoot"
+Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/compute" -AutoRestVersion "v2" -SdkRootDirectory "$PSScriptRoot"

--- a/sdk/azurestack/Microsoft.AzureStack.Management.Fabric.Admin/src/generate.ps1
+++ b/sdk/azurestack/Microsoft.AzureStack.Management.Fabric.Admin/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/fabric" -AutoRestVersion "latest" -SdkRootDirectory $PSScriptRoot
+Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/fabric" -AutoRestVersion "v2" -SdkRootDirectory $PSScriptRoot

--- a/sdk/azurestack/Microsoft.AzureStack.Management.Gallery.Admin/src/generate.ps1
+++ b/sdk/azurestack/Microsoft.AzureStack.Management.Gallery.Admin/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/gallery" -AutoRestVersion "latest" -SdkRootDirectory $PSScriptRoot
+Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/gallery" -AutoRestVersion "v2" -SdkRootDirectory $PSScriptRoot

--- a/sdk/azurestack/Microsoft.AzureStack.Management.InfrastructureInsights.Admin/src/generate.ps1
+++ b/sdk/azurestack/Microsoft.AzureStack.Management.InfrastructureInsights.Admin/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/infrastructureinsights" -AutoRestVersion "latest" -SdkRootDirectory $PSScriptRoot
+Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/infrastructureinsights" -AutoRestVersion "v2" -SdkRootDirectory $PSScriptRoot

--- a/sdk/azurestack/Microsoft.AzureStack.Management.KeyVault.Admin/src/generate.ps1
+++ b/sdk/azurestack/Microsoft.AzureStack.Management.KeyVault.Admin/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/keyvault" -AutoRestVersion "latest" -SdkRootDirectory $PSScriptRoot
+Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/keyvault" -AutoRestVersion "v2" -SdkRootDirectory $PSScriptRoot

--- a/sdk/azurestack/Microsoft.AzureStack.Management.Network.Admin/src/generate.ps1
+++ b/sdk/azurestack/Microsoft.AzureStack.Management.Network.Admin/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/network" -AutoRestVersion "latest" -SdkRootDirectory $PSScriptRoot
+Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/network" -AutoRestVersion "v2" -SdkRootDirectory $PSScriptRoot

--- a/sdk/azurestack/Microsoft.AzureStack.Management.Storage.Admin/src/generate.ps1
+++ b/sdk/azurestack/Microsoft.AzureStack.Management.Storage.Admin/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/storage" -AutoRestVersion "latest" -SdkRootDirectory $PSScriptRoot
+Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/storage" -AutoRestVersion "v2" -SdkRootDirectory $PSScriptRoot

--- a/sdk/azurestack/Microsoft.AzureStack.Management.Subscription/src/generate.ps1
+++ b/sdk/azurestack/Microsoft.AzureStack.Management.Subscription/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/user-subscriptions" -AutoRestVersion "latest" -SdkDirectory $PSScriptRoot
+Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/user-subscriptions" -AutoRestVersion "v2" -SdkDirectory $PSScriptRoot

--- a/sdk/azurestack/Microsoft.AzureStack.Management.Subscriptions.Admin/src/generate.ps1
+++ b/sdk/azurestack/Microsoft.AzureStack.Management.Subscriptions.Admin/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/subscriptions" -AutoRestVersion "latest" -SdkDirectory $PSScriptRoot
+Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/subscriptions" -AutoRestVersion "v2" -SdkDirectory $PSScriptRoot

--- a/sdk/azurestack/Microsoft.AzureStack.Management.Update.Admin/src/generate.ps1
+++ b/sdk/azurestack/Microsoft.AzureStack.Management.Update.Admin/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/update" -AutoRestVersion "latest" -SdkRootDirectory $PSScriptRoot
+Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/update" -AutoRestVersion "v2" -SdkRootDirectory $PSScriptRoot

--- a/sdk/batch/Microsoft.Azure.Management.Batch/src/generate.ps1
+++ b/sdk/batch/Microsoft.Azure.Management.Batch/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "batch/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "batch/resource-manager" -AutoRestVersion "v2"

--- a/sdk/batchai/Microsoft.Azure.Management.BatchAI/src/generate.ps1
+++ b/sdk/batchai/Microsoft.Azure.Management.BatchAI/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "batchai/resource-manager" -AutoRestVersion "latest" 
+Start-AutoRestCodeGeneration -ResourceProvider "batchai/resource-manager" -AutoRestVersion "v2" 

--- a/sdk/billing/Microsoft.Azure.Management.Billing/src/generate.ps1
+++ b/sdk/billing/Microsoft.Azure.Management.Billing/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "billing/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "billing/resource-manager" -AutoRestVersion "v2"

--- a/sdk/blueprint/Microsoft.Azure.Management.Blueprint/src/generate.ps1
+++ b/sdk/blueprint/Microsoft.Azure.Management.Blueprint/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "blueprint/resource-manager" -AutoRestVersion "2.0.4413"
+Start-AutoRestCodeGeneration -ResourceProvider "blueprint/resource-manager" -AutoRestVersion "v2"

--- a/sdk/botservice/Microsoft.Azure.Management.BotService/src/generate.ps1
+++ b/sdk/botservice/Microsoft.Azure.Management.BotService/src/generate.ps1
@@ -1,1 +1,1 @@
-﻿Start-AutoRestCodeGeneration -ResourceProvider "botservice/resource-manager" -AutoRestVersion "latest" -SdkGenerationDirectory "$PSScriptRoot\Generated"
+﻿Start-AutoRestCodeGeneration -ResourceProvider "botservice/resource-manager" -AutoRestVersion "v2" -SdkGenerationDirectory "$PSScriptRoot\Generated"

--- a/sdk/cdn/Microsoft.Azure.Management.Cdn/src/generate.ps1
+++ b/sdk/cdn/Microsoft.Azure.Management.Cdn/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "cdn/resource-manager" -AutoRestVersion "latest" -ConfigFileTag "package-2019-04"
+Start-AutoRestCodeGeneration -ResourceProvider "cdn/resource-manager" -AutoRestVersion "v2" -ConfigFileTag "package-2019-04"

--- a/sdk/cognitiveservices/Microsoft.Azure.Management.CognitiveServices/src/generate.ps1
+++ b/sdk/cognitiveservices/Microsoft.Azure.Management.CognitiveServices/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "cognitiveservices/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "cognitiveservices/resource-manager" -AutoRestVersion "v2"

--- a/sdk/compute/Microsoft.Azure.Management.Compute/src/generate.ps1
+++ b/sdk/compute/Microsoft.Azure.Management.Compute/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "compute/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "compute/resource-manager" -AutoRestVersion "v2"

--- a/sdk/consumption/Microsoft.Azure.Management.Consumption/src/generate.ps1
+++ b/sdk/consumption/Microsoft.Azure.Management.Consumption/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "consumption/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "consumption/resource-manager" -AutoRestVersion "v2"

--- a/sdk/containerinstance/Microsoft.Azure.Management.ContainerInstance/src/generate.ps1
+++ b/sdk/containerinstance/Microsoft.Azure.Management.ContainerInstance/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "containerinstance/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "containerinstance/resource-manager" -AutoRestVersion "v2"

--- a/sdk/containerregistry/Microsoft.Azure.Management.ContainerRegistry/src/generate.ps1
+++ b/sdk/containerregistry/Microsoft.Azure.Management.ContainerRegistry/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider  "containerregistry/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider  "containerregistry/resource-manager" -AutoRestVersion "v2"

--- a/sdk/containerservice/Microsoft.Azure.Management.ContainerService/src/generate.ps1
+++ b/sdk/containerservice/Microsoft.Azure.Management.ContainerService/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "containerservice/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "containerservice/resource-manager" -AutoRestVersion "v2"

--- a/sdk/cosmos-db/Microsoft.Azure.Management.CosmosDB/src/generate.ps1
+++ b/sdk/cosmos-db/Microsoft.Azure.Management.CosmosDB/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "cosmos-db/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "cosmos-db/resource-manager" -AutoRestVersion "v2"

--- a/sdk/cost-management/Microsoft.Azure.Management.CostManagement/src/generate.ps1
+++ b/sdk/cost-management/Microsoft.Azure.Management.CostManagement/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "cost-management/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "cost-management/resource-manager" -AutoRestVersion "v2"

--- a/sdk/customproviders/Microsoft.Azure.Management.CustomProviders/src/generate.ps1
+++ b/sdk/customproviders/Microsoft.Azure.Management.CustomProviders/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "customproviders/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "customproviders/resource-manager" -AutoRestVersion "v2"

--- a/sdk/databox/Microsoft.Azure.Management.DataBox/src/generate.ps1
+++ b/sdk/databox/Microsoft.Azure.Management.DataBox/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "databox/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "databox/resource-manager" -AutoRestVersion "v2"

--- a/sdk/databoxedge/Microsoft.Azure.Management.DataBoxEdge/src/generate.ps1
+++ b/sdk/databoxedge/Microsoft.Azure.Management.DataBoxEdge/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "databoxedge/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "databoxedge/resource-manager" -AutoRestVersion "v2"

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/generate.ps1
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "datafactory/resource-manager" -AutoRestVersion "2.0.4413" -ConfigFileTag "package-2018-06"
+Start-AutoRestCodeGeneration -ResourceProvider "datafactory/resource-manager" -AutoRestVersion "v2" -ConfigFileTag "package-2018-06"

--- a/sdk/datalake-analytics/Microsoft.Azure.Management.DataLake.Analytics/src/generate.ps1
+++ b/sdk/datalake-analytics/Microsoft.Azure.Management.DataLake.Analytics/src/generate.ps1
@@ -1,2 +1,2 @@
-Start-AutoRestCodeGeneration -ResourceProvider "datalake-analytics/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "datalake-analytics/resource-manager" -AutoRestVersion "v2"
 Start-AutoRestCodeGeneration -ResourceProvider "datalake-analytics/data-plane" -AutoRestVersion "latest"

--- a/sdk/datalake-analytics/Microsoft.Azure.Management.DataLake.Analytics/src/generate.ps1
+++ b/sdk/datalake-analytics/Microsoft.Azure.Management.DataLake.Analytics/src/generate.ps1
@@ -1,2 +1,2 @@
 Start-AutoRestCodeGeneration -ResourceProvider "datalake-analytics/resource-manager" -AutoRestVersion "v2"
-Start-AutoRestCodeGeneration -ResourceProvider "datalake-analytics/data-plane" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "datalake-analytics/data-plane" -AutoRestVersion "v2"

--- a/sdk/datalake-store/Microsoft.Azure.Management.DataLake.Store/src/generate.ps1
+++ b/sdk/datalake-store/Microsoft.Azure.Management.DataLake.Store/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "datalake-store/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "datalake-store/resource-manager" -AutoRestVersion "v2"

--- a/sdk/datamigration/Microsoft.Azure.Management.DataMigration/src/generate.ps1
+++ b/sdk/datamigration/Microsoft.Azure.Management.DataMigration/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "datamigration/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "datamigration/resource-manager" -AutoRestVersion "v2"

--- a/sdk/datashare/Microsoft.Azure.Management.DataShare/src/generate.ps1
+++ b/sdk/datashare/Microsoft.Azure.Management.DataShare/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "datashare/resource-manager" -AutoRestVersion "2.0.4413" -ConfigFileTag "package-2019-11-01"
+Start-AutoRestCodeGeneration -ResourceProvider "datashare/resource-manager" -AutoRestVersion "v2" -ConfigFileTag "package-2019-11-01"

--- a/sdk/deploymentmanager/Microsoft.Azure.Management.DeploymentManager/src/generate.ps1
+++ b/sdk/deploymentmanager/Microsoft.Azure.Management.DeploymentManager/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "deploymentmanager/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "deploymentmanager/resource-manager" -AutoRestVersion "v2"

--- a/sdk/devspaces/Microsoft.Azure.Management.DevSpaces/src/generate.ps1
+++ b/sdk/devspaces/Microsoft.Azure.Management.DevSpaces/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "devspaces/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "devspaces/resource-manager" -AutoRestVersion "v2"

--- a/sdk/devtestlabs/Microsoft.Azure.Management.DevTestLabs/src/generate.ps1
+++ b/sdk/devtestlabs/Microsoft.Azure.Management.DevTestLabs/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "devtestlabs/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "devtestlabs/resource-manager" -AutoRestVersion "v2"

--- a/sdk/dns/Microsoft.Azure.Management.Dns/src/generate.ps1
+++ b/sdk/dns/Microsoft.Azure.Management.Dns/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "dns/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "dns/resource-manager" -AutoRestVersion "v2"

--- a/sdk/edgegateway/Microsoft.Azure.Management.EdgeGateway/src/generate.ps1
+++ b/sdk/edgegateway/Microsoft.Azure.Management.EdgeGateway/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "edgegateway/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "edgegateway/resource-manager" -AutoRestVersion "v2"

--- a/sdk/eventgrid/Microsoft.Azure.Management.EventGrid/src/generate.ps1
+++ b/sdk/eventgrid/Microsoft.Azure.Management.EventGrid/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "eventgrid/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "eventgrid/resource-manager" -AutoRestVersion "v2"

--- a/sdk/eventhub/Microsoft.Azure.Management.EventHub/src/generate.ps1
+++ b/sdk/eventhub/Microsoft.Azure.Management.EventHub/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "eventhub/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "eventhub/resource-manager" -AutoRestVersion "v2"

--- a/sdk/frontdoor/Microsoft.Azure.Management.FrontDoor/src/generate.ps1
+++ b/sdk/frontdoor/Microsoft.Azure.Management.FrontDoor/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "frontdoor/resource-manager" -AutoRestVersion "2.0.4413"
+Start-AutoRestCodeGeneration -ResourceProvider "frontdoor/resource-manager" -AutoRestVersion "v2"

--- a/sdk/guestconfiguration/Microsoft.Azure.Management.GuestConfiguration/src/generate.ps1
+++ b/sdk/guestconfiguration/Microsoft.Azure.Management.GuestConfiguration/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "guestconfiguration/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "guestconfiguration/resource-manager" -AutoRestVersion "v2"

--- a/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/src/generate.ps1
+++ b/sdk/hdinsight/Microsoft.Azure.Management.HDInsight/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "hdinsight/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "hdinsight/resource-manager" -AutoRestVersion "v2"

--- a/sdk/healthcareapis/Microsoft.Azure.Management.HealthcareApis/src/generate.ps1
+++ b/sdk/healthcareapis/Microsoft.Azure.Management.HealthcareApis/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "healthcareapis/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "healthcareapis/resource-manager" -AutoRestVersion "v2"

--- a/sdk/hybridcompute/Microsoft.Azure.Management.HybridCompute/src/generate.ps1
+++ b/sdk/hybridcompute/Microsoft.Azure.Management.HybridCompute/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "hybridcompute/resource-manager" -AutoRestVersion "latest" -SpecsRepoName azure-rest-api-specs
+Start-AutoRestCodeGeneration -ResourceProvider "hybridcompute/resource-manager" -AutoRestVersion "v2" -SpecsRepoName azure-rest-api-specs

--- a/sdk/hybriddatamanager/Microsoft.Azure.Management.HybridDataManager/src/generate.ps1
+++ b/sdk/hybriddatamanager/Microsoft.Azure.Management.HybridDataManager/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "hybriddatamanager/resource-manager" -AutoRestVersion "2.0.4413"
+Start-AutoRestCodeGeneration -ResourceProvider "hybriddatamanager/resource-manager" -AutoRestVersion "v2"

--- a/sdk/iotcentral/Microsoft.Azure.Management.IotCentral/src/generate.ps1
+++ b/sdk/iotcentral/Microsoft.Azure.Management.IotCentral/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "iotcentral/resource-manager" -AutoRestVersion "latest" -SdkGenerationDirectory "$PSScriptRoot\Generated"
+Start-AutoRestCodeGeneration -ResourceProvider "iotcentral/resource-manager" -AutoRestVersion "v2" -SdkGenerationDirectory "$PSScriptRoot\Generated"

--- a/sdk/iothub/Microsoft.Azure.Management.IotHub/src/generate.ps1
+++ b/sdk/iothub/Microsoft.Azure.Management.IotHub/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "iothub/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "iothub/resource-manager" -AutoRestVersion "v2"

--- a/sdk/keyvault/Microsoft.Azure.Management.KeyVault/src/generate.ps1
+++ b/sdk/keyvault/Microsoft.Azure.Management.KeyVault/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "keyvault/resource-manager" -AutoRestVersion "2.0.4413" -SdkGenerationDirectory "$PSScriptRoot\Generated"
+Start-AutoRestCodeGeneration -ResourceProvider "keyvault/resource-manager" -AutoRestVersion "v2" -SdkGenerationDirectory "$PSScriptRoot\Generated"

--- a/sdk/kusto/Microsoft.Azure.Management.Kusto/src/generate.ps1
+++ b/sdk/kusto/Microsoft.Azure.Management.Kusto/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "azure-kusto/resource-manager" -AutoRestVersion "2.0.4413"
+Start-AutoRestCodeGeneration -ResourceProvider "azure-kusto/resource-manager" -AutoRestVersion "v2"

--- a/sdk/labservices/Microsoft.Azure.Management.LabServices/src/generate.ps1
+++ b/sdk/labservices/Microsoft.Azure.Management.LabServices/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "labservices/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "labservices/resource-manager" -AutoRestVersion "v2"

--- a/sdk/locationbasedservices/Microsoft.Azure.Management.LocationBasedServices/src/generate.ps1
+++ b/sdk/locationbasedservices/Microsoft.Azure.Management.LocationBasedServices/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "locationbasedservices/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "locationbasedservices/resource-manager" -AutoRestVersion "v2"

--- a/sdk/logic/Microsoft.Azure.Management.Logic/src/generate.ps1
+++ b/sdk/logic/Microsoft.Azure.Management.Logic/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "logic/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "logic/resource-manager" -AutoRestVersion "v2"

--- a/sdk/maintenance/Microsoft.Azure.Management.Maintenance/src/generate.ps1
+++ b/sdk/maintenance/Microsoft.Azure.Management.Maintenance/src/generate.ps1
@@ -1,2 +1,2 @@
-Start-AutoRestCodeGeneration -ResourceProvider "maintenance/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "maintenance/resource-manager" -AutoRestVersion "v2"
 

--- a/sdk/managednetwork/Microsoft.Azure.Management.ManagedNetwork/src/generate.ps1
+++ b/sdk/managednetwork/Microsoft.Azure.Management.ManagedNetwork/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "managednetwork/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "managednetwork/resource-manager" -AutoRestVersion "v2"

--- a/sdk/managedserviceidentity/Microsoft.Azure.Management.ManagedServiceIdentity/src/generate.ps1
+++ b/sdk/managedserviceidentity/Microsoft.Azure.Management.ManagedServiceIdentity/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "msi/resource-manager" -AutoRestVersion "2.0.4283"
+Start-AutoRestCodeGeneration -ResourceProvider "msi/resource-manager" -AutoRestVersion "v2"

--- a/sdk/managedservices/Microsoft.Azure.Management.ManagedServices/src/generate.ps1
+++ b/sdk/managedservices/Microsoft.Azure.Management.ManagedServices/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "managedservices/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "managedservices/resource-manager" -AutoRestVersion "v2"

--- a/sdk/managementgroups/Microsoft.Azure.Management.ManagementGroups/src/generate.ps1
+++ b/sdk/managementgroups/Microsoft.Azure.Management.ManagementGroups/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "managementgroups/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "managementgroups/resource-manager" -AutoRestVersion "v2"

--- a/sdk/managementpartner/Microsoft.Azure.Management.ManagementPartner/src/generate.ps1
+++ b/sdk/managementpartner/Microsoft.Azure.Management.ManagementPartner/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "managementpartner/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "managementpartner/resource-manager" -AutoRestVersion "v2"

--- a/sdk/maps/Microsoft.Azure.Management.Maps/src/generate.ps1
+++ b/sdk/maps/Microsoft.Azure.Management.Maps/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "maps/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "maps/resource-manager" -AutoRestVersion "v2"

--- a/sdk/mediaservices/Microsoft.Azure.Management.Media/src/generate.ps1
+++ b/sdk/mediaservices/Microsoft.Azure.Management.Media/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "mediaservices/resource-manager" -AutoRestVersion "latest" -AutoRestCodeGenerationFlags --opt-in-extensible-enums
+Start-AutoRestCodeGeneration -ResourceProvider "mediaservices/resource-manager" -AutoRestVersion "v2" -AutoRestCodeGenerationFlags --opt-in-extensible-enums

--- a/sdk/mixedreality/Microsoft.Azure.Management.MixedReality/src/generate.ps1
+++ b/sdk/mixedreality/Microsoft.Azure.Management.MixedReality/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "mixedreality/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "mixedreality/resource-manager" -AutoRestVersion "v2"

--- a/sdk/monitor/Microsoft.Azure.Management.Monitor/src/generate.ps1
+++ b/sdk/monitor/Microsoft.Azure.Management.Monitor/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "monitor/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "monitor/resource-manager" -AutoRestVersion "v2"

--- a/sdk/netapp/Microsoft.Azure.Management.NetApp/src/generate.ps1
+++ b/sdk/netapp/Microsoft.Azure.Management.NetApp/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "netapp/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "netapp/resource-manager" -AutoRestVersion "v2"

--- a/sdk/network/Microsoft.Azure.Management.Network/src/generate.ps1
+++ b/sdk/network/Microsoft.Azure.Management.Network/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "network/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "network/resource-manager" -AutoRestVersion "v2"

--- a/sdk/peering/Microsoft.Azure.Management.Peering/src/generate.ps1
+++ b/sdk/peering/Microsoft.Azure.Management.Peering/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "peering/resource-manager" -AutoRestVersion "latest" 
+Start-AutoRestCodeGeneration -ResourceProvider "peering/resource-manager" -AutoRestVersion "v2" 

--- a/sdk/policyinsights/Microsoft.Azure.Management.PolicyInsights/src/generate.ps1
+++ b/sdk/policyinsights/Microsoft.Azure.Management.PolicyInsights/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "policyinsights/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "policyinsights/resource-manager" -AutoRestVersion "v2"

--- a/sdk/postgresql/Microsoft.Azure.Management.PostgreSQL/src/generate.ps1
+++ b/sdk/postgresql/Microsoft.Azure.Management.PostgreSQL/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "postgresql/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "postgresql/resource-manager" -AutoRestVersion "v2"

--- a/sdk/powerbidedicated/Microsoft.Azure.Management.PowerBIDedicated/src/generate.ps1
+++ b/sdk/powerbidedicated/Microsoft.Azure.Management.PowerBIDedicated/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "PowerBIDedicated/resource-manager" -AutoRestVersion "latest" 
+Start-AutoRestCodeGeneration -ResourceProvider "PowerBIDedicated/resource-manager" -AutoRestVersion "v2" 

--- a/sdk/privatedns/Microsoft.Azure.Management.PrivateDns/src/generate.ps1
+++ b/sdk/privatedns/Microsoft.Azure.Management.PrivateDns/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "privatedns/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "privatedns/resource-manager" -AutoRestVersion "v2"

--- a/sdk/recoveryservices-backup/Microsoft.Azure.Management.RecoveryServices.Backup/src/generate.ps1
+++ b/sdk/recoveryservices-backup/Microsoft.Azure.Management.RecoveryServices.Backup/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "recoveryservicesbackup/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "recoveryservicesbackup/resource-manager" -AutoRestVersion "v2"

--- a/sdk/recoveryservices-siterecovery/Microsoft.Azure.Management.RecoveryServices.SiteRecovery/src/generate.ps1
+++ b/sdk/recoveryservices-siterecovery/Microsoft.Azure.Management.RecoveryServices.SiteRecovery/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "recoveryservicessiterecovery/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "recoveryservicessiterecovery/resource-manager" -AutoRestVersion "v2"

--- a/sdk/redis/Microsoft.Azure.Management.RedisCache/src/generate.ps1
+++ b/sdk/redis/Microsoft.Azure.Management.RedisCache/src/generate.ps1
@@ -1,1 +1,1 @@
-﻿Start-AutoRestCodeGeneration -ResourceProvider "redis/resource-manager" -AutoRestVersion "latest"
+﻿Start-AutoRestCodeGeneration -ResourceProvider "redis/resource-manager" -AutoRestVersion "v2"

--- a/sdk/reservations/Microsoft.Azure.Management.Reservations/src/generate.ps1
+++ b/sdk/reservations/Microsoft.Azure.Management.Reservations/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "reservations/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "reservations/resource-manager" -AutoRestVersion "v2"

--- a/sdk/resourcegraph/Microsoft.Azure.Management.ResourceGraph/src/generate.ps1
+++ b/sdk/resourcegraph/Microsoft.Azure.Management.ResourceGraph/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "resourcegraph/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "resourcegraph/resource-manager" -AutoRestVersion "v2"

--- a/sdk/resources/Microsoft.Azure.Management.Resource/src/generate.ps1
+++ b/sdk/resources/Microsoft.Azure.Management.Resource/src/generate.ps1
@@ -6,10 +6,10 @@
 # Start-AutoRestCodeGeneration -ResourceProvider "resources/resource-manager" -SdkRepoRootPath "$PSScriptRoot\..\..\..\.." -AutoRestVersion "v2" -AutoRestCodeGenerationFlags "--tag=package-resources-2019-10" -SdkGenerationDirectory "$PSScriptRoot\Generated\Resources"
 
 # Generate package with subscriptions tag
-# Start-AutoRestCodeGeneration -ResourceProvider "resources/resource-manager" -SdkRepoRootPath "$PSScriptRoot\..\..\..\.." -AutoRestVersion "latest" -AutoRestCodeGenerationFlags "--tag=package-subscriptions-2019-11" -SdkGenerationDirectory "$PSScriptRoot\Generated\Subscriptions"
+# Start-AutoRestCodeGeneration -ResourceProvider "resources/resource-manager" -SdkRepoRootPath "$PSScriptRoot\..\..\..\.." -AutoRestVersion "v2" -AutoRestCodeGenerationFlags "--tag=package-subscriptions-2019-11" -SdkGenerationDirectory "$PSScriptRoot\Generated\Subscriptions"
 
 # Generate package with policy tag
-# Start-AutoRestCodeGeneration -ResourceProvider "resources/resource-manager" -SdkRepoRootPath "$PSScriptRoot\..\..\..\.." -AutoRestVersion "latest" -AutoRestCodeGenerationFlags "--tag=package-policy-2019-09" -SdkGenerationDirectory "$PSScriptRoot\Generated"
+# Start-AutoRestCodeGeneration -ResourceProvider "resources/resource-manager" -SdkRepoRootPath "$PSScriptRoot\..\..\..\.." -AutoRestVersion "v2" -AutoRestCodeGenerationFlags "--tag=package-policy-2019-09" -SdkGenerationDirectory "$PSScriptRoot\Generated"
 
 # Generate package with deployment scripts
- Start-AutoRestCodeGeneration -ResourceProvider "resources/resource-manager" -SdkRepoRootPath "$PSScriptRoot\..\..\..\.." -AutoRestVersion "2.0.4413" -AutoRestCodeGenerationFlags "--tag=package-deploymentscripts-2019-10-preview" -SdkGenerationDirectory "$PSScriptRoot\Generated\DeploymentScripts"
+ Start-AutoRestCodeGeneration -ResourceProvider "resources/resource-manager" -SdkRepoRootPath "$PSScriptRoot\..\..\..\.." -AutoRestVersion "v2" -AutoRestCodeGenerationFlags "--tag=package-deploymentscripts-2019-10-preview" -SdkGenerationDirectory "$PSScriptRoot\Generated\DeploymentScripts"

--- a/sdk/resources/Microsoft.Azure.Management.Resource/src/generate.ps1
+++ b/sdk/resources/Microsoft.Azure.Management.Resource/src/generate.ps1
@@ -3,7 +3,7 @@
 # and copy these new set of files to the main Generated folder. This way exisiting files will not be deleted.
 
 # Generate package with resources tag
-# Start-AutoRestCodeGeneration -ResourceProvider "resources/resource-manager" -SdkRepoRootPath "$PSScriptRoot\..\..\..\.." -AutoRestVersion "latest" -AutoRestCodeGenerationFlags "--tag=package-resources-2019-10" -SdkGenerationDirectory "$PSScriptRoot\Generated\Resources"
+# Start-AutoRestCodeGeneration -ResourceProvider "resources/resource-manager" -SdkRepoRootPath "$PSScriptRoot\..\..\..\.." -AutoRestVersion "v2" -AutoRestCodeGenerationFlags "--tag=package-resources-2019-10" -SdkGenerationDirectory "$PSScriptRoot\Generated\Resources"
 
 # Generate package with subscriptions tag
 # Start-AutoRestCodeGeneration -ResourceProvider "resources/resource-manager" -SdkRepoRootPath "$PSScriptRoot\..\..\..\.." -AutoRestVersion "latest" -AutoRestCodeGenerationFlags "--tag=package-subscriptions-2019-11" -SdkGenerationDirectory "$PSScriptRoot\Generated\Subscriptions"

--- a/sdk/search/Microsoft.Azure.Management.Search/src/generate.ps1
+++ b/sdk/search/Microsoft.Azure.Management.Search/src/generate.ps1
@@ -29,4 +29,4 @@ Param(
 
 "$PSScriptRoot\..\..\Install-BuildTools.ps1"
 
-Start-AutoRestCodeGeneration -ResourceProvider "search/resource-manager" -AutoRestVersion "latest" -SpecsRepoFork $SpecsRepoFork -SpecsRepoBranch $SpecsRepoBranch
+Start-AutoRestCodeGeneration -ResourceProvider "search/resource-manager" -AutoRestVersion "v2" -SpecsRepoFork $SpecsRepoFork -SpecsRepoBranch $SpecsRepoBranch

--- a/sdk/securitycenter/Microsoft.Azure.Management.SecurityCenter/src/generate.ps1
+++ b/sdk/securitycenter/Microsoft.Azure.Management.SecurityCenter/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "security/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "security/resource-manager" -AutoRestVersion "v2"

--- a/sdk/servicebus/Microsoft.Azure.Management.ServiceBus/src/generate.ps1
+++ b/sdk/servicebus/Microsoft.Azure.Management.ServiceBus/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "servicebus/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "servicebus/resource-manager" -AutoRestVersion "v2"

--- a/sdk/servicefabric/Microsoft.Azure.Management.ServiceFabric/src/generate.ps1
+++ b/sdk/servicefabric/Microsoft.Azure.Management.ServiceFabric/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "servicefabric/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "servicefabric/resource-manager" -AutoRestVersion "v2"

--- a/sdk/signalr/Microsoft.Azure.Management.SignalR/src/generate.ps1
+++ b/sdk/signalr/Microsoft.Azure.Management.SignalR/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "signalr/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "signalr/resource-manager" -AutoRestVersion "v2"

--- a/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/src/generate.ps1
+++ b/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "sql/resource-manager" -AutoRestVersion "latest" -SdkRepoRootPath "."
+Start-AutoRestCodeGeneration -ResourceProvider "sql/resource-manager" -AutoRestVersion "v2" -SdkRepoRootPath "."

--- a/sdk/sqlvirtualmachine/Microsoft.Azure.Management.SqlVirtualMachine/src/generate.ps1
+++ b/sdk/sqlvirtualmachine/Microsoft.Azure.Management.SqlVirtualMachine/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "sqlvirtualmachine/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "sqlvirtualmachine/resource-manager" -AutoRestVersion "v2"

--- a/sdk/storage/Microsoft.Azure.Management.Storage/src/generate.ps1
+++ b/sdk/storage/Microsoft.Azure.Management.Storage/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "storage/resource-manager" -AutoRestVersion "latest" -SdkGenerationDirectory "$PSScriptRoot\Generated"
+Start-AutoRestCodeGeneration -ResourceProvider "storage/resource-manager" -AutoRestVersion "v2" -SdkGenerationDirectory "$PSScriptRoot\Generated"

--- a/sdk/storagecache/Microsoft.Azure.Management.StorageCache/src/generate.ps1
+++ b/sdk/storagecache/Microsoft.Azure.Management.StorageCache/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "storagecache/resource-manager" -AutoRestVersion "latest" -SdkGenerationDirectory "$PSScriptRoot\Generated" -Namespace "Microsoft.Azure.Management.StorageCache"
+Start-AutoRestCodeGeneration -ResourceProvider "storagecache/resource-manager" -AutoRestVersion "v2" -SdkGenerationDirectory "$PSScriptRoot\Generated" -Namespace "Microsoft.Azure.Management.StorageCache"

--- a/sdk/storagesync/Microsoft.Azure.Management.StorageSync/src/generate.ps1
+++ b/sdk/storagesync/Microsoft.Azure.Management.StorageSync/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "storagesync/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "storagesync/resource-manager" -AutoRestVersion "v2"

--- a/sdk/storsimple/Microsoft.Azure.Management.StorSimple/src/generate.ps1
+++ b/sdk/storsimple/Microsoft.Azure.Management.StorSimple/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "storSimple1200Series\resource-manager" -AutoRestVersion "v2" -SdkGenerationDirectory�"$PSScriptRoot\Generated"  
+Start-AutoRestCodeGeneration -ResourceProvider "storSimple1200Series\resource-manager" -AutoRestVersion "v2" -SdkGenerationDirectory "$PSScriptRoot\Generated"  

--- a/sdk/storsimple/Microsoft.Azure.Management.StorSimple/src/generate.ps1
+++ b/sdk/storsimple/Microsoft.Azure.Management.StorSimple/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "storSimple1200Series\resource-manager" -AutoRestVersion "latest" -SdkGenerationDirectory "$PSScriptRoot\Generated"  
+Start-AutoRestCodeGeneration -ResourceProvider "storSimple1200Series\resource-manager" -AutoRestVersion "v2" -SdkGenerationDirectoryï¿½"$PSScriptRoot\Generated"  

--- a/sdk/subscription/Microsoft.Azure.Management.Subscription/src/generate.ps1
+++ b/sdk/subscription/Microsoft.Azure.Management.Subscription/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "subscription/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "subscription/resource-manager" -AutoRestVersion "v2"

--- a/sdk/support/Microsoft.Azure.Management.Support/src/generate.ps1
+++ b/sdk/support/Microsoft.Azure.Management.Support/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "support/resource-manager" -AutoRestVersion "2.0.4413"
+Start-AutoRestCodeGeneration -ResourceProvider "support/resource-manager" -AutoRestVersion "v2"

--- a/sdk/synapse/Microsoft.Azure.Management.Synapse/generate.ps1
+++ b/sdk/synapse/Microsoft.Azure.Management.Synapse/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "synapse/resource-manager" -AutoRestVersion "2.0.4413"
+Start-AutoRestCodeGeneration -ResourceProvider "synapse/resource-manager" -AutoRestVersion "v2"

--- a/sdk/trafficmanager/Microsoft.Azure.Management.TrafficManager/src/generate.ps1
+++ b/sdk/trafficmanager/Microsoft.Azure.Management.TrafficManager/src/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "trafficmanager/resource-manager" -AutoRestVersion "latest" -AutoRestCodeGenerationFlags  "--opt-in-extensible-enums"
+Start-AutoRestCodeGeneration -ResourceProvider "trafficmanager/resource-manager" -AutoRestVersion "v2" -AutoRestCodeGenerationFlags  "--opt-in-extensible-enums"


### PR DESCRIPTION
The PR is to prevent the conflict between track 1 generator and autorest v3.

"V2" is the same as "2.0.4413".