### PR TITLE
Remove dependency on track 1 Storage mgmt lib

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,19 +116,13 @@ If for any reason there is an update to the build tools, you will then need to f
 
 ### Live testing
 
-Live tests assume a live resource has been created and appropriate environment
-variables have been set for the test process. To automate setting up live
-resources we use created a script called `New-TestResources.ps1` that deploys
-resources for a given service.
+Before running or recording live tests you need to create
+[live test resources](https://github.com/Azure/azure-sdk-for-net/blob/master/eng/common/TestResources/README.md).
+If recording tests, secrets will be sanitized from saved recordings.
+If you will be working on contributions over time, you should consider
+persisting these variables.
 
-To see what resources will be deployed for a live service, check the
-`test-resources.json` ARM template files in the service you wish to deploy for
-testing, for example `sdk\keyvault\test-resources.json`.
-
-To deploy live resources for testing use the steps documented in [`Example 1 of New-TestResources.ps1`](eng/common/TestResources/New-TestResources.ps1.md#example-1)
-to set up a service principal and deploy live testing resources.
-
-To run live tests after deploying live resources:
+To run live tests after creating live resources:
 
 1. Open Developer Command Prompt
 2. Navigate to service directory e.g. _"sdk\keyvault"_
@@ -168,7 +162,7 @@ Follow instructions provided [here](https://docs.microsoft.com/en-us/nuget/consu
 
 You can also achieve this from the command line.
 
-```nuget.exe sources add -Name “Azure SDK for Net Dev Feed” -Source “https://azuresdkartifacts.blob.core.windows.net/azure-sdk-for-net/index.json”```
+```nuget.exe sources add -Name "Azure SDK for Net Dev Feed" -Source "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-for-net/index.json"```
 
 You can then consume packages from this package source, remember to check the [Include prerelease](https://docs.microsoft.com/en-us/nuget/create-packages/prerelease-packages#installing-and-updating-pre-release-packages) box in Visual Studio when searching for the packages.
 

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -109,7 +109,7 @@ trap {
 }
 
 # Enumerate test resources to deploy. Fail if none found.
-$root = [System.IO.Path]::Combine("$PSScriptRoot/../sdk", $ServiceDirectory) | Resolve-Path
+$root = [System.IO.Path]::Combine("$PSScriptRoot/../../../sdk", $ServiceDirectory) | Resolve-Path
 $templateFileName = 'test-resources.json'
 $templateFiles = @()
 

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -447,7 +447,7 @@ Force creation of resources instead of being prompted.
 Connect-AzAccount -Subscription "REPLACE_WITH_SUBSCRIPTION_ID"
 $testAadApp = New-AzADServicePrincipal -Role Owner -DisplayName 'azure-sdk-live-test-app'
 New-TestResources.ps1 `
-    -BaseName 'myalias' `
+    -BaseName 'uuid123' `
     -ServiceDirectory 'keyvault' `
     -TestApplicationId $testAadApp.ApplicationId.ToString() `
     -TestApplicationSecret (ConvertFrom-SecureString $testAadApp.Secret -AsPlainText)
@@ -475,14 +475,6 @@ New-TestResources.ps1 `
 Run this in an Azure DevOps CI (with approrpiate variables configured) before
 executing live tests. The script will output variables as secrets (to enable
 log redaction).
-
-.OUTPUTS
-Entries from the ARM templates' "output" section in environment variable syntax
-(e.g. $env:RESOURCE_NAME='<< resource name >>') that can be used for running
-live tests.
-
-If run in -CI mode the environment variables will be output in syntax that Azure
-DevOps can consume.
 
 .LINK
 Remove-TestResources.ps1

--- a/eng/common/TestResources/New-TestResources.ps1.md
+++ b/eng/common/TestResources/New-TestResources.ps1.md
@@ -53,11 +53,10 @@ specified in $ProvisionerApplicationId and $ProvisionerApplicationSecret.
 
 ### EXAMPLE 1
 ```
-$subscriptionId = "REPLACE_WITH_SUBSCRIPTION_ID"
-Connect-AzAccount -Subscription $subscriptionId
+Connect-AzAccount -Subscription "REPLACE_WITH_SUBSCRIPTION_ID"
 $testAadApp = New-AzADServicePrincipal -Role Owner -DisplayName 'azure-sdk-live-test-app'
-.\eng\common\LiveTestResources\New-TestResources.ps1 `
-    -BaseName 'myalias' `
+New-TestResources.ps1 `
+    -BaseName 'uuid123' `
     -ServiceDirectory 'keyvault' `
     -TestApplicationId $testAadApp.ApplicationId.ToString() `
     -TestApplicationSecret (ConvertFrom-SecureString $testAadApp.Secret -AsPlainText)
@@ -71,7 +70,7 @@ the SecureString to plaintext by another means.
 
 ### EXAMPLE 2
 ```
-eng/New-TestResources.ps1 `
+New-TestResources.ps1 `
     -BaseName 'Generated' `
     -ServiceDirectory '$(ServiceDirectory)' `
     -TenantId '$(TenantId)' `
@@ -215,7 +214,7 @@ Accept wildcard characters: False
 ```
 
 ### -SubscriptionId
-Optional subscription ID to use for new resources when logging in as a 
+Optional subscription ID to use for new resources when logging in as a
 provisioner.
 You can also use Set-AzContext if not provisioning.
 
@@ -416,16 +415,12 @@ Accept wildcard characters: False
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
+## INPUTS
+
 ## OUTPUTS
 
-### Entries from the ARM templates' "output" section in environment variable syntax
-### (e.g. $env:RESOURCE_NAME='<< resource name >>') that can be used for running
-### live tests.
-### If run in -CI mode the environment variables will be output in syntax that Azure
-### DevOps can consume.
 ## NOTES
 
 ## RELATED LINKS
 
-[Remove-TestResources.ps1](./New-TestResources.ps1.md)
-
+[Remove-TestResources.ps1](./Remove-TestResources.ps1.md)

--- a/eng/common/TestResources/README.md
+++ b/eng/common/TestResources/README.md
@@ -34,14 +34,14 @@ Along with some log messages, this will output environment variables based on
 your current shell like in the following example:
 
 ```powershell
-$env:AZURE_TENANT_ID = '04acef35-c7bd-4d14-bfd9-59f11b7b9eac'
-$env:AZURE_CLIENT_ID = 'ce1a3a01-424f-4e34-b9a6-823e2b1ae783'
-$env:AZURE_CLIENT_SECRET = 'c27ccc92-e1ca-4d29-8f4e-c6a1ee61ff57'
-$env:AZURE_SUBSCRIPTION_ID = 'd686c17c-aade-4238-bce0-290453cfcf97'
+$env:AZURE_TENANT_ID = '<<secret>>'
+$env:AZURE_CLIENT_ID = '<<secret>>'
+$env:AZURE_CLIENT_SECRET = '<<secret>>'
+$env:AZURE_SUBSCRIPTION_ID = 'YOUR SUBSCRIPTION ID'
 $env:AZURE_RESOURCE_GROUP = 'rg-myusername'
 $env:AZURE_LOCATION = 'westus2'
 $env:AZURE_SEARCH_STORAGE_NAME = 'myusernamestg'
-$env:AZURE_SEARCH_STORAGE_KEY = 'Of2O5Snep5tl13bfjh02/fSNYfrBPXV7CYK7EVnMm/z9fN7zCcq6WKuWfZDM9QsTORvC7zYLifyIEtymI5VCmA=='
+$env:AZURE_SEARCH_STORAGE_KEY = '<<secret>>'
 ```
 
 For security reasons we do not set these environment variables automatically

--- a/eng/common/TestResources/README.md
+++ b/eng/common/TestResources/README.md
@@ -1,29 +1,112 @@
 # Live Test Resource Management
 
-Live test runs require pre-existing resources in Azure. This set of PowerShell
-commands automates creation and teardown of live test resources for Desktop and
-CI scenarios.
+Running and recording live tests often requires first creating some resources
+in Azure. Service directories that include a test-resources.yml file require
+running [New-TestResources.ps1][] to create these resources and output
+environment variables you must set.
 
-* [New-TestResources.ps1](./New-TestResources.ps1.md) - Create new test resources
-for the given service.
-* [Remove-TestResources.ps1](./New-TestResources.ps1.md) - Deletes resources
+The following scripts can be used both in on your desktop for developer
+scenarios as well as on hosted agents for continuous integration testing.
+
+* [New-TestResources.ps1][] - Creates new test resources for a given service.
+* [Remove-TestResources.ps1][] - Deletes previously created resources.
 
 ## On the Desktop
 
-Run `New-TestResources.ps1` on your desktop to create live test resources for a
-given service (e.g. Storage, Key Vault, etc.). The command will output
-environment variables that need to be set when running the live tests.
+To set up your Azure account to run live tests, you'll need to log into Azure,
+create a service principal, and set up your resources defined in
+test-resources.json as shown in the following example using Azure Search.
 
-See examples for how to create the needed Service Principals and execute live
-tests.
+Note that `-Subscription` is an optional parameter but recommended if your account
+is a member of multiple subscriptions.
+
+```powershell
+Connect-AzAccount -Subscription 'YOUR SUBSCRIPTION ID'
+$sp = New-AzADServicePrincipal -Role Owner
+eng\common\TestResources\New-TestResources.ps1 `
+  -BaseName 'myusername' `
+  -ServiceDirectory 'search' `
+  -TestApplicationId $sp.ApplicationId `
+  -TestApplicationSecret (ConvertFrom-SecureString $sp.Secret -AsPlainText)
+```
+
+Along with some log messages, this will output environment variables based on
+your current shell like in the following example:
+
+```powershell
+$env:AZURE_TENANT_ID = '04acef35-c7bd-4d14-bfd9-59f11b7b9eac'
+$env:AZURE_CLIENT_ID = 'ce1a3a01-424f-4e34-b9a6-823e2b1ae783'
+$env:AZURE_CLIENT_SECRET = 'c27ccc92-e1ca-4d29-8f4e-c6a1ee61ff57'
+$env:AZURE_SUBSCRIPTION_ID = 'd686c17c-aade-4238-bce0-290453cfcf97'
+$env:AZURE_RESOURCE_GROUP = 'rg-myusername'
+$env:AZURE_LOCATION = 'westus2'
+$env:AZURE_SEARCH_STORAGE_NAME = 'myusernamestg'
+$env:AZURE_SEARCH_STORAGE_KEY = 'Of2O5Snep5tl13bfjh02/fSNYfrBPXV7CYK7EVnMm/z9fN7zCcq6WKuWfZDM9QsTORvC7zYLifyIEtymI5VCmA=='
+```
+
+For security reasons we do not set these environment variables automatically
+for either the current process or persistently for future sessions. You must
+do that yourself based on your current platform and shell.
+
+If your current shell was detected properly, you should be able to copy and
+paste the output directly in your terminal and add to your profile script.
+For example, in PowerShell on Windows you can copy the output above and paste
+it back into the terminal to set those environment variables for the current
+process. To persist these variables for future terminal sessions or for
+applications started outside the terminal, you could copy and paste the
+following commands:
+
+```powershell
+setx AZURE_TENANT_ID $env:AZURE_TENANT_ID
+setx AZURE_CLIENT_ID $env:AZURE_CLIENT_ID
+setx AZURE_CLIENT_SECRET $env:AZURE_CLIENT_SECRET
+setx AZURE_SUBSCRIPTION_ID $env:AZURE_SUBSCRIPTION_ID
+setx AZURE_RESOURCE_GROUP $env:AZURE_RESOURCE_GROUP
+setx AZURE_LOCATION $env:AZURE_LOCATION
+setx AZURE_SEARCH_STORAGE_NAME $env:AZURE_SEARCH_STORAGE_NAME
+setx AZURE_SEARCH_STORAGE_KEY $env:AZURE_SEARCH_STORAGE_KEY
+```
+
+After running or recording live tests, if you do not plan on further testing
+you can remove the test resources you created above by running
+[Remove-TestResources.ps1][]:
+
+```powershell
+Remove-TestResources.ps1 -BaseName 'myusername' -Force
+```
+
+If you persisted environment variables, you should also remove those as well.
 
 ## In CI
 
-The `New-TestResources.ps1` script is invoked on each test job to create an
-isolated environment for live tests. Test resource isolation makes it easier to
-parallelize test runs.
+Test pipelines should include deploy-test-resources.yml and
+remove-test-resources.yml like in the following examples:
 
-## Other
+```yml
+- template: /eng/common/TestResources/deploy-test-resources.yml
+  parameters:
+    ServiceDirectory: '${{ parameters.ServiceDirectory }}'
 
-PowerShell markdown documentation created with
-[PlatyPS](https://github.com/PowerShell/platyPS)
+# Run tests
+
+- template: /eng/common/TestResources/remove-test-resources.yml
+```
+
+Be sure to link the **Secrets for Resource Provisioner** variable group
+into the test pipeline for these scripts to work.
+
+## Documentation
+
+To regenerate documentation for scripts within this directory, you can install
+[platyPS][] and run it like in the following example:
+
+```powershell
+Install-Module platyPS -Scope CurrentUser -Force
+New-MarkdownHelp -Command .\New-TestResources.ps1 -OutputFolder . -Force
+```
+
+PowerShell markdown documentation created with [platyPS][].
+
+  [New-TestResources.ps1]: ./New-TestResources.ps1.md
+  [Remove-TestResources.ps1]: ./Remove-TestResources.ps1.md
+  [platyPS]: https://github.com/PowerShell/platyPS

--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -165,7 +165,7 @@ Name of the cloud environment. The default is the Azure Public Cloud
 Force removal of resource group without asking for user confirmation
 
 .EXAMPLE
-./Remove-TestResources.ps1 -BaseName uuid123 -Force
+Remove-TestResources.ps1 -BaseName 'uuid123' -Force
 
 Use the currently logged-in account to delete the resource group by the name of
 'rg-uuid123'

--- a/eng/common/TestResources/Remove-TestResources.ps1.md
+++ b/eng/common/TestResources/Remove-TestResources.ps1.md
@@ -53,7 +53,7 @@ create resources.
 
 ### EXAMPLE 1
 ```
-./Remove-TestResources.ps1 -BaseName uuid123 -Force
+Remove-TestResources.ps1 -BaseName 'uuid123' -Force
 ```
 
 Use the currently logged-in account to delete the resource group by the name of
@@ -61,7 +61,7 @@ Use the currently logged-in account to delete the resource group by the name of
 
 ### EXAMPLE 2
 ```
-eng/Remove-TestResources.ps1 `
+Remove-TestResources.ps1 `
     -ResourceGroupName "${env:AZURE_RESOURCEGROUP_NAME}" `
     -TenantId '$(TenantId)' `
     -ProvisionerApplicationId '$(AppId)' `
@@ -123,7 +123,7 @@ Accept wildcard characters: False
 ```
 
 ### -SubscriptionId
-Optional subscription ID to use for new resources when logging in as a 
+Optional subscription ID to use for new resources when logging in as a
 provisioner.
 You can also use Set-AzContext if not provisioning.
 
@@ -235,7 +235,12 @@ Accept wildcard characters: False
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
 ## RELATED LINKS
 
 [New-TestResources.ps1](./New-TestResources.ps1.md)
-

--- a/sdk/search/Azure.Search.Documents/tests/Azure.Search.Documents.Tests.csproj
+++ b/sdk/search/Azure.Search.Documents/tests/Azure.Search.Documents.Tests.csproj
@@ -26,7 +26,6 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Azure.Management.Search" />
-    <PackageReference Include="Microsoft.Azure.Management.Storage" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" />
 
     <!-- TODO: Remove this when https://github.com/Azure/azure-sdk-for-net/issues/10592 is resolved. -->

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/CreateAzureBlobIndexer.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/CreateAzureBlobIndexer.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-exlslvxv.search.windows.net/datasources?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-crqluosy.search.windows.net/datasources?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "Content-Length": "310",
+        "Content-Length": "226",
         "Content-Type": "application/json",
-        "traceparent": "00-7aa2c621aab4a144b06f60535d3d36a1-71649f4c7277ad47-00",
+        "traceparent": "00-d101e1bd274e2246aa0ac90fbdcb074b-cc38f403aae8614a-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200409.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -22,10 +22,10 @@
         "name": "adpnetsearchstg",
         "type": "azureblob",
         "credentials": {
-          "connectionString": "DefaultEndpointsProtocol=https;AccountName=adpnetsearchstg;AccountKey=r72v9Brt0bNoOiXHv0wQ9EPNP52SlSxCxspjwfOYFTp\u002BzlMUFURgwUp0hNUHE/Vwnx8UZZfx4hh1n9i0zpIRzA==;EndpointSuffix=core.windows.net"
+          "connectionString": "DefaultEndpointsProtocol=https;AccountName=adpnetsearchstg;AccountKey=Sanitized;EndpointSuffix=core.windows.net"
         },
         "container": {
-          "name": "afmmfxgp"
+          "name": "ejlyochb"
         }
       },
       "StatusCode": 201,
@@ -33,20 +33,20 @@
         "Cache-Control": "no-cache",
         "Content-Length": "363",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 09 Apr 2020 03:38:31 GMT",
-        "elapsed-time": "47",
-        "ETag": "W/\u00220x8D7DC3779D5BEFB\u0022",
+        "Date": "Fri, 10 Apr 2020 02:24:53 GMT",
+        "elapsed-time": "60",
+        "ETag": "W/\u00220x8D7DCF65A75B7DC\u0022",
         "Expires": "-1",
-        "Location": "https://azs-net-exlslvxv.search.windows.net/datasources(\u0027adpnetsearchstg\u0027)?api-version=2019-05-06-Preview",
+        "Location": "https://azs-net-crqluosy.search.windows.net/datasources(\u0027adpnetsearchstg\u0027)?api-version=2019-05-06-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "e8673d53-a1d5-4317-a000-991a0ed53e71",
+        "request-id": "ca4cde43-95fb-46c5-a89c-6c080ab3ca73",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-exlslvxv.search.windows.net/$metadata#datasources/$entity",
-        "@odata.etag": "\u00220x8D7DC3779D5BEFB\u0022",
+        "@odata.context": "https://azs-net-crqluosy.search.windows.net/$metadata#datasources/$entity",
+        "@odata.etag": "\u00220x8D7DCF65A75B7DC\u0022",
         "name": "adpnetsearchstg",
         "description": null,
         "type": "azureblob",
@@ -55,7 +55,7 @@
           "connectionString": null
         },
         "container": {
-          "name": "afmmfxgp",
+          "name": "ejlyochb",
           "query": null
         },
         "dataChangeDetectionPolicy": null,
@@ -63,15 +63,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-exlslvxv.search.windows.net/indexers?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-crqluosy.search.windows.net/indexers?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "api-key": "Sanitized",
         "Content-Length": "83",
         "Content-Type": "application/json",
-        "traceparent": "00-db06c75cc49a024d9b23a2af53529c08-24cb822c6bcc6846-00",
+        "traceparent": "00-f1d7a18567fb3248b3f8b410d9c295b5-65208fbc3f6abb45-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200409.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -83,32 +83,32 @@
       "RequestBody": {
         "name": "jyhrmyol",
         "dataSourceName": "adpnetsearchstg",
-        "targetIndexName": "dxbqdilo"
+        "targetIndexName": "waicuimk"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "357",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 09 Apr 2020 03:38:40 GMT",
-        "elapsed-time": "9378",
-        "ETag": "W/\u00220x8D7DC377F61F933\u0022",
+        "Date": "Fri, 10 Apr 2020 02:25:03 GMT",
+        "elapsed-time": "10559",
+        "ETag": "W/\u00220x8D7DCF6609EBEF1\u0022",
         "Expires": "-1",
-        "Location": "https://azs-net-exlslvxv.search.windows.net/indexers(\u0027jyhrmyol\u0027)?api-version=2019-05-06-Preview",
+        "Location": "https://azs-net-crqluosy.search.windows.net/indexers(\u0027jyhrmyol\u0027)?api-version=2019-05-06-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "565a706c-10a8-4140-90d2-ebde6a1cf405",
+        "request-id": "690b2d19-8594-4428-9828-f2fb1aa7d7e4",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-exlslvxv.search.windows.net/$metadata#indexers/$entity",
-        "@odata.etag": "\u00220x8D7DC377F61F933\u0022",
+        "@odata.context": "https://azs-net-crqluosy.search.windows.net/$metadata#indexers/$entity",
+        "@odata.etag": "\u00220x8D7DCF6609EBEF1\u0022",
         "name": "jyhrmyol",
         "description": null,
         "dataSourceName": "adpnetsearchstg",
         "skillsetName": null,
-        "targetIndexName": "dxbqdilo",
+        "targetIndexName": "waicuimk",
         "disabled": null,
         "schedule": null,
         "parameters": null,
@@ -118,17 +118,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-exlslvxv.search.windows.net/indexers(\u0027jyhrmyol\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-crqluosy.search.windows.net/indexers(\u0027jyhrmyol\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "api-key": "Sanitized",
         "Content-Length": "209",
         "Content-Type": "application/json",
-        "If-Match": "\u00220x8D7DC377F61F933\u0022",
+        "If-Match": "\u00220x8D7DCF6609EBEF1\u0022",
         "Prefer": "return=representation",
-        "traceparent": "00-1871e6a5ff231e469ba5654d116df115-012ec990f2932341-00",
+        "traceparent": "00-e809b7a5edcee8428e8aa66a2015d04a-50b957c1ad12364a-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200409.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -141,34 +141,34 @@
         "name": "jyhrmyol",
         "description": "Updated description",
         "dataSourceName": "adpnetsearchstg",
-        "targetIndexName": "dxbqdilo",
+        "targetIndexName": "waicuimk",
         "fieldMappings": [],
         "outputFieldMappings": [],
-        "@odata.etag": "\u00220x8D7DC377F61F933\u0022"
+        "@odata.etag": "\u00220x8D7DCF6609EBEF1\u0022"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "374",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 09 Apr 2020 03:38:40 GMT",
-        "elapsed-time": "122",
-        "ETag": "W/\u00220x8D7DC377F998E10\u0022",
+        "Date": "Fri, 10 Apr 2020 02:25:04 GMT",
+        "elapsed-time": "170",
+        "ETag": "W/\u00220x8D7DCF6610CFDBC\u0022",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "b1f2783f-75bb-41c5-bfb7-fca2ca1a220b",
+        "request-id": "b9b650af-6d6a-4283-92fa-a0d77fcb5705",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-exlslvxv.search.windows.net/$metadata#indexers/$entity",
-        "@odata.etag": "\u00220x8D7DC377F998E10\u0022",
+        "@odata.context": "https://azs-net-crqluosy.search.windows.net/$metadata#indexers/$entity",
+        "@odata.etag": "\u00220x8D7DCF6610CFDBC\u0022",
         "name": "jyhrmyol",
         "description": "Updated description",
         "dataSourceName": "adpnetsearchstg",
         "skillsetName": null,
-        "targetIndexName": "dxbqdilo",
+        "targetIndexName": "waicuimk",
         "disabled": null,
         "schedule": null,
         "parameters": null,
@@ -178,13 +178,13 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-exlslvxv.search.windows.net/indexers(\u0027jyhrmyol\u0027)/search.status?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-crqluosy.search.windows.net/indexers(\u0027jyhrmyol\u0027)/search.status?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "traceparent": "00-f39eeafd8294774789a60dbe32197b12-4f42be773b8a544c-00",
+        "traceparent": "00-21afcffc7643fa48be74508ef8478ba6-7a8ddb787157e940-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200409.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -197,25 +197,25 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "552",
+        "Content-Length": "551",
         "Content-Type": "application/json; odata.metadata=minimal; odata.streaming=true",
-        "Date": "Thu, 09 Apr 2020 03:38:50 GMT",
-        "elapsed-time": "9",
+        "Date": "Fri, 10 Apr 2020 02:25:14 GMT",
+        "elapsed-time": "12",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "ac1b8c73-d733-46c3-9bac-c20e4d5e63b9",
+        "request-id": "5ed4e3df-9a28-432d-a23d-3395fe8bb06e",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-exlslvxv.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
+        "@odata.context": "https://azs-net-crqluosy.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
         "name": "jyhrmyol",
         "status": "running",
         "lastResult": {
           "status": "inProgress",
           "errorMessage": null,
-          "startTime": "2020-04-09T03:38:42.676Z",
+          "startTime": "2020-04-10T02:25:10.67Z",
           "endTime": null,
           "itemsProcessed": 0,
           "itemsFailed": 0,
@@ -234,13 +234,13 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-exlslvxv.search.windows.net/indexers(\u0027jyhrmyol\u0027)/search.status?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-crqluosy.search.windows.net/indexers(\u0027jyhrmyol\u0027)/search.status?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "traceparent": "00-7a7f706449d9ba488ccaa4df1ab398fd-34ee77581dba694a-00",
+        "traceparent": "00-9d8463df4060df459cff8956009dfdda-72427da98aa88e44-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200409.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -253,30 +253,30 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1517",
+        "Content-Length": "1515",
         "Content-Type": "application/json; odata.metadata=minimal; odata.streaming=true",
-        "Date": "Thu, 09 Apr 2020 03:39:01 GMT",
-        "elapsed-time": "14",
+        "Date": "Fri, 10 Apr 2020 02:25:24 GMT",
+        "elapsed-time": "19",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "a8fe6d69-4068-44e4-a369-975827e63ad0",
+        "request-id": "7b92dd40-7239-46db-896d-b402590be50a",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-exlslvxv.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
+        "@odata.context": "https://azs-net-crqluosy.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
         "name": "jyhrmyol",
         "status": "running",
         "lastResult": {
           "status": "success",
           "errorMessage": null,
-          "startTime": "2020-04-09T03:38:42.692Z",
-          "endTime": "2020-04-09T03:38:53.328Z",
+          "startTime": "2020-04-10T02:25:10.67Z",
+          "endTime": "2020-04-10T02:25:20.543Z",
           "itemsProcessed": 10,
           "itemsFailed": 0,
-          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-09T03:38:42.708Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-09T03:38:12.7080672\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-09T03:38:12.7080672\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-10T02:25:10.685Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-10T02:24:40.6857011\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-10T02:24:40.6857011\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
           "errors": [],
           "warnings": [],
           "metrics": null
@@ -285,12 +285,12 @@
           {
             "status": "success",
             "errorMessage": null,
-            "startTime": "2020-04-09T03:38:42.692Z",
-            "endTime": "2020-04-09T03:38:53.328Z",
+            "startTime": "2020-04-10T02:25:10.67Z",
+            "endTime": "2020-04-10T02:25:20.543Z",
             "itemsProcessed": 10,
             "itemsFailed": 0,
-            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-09T03:38:42.708Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-09T03:38:12.7080672\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-09T03:38:12.7080672\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-10T02:25:10.685Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-10T02:24:40.6857011\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-10T02:24:40.6857011\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
             "errors": [],
             "warnings": [],
             "metrics": null
@@ -304,13 +304,13 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-exlslvxv.search.windows.net/indexers(\u0027jyhrmyol\u0027)/search.run?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-crqluosy.search.windows.net/indexers(\u0027jyhrmyol\u0027)/search.run?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "traceparent": "00-00f0b63f22b9334ab140cb1ace74a754-012a722fc1c7174a-00",
+        "traceparent": "00-a016bb97dc8b3949bfc6b7548cf4d197-d61902e542fe3749-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200409.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -324,23 +324,23 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Thu, 09 Apr 2020 03:39:01 GMT",
-        "elapsed-time": "56",
+        "Date": "Fri, 10 Apr 2020 02:25:24 GMT",
+        "elapsed-time": "133",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "29647eb5-b275-4b39-8f25-c352250c8411",
+        "request-id": "cb9d016c-9dd8-42a3-b66a-56149ac6d064",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://azs-net-exlslvxv.search.windows.net/indexers(\u0027jyhrmyol\u0027)/search.status?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-crqluosy.search.windows.net/indexers(\u0027jyhrmyol\u0027)/search.status?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "traceparent": "00-c51bef18441a13469d2b9bc3b07b0323-b91f0a49d7fbb444-00",
+        "traceparent": "00-a950d45b2e93bb419dd1c50e9984c2bb-facc257a2c37d346-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200409.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -353,30 +353,30 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "2122",
+        "Content-Length": "2121",
         "Content-Type": "application/json; odata.metadata=minimal; odata.streaming=true",
-        "Date": "Thu, 09 Apr 2020 03:39:11 GMT",
-        "elapsed-time": "11",
+        "Date": "Fri, 10 Apr 2020 02:25:33 GMT",
+        "elapsed-time": "12",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "5827980d-55d1-4d61-893c-45073c8c650e",
+        "request-id": "12bb09f8-8fb3-41ee-9525-57c68cc933f5",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-exlslvxv.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
+        "@odata.context": "https://azs-net-crqluosy.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
         "name": "jyhrmyol",
         "status": "running",
         "lastResult": {
           "status": "success",
           "errorMessage": null,
-          "startTime": "2020-04-09T03:39:02.753Z",
-          "endTime": "2020-04-09T03:39:03.112Z",
+          "startTime": "2020-04-10T02:25:24.994Z",
+          "endTime": "2020-04-10T02:25:26.885Z",
           "itemsProcessed": 10,
           "itemsFailed": 0,
-          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00222020-04-09T03:38:12.708Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-09T03:39:02.768Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-09T03:38:32.7685738\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-09T03:38:32.7685738\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00222020-04-10T02:24:40.685Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-10T02:25:25.026Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-10T02:24:55.0261983\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-10T02:24:55.0261983\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
           "errors": [],
           "warnings": [],
           "metrics": null
@@ -385,12 +385,12 @@
           {
             "status": "success",
             "errorMessage": null,
-            "startTime": "2020-04-09T03:39:02.753Z",
-            "endTime": "2020-04-09T03:39:03.112Z",
+            "startTime": "2020-04-10T02:25:24.994Z",
+            "endTime": "2020-04-10T02:25:26.885Z",
             "itemsProcessed": 10,
             "itemsFailed": 0,
-            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00222020-04-09T03:38:12.708Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-09T03:39:02.768Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-09T03:38:32.7685738\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-09T03:38:32.7685738\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00222020-04-10T02:24:40.685Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-10T02:25:25.026Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-10T02:24:55.0261983\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-10T02:24:55.0261983\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
             "errors": [],
             "warnings": [],
             "metrics": null
@@ -398,12 +398,12 @@
           {
             "status": "success",
             "errorMessage": null,
-            "startTime": "2020-04-09T03:38:42.692Z",
-            "endTime": "2020-04-09T03:38:53.328Z",
+            "startTime": "2020-04-10T02:25:10.67Z",
+            "endTime": "2020-04-10T02:25:20.543Z",
             "itemsProcessed": 10,
             "itemsFailed": 0,
-            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-09T03:38:42.708Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-09T03:38:12.7080672\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-09T03:38:12.7080672\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-10T02:25:10.685Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-10T02:24:40.6857011\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-10T02:24:40.6857011\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
             "errors": [],
             "warnings": [],
             "metrics": null
@@ -417,12 +417,12 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-exlslvxv.search.windows.net/indexes(\u0027dxbqdilo\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-crqluosy.search.windows.net/indexes(\u0027waicuimk\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "api-key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200409.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -437,24 +437,24 @@
         "Cache-Control": "no-cache",
         "Content-Length": "5",
         "Content-Type": "text/plain",
-        "Date": "Thu, 09 Apr 2020 03:39:11 GMT",
-        "elapsed-time": "79",
+        "Date": "Fri, 10 Apr 2020 02:25:33 GMT",
+        "elapsed-time": "4",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "049b0b1f-577c-4ce3-a914-21903e390a03",
+        "request-id": "ceed8504-c204-43d6-8b22-fc2a8bd05d73",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": "\uFEFF10"
     }
   ],
   "Variables": {
-    "AZURE_SEARCH_STORAGE_KEY": "r72v9Brt0bNoOiXHv0wQ9EPNP52SlSxCxspjwfOYFTp\u002BzlMUFURgwUp0hNUHE/Vwnx8UZZfx4hh1n9i0zpIRzA==",
+    "AZURE_SEARCH_STORAGE_KEY": "Sanitized",
     "AZURE_SEARCH_STORAGE_NAME": "adpnetsearchstg",
-    "BlobContainerName": "afmmfxgp",
+    "BlobContainerName": "ejlyochb",
     "RandomSeed": "1401021797",
-    "SearchIndexName": "dxbqdilo",
-    "SearchServiceName": "azs-net-exlslvxv"
+    "SearchIndexName": "waicuimk",
+    "SearchServiceName": "azs-net-crqluosy"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/CreateAzureBlobIndexer.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/CreateAzureBlobIndexer.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-peprnuco.search.windows.net/datasources?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-exlslvxv.search.windows.net/datasources?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "Content-Length": "311",
+        "Content-Length": "310",
         "Content-Type": "application/json",
-        "traceparent": "00-4f9844228f7ba541a405338eb0abad8f-56b0a606b505c549-00",
+        "traceparent": "00-7aa2c621aab4a144b06f60535d3d36a1-71649f4c7277ad47-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200407.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -19,35 +19,35 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "azsnetyajaxiuy",
+        "name": "adpnetsearchstg",
         "type": "azureblob",
         "credentials": {
-          "connectionString": "DefaultEndpointsProtocol=https;AccountName=azsnetyajaxiuy;AccountKey=H4Q6\u002BwLogzoaDNWc1BLxgE7OkztuFjblhsRC\u002BKARuaAMt1T1xgdtOvxSG72LVYn9GH0WO65M4eHTMB6h2vQWFA==;EndpointSuffix=core.windows.net"
+          "connectionString": "DefaultEndpointsProtocol=https;AccountName=adpnetsearchstg;AccountKey=r72v9Brt0bNoOiXHv0wQ9EPNP52SlSxCxspjwfOYFTp\u002BzlMUFURgwUp0hNUHE/Vwnx8UZZfx4hh1n9i0zpIRzA==;EndpointSuffix=core.windows.net"
         },
         "container": {
-          "name": "hotels"
+          "name": "afmmfxgp"
         }
       },
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "360",
+        "Content-Length": "363",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Wed, 08 Apr 2020 07:52:11 GMT",
-        "elapsed-time": "45",
-        "ETag": "W/\u00220x8D7DB91BF1D771F\u0022",
+        "Date": "Thu, 09 Apr 2020 03:38:31 GMT",
+        "elapsed-time": "47",
+        "ETag": "W/\u00220x8D7DC3779D5BEFB\u0022",
         "Expires": "-1",
-        "Location": "https://azs-net-peprnuco.search.windows.net/datasources(\u0027azsnetyajaxiuy\u0027)?api-version=2019-05-06-Preview",
+        "Location": "https://azs-net-exlslvxv.search.windows.net/datasources(\u0027adpnetsearchstg\u0027)?api-version=2019-05-06-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "03d15114-a449-436d-913d-7d94d6878d52",
+        "request-id": "e8673d53-a1d5-4317-a000-991a0ed53e71",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-peprnuco.search.windows.net/$metadata#datasources/$entity",
-        "@odata.etag": "\u00220x8D7DB91BF1D771F\u0022",
-        "name": "azsnetyajaxiuy",
+        "@odata.context": "https://azs-net-exlslvxv.search.windows.net/$metadata#datasources/$entity",
+        "@odata.etag": "\u00220x8D7DC3779D5BEFB\u0022",
+        "name": "adpnetsearchstg",
         "description": null,
         "type": "azureblob",
         "subtype": null,
@@ -55,7 +55,7 @@
           "connectionString": null
         },
         "container": {
-          "name": "hotels",
+          "name": "afmmfxgp",
           "query": null
         },
         "dataChangeDetectionPolicy": null,
@@ -63,15 +63,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-peprnuco.search.windows.net/indexers?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-exlslvxv.search.windows.net/indexers?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "Content-Length": "82",
+        "Content-Length": "83",
         "Content-Type": "application/json",
-        "traceparent": "00-51b7e8214ac4864493fad1ba80363d6d-cead04f87047a54e-00",
+        "traceparent": "00-db06c75cc49a024d9b23a2af53529c08-24cb822c6bcc6846-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200407.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -82,33 +82,33 @@
       },
       "RequestBody": {
         "name": "jyhrmyol",
-        "dataSourceName": "azsnetyajaxiuy",
-        "targetIndexName": "ffnomwlj"
+        "dataSourceName": "adpnetsearchstg",
+        "targetIndexName": "dxbqdilo"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "356",
+        "Content-Length": "357",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Wed, 08 Apr 2020 07:52:13 GMT",
-        "elapsed-time": "1567",
-        "ETag": "W/\u00220x8D7DB91C0047EA8\u0022",
+        "Date": "Thu, 09 Apr 2020 03:38:40 GMT",
+        "elapsed-time": "9378",
+        "ETag": "W/\u00220x8D7DC377F61F933\u0022",
         "Expires": "-1",
-        "Location": "https://azs-net-peprnuco.search.windows.net/indexers(\u0027jyhrmyol\u0027)?api-version=2019-05-06-Preview",
+        "Location": "https://azs-net-exlslvxv.search.windows.net/indexers(\u0027jyhrmyol\u0027)?api-version=2019-05-06-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "21e36704-b1ae-426c-a810-ed899d4e1399",
+        "request-id": "565a706c-10a8-4140-90d2-ebde6a1cf405",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-peprnuco.search.windows.net/$metadata#indexers/$entity",
-        "@odata.etag": "\u00220x8D7DB91C0047EA8\u0022",
+        "@odata.context": "https://azs-net-exlslvxv.search.windows.net/$metadata#indexers/$entity",
+        "@odata.etag": "\u00220x8D7DC377F61F933\u0022",
         "name": "jyhrmyol",
         "description": null,
-        "dataSourceName": "azsnetyajaxiuy",
+        "dataSourceName": "adpnetsearchstg",
         "skillsetName": null,
-        "targetIndexName": "ffnomwlj",
+        "targetIndexName": "dxbqdilo",
         "disabled": null,
         "schedule": null,
         "parameters": null,
@@ -118,17 +118,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-peprnuco.search.windows.net/indexers(\u0027jyhrmyol\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-exlslvxv.search.windows.net/indexers(\u0027jyhrmyol\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "Content-Length": "208",
+        "Content-Length": "209",
         "Content-Type": "application/json",
-        "If-Match": "\u00220x8D7DB91C0047EA8\u0022",
+        "If-Match": "\u00220x8D7DC377F61F933\u0022",
         "Prefer": "return=representation",
-        "traceparent": "00-7f1a3a1430e5b34baea2086d59287ea6-09ac0f7bc6072748-00",
+        "traceparent": "00-1871e6a5ff231e469ba5654d116df115-012ec990f2932341-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200407.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -140,35 +140,35 @@
       "RequestBody": {
         "name": "jyhrmyol",
         "description": "Updated description",
-        "dataSourceName": "azsnetyajaxiuy",
-        "targetIndexName": "ffnomwlj",
+        "dataSourceName": "adpnetsearchstg",
+        "targetIndexName": "dxbqdilo",
         "fieldMappings": [],
         "outputFieldMappings": [],
-        "@odata.etag": "\u00220x8D7DB91C0047EA8\u0022"
+        "@odata.etag": "\u00220x8D7DC377F61F933\u0022"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "373",
+        "Content-Length": "374",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Wed, 08 Apr 2020 07:52:13 GMT",
-        "elapsed-time": "89",
-        "ETag": "W/\u00220x8D7DB91C04367D5\u0022",
+        "Date": "Thu, 09 Apr 2020 03:38:40 GMT",
+        "elapsed-time": "122",
+        "ETag": "W/\u00220x8D7DC377F998E10\u0022",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "722c2cb0-ef2d-4404-98da-ce2886aee379",
+        "request-id": "b1f2783f-75bb-41c5-bfb7-fca2ca1a220b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-peprnuco.search.windows.net/$metadata#indexers/$entity",
-        "@odata.etag": "\u00220x8D7DB91C04367D5\u0022",
+        "@odata.context": "https://azs-net-exlslvxv.search.windows.net/$metadata#indexers/$entity",
+        "@odata.etag": "\u00220x8D7DC377F998E10\u0022",
         "name": "jyhrmyol",
         "description": "Updated description",
-        "dataSourceName": "azsnetyajaxiuy",
+        "dataSourceName": "adpnetsearchstg",
         "skillsetName": null,
-        "targetIndexName": "ffnomwlj",
+        "targetIndexName": "dxbqdilo",
         "disabled": null,
         "schedule": null,
         "parameters": null,
@@ -178,13 +178,13 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-peprnuco.search.windows.net/indexers(\u0027jyhrmyol\u0027)/search.status?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-exlslvxv.search.windows.net/indexers(\u0027jyhrmyol\u0027)/search.status?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "traceparent": "00-8fe6dd7d14d2544e903cadbac204cb2e-71222c6e0f13e94b-00",
+        "traceparent": "00-f39eeafd8294774789a60dbe32197b12-4f42be773b8a544c-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200407.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -197,49 +197,35 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1517",
+        "Content-Length": "552",
         "Content-Type": "application/json; odata.metadata=minimal; odata.streaming=true",
-        "Date": "Wed, 08 Apr 2020 07:52:24 GMT",
-        "elapsed-time": "16",
+        "Date": "Thu, 09 Apr 2020 03:38:50 GMT",
+        "elapsed-time": "9",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "7d0952bb-032b-4dc1-aebc-f482ebb11aa6",
+        "request-id": "ac1b8c73-d733-46c3-9bac-c20e4d5e63b9",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-peprnuco.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
+        "@odata.context": "https://azs-net-exlslvxv.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
         "name": "jyhrmyol",
         "status": "running",
         "lastResult": {
-          "status": "success",
+          "status": "inProgress",
           "errorMessage": null,
-          "startTime": "2020-04-08T07:52:14.521Z",
-          "endTime": "2020-04-08T07:52:16.303Z",
-          "itemsProcessed": 10,
+          "startTime": "2020-04-09T03:38:42.676Z",
+          "endTime": null,
+          "itemsProcessed": 0,
           "itemsFailed": 0,
-          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-08T07:52:14.521Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-08T07:51:44.5216544\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-08T07:51:44.5216544\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+          "initialTrackingState": null,
+          "finalTrackingState": null,
           "errors": [],
           "warnings": [],
           "metrics": null
         },
-        "executionHistory": [
-          {
-            "status": "success",
-            "errorMessage": null,
-            "startTime": "2020-04-08T07:52:14.521Z",
-            "endTime": "2020-04-08T07:52:16.303Z",
-            "itemsProcessed": 10,
-            "itemsFailed": 0,
-            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-08T07:52:14.521Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-08T07:51:44.5216544\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-08T07:51:44.5216544\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
-            "errors": [],
-            "warnings": [],
-            "metrics": null
-          }
-        ],
+        "executionHistory": [],
         "limits": {
           "maxRunTime": "PT2M",
           "maxDocumentExtractionSize": 16777216,
@@ -248,13 +234,13 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-peprnuco.search.windows.net/indexers(\u0027jyhrmyol\u0027)/search.run?api-version=2019-05-06-Preview",
-      "RequestMethod": "POST",
+      "RequestUri": "https://azs-net-exlslvxv.search.windows.net/indexers(\u0027jyhrmyol\u0027)/search.status?api-version=2019-05-06-Preview",
+      "RequestMethod": "GET",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "traceparent": "00-6fbed9cdef62514a8ff44132f766eced-cb449f44c7ee2e47-00",
+        "traceparent": "00-7a7f706449d9ba488ccaa4df1ab398fd-34ee77581dba694a-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200407.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -264,63 +250,33 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
-      "StatusCode": 202,
-      "ResponseHeaders": {
-        "Cache-Control": "no-cache",
-        "Content-Length": "0",
-        "Date": "Wed, 08 Apr 2020 07:52:24 GMT",
-        "elapsed-time": "46",
-        "Expires": "-1",
-        "Pragma": "no-cache",
-        "request-id": "68cc9ee7-1544-40a1-8f06-15133c7782ef",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://azs-net-peprnuco.search.windows.net/indexers(\u0027jyhrmyol\u0027)/search.status?api-version=2019-05-06-Preview",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "api-key": "Sanitized",
-        "traceparent": "00-000c0a70af23a94dbf358feabddde10d-6de8e9d3ead3b844-00",
-        "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200407.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": [
-          "0129e5ff-cf3a-d4c2-b3f8-9041f92b79a8",
-          "d8ba6f9f014755f3990d5dee0620541f"
-        ],
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "2122",
+        "Content-Length": "1517",
         "Content-Type": "application/json; odata.metadata=minimal; odata.streaming=true",
-        "Date": "Wed, 08 Apr 2020 07:52:33 GMT",
-        "elapsed-time": "11",
+        "Date": "Thu, 09 Apr 2020 03:39:01 GMT",
+        "elapsed-time": "14",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "dd744f50-01ab-4525-9ee6-ec3d50f74181",
+        "request-id": "a8fe6d69-4068-44e4-a369-975827e63ad0",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-peprnuco.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
+        "@odata.context": "https://azs-net-exlslvxv.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
         "name": "jyhrmyol",
         "status": "running",
         "lastResult": {
           "status": "success",
           "errorMessage": null,
-          "startTime": "2020-04-08T07:52:24.537Z",
-          "endTime": "2020-04-08T07:52:24.902Z",
+          "startTime": "2020-04-09T03:38:42.692Z",
+          "endTime": "2020-04-09T03:38:53.328Z",
           "itemsProcessed": 10,
           "itemsFailed": 0,
-          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00222020-04-08T07:51:44.521Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-08T07:52:24.553Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-08T07:51:54.5534336\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-08T07:51:54.5534336\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-09T03:38:42.708Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-09T03:38:12.7080672\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-09T03:38:12.7080672\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
           "errors": [],
           "warnings": [],
           "metrics": null
@@ -329,25 +285,12 @@
           {
             "status": "success",
             "errorMessage": null,
-            "startTime": "2020-04-08T07:52:24.537Z",
-            "endTime": "2020-04-08T07:52:24.902Z",
+            "startTime": "2020-04-09T03:38:42.692Z",
+            "endTime": "2020-04-09T03:38:53.328Z",
             "itemsProcessed": 10,
             "itemsFailed": 0,
-            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00222020-04-08T07:51:44.521Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-08T07:52:24.553Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-08T07:51:54.5534336\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-08T07:51:54.5534336\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
-            "errors": [],
-            "warnings": [],
-            "metrics": null
-          },
-          {
-            "status": "success",
-            "errorMessage": null,
-            "startTime": "2020-04-08T07:52:14.521Z",
-            "endTime": "2020-04-08T07:52:16.303Z",
-            "itemsProcessed": 10,
-            "itemsFailed": 0,
-            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-08T07:52:14.521Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-08T07:51:44.5216544\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-08T07:51:44.5216544\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-09T03:38:42.708Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-09T03:38:12.7080672\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-09T03:38:12.7080672\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
             "errors": [],
             "warnings": [],
             "metrics": null
@@ -361,12 +304,43 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-peprnuco.search.windows.net/indexes(\u0027ffnomwlj\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-exlslvxv.search.windows.net/indexers(\u0027jyhrmyol\u0027)/search.run?api-version=2019-05-06-Preview",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "api-key": "Sanitized",
+        "traceparent": "00-00f0b63f22b9334ab140cb1ace74a754-012a722fc1c7174a-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": [
+          "0129e5ff-cf3a-d4c2-b3f8-9041f92b79a8",
+          "d8ba6f9f014755f3990d5dee0620541f"
+        ],
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "0",
+        "Date": "Thu, 09 Apr 2020 03:39:01 GMT",
+        "elapsed-time": "56",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "29647eb5-b275-4b39-8f25-c352250c8411",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://azs-net-exlslvxv.search.windows.net/indexers(\u0027jyhrmyol\u0027)/search.status?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "api-key": "Sanitized",
+        "traceparent": "00-c51bef18441a13469d2b9bc3b07b0323-b91f0a49d7fbb444-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200407.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -379,25 +353,108 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "5",
-        "Content-Type": "text/plain",
-        "Date": "Wed, 08 Apr 2020 07:52:33 GMT",
-        "elapsed-time": "50",
+        "Content-Length": "2122",
+        "Content-Type": "application/json; odata.metadata=minimal; odata.streaming=true",
+        "Date": "Thu, 09 Apr 2020 03:39:11 GMT",
+        "elapsed-time": "11",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "b7661aa0-49c4-482a-9120-4c3ae1567ebf",
+        "request-id": "5827980d-55d1-4d61-893c-45073c8c650e",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://azs-net-exlslvxv.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
+        "name": "jyhrmyol",
+        "status": "running",
+        "lastResult": {
+          "status": "success",
+          "errorMessage": null,
+          "startTime": "2020-04-09T03:39:02.753Z",
+          "endTime": "2020-04-09T03:39:03.112Z",
+          "itemsProcessed": 10,
+          "itemsFailed": 0,
+          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00222020-04-09T03:38:12.708Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-09T03:39:02.768Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-09T03:38:32.7685738\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-09T03:38:32.7685738\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+          "errors": [],
+          "warnings": [],
+          "metrics": null
+        },
+        "executionHistory": [
+          {
+            "status": "success",
+            "errorMessage": null,
+            "startTime": "2020-04-09T03:39:02.753Z",
+            "endTime": "2020-04-09T03:39:03.112Z",
+            "itemsProcessed": 10,
+            "itemsFailed": 0,
+            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00222020-04-09T03:38:12.708Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-09T03:39:02.768Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-09T03:38:32.7685738\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-09T03:38:32.7685738\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+            "errors": [],
+            "warnings": [],
+            "metrics": null
+          },
+          {
+            "status": "success",
+            "errorMessage": null,
+            "startTime": "2020-04-09T03:38:42.692Z",
+            "endTime": "2020-04-09T03:38:53.328Z",
+            "itemsProcessed": 10,
+            "itemsFailed": 0,
+            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-09T03:38:42.708Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-09T03:38:12.7080672\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-09T03:38:12.7080672\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+            "errors": [],
+            "warnings": [],
+            "metrics": null
+          }
+        ],
+        "limits": {
+          "maxRunTime": "PT2M",
+          "maxDocumentExtractionSize": 16777216,
+          "maxDocumentContentCharactersToExtract": 32768
+        }
+      }
+    },
+    {
+      "RequestUri": "https://azs-net-exlslvxv.search.windows.net/indexes(\u0027dxbqdilo\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "api-key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": [
+          "fdbe70a4-f146-9be0-16ce-cc6fed5127ff",
+          "319b1f5e508fe75077e796f49c2b7937"
+        ],
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "5",
+        "Content-Type": "text/plain",
+        "Date": "Thu, 09 Apr 2020 03:39:11 GMT",
+        "elapsed-time": "79",
+        "Expires": "-1",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "049b0b1f-577c-4ce3-a914-21903e390a03",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": "\uFEFF10"
     }
   ],
   "Variables": {
+    "AZURE_SEARCH_STORAGE_KEY": "r72v9Brt0bNoOiXHv0wQ9EPNP52SlSxCxspjwfOYFTp\u002BzlMUFURgwUp0hNUHE/Vwnx8UZZfx4hh1n9i0zpIRzA==",
+    "AZURE_SEARCH_STORAGE_NAME": "adpnetsearchstg",
+    "BlobContainerName": "afmmfxgp",
     "RandomSeed": "1401021797",
-    "SearchIndexName": "ffnomwlj",
-    "SearchServiceName": "azs-net-peprnuco",
-    "StorageAccountConnectionString": "DefaultEndpointsProtocol=https;AccountName=azsnetyajaxiuy;AccountKey=H4Q6\u002BwLogzoaDNWc1BLxgE7OkztuFjblhsRC\u002BKARuaAMt1T1xgdtOvxSG72LVYn9GH0WO65M4eHTMB6h2vQWFA==;EndpointSuffix=core.windows.net",
-    "StorageAccountName": "azsnetyajaxiuy"
+    "SearchIndexName": "dxbqdilo",
+    "SearchServiceName": "azs-net-exlslvxv"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/CreateAzureBlobIndexerAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/CreateAzureBlobIndexerAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-phjinuhg.search.windows.net/datasources?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-vmpkricx.search.windows.net/datasources?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "Content-Length": "306",
+        "Content-Length": "310",
         "Content-Type": "application/json",
-        "traceparent": "00-034a796d9718ca4fb9275d0c3b85ee57-f25ee0cdcbe7274f-00",
+        "traceparent": "00-20ac70f5169f3542a51ffa01eb21c25c-7be3a6eb91a76844-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200407.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -19,35 +19,35 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "azsneteamvbfbw",
+        "name": "adpnetsearchstg",
         "type": "azureblob",
         "credentials": {
-          "connectionString": "DefaultEndpointsProtocol=https;AccountName=azsneteamvbfbw;AccountKey=a20wAqHUDFyr0cR\u002ByAYgohrHUryBej3QvfED2bbCBerF96LQI8vzwni4ux35SQagXHLhEHx0FxxE9vWeRuMlXA==;EndpointSuffix=core.windows.net"
+          "connectionString": "DefaultEndpointsProtocol=https;AccountName=adpnetsearchstg;AccountKey=r72v9Brt0bNoOiXHv0wQ9EPNP52SlSxCxspjwfOYFTp\u002BzlMUFURgwUp0hNUHE/Vwnx8UZZfx4hh1n9i0zpIRzA==;EndpointSuffix=core.windows.net"
         },
         "container": {
-          "name": "hotels"
+          "name": "xqjfoxck"
         }
       },
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "360",
+        "Content-Length": "363",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Wed, 08 Apr 2020 07:53:01 GMT",
-        "elapsed-time": "76",
-        "ETag": "W/\u00220x8D7DB91DCF5C5D3\u0022",
+        "Date": "Thu, 09 Apr 2020 03:39:37 GMT",
+        "elapsed-time": "46",
+        "ETag": "W/\u00220x8D7DC37A16180B7\u0022",
         "Expires": "-1",
-        "Location": "https://azs-net-phjinuhg.search.windows.net/datasources(\u0027azsneteamvbfbw\u0027)?api-version=2019-05-06-Preview",
+        "Location": "https://azs-net-vmpkricx.search.windows.net/datasources(\u0027adpnetsearchstg\u0027)?api-version=2019-05-06-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "e9eb4cad-3be7-4a31-b14e-826fab621977",
+        "request-id": "94d7b3b4-e3f9-4abb-9b2a-95c2a8f77606",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-phjinuhg.search.windows.net/$metadata#datasources/$entity",
-        "@odata.etag": "\u00220x8D7DB91DCF5C5D3\u0022",
-        "name": "azsneteamvbfbw",
+        "@odata.context": "https://azs-net-vmpkricx.search.windows.net/$metadata#datasources/$entity",
+        "@odata.etag": "\u00220x8D7DC37A16180B7\u0022",
+        "name": "adpnetsearchstg",
         "description": null,
         "type": "azureblob",
         "subtype": null,
@@ -55,7 +55,7 @@
           "connectionString": null
         },
         "container": {
-          "name": "hotels",
+          "name": "xqjfoxck",
           "query": null
         },
         "dataChangeDetectionPolicy": null,
@@ -63,15 +63,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-phjinuhg.search.windows.net/indexers?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-vmpkricx.search.windows.net/indexers?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "Content-Length": "82",
+        "Content-Length": "83",
         "Content-Type": "application/json",
-        "traceparent": "00-6608ce15455a3c4e9bbe7d0c0fbc0456-0231b37d19ac9d4c-00",
+        "traceparent": "00-b3a5f9d643893f46bf902c2919803009-5008438c346a4f4f-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200407.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -82,33 +82,33 @@
       },
       "RequestBody": {
         "name": "jgiorpcc",
-        "dataSourceName": "azsneteamvbfbw",
-        "targetIndexName": "uelocdkh"
+        "dataSourceName": "adpnetsearchstg",
+        "targetIndexName": "jtsoksuk"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "356",
+        "Content-Length": "357",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Wed, 08 Apr 2020 07:53:11 GMT",
-        "elapsed-time": "9630",
-        "ETag": "W/\u00220x8D7DB91E2A3BEC4\u0022",
+        "Date": "Thu, 09 Apr 2020 03:39:39 GMT",
+        "elapsed-time": "1472",
+        "ETag": "W/\u00220x8D7DC37A23375C7\u0022",
         "Expires": "-1",
-        "Location": "https://azs-net-phjinuhg.search.windows.net/indexers(\u0027jgiorpcc\u0027)?api-version=2019-05-06-Preview",
+        "Location": "https://azs-net-vmpkricx.search.windows.net/indexers(\u0027jgiorpcc\u0027)?api-version=2019-05-06-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "151adc29-362e-414e-960c-77e5033469c8",
+        "request-id": "4c4485bd-dbc1-4fa5-aa58-46b1e40278d7",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-phjinuhg.search.windows.net/$metadata#indexers/$entity",
-        "@odata.etag": "\u00220x8D7DB91E2A3BEC4\u0022",
+        "@odata.context": "https://azs-net-vmpkricx.search.windows.net/$metadata#indexers/$entity",
+        "@odata.etag": "\u00220x8D7DC37A23375C7\u0022",
         "name": "jgiorpcc",
         "description": null,
-        "dataSourceName": "azsneteamvbfbw",
+        "dataSourceName": "adpnetsearchstg",
         "skillsetName": null,
-        "targetIndexName": "uelocdkh",
+        "targetIndexName": "jtsoksuk",
         "disabled": null,
         "schedule": null,
         "parameters": null,
@@ -118,17 +118,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-phjinuhg.search.windows.net/indexers(\u0027jgiorpcc\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-vmpkricx.search.windows.net/indexers(\u0027jgiorpcc\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "Content-Length": "208",
+        "Content-Length": "209",
         "Content-Type": "application/json",
-        "If-Match": "\u00220x8D7DB91E2A3BEC4\u0022",
+        "If-Match": "\u00220x8D7DC37A23375C7\u0022",
         "Prefer": "return=representation",
-        "traceparent": "00-0b663f2a433bc14d93a695e840004176-3643e89b11eae54d-00",
+        "traceparent": "00-ab3c0bb547f18c428fc3720c2a09f799-8c47b4ac3f39fd48-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200407.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -140,35 +140,35 @@
       "RequestBody": {
         "name": "jgiorpcc",
         "description": "Updated description",
-        "dataSourceName": "azsneteamvbfbw",
-        "targetIndexName": "uelocdkh",
+        "dataSourceName": "adpnetsearchstg",
+        "targetIndexName": "jtsoksuk",
         "fieldMappings": [],
         "outputFieldMappings": [],
-        "@odata.etag": "\u00220x8D7DB91E2A3BEC4\u0022"
+        "@odata.etag": "\u00220x8D7DC37A23375C7\u0022"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "373",
+        "Content-Length": "374",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Wed, 08 Apr 2020 07:53:11 GMT",
-        "elapsed-time": "219",
-        "ETag": "W/\u00220x8D7DB91E2E2CF21\u0022",
+        "Date": "Thu, 09 Apr 2020 03:39:39 GMT",
+        "elapsed-time": "179",
+        "ETag": "W/\u00220x8D7DC37A26D5501\u0022",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "8938fb60-45ff-48ac-a65a-cafc84a35d9b",
+        "request-id": "02639883-e1ac-4936-a2de-f30b72870b7d",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-phjinuhg.search.windows.net/$metadata#indexers/$entity",
-        "@odata.etag": "\u00220x8D7DB91E2E2CF21\u0022",
+        "@odata.context": "https://azs-net-vmpkricx.search.windows.net/$metadata#indexers/$entity",
+        "@odata.etag": "\u00220x8D7DC37A26D5501\u0022",
         "name": "jgiorpcc",
         "description": "Updated description",
-        "dataSourceName": "azsneteamvbfbw",
+        "dataSourceName": "adpnetsearchstg",
         "skillsetName": null,
-        "targetIndexName": "uelocdkh",
+        "targetIndexName": "jtsoksuk",
         "disabled": null,
         "schedule": null,
         "parameters": null,
@@ -178,13 +178,13 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-phjinuhg.search.windows.net/indexers(\u0027jgiorpcc\u0027)/search.status?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-vmpkricx.search.windows.net/indexers(\u0027jgiorpcc\u0027)/search.status?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "traceparent": "00-ddd43dd072c7ce4483d3a3e6ddaa0212-5ae3163f45fe3e47-00",
+        "traceparent": "00-74c162779671b24a9527330d4f6e1c8b-c413faefdcf7394e-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200407.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -199,28 +199,28 @@
         "Cache-Control": "no-cache",
         "Content-Length": "1517",
         "Content-Type": "application/json; odata.metadata=minimal; odata.streaming=true",
-        "Date": "Wed, 08 Apr 2020 07:53:22 GMT",
-        "elapsed-time": "47",
+        "Date": "Thu, 09 Apr 2020 03:39:50 GMT",
+        "elapsed-time": "10",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "f02bdc61-b2f8-49f7-b9a0-5783c32ef04a",
+        "request-id": "1a60d2f1-e869-4b23-a0d6-40c7a2aef250",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-phjinuhg.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
+        "@odata.context": "https://azs-net-vmpkricx.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
         "name": "jgiorpcc",
         "status": "running",
         "lastResult": {
           "status": "success",
           "errorMessage": null,
-          "startTime": "2020-04-08T07:53:14.628Z",
-          "endTime": "2020-04-08T07:53:15.347Z",
+          "startTime": "2020-04-09T03:39:40.308Z",
+          "endTime": "2020-04-09T03:39:42.121Z",
           "itemsProcessed": 10,
           "itemsFailed": 0,
-          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-08T07:53:14.644Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-08T07:52:44.6445552\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-08T07:52:44.6445552\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-09T03:39:40.324Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-09T03:39:10.3241323\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-09T03:39:10.3241323\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
           "errors": [],
           "warnings": [],
           "metrics": null
@@ -229,12 +229,12 @@
           {
             "status": "success",
             "errorMessage": null,
-            "startTime": "2020-04-08T07:53:14.628Z",
-            "endTime": "2020-04-08T07:53:15.347Z",
+            "startTime": "2020-04-09T03:39:40.308Z",
+            "endTime": "2020-04-09T03:39:42.121Z",
             "itemsProcessed": 10,
             "itemsFailed": 0,
-            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-08T07:53:14.644Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-08T07:52:44.6445552\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-08T07:52:44.6445552\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-09T03:39:40.324Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-09T03:39:10.3241323\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-09T03:39:10.3241323\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
             "errors": [],
             "warnings": [],
             "metrics": null
@@ -248,13 +248,13 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-phjinuhg.search.windows.net/indexers(\u0027jgiorpcc\u0027)/search.run?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-vmpkricx.search.windows.net/indexers(\u0027jgiorpcc\u0027)/search.run?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "traceparent": "00-49b343582248f2458d601e2b7badc2ef-b86ba993ebd0fe47-00",
+        "traceparent": "00-611182c0e0c9654d9e9c666aea6efb8b-4536aeaadc3b224f-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200407.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -268,23 +268,23 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Wed, 08 Apr 2020 07:53:22 GMT",
-        "elapsed-time": "77",
+        "Date": "Thu, 09 Apr 2020 03:39:50 GMT",
+        "elapsed-time": "61",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "38129920-90d2-442a-9305-97d73f71184f",
+        "request-id": "5e66c78e-c1ba-408d-b873-c7310cc3a95b",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://azs-net-phjinuhg.search.windows.net/indexers(\u0027jgiorpcc\u0027)/search.status?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-vmpkricx.search.windows.net/indexers(\u0027jgiorpcc\u0027)/search.status?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "traceparent": "00-31dff01ba2a8544a884f6b1ecd6a9840-1c2ebcd6589b9e45-00",
+        "traceparent": "00-cc645b3a32363040b13b6d53492b5586-9068bdbec8084049-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200407.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -299,28 +299,28 @@
         "Cache-Control": "no-cache",
         "Content-Length": "2122",
         "Content-Type": "application/json; odata.metadata=minimal; odata.streaming=true",
-        "Date": "Wed, 08 Apr 2020 07:53:32 GMT",
-        "elapsed-time": "18",
+        "Date": "Thu, 09 Apr 2020 03:40:00 GMT",
+        "elapsed-time": "11",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "6affd0ea-e689-4fd4-a34a-16a9bc7b3f02",
+        "request-id": "f44f1489-eb71-4730-882e-91c6ab15cd30",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-phjinuhg.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
+        "@odata.context": "https://azs-net-vmpkricx.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
         "name": "jgiorpcc",
         "status": "running",
         "lastResult": {
           "status": "success",
           "errorMessage": null,
-          "startTime": "2020-04-08T07:53:24.651Z",
-          "endTime": "2020-04-08T07:53:24.979Z",
+          "startTime": "2020-04-09T03:39:52.937Z",
+          "endTime": "2020-04-09T03:39:53.296Z",
           "itemsProcessed": 10,
           "itemsFailed": 0,
-          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00222020-04-08T07:52:44.644Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-08T07:53:24.651Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-08T07:52:54.6512667\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-08T07:52:54.6512667\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00222020-04-09T03:39:10.324Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-09T03:39:52.952Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-09T03:39:22.9529272\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-09T03:39:22.9529272\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
           "errors": [],
           "warnings": [],
           "metrics": null
@@ -329,12 +329,12 @@
           {
             "status": "success",
             "errorMessage": null,
-            "startTime": "2020-04-08T07:53:24.651Z",
-            "endTime": "2020-04-08T07:53:24.979Z",
+            "startTime": "2020-04-09T03:39:52.937Z",
+            "endTime": "2020-04-09T03:39:53.296Z",
             "itemsProcessed": 10,
             "itemsFailed": 0,
-            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00222020-04-08T07:52:44.644Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-08T07:53:24.651Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-08T07:52:54.6512667\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-08T07:52:54.6512667\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00222020-04-09T03:39:10.324Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-09T03:39:52.952Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-09T03:39:22.9529272\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-09T03:39:22.9529272\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
             "errors": [],
             "warnings": [],
             "metrics": null
@@ -342,12 +342,12 @@
           {
             "status": "success",
             "errorMessage": null,
-            "startTime": "2020-04-08T07:53:14.628Z",
-            "endTime": "2020-04-08T07:53:15.347Z",
+            "startTime": "2020-04-09T03:39:40.308Z",
+            "endTime": "2020-04-09T03:39:42.121Z",
             "itemsProcessed": 10,
             "itemsFailed": 0,
-            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-08T07:53:14.644Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-08T07:52:44.6445552\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-08T07:52:44.6445552\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-09T03:39:40.324Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-09T03:39:10.3241323\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-09T03:39:10.3241323\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
             "errors": [],
             "warnings": [],
             "metrics": null
@@ -361,12 +361,12 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-phjinuhg.search.windows.net/indexes(\u0027uelocdkh\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-vmpkricx.search.windows.net/indexes(\u0027jtsoksuk\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "api-key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200407.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -381,23 +381,24 @@
         "Cache-Control": "no-cache",
         "Content-Length": "5",
         "Content-Type": "text/plain",
-        "Date": "Wed, 08 Apr 2020 07:53:32 GMT",
-        "elapsed-time": "22",
+        "Date": "Thu, 09 Apr 2020 03:40:00 GMT",
+        "elapsed-time": "72",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "7ca63b76-7a03-47ef-b87d-84538cce1c31",
+        "request-id": "cfa1c89e-2f23-4099-81e7-345c4f627a86",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": "\uFEFF10"
     }
   ],
   "Variables": {
+    "AZURE_SEARCH_STORAGE_KEY": "r72v9Brt0bNoOiXHv0wQ9EPNP52SlSxCxspjwfOYFTp\u002BzlMUFURgwUp0hNUHE/Vwnx8UZZfx4hh1n9i0zpIRzA==",
+    "AZURE_SEARCH_STORAGE_NAME": "adpnetsearchstg",
+    "BlobContainerName": "xqjfoxck",
     "RandomSeed": "939854059",
-    "SearchIndexName": "uelocdkh",
-    "SearchServiceName": "azs-net-phjinuhg",
-    "StorageAccountConnectionString": "DefaultEndpointsProtocol=https;AccountName=azsneteamvbfbw;AccountKey=a20wAqHUDFyr0cR\u002ByAYgohrHUryBej3QvfED2bbCBerF96LQI8vzwni4ux35SQagXHLhEHx0FxxE9vWeRuMlXA==;EndpointSuffix=core.windows.net",
-    "StorageAccountName": "azsneteamvbfbw"
+    "SearchIndexName": "jtsoksuk",
+    "SearchServiceName": "azs-net-vmpkricx"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/CreateAzureBlobIndexerAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/CreateAzureBlobIndexerAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-vmpkricx.search.windows.net/datasources?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-fsbxkrts.search.windows.net/datasources?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "Content-Length": "310",
+        "Content-Length": "226",
         "Content-Type": "application/json",
-        "traceparent": "00-20ac70f5169f3542a51ffa01eb21c25c-7be3a6eb91a76844-00",
+        "traceparent": "00-81f9e9aaa181b843a93ab0060f46851a-a3baf92cce3fc54b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200409.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -22,10 +22,10 @@
         "name": "adpnetsearchstg",
         "type": "azureblob",
         "credentials": {
-          "connectionString": "DefaultEndpointsProtocol=https;AccountName=adpnetsearchstg;AccountKey=r72v9Brt0bNoOiXHv0wQ9EPNP52SlSxCxspjwfOYFTp\u002BzlMUFURgwUp0hNUHE/Vwnx8UZZfx4hh1n9i0zpIRzA==;EndpointSuffix=core.windows.net"
+          "connectionString": "DefaultEndpointsProtocol=https;AccountName=adpnetsearchstg;AccountKey=Sanitized;EndpointSuffix=core.windows.net"
         },
         "container": {
-          "name": "xqjfoxck"
+          "name": "vjkoiojl"
         }
       },
       "StatusCode": 201,
@@ -33,20 +33,20 @@
         "Cache-Control": "no-cache",
         "Content-Length": "363",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 09 Apr 2020 03:39:37 GMT",
-        "elapsed-time": "46",
-        "ETag": "W/\u00220x8D7DC37A16180B7\u0022",
+        "Date": "Fri, 10 Apr 2020 02:26:02 GMT",
+        "elapsed-time": "65",
+        "ETag": "W/\u00220x8D7DCF6836746C7\u0022",
         "Expires": "-1",
-        "Location": "https://azs-net-vmpkricx.search.windows.net/datasources(\u0027adpnetsearchstg\u0027)?api-version=2019-05-06-Preview",
+        "Location": "https://azs-net-fsbxkrts.search.windows.net/datasources(\u0027adpnetsearchstg\u0027)?api-version=2019-05-06-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "94d7b3b4-e3f9-4abb-9b2a-95c2a8f77606",
+        "request-id": "dbcd8435-c321-4c9f-a3ae-87c321f39dd4",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-vmpkricx.search.windows.net/$metadata#datasources/$entity",
-        "@odata.etag": "\u00220x8D7DC37A16180B7\u0022",
+        "@odata.context": "https://azs-net-fsbxkrts.search.windows.net/$metadata#datasources/$entity",
+        "@odata.etag": "\u00220x8D7DCF6836746C7\u0022",
         "name": "adpnetsearchstg",
         "description": null,
         "type": "azureblob",
@@ -55,7 +55,7 @@
           "connectionString": null
         },
         "container": {
-          "name": "xqjfoxck",
+          "name": "vjkoiojl",
           "query": null
         },
         "dataChangeDetectionPolicy": null,
@@ -63,15 +63,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-vmpkricx.search.windows.net/indexers?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-fsbxkrts.search.windows.net/indexers?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "api-key": "Sanitized",
         "Content-Length": "83",
         "Content-Type": "application/json",
-        "traceparent": "00-b3a5f9d643893f46bf902c2919803009-5008438c346a4f4f-00",
+        "traceparent": "00-0ec5d87a4d9487468f191593664561da-5ab53d179ee37542-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200409.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -83,32 +83,32 @@
       "RequestBody": {
         "name": "jgiorpcc",
         "dataSourceName": "adpnetsearchstg",
-        "targetIndexName": "jtsoksuk"
+        "targetIndexName": "tqkifeie"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "357",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 09 Apr 2020 03:39:39 GMT",
-        "elapsed-time": "1472",
-        "ETag": "W/\u00220x8D7DC37A23375C7\u0022",
+        "Date": "Fri, 10 Apr 2020 02:26:11 GMT",
+        "elapsed-time": "9426",
+        "ETag": "W/\u00220x8D7DCF688E102D0\u0022",
         "Expires": "-1",
-        "Location": "https://azs-net-vmpkricx.search.windows.net/indexers(\u0027jgiorpcc\u0027)?api-version=2019-05-06-Preview",
+        "Location": "https://azs-net-fsbxkrts.search.windows.net/indexers(\u0027jgiorpcc\u0027)?api-version=2019-05-06-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "4c4485bd-dbc1-4fa5-aa58-46b1e40278d7",
+        "request-id": "a9fec215-8fef-4679-bcda-b45e40785d5a",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-vmpkricx.search.windows.net/$metadata#indexers/$entity",
-        "@odata.etag": "\u00220x8D7DC37A23375C7\u0022",
+        "@odata.context": "https://azs-net-fsbxkrts.search.windows.net/$metadata#indexers/$entity",
+        "@odata.etag": "\u00220x8D7DCF688E102D0\u0022",
         "name": "jgiorpcc",
         "description": null,
         "dataSourceName": "adpnetsearchstg",
         "skillsetName": null,
-        "targetIndexName": "jtsoksuk",
+        "targetIndexName": "tqkifeie",
         "disabled": null,
         "schedule": null,
         "parameters": null,
@@ -118,17 +118,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-vmpkricx.search.windows.net/indexers(\u0027jgiorpcc\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-fsbxkrts.search.windows.net/indexers(\u0027jgiorpcc\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "api-key": "Sanitized",
         "Content-Length": "209",
         "Content-Type": "application/json",
-        "If-Match": "\u00220x8D7DC37A23375C7\u0022",
+        "If-Match": "\u00220x8D7DCF688E102D0\u0022",
         "Prefer": "return=representation",
-        "traceparent": "00-ab3c0bb547f18c428fc3720c2a09f799-8c47b4ac3f39fd48-00",
+        "traceparent": "00-8bf7ee71173913448955761cfaa1ca1a-57ae2495b9ea7f4a-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200409.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -141,34 +141,34 @@
         "name": "jgiorpcc",
         "description": "Updated description",
         "dataSourceName": "adpnetsearchstg",
-        "targetIndexName": "jtsoksuk",
+        "targetIndexName": "tqkifeie",
         "fieldMappings": [],
         "outputFieldMappings": [],
-        "@odata.etag": "\u00220x8D7DC37A23375C7\u0022"
+        "@odata.etag": "\u00220x8D7DCF688E102D0\u0022"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "374",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Thu, 09 Apr 2020 03:39:39 GMT",
-        "elapsed-time": "179",
-        "ETag": "W/\u00220x8D7DC37A26D5501\u0022",
+        "Date": "Fri, 10 Apr 2020 02:26:11 GMT",
+        "elapsed-time": "128",
+        "ETag": "W/\u00220x8D7DCF6891D5341\u0022",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "02639883-e1ac-4936-a2de-f30b72870b7d",
+        "request-id": "fc535fd9-d185-4fc7-b27d-2d78b96e715c",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-vmpkricx.search.windows.net/$metadata#indexers/$entity",
-        "@odata.etag": "\u00220x8D7DC37A26D5501\u0022",
+        "@odata.context": "https://azs-net-fsbxkrts.search.windows.net/$metadata#indexers/$entity",
+        "@odata.etag": "\u00220x8D7DCF6891D5341\u0022",
         "name": "jgiorpcc",
         "description": "Updated description",
         "dataSourceName": "adpnetsearchstg",
         "skillsetName": null,
-        "targetIndexName": "jtsoksuk",
+        "targetIndexName": "tqkifeie",
         "disabled": null,
         "schedule": null,
         "parameters": null,
@@ -178,13 +178,13 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-vmpkricx.search.windows.net/indexers(\u0027jgiorpcc\u0027)/search.status?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-fsbxkrts.search.windows.net/indexers(\u0027jgiorpcc\u0027)/search.status?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "traceparent": "00-74c162779671b24a9527330d4f6e1c8b-c413faefdcf7394e-00",
+        "traceparent": "00-cf7dcbfde570414c9e56b16519947d66-2e361bdbd1cf6144-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200409.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -197,30 +197,30 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1517",
+        "Content-Length": "1511",
         "Content-Type": "application/json; odata.metadata=minimal; odata.streaming=true",
-        "Date": "Thu, 09 Apr 2020 03:39:50 GMT",
-        "elapsed-time": "10",
+        "Date": "Fri, 10 Apr 2020 02:26:21 GMT",
+        "elapsed-time": "15",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "1a60d2f1-e869-4b23-a0d6-40c7a2aef250",
+        "request-id": "9739397b-a226-4f74-95b0-f150feef685d",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-vmpkricx.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
+        "@odata.context": "https://azs-net-fsbxkrts.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
         "name": "jgiorpcc",
         "status": "running",
         "lastResult": {
           "status": "success",
           "errorMessage": null,
-          "startTime": "2020-04-09T03:39:40.308Z",
-          "endTime": "2020-04-09T03:39:42.121Z",
+          "startTime": "2020-04-10T02:26:14.7Z",
+          "endTime": "2020-04-10T02:26:16.31Z",
           "itemsProcessed": 10,
           "itemsFailed": 0,
-          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-09T03:39:40.324Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-09T03:39:10.3241323\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-09T03:39:10.3241323\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-10T02:26:14.721Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-10T02:25:44.7211405\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-10T02:25:44.7211405\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
           "errors": [],
           "warnings": [],
           "metrics": null
@@ -229,12 +229,12 @@
           {
             "status": "success",
             "errorMessage": null,
-            "startTime": "2020-04-09T03:39:40.308Z",
-            "endTime": "2020-04-09T03:39:42.121Z",
+            "startTime": "2020-04-10T02:26:14.7Z",
+            "endTime": "2020-04-10T02:26:16.31Z",
             "itemsProcessed": 10,
             "itemsFailed": 0,
-            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-09T03:39:40.324Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-09T03:39:10.3241323\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-09T03:39:10.3241323\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-10T02:26:14.721Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-10T02:25:44.7211405\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-10T02:25:44.7211405\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
             "errors": [],
             "warnings": [],
             "metrics": null
@@ -248,13 +248,13 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-vmpkricx.search.windows.net/indexers(\u0027jgiorpcc\u0027)/search.run?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-fsbxkrts.search.windows.net/indexers(\u0027jgiorpcc\u0027)/search.run?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "traceparent": "00-611182c0e0c9654d9e9c666aea6efb8b-4536aeaadc3b224f-00",
+        "traceparent": "00-dec4a64d6531e348aeecd0d581f7f4cb-620e0274de513743-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200409.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -268,23 +268,23 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Thu, 09 Apr 2020 03:39:50 GMT",
-        "elapsed-time": "61",
+        "Date": "Fri, 10 Apr 2020 02:26:21 GMT",
+        "elapsed-time": "72",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "5e66c78e-c1ba-408d-b873-c7310cc3a95b",
+        "request-id": "ff9265a3-7b53-4f95-b36d-73014e47d3d1",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://azs-net-vmpkricx.search.windows.net/indexers(\u0027jgiorpcc\u0027)/search.status?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-fsbxkrts.search.windows.net/indexers(\u0027jgiorpcc\u0027)/search.status?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "api-key": "Sanitized",
-        "traceparent": "00-cc645b3a32363040b13b6d53492b5586-9068bdbec8084049-00",
+        "traceparent": "00-17448514c3ca4942bcf0d983849ba6ec-4fe897cfc3357e42-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200409.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -297,30 +297,30 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "2122",
+        "Content-Length": "2119",
         "Content-Type": "application/json; odata.metadata=minimal; odata.streaming=true",
-        "Date": "Thu, 09 Apr 2020 03:40:00 GMT",
-        "elapsed-time": "11",
+        "Date": "Fri, 10 Apr 2020 02:26:31 GMT",
+        "elapsed-time": "57",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "f44f1489-eb71-4730-882e-91c6ab15cd30",
+        "request-id": "43a75de3-9f76-4c30-8817-e79794fb55a8",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-vmpkricx.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
+        "@odata.context": "https://azs-net-fsbxkrts.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
         "name": "jgiorpcc",
         "status": "running",
         "lastResult": {
           "status": "success",
           "errorMessage": null,
-          "startTime": "2020-04-09T03:39:52.937Z",
-          "endTime": "2020-04-09T03:39:53.296Z",
+          "startTime": "2020-04-10T02:26:24.763Z",
+          "endTime": "2020-04-10T02:26:25.622Z",
           "itemsProcessed": 10,
           "itemsFailed": 0,
-          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00222020-04-09T03:39:10.324Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-09T03:39:52.952Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-09T03:39:22.9529272\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-09T03:39:22.9529272\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00222020-04-10T02:25:44.721Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-10T02:26:24.778Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-10T02:25:54.7787611\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-10T02:25:54.7787611\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
           "errors": [],
           "warnings": [],
           "metrics": null
@@ -329,12 +329,12 @@
           {
             "status": "success",
             "errorMessage": null,
-            "startTime": "2020-04-09T03:39:52.937Z",
-            "endTime": "2020-04-09T03:39:53.296Z",
+            "startTime": "2020-04-10T02:26:24.763Z",
+            "endTime": "2020-04-10T02:26:25.622Z",
             "itemsProcessed": 10,
             "itemsFailed": 0,
-            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00222020-04-09T03:39:10.324Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-09T03:39:52.952Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-09T03:39:22.9529272\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-09T03:39:22.9529272\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00222020-04-10T02:25:44.721Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-10T02:26:24.778Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-10T02:25:54.7787611\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-10T02:25:54.7787611\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
             "errors": [],
             "warnings": [],
             "metrics": null
@@ -342,12 +342,12 @@
           {
             "status": "success",
             "errorMessage": null,
-            "startTime": "2020-04-09T03:39:40.308Z",
-            "endTime": "2020-04-09T03:39:42.121Z",
+            "startTime": "2020-04-10T02:26:14.7Z",
+            "endTime": "2020-04-10T02:26:16.31Z",
             "itemsProcessed": 10,
             "itemsFailed": 0,
-            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-09T03:39:40.324Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-09T03:39:10.3241323\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-09T03:39:10.3241323\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-10T02:26:14.721Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-10T02:25:44.7211405\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-10T02:25:44.7211405\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
             "errors": [],
             "warnings": [],
             "metrics": null
@@ -361,12 +361,12 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-vmpkricx.search.windows.net/indexes(\u0027jtsoksuk\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-fsbxkrts.search.windows.net/indexes(\u0027tqkifeie\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "api-key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200408.1",
+          "azsdk-net-Search.Documents/1.0.0-dev.20200409.1",
           "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": [
@@ -381,24 +381,24 @@
         "Cache-Control": "no-cache",
         "Content-Length": "5",
         "Content-Type": "text/plain",
-        "Date": "Thu, 09 Apr 2020 03:40:00 GMT",
-        "elapsed-time": "72",
+        "Date": "Fri, 10 Apr 2020 02:26:31 GMT",
+        "elapsed-time": "4",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "cfa1c89e-2f23-4099-81e7-345c4f627a86",
+        "request-id": "a7cbb94d-eabf-4d07-9688-d4b0914d70b9",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": "\uFEFF10"
     }
   ],
   "Variables": {
-    "AZURE_SEARCH_STORAGE_KEY": "r72v9Brt0bNoOiXHv0wQ9EPNP52SlSxCxspjwfOYFTp\u002BzlMUFURgwUp0hNUHE/Vwnx8UZZfx4hh1n9i0zpIRzA==",
+    "AZURE_SEARCH_STORAGE_KEY": "Sanitized",
     "AZURE_SEARCH_STORAGE_NAME": "adpnetsearchstg",
-    "BlobContainerName": "xqjfoxck",
+    "BlobContainerName": "vjkoiojl",
     "RandomSeed": "939854059",
-    "SearchIndexName": "jtsoksuk",
-    "SearchServiceName": "azs-net-vmpkricx"
+    "SearchIndexName": "tqkifeie",
+    "SearchServiceName": "azs-net-fsbxkrts"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/Utilities/SearchRecordedTestSanitizer.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Utilities/SearchRecordedTestSanitizer.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
+using System.Text.Encodings.Web;
 using Azure.Core.Testing;
 
 namespace Azure.Search.Documents.Tests
@@ -18,6 +20,36 @@ namespace Azure.Search.Documents.Tests
         private const string ApiKeyHeaderName = "api-key";
 
         /// <summary>
+        /// Secret values to sanitize from body.
+        /// </summary>
+        private readonly HashSet<string> _secrets = new HashSet<string>();
+
+        /// <summary>
+        /// Redact sensitive body content.
+        /// </summary>
+        /// <param name="contentType">The Content-Type of the body content.</param>
+        /// <param name="body">The body content.</param>
+        /// <returns>The sanitized body content.</returns>
+        public override string SanitizeTextBody(string contentType, string body)
+        {
+            if (_secrets.Count > 0 &&
+                !string.IsNullOrEmpty(body) &&
+                contentType != null &&
+                contentType.StartsWith("application/json", StringComparison.OrdinalIgnoreCase))
+            {
+                StringBuilder sanitized = new StringBuilder(body);
+                foreach (string secret in _secrets)
+                {
+                    sanitized.Replace(secret, SanitizeValue);
+                }
+
+                return sanitized.ToString();
+            }
+
+            return base.SanitizeTextBody(contentType, body);
+        }
+
+        /// <summary>
         /// Redact sensitive headers.
         /// </summary>
         /// <param name="headers">The recording headers.</param>
@@ -28,6 +60,27 @@ namespace Azure.Search.Documents.Tests
                 headers[ApiKeyHeaderName] = new string[] { SanitizeValue };
             }
             base.SanitizeHeaders(headers);
+        }
+
+        /// <summary>
+        /// Redact sensitive variables.
+        /// </summary>
+        /// <param name="variableName">The name of the variable.</param>
+        /// <param name="environmentVariableValue">The value of the variable.</param>
+        /// <returns>The sanitized variable value.</returns>
+        public override string SanitizeVariable(string variableName, string environmentVariableValue)
+        {
+            if (SearchResources.StorageAccountKeyVariableName.Equals(variableName, StringComparison.OrdinalIgnoreCase))
+            {
+                // Assumes the secret content is destined to appear in JSON, for which certain common characters in account keys are escaped.
+                // See https://github.com/dotnet/runtime/blob/8640eed0/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
+                string encoded = JavaScriptEncoder.Default.Encode(environmentVariableValue);
+                _secrets.Add(encoded);
+
+                return SanitizeValue;
+            }
+
+            return base.SanitizeVariable(variableName, environmentVariableValue);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/tests/Utilities/SearchResources.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Utilities/SearchResources.cs
@@ -132,7 +132,12 @@ namespace Azure.Search.Documents.Tests
         /// <summary>
         /// The storage account key.
         /// </summary>
-        public string StorageAccountKey => TestFixture.Recording.GetVariableFromEnvironment("AZURE_SEARCH_STORAGE_KEY");
+        public string StorageAccountKey => TestFixture.Recording.GetVariableFromEnvironment(StorageAccountKeyVariableName);
+
+        /// <summary>
+        /// The name of the <see cref="StorageAccountKey"/> environment variable.
+        /// </summary>
+        internal const string StorageAccountKeyVariableName = "AZURE_SEARCH_STORAGE_KEY";
 
         /// <summary>
         /// The storage account connection string.
@@ -540,7 +545,7 @@ namespace Azure.Search.Documents.Tests
                 using CancellationTokenSource cts = new CancellationTokenSource(Settings.Timeout);
 
                 BlobContainerClient client = new BlobContainerClient(StorageAccountConnectionString, BlobContainerName);
-                await client.CreateAsync(cancellationToken: cts.Token);
+                await client.CreateIfNotExistsAsync(cancellationToken: cts.Token);
 
                 RequiresBlobContainerCleanup = true;
 

--- a/sdk/search/Azure.Search.Documents/tests/Utilities/SearchResources.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Utilities/SearchResources.cs
@@ -17,8 +17,6 @@ using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
 using Microsoft.Azure.Management.Search;
 using Microsoft.Azure.Management.Search.Models;
-using Microsoft.Azure.Management.Storage;
-using Microsoft.Azure.Management.Storage.Models;
 using NUnit.Framework;
 
 namespace Azure.Search.Documents.Tests
@@ -129,35 +127,31 @@ namespace Azure.Search.Documents.Tests
         /// <summary>
         /// The storage account name.
         /// </summary>
-        public string StorageAccountName
-        {
-            get => TestFixture.Recording.GetVariable("StorageAccountName", _storageAccountName);
-            set
-            {
-                TestFixture.Recording.SetVariable("StorageAccountName", value);
-                _storageAccountName = value;
-            }
-        }
-        private string _storageAccountName = null;
+        public string StorageAccountName => TestFixture.Recording.GetVariableFromEnvironment("AZURE_SEARCH_STORAGE_NAME");
 
         /// <summary>
-        /// Gets the storage account endpoint for blobs.
+        /// The storage account key.
         /// </summary>
-        public string StorageAccountConnectionString
-        {
-            get => TestFixture.Recording.GetVariable("StorageAccountConnectionString", _storageAccountConnectionString);
-            set
-            {
-                TestFixture.Recording.SetVariable("StorageAccountConnectionString", value);
-                _storageAccountConnectionString = value;
-            }
-        }
-        private string _storageAccountConnectionString;
+        public string StorageAccountKey => TestFixture.Recording.GetVariableFromEnvironment("AZURE_SEARCH_STORAGE_KEY");
 
         /// <summary>
-        /// Gets the name of the blob container.
+        /// The storage account connection string.
         /// </summary>
-        public string BlobContainerName { get; } = "hotels";
+        public string StorageAccountConnectionString => $"DefaultEndpointsProtocol=https;AccountName={StorageAccountName};AccountKey={StorageAccountKey};EndpointSuffix=core.windows.net";
+
+        /// <summary>
+        /// The name of the blob container.
+        /// </summary>
+        public string BlobContainerName
+        {
+            get => TestFixture.Recording.GetVariable("BlobContainerName", _blobContainerName);
+            set
+            {
+                TestFixture.Recording.SetVariable("BlobContainerName", value);
+                _blobContainerName = value;
+            }
+        }
+        private string _blobContainerName = null;
 
         /// <summary>
         /// The name of the index created for test data.
@@ -199,7 +193,7 @@ namespace Azure.Search.Documents.Tests
         /// Flag indicating whether these storage resources need to be cleaned up.
         /// This is true for any storage resources that we created.
         /// </summary>
-        public bool RequiresStorageCleanup { get; private set; }
+        public bool RequiresBlobContainerCleanup { get; private set; }
 
         /// <summary>
         /// The TestFixture with context about our current test run,
@@ -276,13 +270,10 @@ namespace Azure.Search.Documents.Tests
         public static async Task<SearchResources> CreateWithBlobStorageAndIndexAsync(SearchTestBase fixture)
         {
             var resources = new SearchResources(fixture);
-            await Task.WhenAll(
-                resources.CreateSearchServiceAndIndexAsync(),
-                Task.Run(async () =>
-                {
-                    await resources.CreateStorageAccountAsync();
-                    await resources.CreateHotelsContainerAsync();
-                }));
+
+            // Keep them ordered or records may not match seeded random names.
+            await resources.CreateSearchServiceAndIndexAsync();
+            await resources.CreateHotelsBlobContainerAsync();
 
             return resources;
         }
@@ -376,29 +367,12 @@ namespace Azure.Search.Documents.Tests
                 };
 
         /// <summary>
-        /// Creates a storage client that can be used to create and delete storage accounts.
-        /// </summary>
-        /// <returns>
-        /// A storage client that can be used to create and delete storage accounts.
-        /// </returns>
-        private static StorageManagementClient GetStorageManagementClient() =>
-            new StorageManagementClient(
-                new AzureCredentialsFactory().FromServicePrincipal(
-                    Settings.ClientId,
-                    Settings.ClientSecret,
-                    Settings.TenantId,
-                    AzureEnvironment.AzureGlobalCloud))
-                {
-                    SubscriptionId = Settings.SubscriptionId
-                };
-
-        /// <summary>
         /// Automatically delete the Search Service when the resources are no
         /// longer needed.
         /// </summary>
         public async ValueTask DisposeAsync() => await Task.WhenAll(
             DeleteSearchSeviceAsync(),
-            DeleteStorageAccount());
+            DeleteBlobContainerAsync());
 
         /// <summary>
         /// Delete the Search Service created as a test resource.
@@ -415,16 +389,16 @@ namespace Azure.Search.Documents.Tests
         }
 
         /// <summary>
-        /// Delete the storage account created as a test resource.
+        /// Delete the Storage blob container created as a test resource.
         /// </summary>
         /// <returns></returns>
-        private async Task DeleteStorageAccount()
+        private async Task DeleteBlobContainerAsync()
         {
-            if (RequiresStorageCleanup)
+            if (RequiresBlobContainerCleanup)
             {
-                StorageManagementClient client = GetStorageManagementClient();
-                await client.StorageAccounts.DeleteAsync(Settings.ResourceGroup, StorageAccountName);
-                RequiresStorageCleanup = false;
+                BlobContainerClient client = new BlobContainerClient(StorageAccountConnectionString, BlobContainerName);
+                await client.DeleteIfExistsAsync();
+                RequiresBlobContainerCleanup = false;
             }
         }
 
@@ -554,62 +528,21 @@ namespace Azure.Search.Documents.Tests
         }
 
         /// <summary>
-        /// Creates a new storage account.
+        /// Upload <see cref="TestDocuments"/> to a new blob storage container identified by <see cref="BlobContainerName"/>.
         /// </summary>
         /// <returns>The current <see cref="SearchResources"/>.</returns>
-        private async Task<SearchResources> CreateStorageAccountAsync()
+        private async Task<SearchResources> CreateHotelsBlobContainerAsync()
         {
             if (TestFixture.Mode != RecordedTestMode.Playback)
             {
+                BlobContainerName = Settings.Random.GetName(8);
+
                 using CancellationTokenSource cts = new CancellationTokenSource(Settings.Timeout);
 
-                StorageManagementClient client = GetStorageManagementClient();
-
-                // Use same resource name but without dashes that are invalid for storage account names.
-                StorageAccountName = Settings.ResourcePrefix.Replace("-", string.Empty) + Settings.Random.GetName(8);
-                StorageAccountCreateParameters parameters = new StorageAccountCreateParameters
-                {
-                    AccessTier = AccessTier.Hot,
-                    Kind = Microsoft.Azure.Management.Storage.Models.Kind.BlobStorage,
-                    Location = Settings.Location,
-                    Sku = new Microsoft.Azure.Management.Storage.Models.Sku
-                    {
-                        Name = Microsoft.Azure.Management.Storage.Models.SkuName.StandardLRS,
-                    },
-                };
-
-                StorageAccount account = await client.StorageAccounts.CreateAsync(
-                    Settings.ResourceGroup,
-                    StorageAccountName,
-                    parameters,
-                    cts.Token);
-
-                RequiresStorageCleanup = true;
-
-                StorageAccountListKeysResult keys = await client.StorageAccounts.ListKeysAsync(
-                    Settings.ResourceGroup,
-                    account.Name,
-                    cts.Token);
-                StorageAccountKey key = keys.Keys[0];
-
-                StorageAccountConnectionString = $"DefaultEndpointsProtocol=https;AccountName={account.Name};AccountKey={key.Value};EndpointSuffix=core.windows.net";
-            }
-
-            return this;
-        }
-
-        /// <summary>
-        /// Upload <see cref="TestDocuments"/> to a new blob storage container named "hotels".
-        /// </summary>
-        /// <returns>The current <see cref="SearchResources"/>.</returns>
-        private async Task<SearchResources> CreateHotelsContainerAsync()
-        {
-            if (TestFixture.Mode != RecordedTestMode.Playback)
-            {
-                using CancellationTokenSource cts = new CancellationTokenSource(Settings.Timeout);
-
-                BlobContainerClient client = new BlobContainerClient(StorageAccountConnectionString, "hotels");
+                BlobContainerClient client = new BlobContainerClient(StorageAccountConnectionString, BlobContainerName);
                 await client.CreateAsync(cancellationToken: cts.Token);
+
+                RequiresBlobContainerCleanup = true;
 
                 Hotel[] hotels = TestDocuments;
                 List<Task> tasks = new List<Task>(hotels.Length);

--- a/sdk/search/CONTRIBUTING.md
+++ b/sdk/search/CONTRIBUTING.md
@@ -72,55 +72,11 @@ live tests against a pull request by commenting `/azp run net - search - tests`
 in the PR.
 
 ### Live Test Resources
-To set up your Azure account to run live tests, you'll need to log into Azure,
-create a service principal, and set up your resources defined in
-[test-resources.json](./test-resources.json) as shown in the following example.
-Note that `-Subscription` is an optional parameter but recommended if your account
-is a member of multiple subscriptions.
-
-```powershell
-PS C:\src> Connect-AzAccount -Subscription 'YOUR SUBSCRIPTION ID'
-PS C:\src> $sp = New-AzADServicePrincipal -Role Owner
-PS C:\src> eng\common\TestResources\New-TestResources.ps1 `
-  -BaseName 'myusername' `
-  -ServiceDirectory search `
-  -TestApplicationId $sp.ApplicationId `
-  -TestApplicationSecret (ConvertFrom-SecureString $sp.Secret -AsPlainText)
-```
-
-Along with some log messages, this will output environment variables based on your
-current shell like in the following example:
-
-```
-$env:AZURE_TENANT_ID = '04acef35-c7bd-4d14-bfd9-59f11b7b9eac'
-$env:AZURE_CLIENT_ID = 'ce1a3a01-424f-4e34-b9a6-823e2b1ae783'
-$env:AZURE_CLIENT_SECRET = 'c27ccc92-e1ca-4d29-8f4e-c6a1ee61ff57'
-$env:AZURE_SUBSCRIPTION_ID = 'd686c17c-aade-4238-bce0-290453cfcf97'
-$env:AZURE_RESOURCE_GROUP = 'rg-myusername'
-$env:AZURE_LOCATION = 'westus2'
-$env:AZURE_SEARCH_STORAGE_NAME = 'myusernamestg'
-$env:AZURE_SEARCH_STORAGE_KEY = 'Of2O5Snep5tl13bfjh02/fSNYfrBPXV7CYK7EVnMm/z9fN7zCcq6WKuWfZDM9QsTORvC7zYLifyIEtymI5VCmA=='
-```
-
-For security reasons we do not set these environment variables automatically for either
-the current process or persistently for future sessions. You must do that yourself.
-
-If your current shell was detected propertly, you should be able to copy and paste the
-output directly in your terminal and add to your profile script. For example,
-in PowerShell on Windows you could copy and paste the output and run the following command:
-
-```powershell
-$env:AZURE_TENANT_ID = '04acef35-c7bd-4d14-bfd9-59f11b7b9eac'
-$env:AZURE_CLIENT_ID = 'ce1a3a01-424f-4e34-b9a6-823e2b1ae783'
-$env:AZURE_CLIENT_SECRET = 'c27ccc92-e1ca-4d29-8f4e-c6a1ee61ff57'
-$env:AZURE_SUBSCRIPTION_ID = 'd686c17c-aade-4238-bce0-290453cfcf97'
-$env:AZURE_RESOURCE_GROUP = 'rg-myusername'
-$env:AZURE_LOCATION = 'westus2'
-$env:AZURE_SEARCH_STORAGE_NAME = 'myusernamestg'
-$env:AZURE_SEARCH_STORAGE_KEY = 'Of2O5Snep5tl13bfjh02/fSNYfrBPXV7CYK7EVnMm/z9fN7zCcq6WKuWfZDM9QsTORvC7zYLifyIEtymI5VCmA=='
-
-dir env:AZURE* | % { setx $_.Name $_.Value }
-```
+Before running or recording live tests you need to create
+[live test resources](https://github.com/Azure/azure-sdk-for-net/blob/master/eng/common/TestResources/README.md).
+If recording tests, secrets will be sanitized from saved recordings.
+If you will be working on contributions over time, you should consider
+persisting these variables.
 
 ### Samples
 Our samples are structured as unit tests so we can easily verify they're up to

--- a/sdk/search/test-resources.json
+++ b/sdk/search/test-resources.json
@@ -30,7 +30,6 @@
         },
         "testApplicationOid": {
             "type": "string",
-            "defaultValue": "b3653439-8136-4cd5-aac3-2a9460871ca6",
             "metadata": {
                 "description": "The client OID to grant access to test resources."
             }
@@ -43,7 +42,26 @@
             }
         }
     },
-    "resources": [],
+    "variables": {
+        "storageAccountName": "[concat(parameters('baseName'), 'stg')]",
+        "storageApiVersion": "2019-06-01"
+    },
+    "resources": [
+        {
+            "name": "[variables('storageAccountName')]",
+            "type": "Microsoft.Storage/storageAccounts",
+            "apiVersion": "[variables('storageApiVersion')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "accessTier": "Hot",
+                "supportsHttpsTrafficOnly": true
+            },
+            "sku": {
+                "name": "Standard_LRS"
+            },
+            "kind": "BlobStorage"
+        }
+    ],
     "outputs": {
         "AZURE_TENANT_ID": {
             "type": "string",
@@ -68,6 +86,14 @@
         "AZURE_LOCATION": {
             "type": "string",
             "value": "[parameters('location')]"
+        },
+        "AZURE_SEARCH_STORAGE_NAME": {
+            "type": "string",
+            "value": "[variables('storageAccountName')]"
+        },
+        "AZURE_SEARCH_STORAGE_KEY": {
+            "type": "string",
+            "value": "[listKeys(variables('storageAccountName'), variables('storageApiVersion')).keys[0].value]"
         }
     }
 }


### PR DESCRIPTION
Changes CONTRIBUTING.md to use the New-TestResources.ps1 script, along with related PowerShell cmdlets you'd have installed to use the script (instead of mixing that with the az CLI). Removes the dependency on track 1 Microsoft.Azure.Management.Search.

The accounts used to record were removed immediately after successfully recording and playing back tests.

Fixes #11088