### PR TITLE
Use IClientAssertionCertificate instead

### DIFF
--- a/sdk/mgmtcommon/Auth/Az.Auth/Az.Authentication/CertificateAuthenticationProvider.cs
+++ b/sdk/mgmtcommon/Auth/Az.Auth/Az.Authentication/CertificateAuthenticationProvider.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Rest.Azure.Authentication
             _assertionProvider = (clientId) => Task.FromResult<ClientAssertionCertificate>(new ClientAssertionCertificate(clientId, certificateFilePath));
         }
 
-        public CertificateAuthenticationProvider(ClientAssertionCertificate certAssertion, bool IsCertRollOverEnabled) : this()
+        public CertificateAuthenticationProvider(IClientAssertionCertificate certAssertion, bool IsCertRollOverEnabled) : this()
         {
             _isCertRollOverEnabled = IsCertRollOverEnabled;
             _assertionProvider = (clientId) => Task.FromResult<ClientAssertionCertificate>(certAssertion);


### PR DESCRIPTION
After my testing, there is issue in `ClientAssertionCertificate` to sign certificate. https://github.com/Azure/azure-libraries-for-net/pull/1041
I want to use the `IdentityModel.Clients.ActiveDirectory.ClientAssertionCertificate`, so I change the parameter to `IClientAssertionCertificate` instead