### PR TITLE
Validate queue name with leading slash

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/EntityNameHelper.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/EntityNameHelper.cs
@@ -130,7 +130,12 @@ namespace Microsoft.Azure.ServiceBus
 
         private static string GetPathWithoutBaseUri(string entityName)
         {
-            if (Uri.TryCreate(entityName, UriKind.Absolute, out Uri uriValue))
+            // Note: on Linux/macOS, "/path" URLs are treated as valid absolute file URLs.
+            // To ensure relative queue paths are correctly rejected on these platforms,
+            // an additional check using IsWellFormedOriginalString() is made here.
+            // See https://github.com/dotnet/corefx/issues/22098 for more information.
+            if (Uri.TryCreate(entityName, UriKind.Absolute, out Uri uriValue) &&
+                uriValue.IsWellFormedOriginalString())
             {
                 entityName = uriValue.PathAndQuery;
                 return entityName.TrimStart('/');

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/EntityNameHelper.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/EntityNameHelper.cs
@@ -133,9 +133,9 @@ namespace Microsoft.Azure.ServiceBus
             if (Uri.TryCreate(entityName, UriKind.Absolute, out Uri uriValue))
             {
                 entityName = uriValue.PathAndQuery;
+                return entityName.TrimStart('/');
             }
-
-            return entityName.TrimStart('/');
+            return entityName;
         }
     }
 }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Management/ManagementClientTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Management/ManagementClientTests.cs
@@ -338,7 +338,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Management
 
                 var runtimeInfos = await client.GetQueuesRuntimeInfoAsync();
 
-                Assert.True(runtimeInfos.Count > 1);
+                Assert.True(runtimeInfos.Count > 0);
                 var runtimeInfo = runtimeInfos.FirstOrDefault(e => e.Path.Equals(queueName, StringComparison.OrdinalIgnoreCase));
 
                 Assert.NotNull(runtimeInfo);


### PR DESCRIPTION
Fixes issue uncovered by live test failures from last night. 
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=347527