### PR TITLE
[Event Hubs Client] Consumer Live Test Refactor

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventGenerator.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventGenerator.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Producer;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   Provides operations related to generating instances of <see cref="EventData" />
+    ///   and <see cref="EventDataBatch" /> for use in testing scenarios.
+    /// </summary>
+    ///
+    public static class EventGenerator
+    {
+        /// <summary>The seed to use for initializing random number generated for a given thread-specific instance.</summary>
+        private static int s_randomSeed = Environment.TickCount;
+
+        /// <summary>The name of the custom event property which holds a test-specific artificial event identifier.</summary>
+        public static readonly string IdPropertyName = $"{ nameof(EventGenerator) }::Identifier";
+
+        /// <summary>The random number generator to use for a specific thread.</summary>
+        private static readonly ThreadLocal<Random> RandomNumberGenerator = new ThreadLocal<Random>(() => new Random(Interlocked.Increment(ref s_randomSeed)), false);
+
+        /// <summary>
+        ///   Creates a set of events with random data and random body size.
+        /// </summary>
+        ///
+        /// <param name="numberOfEvents">The number of events to create.</param>
+        ///
+        /// <returns>The requested set of events.</returns>
+        ///
+        public static IEnumerable<EventData> CreateEvents(int numberOfEvents)
+        {
+            const int minimumBodySize = 15;
+            const int maximumBodySize = 83886;
+
+            for (var index = 0; index < numberOfEvents; ++index)
+            {
+                var buffer = new byte[RandomNumberGenerator.Value.Next(minimumBodySize, maximumBodySize)];
+                RandomNumberGenerator.Value.NextBytes(buffer);
+
+                yield return CreateEventFromBody(buffer);
+            }
+        }
+
+        /// <summary>
+        ///   Creates and configures an <see cref="EventData" /> instance using the
+        ///   provided <paramref name="eventBody" /> as the embedded data.
+        /// </summary>
+        ///
+        /// <param name="eventBody">The set of bytes to use as the data body of the event.</param>
+        ///
+        /// <returns>The event that was created.</returns>
+        ///
+        public static EventData CreateEventFromBody(ReadOnlyMemory<byte> eventBody)
+        {
+            var currentEvent = new EventData(eventBody);
+            currentEvent.Properties.Add(IdPropertyName, Guid.NewGuid().ToString());
+
+            return currentEvent;
+        }
+
+        /// <summary>
+        ///   Builds a set of batches from the provided events.
+        /// </summary>
+        ///
+        /// <param name="events">The events to group into batches.</param>
+        /// <param name="producer">The producer to use for creating batches.</param>
+        /// <param name="batchEvents">A dictionary to which the events included in the batches should be tracked.</param>
+        /// <param name="batchOptions">The set of options to apply when creating batches.</param>
+        /// <param name="cancellationToken">The token used to signal a cancellation request.</param>
+        ///
+        /// <returns>The set of batches needed to contain the entire set of <paramref name="events"/>.</returns>
+        ///
+        /// <remarks>
+        ///   Callers are assumed to be responsible for taking ownership of the lifespan of the returned batches, including
+        ///   their disposal.
+        ///
+        ///   This method is intended for use within the test suite only; it is not hardened for general purpose use.
+        /// </remarks>
+        ///
+        public static async Task<IEnumerable<EventDataBatch>> BuildBatchesAsync(IEnumerable<EventData> events,
+                                                                                EventHubProducerClient producer,
+                                                                                CreateBatchOptions batchOptions = default,
+                                                                                CancellationToken cancellationToken = default)
+        {
+            EventData eventData;
+
+            var queuedEvents = new Queue<EventData>(events);
+            var batches = new List<EventDataBatch>();
+            var currentBatch = default(EventDataBatch);
+
+            while (queuedEvents.Count > 0)
+            {
+                currentBatch ??= (await producer.CreateBatchAsync(batchOptions, cancellationToken).ConfigureAwait(false));
+                eventData = queuedEvents.Peek();
+
+                if (!currentBatch.TryAdd(eventData))
+                {
+                    if (currentBatch.Count == 0)
+                    {
+                        throw new InvalidOperationException("There was an event too large to fit into a batch.");
+                    }
+
+                    batches.Add(currentBatch);
+                    currentBatch = default;
+                }
+                else
+                {
+                   queuedEvents.Dequeue();
+                }
+            }
+
+            if ((currentBatch != default) && (currentBatch.Count > 0))
+            {
+                batches.Add(currentBatch);
+            }
+
+            return batches;
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -32,11 +33,8 @@ namespace Azure.Messaging.EventHubs.Tests
     [Category(TestCategory.DisallowVisualStudioLiveUnitTesting)]
     public class EventHubConsumerClientLiveTests
     {
-        /// <summary>The default retry policy to use when performing operations.</summary>
-        private readonly EventHubsRetryPolicy DefaultRetryPolicy = new EventHubsRetryOptions().ToRetryPolicy();
-
-        /// <summary>The default set of options for reading, allowing a small wait time.</summary>
-        private readonly ReadEventOptions DefaultReadOptions = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(250) };
+        /// <summary>The default set of options for reading, allowing an infinite wait time.</summary>
+        private readonly ReadEventOptions DefaultReadOptions = new ReadEventOptions { MaximumWaitTime = null };
 
         /// <summary>
         ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
@@ -50,17 +48,22 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
                 await using (var connection = new EventHubConnection(connectionString, new EventHubConnectionOptions { TransportType = transportType }))
                 {
-                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
+                    var partition = (await connection.GetPartitionIdsAsync(new EventHubsRetryOptions().ToRetryPolicy(), cancellationSource.Token)).First();
 
                     await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
                     {
-                        Assert.That(async () => await ReadNothingAsync(consumer, partition, EventPosition.Latest), Throws.Nothing);
+                        Assert.That(async () => await ReadNothingAsync(consumer, partition, cancellationSource.Token, EventPosition.Latest), Throws.Nothing);
                     }
                 }
+
+                cancellationSource.Cancel();
             }
         }
 
@@ -76,78 +79,20 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-                var options = new EventHubConsumerClientOptions { RetryOptions = new EventHubsRetryOptions { MaximumRetries = 7 } };
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
 
-                await using (var connection = new EventHubConnection(connectionString, new EventHubConnectionOptions { TransportType = transportType }))
+                var options = new EventHubConsumerClientOptions();
+                options.RetryOptions.MaximumRetries = 7;
+                options.ConnectionOptions.TransportType = transportType;
+
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, TestEnvironment.EventHubsConnectionString, scope.EventHubName, options))
                 {
-                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
-
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection, options))
-                    {
-                        Assert.That(async () => await ReadNothingAsync(consumer, partition, EventPosition.Latest), Throws.Nothing);
-                    }
+                    var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
+                    Assert.That(async () => await ReadNothingAsync(consumer, partition, cancellationSource.Token, EventPosition.Latest), Throws.Nothing);
                 }
-            }
-        }
 
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
-        public async Task ConsumerCanReadSingleEvent()
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
-            {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
-                EventData[] eventBatch = new[]
-                {
-                    new EventData(Encoding.UTF8.GetBytes("Lonely"))
-                };
-
-                await using (var connection = new EventHubConnection(connectionString))
-                {
-                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
-
-                    await using (var producer = new EventHubProducerClient(connection))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
-                    {
-                        var wereEventsPublished = false;
-
-                        async Task<bool> PublishEvents()
-                        {
-                            if (!wereEventsPublished)
-                            {
-                                await producer.SendAsync(eventBatch, new SendEventOptions { PartitionId = partition }).ConfigureAwait(false);
-                                wereEventsPublished = true;
-                            }
-
-                            return false;
-                        }
-
-                        // Read the events.
-
-                        using var cancellationSource = new CancellationTokenSource();
-                        cancellationSource.CancelAfter(TimeSpan.FromSeconds(45));
-
-                        var receivedEvents = await ReadUntilEmptyAsync(consumer, partition, EventPosition.Latest, expectedEventCount: eventBatch.Length, iterationCallback: PublishEvents, cancellationToken: cancellationSource.Token);
-
-                        // Validate the events; because there's a custom equality check, the built-in collection comparison is not adequate.
-
-                        var index = 0;
-
-                        foreach (EventData receivedEvent in receivedEvents.Select(item => item.Data))
-                        {
-                            Assert.That(receivedEvent.IsEquivalentTo(eventBatch[index]), Is.True, $"The received event at index: { index } did not match the sent batch.");
-                            ++index;
-                        }
-
-                        Assert.That(index, Is.EqualTo(eventBatch.Length), "The number of received events did not match the batch size.");
-                    }
-                }
+                cancellationSource.Cancel();
             }
         }
 
@@ -161,53 +106,27 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var singleEvent = EventGenerator.CreateEventFromBody(Array.Empty<byte>());
 
-                EventData[] eventBatch = new[]
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                 {
-                    new EventData(new byte[0])
-                };
+                    var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
+                    await SendEventsAsync(connectionString, new EventData[] { singleEvent }, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
 
-                await using (var connection = new EventHubConnection(connectionString))
-                {
-                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
+                    // Read the events and validate the resulting state.
 
-                    await using (var producer = new EventHubProducerClient(connection))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
-                    {
-                        var wereEventsPublished = false;
+                    var readState = await ReadEventsFromPartitionAsync(consumer, partition, 1, cancellationSource.Token);
 
-                        async Task<bool> PublishEvents()
-                        {
-                            if (!wereEventsPublished)
-                            {
-                                await producer.SendAsync(eventBatch, new SendEventOptions { PartitionId = partition }).ConfigureAwait(false);
-                                wereEventsPublished = true;
-                            }
-
-                            return false;
-                        }
-
-                        // Read the events.
-
-                        using var cancellationSource = new CancellationTokenSource();
-                        cancellationSource.CancelAfter(TimeSpan.FromSeconds(45));
-
-                        var receivedEvents = await ReadUntilEmptyAsync(consumer, partition, EventPosition.Latest, expectedEventCount: eventBatch.Length, iterationCallback: PublishEvents, cancellationToken: cancellationSource.Token);
-
-                        // Validate the events; because there's a custom equality check, the built-in collection comparison is not adequate.
-
-                        var index = 0;
-
-                        foreach (EventData receivedEvent in receivedEvents.Select(item => item.Data))
-                        {
-                            Assert.That(receivedEvent.IsEquivalentTo(eventBatch[index]), Is.True, $"The received event at index: { index } did not match the sent batch.");
-                            ++index;
-                        }
-
-                        Assert.That(index, Is.EqualTo(eventBatch.Length), "The number of received events did not match the batch size.");
-                    }
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+                    Assert.That(readState.Events.Count, Is.EqualTo(1), "A single event was sent.");
+                    Assert.That(readState.Events.Values.Single().Data.IsEquivalentTo(singleEvent), "The single event did not match the corresponding read event.");
                 }
+
+                cancellationSource.Cancel();
             }
         }
 
@@ -217,61 +136,31 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task ConsumerCanReadOneZeroLengthEventSet()
+        public async Task ConsumerCanReadSingleEvent()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var singleEvent = EventGenerator.CreateEvents(1).Single();
 
-                EventData[] eventSet = new[]
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                 {
-                    new EventData(new byte[0]),
-                    new EventData(new byte[0]),
-                    new EventData(new byte[0])
-                };
+                    var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
+                    await SendEventsAsync(connectionString, new EventData[] { singleEvent }, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
 
-                await using (var connection = new EventHubConnection(connectionString))
-                {
-                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
+                    // Read the events and validate the resulting state.
 
-                    await using (var producer = new EventHubProducerClient(connection))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
-                    {
-                        var wereEventsPublished = false;
+                    var readState = await ReadEventsFromPartitionAsync(consumer, partition, 1, cancellationSource.Token);
 
-                        async Task<bool> PublishEvents()
-                        {
-                            if (!wereEventsPublished)
-                            {
-                                await producer.SendAsync(eventSet, new SendEventOptions { PartitionId = partition }).ConfigureAwait(false);
-                                wereEventsPublished = true;
-                            }
-
-                            return false;
-                        }
-
-                        // Read the events.
-
-                        using var cancellationSource = new CancellationTokenSource();
-                        cancellationSource.CancelAfter(TimeSpan.FromSeconds(45));
-
-                        var receivedEvents = await ReadUntilEmptyAsync(consumer, partition, EventPosition.Latest, expectedEventCount: eventSet.Length, iterationCallback: PublishEvents, cancellationToken: cancellationSource.Token);
-
-                        // Validate the events; because there's a custom equality check, the built-in collection comparison is not adequate.
-
-                        var index = 0;
-
-                        Assert.That(receivedEvents, Is.Not.Empty, "There should have been a set of events received.");
-
-                        foreach (EventData receivedEvent in receivedEvents.Select(item => item.Data))
-                        {
-                            Assert.That(receivedEvent.IsEquivalentTo(eventSet[index]), Is.True, $"The received event at index: { index } did not match the sent batch.");
-                            ++index;
-                        }
-
-                        Assert.That(index, Is.EqualTo(eventSet.Length), "The number of received events did not match the batch size.");
-                    }
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+                    Assert.That(readState.Events.Count, Is.EqualTo(1), "A single event was sent.");
+                    Assert.That(readState.Events.Values.Single().Data.IsEquivalentTo(singleEvent), "The single event did not match the corresponding read event.");
                 }
+
+                cancellationSource.Cancel();
             }
         }
 
@@ -281,61 +170,34 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task ConsumerCanReadLargeEvent()
+        public async Task ConsumerCanReadSingleLargeEvent()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
+
+                var buffer = new byte[100000];
+                new Random().NextBytes(buffer);
+
+                var singleEvent = EventGenerator.CreateEventFromBody(buffer);
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
-                // The actual limit is 1046520 for a single event
-
-                EventData[] eventBatch = new[]
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                 {
-                    new EventData(new byte[100000])
-                };
+                    var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
+                    await SendEventsAsync(connectionString, new EventData[] { singleEvent }, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
 
-                await using (var connection = new EventHubConnection(connectionString))
-                {
-                    var retryOptions = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromMinutes(5) };
-                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
+                    // Read the events and validate the resulting state.
 
-                    await using (var producer = new EventHubProducerClient(connection))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
-                    {
-                        var wereEventsPublished = false;
-                        var readOptions = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromSeconds(2) };
+                    var readState = await ReadEventsFromPartitionAsync(consumer, partition, 1, cancellationSource.Token);
 
-                        async Task<bool> PublishEvents()
-                        {
-                            if (!wereEventsPublished)
-                            {
-                                await producer.SendAsync(eventBatch, new SendEventOptions { PartitionId = partition }).ConfigureAwait(false);
-                                wereEventsPublished = true;
-                            }
-
-                            return false;
-                        }
-
-                        // Read the events.
-
-                        using var cancellationSource = new CancellationTokenSource();
-                        cancellationSource.CancelAfter(TimeSpan.FromSeconds(45));
-
-                        var receivedEvents = await ReadUntilEmptyAsync(consumer, partition, EventPosition.Latest, readOptions, expectedEventCount: eventBatch.Length, iterationCallback: PublishEvents, cancellationToken: cancellationSource.Token);
-
-                        // Validate the events; because there's a custom equality check, the built-in collection comparison is not adequate.
-
-                        var index = 0;
-
-                        foreach (EventData receivedEvent in receivedEvents.Select(item => item.Data))
-                        {
-                            Assert.That(receivedEvent.IsEquivalentTo(eventBatch[index]), Is.True, $"The received event at index: { index } did not match the sent batch.");
-                            ++index;
-                        }
-
-                        Assert.That(index, Is.EqualTo(eventBatch.Length), "The number of received events did not match the batch size.");
-                    }
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+                    Assert.That(readState.Events.Count, Is.EqualTo(1), "A single event was sent.");
+                    Assert.That(readState.Events.Values.Single().Data.IsEquivalentTo(singleEvent), "The single event did not match the corresponding read event.");
                 }
+
+                cancellationSource.Cancel();
             }
         }
 
@@ -345,66 +207,39 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task ConsumerCanReadEventWithCustomProperties()
+        public async Task ConsumerCanReadBatchOfZeroLengthEvents()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
-                EventData[] eventBatch = new[]
-                {
-                    new EventData(new byte[] { 0x22, 0x33 }),
-                    new EventData(Encoding.UTF8.GetBytes("This is a really long string of stuff that I wanted to type because I like to")),
-                    new EventData(Encoding.UTF8.GetBytes("I wanted to type because I like to")),
-                    new EventData(Encoding.UTF8.GetBytes("If you are reading this, you really like test cases"))
-                };
+                var sourceEvents = Enumerable
+                    .Range(0, 25)
+                    .Select(index => EventGenerator.CreateEventFromBody(Array.Empty<byte>()))
+                    .ToList();
 
-                for (var index = 0; index < eventBatch.Length; ++index)
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                 {
-                    eventBatch[index].Properties[index.ToString()] = "some value";
-                    eventBatch[index].Properties["Type"] = $"com.microsoft.test.Type{ index }";
-                }
+                    var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
+                    await SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
 
-                await using (var connection = new EventHubConnection(connectionString))
-                {
-                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
+                    // Read the events and validate the resulting state.
 
-                    await using (var producer = new EventHubProducerClient(connection))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
+                    var readState = await ReadEventsFromPartitionAsync(consumer, partition, sourceEvents.Count, cancellationSource.Token);
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    foreach (var sourceEvent in sourceEvents)
                     {
-                        var wereEventsPublished = false;
-
-                        async Task<bool> PublishEvents()
-                        {
-                            if (!wereEventsPublished)
-                            {
-                                await producer.SendAsync(eventBatch, new SendEventOptions { PartitionId = partition }).ConfigureAwait(false);
-                                wereEventsPublished = true;
-                            }
-
-                            return false;
-                        }
-
-                        // Read the events.
-
-                        using var cancellationSource = new CancellationTokenSource();
-                        cancellationSource.CancelAfter(TimeSpan.FromSeconds(45));
-
-                        var receivedEvents = await ReadUntilEmptyAsync(consumer, partition, EventPosition.Latest, expectedEventCount: eventBatch.Length, iterationCallback: PublishEvents, cancellationToken: cancellationSource.Token);
-
-                        // Validate the events; because there's a custom equality check, the built-in collection comparison is not adequate.
-
-                        var index = 0;
-
-                        foreach (EventData receivedEvent in receivedEvents.Select(item => item.Data))
-                        {
-                            Assert.That(receivedEvent.IsEquivalentTo(eventBatch[index]), Is.True, $"The received event at index: { index } did not match the sent batch.");
-                            ++index;
-                        }
-
-                        Assert.That(index, Is.EqualTo(eventBatch.Length), "The number of received events did not match the batch size.");
+                        var sourceId = sourceEvent.Properties[EventGenerator.IdPropertyName].ToString();
+                        Assert.That(readState.Events.TryGetValue(sourceId, out var readEvent), Is.True, $"The event with custom identifier [{ sourceId }] was not processed." );
+                        Assert.That(sourceEvent.IsEquivalentTo(readEvent.Data), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event.");
                     }
                 }
+
+                cancellationSource.Cancel();
             }
         }
 
@@ -414,56 +249,35 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task ConsumerCanReadFromLatestEvent()
+        public async Task ConsumerCanReadBatchOfEvents()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var sourceEvents = EventGenerator.CreateEvents(500).ToList();
 
-                await using (var connection = new EventHubConnection(connectionString))
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                 {
-                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
-                    var expectedEventsCount = 1;
-                    var wereEventsPublished = false;
+                    var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
+                    await SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
 
-                    var stampEvent = new EventData(new byte[1]);
-                    stampEvent.Properties["stamp"] = Guid.NewGuid().ToString();
+                    // Read the events and validate the resulting state.
 
-                    await using (var producer = new EventHubProducerClient(connection))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
+                    var readState = await ReadEventsFromPartitionAsync(consumer, partition, sourceEvents.Count, cancellationSource.Token);
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    foreach (var sourceEvent in sourceEvents)
                     {
-                        // Sending some events beforehand so the partition has some information.
-                        // We are not expecting to receive these.
-
-                        for (int i = 0; i < 10; i++)
-                        {
-                            await producer.SendAsync(new EventData(new byte[1]));
-                        }
-
-                        async Task<bool> PublishStampEvent()
-                        {
-                            if (!wereEventsPublished)
-                            {
-                                await producer.SendAsync(stampEvent, new SendEventOptions { PartitionId = partition }).ConfigureAwait(false);
-                                wereEventsPublished = true;
-                            }
-
-                            return false;
-                        }
-
-                        // Read the events.
-
-                        using var cancellationSource = new CancellationTokenSource();
-                        cancellationSource.CancelAfter(TimeSpan.FromSeconds(45));
-
-                        var receivedEvents = await ReadUntilEmptyAsync(consumer, partition, EventPosition.Latest, expectedEventCount: expectedEventsCount, iterationCallback: PublishStampEvent, cancellationToken: cancellationSource.Token);
-
-                        // Validate the events.
-
-                        Assert.That(receivedEvents.Count, Is.EqualTo(expectedEventsCount), $"The number of received events should be { expectedEventsCount }.");
-                        Assert.That(receivedEvents.Single().Data.IsEquivalentTo(stampEvent), Is.True, "The received event did not match the sent event.");
+                        var sourceId = sourceEvent.Properties[EventGenerator.IdPropertyName].ToString();
+                        Assert.That(readState.Events.TryGetValue(sourceId, out var readEvent), Is.True, $"The event with custom identifier [{ sourceId }] was not processed." );
+                        Assert.That(sourceEvent.IsEquivalentTo(readEvent.Data), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event.");
                     }
                 }
+
+                cancellationSource.Cancel();
             }
         }
 
@@ -473,37 +287,173 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task ConsumerCanReadFromEarliestEvent()
+        public async Task ConsumerCanReadEventsWithCustomProperties()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
-                await using (var connection = new EventHubConnection(connectionString))
-                {
-                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
-                    var expectedEventsCount = 10;
-
-                    await using (var producer = new EventHubProducerClient(connection))
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
+                var sourceEvents = EventGenerator.CreateEvents(50)
+                    .Select(current =>
                     {
-                        for (int i = 0; i < expectedEventsCount; i++)
-                        {
-                            await producer.SendAsync(new EventData(new byte[1]), new SendEventOptions { PartitionId = partition });
-                        }
+                        current.Properties["Something"] = DateTimeOffset.UtcNow;
+                        current.Properties["Other"] = Guid.NewGuid().ToString();
 
-                        // Read the events.
+                        return current;
+                    })
+                    .ToList();
 
-                        using var cancellationSource = new CancellationTokenSource();
-                        cancellationSource.CancelAfter(TimeSpan.FromSeconds(45));
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
+                {
+                    var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
+                    await SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
 
-                        var receivedEvents = await ReadUntilEmptyAsync(consumer, partition, EventPosition.Earliest, expectedEventCount: expectedEventsCount, cancellationToken: cancellationSource.Token);
+                    // Read the events and validate the resulting state.
 
-                        // Validate the events.
+                    var readState = await ReadEventsFromPartitionAsync(consumer, partition, sourceEvents.Count, cancellationSource.Token);
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
-                        Assert.That(receivedEvents.Count, Is.EqualTo(expectedEventsCount), $"The number of received events should be { expectedEventsCount }.");
+                    foreach (var sourceEvent in sourceEvents)
+                    {
+                        var sourceId = sourceEvent.Properties[EventGenerator.IdPropertyName].ToString();
+                        Assert.That(readState.Events.TryGetValue(sourceId, out var readEvent), Is.True, $"The event with custom identifier [{ sourceId }] was not processed." );
+                        Assert.That(sourceEvent.IsEquivalentTo(readEvent.Data), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event.");
                     }
                 }
+
+                cancellationSource.Cancel();
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ConsumerCanReadEventsUsingAnIdentityCredential()
+        {
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
+            {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+
+                var credential = new ClientSecretCredential(TestEnvironment.EventHubsTenant, TestEnvironment.EventHubsClient, TestEnvironment.EventHubsSecret);
+                var sourceEvents = EventGenerator.CreateEvents(500).ToList();
+
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, TestEnvironment.FullyQualifiedNamespace, scope.EventHubName, credential))
+                {
+                    var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
+                    var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+                    await SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
+
+                    // Read the events and validate the resulting state.
+
+                    var readState = await ReadEventsFromPartitionAsync(consumer, partition, sourceEvents.Count, cancellationSource.Token);
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    foreach (var sourceEvent in sourceEvents)
+                    {
+                        var sourceId = sourceEvent.Properties[EventGenerator.IdPropertyName].ToString();
+                        Assert.That(readState.Events.TryGetValue(sourceId, out var readEvent), Is.True, $"The event with custom identifier [{ sourceId }] was not processed." );
+                        Assert.That(sourceEvent.IsEquivalentTo(readEvent.Data), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event.");
+                    }
+                }
+
+                cancellationSource.Cancel();
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ConsumerCanReadFromEarliest()
+        {
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
+            {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var sourceEvents = EventGenerator.CreateEvents(200).ToList();
+
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
+                {
+                    var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
+                    await SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
+
+                    // Read the events and validate the resulting state.
+
+                    var readState = await ReadEventsFromPartitionAsync(consumer, partition, sourceEvents.Count, cancellationSource.Token, EventPosition.Earliest);
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    foreach (var sourceEvent in sourceEvents)
+                    {
+                        var sourceId = sourceEvent.Properties[EventGenerator.IdPropertyName].ToString();
+                        Assert.That(readState.Events.TryGetValue(sourceId, out var readEvent), Is.True, $"The event with custom identifier [{ sourceId }] was not processed." );
+                        Assert.That(sourceEvent.IsEquivalentTo(readEvent.Data), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event.");
+                    }
+                }
+
+                cancellationSource.Cancel();
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ConsumerCanReadFromLatest()
+        {
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
+            {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var sourceEvents = EventGenerator.CreateEvents(200).ToList();
+
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
+                {
+                    // Send a set of seed events to the partition, which should not be read.
+
+                    var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
+                    await SendEventsAsync(connectionString, EventGenerator.CreateEvents(50), new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
+
+                    // Begin reading though no events have been published.  This is necessary to open the connection and
+                    // ensure that the consumer is watching the partition.
+
+                    var readTask = ReadEventsFromPartitionAsync(consumer, partition, sourceEvents.Count, cancellationSource.Token, EventPosition.Latest);
+
+                    // Give the consumer a moment to ensure that it is established and then send events for it to read.
+
+                    await Task.Delay(250);
+                    await SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
+
+                    // Await reading of the events and validate the resulting state.
+
+                    var readState = await readTask;
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+                    Assert.That(readState.Events.Count, Is.EqualTo(sourceEvents.Count), "Only the source events should have been read.");
+
+                    foreach (var sourceEvent in sourceEvents)
+                    {
+                        var sourceId = sourceEvent.Properties[EventGenerator.IdPropertyName].ToString();
+                        Assert.That(readState.Events.TryGetValue(sourceId, out var readEvent), Is.True, $"The event with custom identifier [{ sourceId }] was not processed." );
+                        Assert.That(sourceEvent.IsEquivalentTo(readEvent.Data), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event.");
+                    }
+                }
+
+                cancellationSource.Cancel();
             }
         }
 
@@ -519,110 +469,50 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var seedEvents = EventGenerator.CreateEvents(50).ToList();
+                var sourceEvents = EventGenerator.CreateEvents(100).ToList();
 
-                await using (var connection = new EventHubConnection(connectionString))
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                 {
-                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
+                    // Seed the partition with a set of events prior to reading.  When the send call returns, all events were
+                    // accepted by the Event Hubs service and should be available in the partition.  Provide a minor delay to
+                    // allow for any latency within the service.
 
-                    await using (var producer = new EventHubProducerClient(connection))
+                    var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
+
+                    await SendEventsAsync(connectionString, seedEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
+                    await Task.Delay(250);
+
+                    // Query the partition and determine the offset of the last enqueued event, then send the new set
+                    // of events that should appear after the starting position.
+
+                    var lastOffset = (await consumer.GetPartitionPropertiesAsync(partition, cancellationSource.Token)).LastEnqueuedOffset;
+                    var startingPosition = EventPosition.FromOffset(lastOffset, isInclusive);
+
+                    await SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
+
+                    // Read the events and validate the resulting state.
+
+                    var expectedCount = (isInclusive) ? sourceEvents.Count + 1 : sourceEvents.Count;
+                    var readState = await ReadEventsFromPartitionAsync(consumer, partition, expectedCount, cancellationSource.Token, startingPosition);
+
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+                    Assert.That(readState.Events.Count, Is.EqualTo(expectedCount), "The wrong number of events was read for the value of the inclusive flag.");
+                    Assert.That(readState.Events.Values.Any(readEvent => readEvent.Data.Offset == lastOffset), Is.EqualTo(isInclusive), $"The event with offset [{ lastOffset }] was { ((isInclusive) ? "not" : "") } in the set of read events, which is inconsistent with the inclusive flag.");
+
+                    foreach (var sourceEvent in sourceEvents)
                     {
-                        // Sending some events beforehand so the partition has some information.
-
-                        for (var i = 0; i < 10; i++)
-                        {
-                            await producer.SendAsync(new EventData(new byte[1]), new SendEventOptions { PartitionId = partition });
-                        }
-
-                        // Store last enqueued offset.
-
-                        var offset = (await producer.GetPartitionPropertiesAsync(partition)).LastEnqueuedOffset;
-
-                        await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
-                        {
-                            // Send a single event which is expected to go to the end of stream.
-
-                            var stampEvent = new EventData(new byte[1]);
-                            stampEvent.Properties["stamp"] = Guid.NewGuid().ToString();
-
-                            await producer.SendAsync(stampEvent);
-
-                            // Read the events.
-
-                            var expectedEventsCount = isInclusive ? 2 : 1;
-                            var readOptions = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromSeconds(1) };
-
-                            using var cancellationSource = new CancellationTokenSource();
-                            cancellationSource.CancelAfter(TimeSpan.FromSeconds(45));
-
-                            var receivedEvents = await ReadUntilEmptyAsync(consumer, partition, EventPosition.FromOffset(offset, isInclusive), readOptions, expectedEventCount: expectedEventsCount, cancellationToken: cancellationSource.Token);
-
-                            // Validate the events.
-
-                            Assert.That(receivedEvents.Count, Is.EqualTo(expectedEventsCount), $"The number of received events should be { expectedEventsCount }.");
-                            Assert.That(receivedEvents.Last().Data.IsEquivalentTo(stampEvent), Is.True, "The received event did not match the sent event.");
-                        }
+                        var sourceId = sourceEvent.Properties[EventGenerator.IdPropertyName].ToString();
+                        Assert.That(readState.Events.TryGetValue(sourceId, out var readEvent), Is.True, $"The event with custom identifier [{ sourceId }] was not processed." );
+                        Assert.That(sourceEvent.IsEquivalentTo(readEvent.Data), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event.");
                     }
                 }
-            }
-        }
 
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
-        public async Task ConsumerCanReadFromEnqueuedTime()
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
-            {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
-                await using (var connection = new EventHubConnection(connectionString))
-                {
-                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
-
-                    await using (var producer = new EventHubProducerClient(connection))
-                    {
-                        // Sending some events beforehand so the partition has some information.
-
-                        for (var i = 0; i < 10; i++)
-                        {
-                            await producer.SendAsync(new EventData(new byte[1]), new SendEventOptions { PartitionId = partition });
-                        }
-
-                        // Store last enqueued time.
-
-                        DateTimeOffset enqueuedTime = (await producer.GetPartitionPropertiesAsync(partition)).LastEnqueuedTime;
-
-                        // Send a single event which is expected to go to the end of stream.
-                        // We are expecting to receive only this message.
-
-                        var stampEvent = new EventData(new byte[1]);
-                        stampEvent.Properties["stamp"] = Guid.NewGuid().ToString();
-
-                        await producer.SendAsync(stampEvent);
-
-                        await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
-                        {
-                            // Read the events.
-
-                            var expectedEventsCount = 1;
-                            var readOptions = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromSeconds(1) };
-
-                            using var cancellationSource = new CancellationTokenSource();
-                            cancellationSource.CancelAfter(TimeSpan.FromSeconds(45));
-
-                            var receivedEvents = await ReadUntilEmptyAsync(consumer, partition, EventPosition.FromEnqueuedTime(enqueuedTime), readOptions, expectedEventCount: expectedEventsCount, cancellationToken: cancellationSource.Token);
-
-                            // Validate the events.
-
-                            Assert.That(receivedEvents.Count, Is.EqualTo(expectedEventsCount), $"The number of received events should be { expectedEventsCount }.");
-                            Assert.That(receivedEvents.Single().Data.IsEquivalentTo(stampEvent), Is.True, "The received event did not match the sent event.");
-                        }
-                    }
-                }
+                cancellationSource.Cancel();
             }
         }
 
@@ -638,113 +528,50 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
-                await using (var connection = new EventHubConnection(connectionString))
-                {
-                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
-
-                    await using (var producer = new EventHubProducerClient(connection))
-                    {
-                        // Sending some events beforehand so the partition has some information.
-
-                        for (var i = 0; i < 10; i++)
-                        {
-                            await producer.SendAsync(new EventData(new byte[1]));
-                        }
-
-                        // Store last enqueued sequence number.
-
-                        var sequenceNumber = (await producer.GetPartitionPropertiesAsync(partition)).LastEnqueuedSequenceNumber;
-
-                        await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
-                        {
-                            // Send a single event which is expected to go to the end of stream.
-
-                            var stampEvent = new EventData(new byte[1]);
-                            stampEvent.Properties["stamp"] = Guid.NewGuid().ToString();
-
-                            await producer.SendAsync(stampEvent, new SendEventOptions { PartitionId = partition });
-
-                            // Read the events.
-
-                            var expectedEventsCount = isInclusive ? 2 : 1;
-                            var readOptions = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromSeconds(1) };
-
-                            using var cancellationSource = new CancellationTokenSource();
-                            cancellationSource.CancelAfter(TimeSpan.FromSeconds(45));
-
-                            var receivedEvents = await ReadUntilEmptyAsync(consumer, partition, EventPosition.FromSequenceNumber(sequenceNumber, isInclusive), readOptions, expectedEventCount: expectedEventsCount, cancellationToken: cancellationSource.Token);
-
-                            // Validate the events.
-
-                            Assert.That(receivedEvents.Count, Is.EqualTo(expectedEventsCount), $"The number of received events should be { expectedEventsCount }.");
-                            Assert.That(receivedEvents.Last().Data.IsEquivalentTo(stampEvent), Is.True, "The received event did not match the sent event.");
-                        }
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
-        public async Task ConsumerCanReadFromAllPartitions()
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(4))
-            {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromSeconds(90));
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var seedEvents = EventGenerator.CreateEvents(50).ToList();
+                var sourceEvents = EventGenerator.CreateEvents(100).ToList();
 
                 await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                 {
-                    var partitions = await consumer.GetPartitionIdsAsync(cancellationSource.Token);
-                    var eventsPerPartition = 10;
-                    var expectedCount = (eventsPerPartition * partitions.Length);
+                    // Seed the partition with a set of events prior to reading.  When the send call returns, all events were
+                    // accepted by the Event Hubs service and should be available in the partition.  Provide a minor delay to
+                    // allow for any latency within the service.
 
-                    // Send events to each partition.  Because reading begins at the beginning of the partition by
-                    // default, these should be observed without publishing in the read loop.
+                    var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
 
-                    await using (var producer = new EventHubProducerClient(connectionString))
+                    await SendEventsAsync(connectionString, seedEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
+                    await Task.Delay(250);
+
+                    // Query the partition and determine the offset of the last enqueued event, then send the new set
+                    // of events that should appear after the starting position.
+
+                    var lastSequence = (await consumer.GetPartitionPropertiesAsync(partition, cancellationSource.Token)).LastEnqueuedSequenceNumber;
+                    var startingPosition = EventPosition.FromSequenceNumber(lastSequence, isInclusive);
+
+                    await SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
+
+                    // Read the events and validate the resulting state.
+
+                    var expectedCount = (isInclusive) ? sourceEvents.Count + 1 : sourceEvents.Count;
+                    var readState = await ReadEventsFromPartitionAsync(consumer, partition, expectedCount, cancellationSource.Token, startingPosition);
+
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+                    Assert.That(readState.Events.Count, Is.EqualTo(expectedCount), "The wrong number of events was read for the value of the inclusive flag.");
+                    Assert.That(readState.Events.Values.Any(readEvent => readEvent.Data.SequenceNumber == lastSequence), Is.EqualTo(isInclusive), $"The event with sequence number [{ lastSequence }] was { ((isInclusive) ? "not" : "") } in the set of read events, which is inconsistent with the inclusive flag.");
+
+                    foreach (var sourceEvent in sourceEvents)
                     {
-                        foreach (var partition in partitions)
-                        {
-                            using var batch = await producer.CreateBatchAsync(new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
-
-                            for (var index = 0; index < eventsPerPartition; ++index)
-                            {
-                                batch.TryAdd(new EventData(Encoding.UTF8.GetBytes($"Event: { index } for Partition: { partition }")));
-                            }
-
-                            await producer.SendAsync(batch, cancellationSource.Token);
-                        }
-                    }
-
-                    // Read events from all partitions.
-
-                    var receivedEvents = partitions.ToDictionary(partitionId => partitionId, _ => 0);
-                    var receivedPartitionEvents = await ReadUntilEmptyAsync(consumer, expectedEventCount: expectedCount, cancellationToken: cancellationSource.Token);
-
-                    foreach (var partitionEvent in receivedPartitionEvents)
-                    {
-                        ++receivedEvents[partitionEvent.Partition.PartitionId];
-                    }
-
-                    // Verify the results.
-
-                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The publishing and reading should have completed normally.");
-                    Assert.That(receivedPartitionEvents.Count, Is.GreaterThanOrEqualTo(expectedCount), "There was an incorrect number of events received.");
-
-                    foreach (var partition in partitions)
-                    {
-                        Assert.That(receivedEvents[partition], Is.EqualTo(eventsPerPartition), $"The wrong number of events was received for Partition: { partition }.");
+                        var sourceId = sourceEvent.Properties[EventGenerator.IdPropertyName].ToString();
+                        Assert.That(readState.Events.TryGetValue(sourceId, out var readEvent), Is.True, $"The event with custom identifier [{ sourceId }] was not processed." );
+                        Assert.That(sourceEvent.IsEquivalentTo(readEvent.Data), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event.");
                     }
                 }
+
+                cancellationSource.Cancel();
             }
         }
 
@@ -754,143 +581,50 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task ConsumerCanReadAllPartitionsFromLatest()
+        public async Task ConsumerCanReadFromEnqueuedTime()
         {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(3))
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromSeconds(90));
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
 
-                await using (var producer = new EventHubProducerClient(connectionString))
-                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
-                {
-                    var partitions = await consumer.GetPartitionIdsAsync(cancellationSource.Token);
-                    var eventsPerPartition = 10;
-                    var expectedCount = (eventsPerPartition * partitions.Length);
-
-                    // Define a local function to publish events, since it will be done multiple times.
-
-                    async Task PublishEvents()
-                    {
-                        foreach (var partition in partitions)
-                        {
-                            using var batch = await producer.CreateBatchAsync(new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
-
-                            for (var index = 0; index < eventsPerPartition; ++index)
-                            {
-                                batch.TryAdd(new EventData(Encoding.UTF8.GetBytes($"Event: { index } for Partition: { partition }")));
-                            }
-
-                            await producer.SendAsync(batch, cancellationSource.Token);
-                            await Task.Delay(TimeSpan.FromSeconds(1), cancellationSource.Token);
-                        }
-                    }
-
-                    // Publish events before reading, then verify that they were not read.
-
-                    await PublishEvents();
-
-                    // Read events from all partitions.
-
-                    var receivedEvents = partitions.ToDictionary(partitionId => partitionId, _ => 0);
-                    var receivedPartitionEvents = await ReadUntilEmptyAsync(consumer, new ReadEventOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(50) }, startReadingAtFirst: false, expectedEventCount: 0, cancellationToken: cancellationSource.Token);
-
-                    foreach (var partitionEvent in receivedPartitionEvents)
-                    {
-                        ++receivedEvents[partitionEvent.Partition.PartitionId];
-                    }
-
-                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The publishing and reading should have completed normally.");
-                    Assert.That(receivedPartitionEvents.Count, Is.EqualTo(0), "No events should have been read.");
-
-                    // Read events across partitions, starting at the latest.  To ensure that events are observed, publish during the first
-                    // empty event emitted.
-
-                    var wereEventsPublished = false;
-
-                    async Task<bool> PublishOnFirstIteration()
-                    {
-                        if (!wereEventsPublished)
-                        {
-                            await PublishEvents().ConfigureAwait(false);
-                            wereEventsPublished = true;
-                        }
-
-                        return false;
-                    }
-
-                    receivedEvents = partitions.ToDictionary(partitionId => partitionId, _ => 0);
-                    receivedPartitionEvents = await ReadUntilEmptyAsync(consumer, startReadingAtFirst: false, expectedEventCount: expectedCount, iterationCallback: PublishOnFirstIteration, cancellationToken: cancellationSource.Token);
-
-                    foreach (var partitionEvent in receivedPartitionEvents)
-                    {
-                        ++receivedEvents[partitionEvent.Partition.PartitionId];
-                    }
-
-                    // Verify the results; events for the partitions should now have been present.
-
-                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The publishing and reading should have completed normally.");
-                    Assert.That(receivedPartitionEvents.Count, Is.GreaterThanOrEqualTo(expectedCount), "There was an incorrect number of events received.");
-
-                    foreach (var partition in partitions)
-                    {
-                        Assert.That(receivedEvents[partition], Is.EqualTo(eventsPerPartition), $"The wrong number of events was received for Partition: { partition }.");
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
-        public async Task ConsumerCanReadFromAllPartitionsWhenUsingPartitionKeys()
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(4))
-            {
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
-                using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromSeconds(90));
+                var seedEvents = EventGenerator.CreateEvents(50).ToList();
+                var sourceEvents = EventGenerator.CreateEvents(100).ToList();
 
                 await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                 {
-                    var partitions = await consumer.GetPartitionIdsAsync(cancellationSource.Token);
-                    var eventsPerPartition = 5;
-                    var expectedCount = (eventsPerPartition * partitions.Length);
+                    // Seed the partition with a set of events prior to reading.  When the send call returns, all events were
+                    // accepted by the Event Hubs service and should be available in the partition.  Provide a minor delay to
+                    // allow for any latency within the service.
 
-                    // Send events using a set of partition keys.  Routing is controlled by the service and partitions may not
-                    // receive an even distribution.  Because reading begins at the beginning of the partition by default, these
-                    // should be observed without publishing in the read loop.
+                    var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
 
-                    await using (var producer = new EventHubProducerClient(connectionString))
+                    await SendEventsAsync(connectionString, seedEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
+                    await Task.Delay(250);
+
+                    // Query the partition and determine the offset of the last enqueued event, then send the new set
+                    // of events that should appear after the starting position.
+
+                    var lastEnqueuedTime = (await consumer.GetPartitionPropertiesAsync(partition, cancellationSource.Token)).LastEnqueuedTime;
+                    var startingPosition = EventPosition.FromEnqueuedTime(lastEnqueuedTime);
+
+                    await SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
+
+                    // Read the events and validate the resulting state.
+
+                    var readState = await ReadEventsFromPartitionAsync(consumer, partition, sourceEvents.Count, cancellationSource.Token, startingPosition);
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    foreach (var sourceEvent in sourceEvents)
                     {
-                        foreach (var partition in partitions)
-                        {
-                            using var batch = await producer.CreateBatchAsync(new CreateBatchOptions { PartitionKey = $"Key{ partition.GetHashCode() }" }, cancellationSource.Token);
-
-                            for (var index = 0; index < eventsPerPartition; ++index)
-                            {
-                                batch.TryAdd(new EventData(Encoding.UTF8.GetBytes($"Event: { index } for Partition: { partition }")));
-                            }
-
-                            await producer.SendAsync(batch, cancellationSource.Token);
-                        }
+                        var sourceId = sourceEvent.Properties[EventGenerator.IdPropertyName].ToString();
+                        Assert.That(readState.Events.TryGetValue(sourceId, out var readEvent), Is.True, $"The event with custom identifier [{ sourceId }] was not processed." );
+                        Assert.That(sourceEvent.IsEquivalentTo(readEvent.Data), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event.");
                     }
-
-                    // Read events from all partitions.
-
-                    var receivedEvents = await ReadUntilEmptyAsync(consumer, expectedEventCount: expectedCount, cancellationToken: cancellationSource.Token);
-
-                    // Verify the results.
-
-                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The publishing and reading should have completed normally.");
-                    Assert.That(receivedEvents.Count, Is.EqualTo(expectedCount), "There was an incorrect number of events received.");
                 }
+
+                cancellationSource.Cancel();
             }
         }
 
@@ -900,981 +634,46 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task ConsumerCanReadFromAllPartitionsWhenUsingAutomaticRouting()
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(4))
-            {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
-                using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromSeconds(90));
-
-                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
-                {
-                    var partitions = await consumer.GetPartitionIdsAsync(cancellationSource.Token);
-                    var eventsPerPartition = 5;
-                    var expectedCount = (eventsPerPartition * partitions.Length);
-                    var eventsBatched = 0;
-
-                    // Send events without influencing the partition.  Routing is controlled by the service and partitions may not
-                    // receive an even distribution.  Because reading begins at the beginning of the partition by default, these
-                    // should be observed without publishing in the read loop.
-
-                    await using (var producer = new EventHubProducerClient(connectionString))
-                    {
-                        foreach (var partition in partitions)
-                        {
-                            using var batch = await producer.CreateBatchAsync(cancellationSource.Token);
-
-                            for (var index = 0; index < eventsPerPartition; ++index)
-                            {
-                                batch.TryAdd(new EventData(Encoding.UTF8.GetBytes($"Event: { index } of this batch.  Number: { ++eventsBatched } overall.")));
-                            }
-
-                            await producer.SendAsync(batch, cancellationSource.Token);
-                        }
-                    }
-
-                    // Read events from all partitions.
-
-                    var receivedEvents = await ReadUntilEmptyAsync(consumer, expectedEventCount: expectedCount, cancellationToken: cancellationSource.Token);
-
-                    // Verify the results.
-
-                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The publishing and reading should have completed normally.");
-                    Assert.That(receivedEvents.Count, Is.EqualTo(expectedCount), "There was an incorrect number of events received.");
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
-        public async Task ConsumerCanReadUsingAnIdentityCredential()
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
-            {
-                var credential = new ClientSecretCredential(TestEnvironment.EventHubsTenant, TestEnvironment.EventHubsClient, TestEnvironment.EventHubsSecret);
-
-                await using (var producer = new EventHubProducerClient(TestEnvironment.FullyQualifiedNamespace, scope.EventHubName, credential))
-                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, TestEnvironment.FullyQualifiedNamespace, scope.EventHubName, credential))
-                {
-                    var partition = (await consumer.GetPartitionIdsAsync()).First();
-                    var expectedEventsCount = 10;
-
-                    for (int i = 0; i < expectedEventsCount; i++)
-                    {
-                        await producer.SendAsync(new EventData(new byte[1]), new SendEventOptions { PartitionId = partition });
-                    }
-
-                    // Read the events.
-
-                    using var cancellationSource = new CancellationTokenSource();
-                    cancellationSource.CancelAfter(TimeSpan.FromSeconds(45));
-
-                    var receivedEvents = await ReadUntilEmptyAsync(consumer, partition, EventPosition.Earliest, expectedEventCount: expectedEventsCount, cancellationToken: cancellationSource.Token);
-                    Assert.That(receivedEvents.Count, Is.EqualTo(expectedEventsCount), $"The number of received events should be { expectedEventsCount }.");
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
-        public async Task ConsumerCanReadFromAllPartitionsUsingAnIdentityCredential()
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(4))
-            {
-                var credential = new ClientSecretCredential(TestEnvironment.EventHubsTenant, TestEnvironment.EventHubsClient, TestEnvironment.EventHubsSecret);
-
-                using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromSeconds(90));
-
-                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, TestEnvironment.FullyQualifiedNamespace, scope.EventHubName, credential))
-                {
-                    var partitions = await consumer.GetPartitionIdsAsync(cancellationSource.Token);
-                    var eventsPerPartition = 10;
-                    var expectedCount = (eventsPerPartition * partitions.Length);
-
-                    // Send events to each partition.  Because reading begins at the beginning of the partition by
-                    // default, these should be observed without publishing in the read loop.
-
-                    await using (var producer = new EventHubProducerClient(TestEnvironment.FullyQualifiedNamespace, scope.EventHubName, credential))
-                    {
-                        foreach (var partition in partitions)
-                        {
-                            using var batch = await producer.CreateBatchAsync(new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
-
-                            for (var index = 0; index < eventsPerPartition; ++index)
-                            {
-                                batch.TryAdd(new EventData(Encoding.UTF8.GetBytes($"Event: { index } for Partition: { partition }")));
-                            }
-
-                            await producer.SendAsync(batch, cancellationSource.Token);
-                        }
-                    }
-
-                    // Read events from all partitions.
-
-                    var receivedEvents = await ReadUntilEmptyAsync(consumer, expectedEventCount: expectedCount, cancellationToken: cancellationSource.Token);
-
-                    // Verify the results.
-
-                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The publishing and reading should have completed normally.");
-                    Assert.That(receivedEvents.Count, Is.GreaterThanOrEqualTo(expectedCount), "There was an incorrect number of events received.");
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
-        [TestCase(true)]
-        [TestCase(false)]
-        public async Task ConsumerCannotReadWhenClosed(bool sync)
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
-            {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
-                await using (var connection = new EventHubConnection(connectionString))
-                {
-                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
-
-                    await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection))
-                    {
-                        Func<Task> readAfterClose = async () =>
-                        {
-                            var count = 0;
-                            var maximumCount = 25;
-                            var countBeforeClose = 3;
-                            var closeCalled = false;
-
-                            await foreach (var partitionEvent in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.Latest, DefaultReadOptions))
-                            {
-                                ++count;
-
-                                if ((count == countBeforeClose) && (!closeCalled))
-                                {
-                                    await consumer.CloseAsync();
-                                }
-
-                                if (count >= maximumCount)
-                                {
-                                    break;
-                                }
-                            }
-                        };
-
-                        Assert.That(async () => await readAfterClose(), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
-        [TestCase("XYZ")]
-        [TestCase("-1")]
-        [TestCase("1000")]
-        [TestCase("-")]
-        public async Task ConsumerCannotReceiveFromInvalidPartition(string invalidPartition)
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
-            {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
-                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
-                {
-                    Assert.That(async () => await ReadNothingAsync(consumer, invalidPartition, EventPosition.Latest), Throws.InstanceOf<ArgumentOutOfRangeException>());
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
-        public async Task ConsumerCannotReceiveFromNonExistentConsumerGroup()
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
-            {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
-                await using (var connection = new EventHubConnection(connectionString))
-                {
-                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
-
-                    await using (var consumer = new EventHubConsumerClient("nonExistentConsumerGroup", connection))
-                    {
-                        Assert.That(async () => await ReadNothingAsync(consumer, partition, EventPosition.Latest), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ResourceNotFound));
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
-        public async Task NoOwnerLevelConsumerCannotStartReading()
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
-            {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
-                await using (var connection = new EventHubConnection(connectionString))
-                {
-                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
-                    var firstIteration = true;
-
-                    var exclusiveReadOptions = DefaultReadOptions.Clone();
-                    exclusiveReadOptions.OwnerLevel = 20;
-
-                    using var cancellationSource = new CancellationTokenSource();
-                    cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
-
-                    await using var exclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
-                    await foreach (var exclusiveEvent in exclusiveConsumer.ReadEventsFromPartitionAsync(partition, EventPosition.Latest, exclusiveReadOptions, cancellationSource.Token))
-                    {
-                        if (!firstIteration)
-                        {
-                            await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
-                            Assert.That(async () => await ReadNothingAsync(nonExclusiveConsumer, partition, EventPosition.Latest), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ConsumerDisconnected));
-
-                            break;
-                        }
-
-                        await Task.Delay(250);
-                        firstIteration = false;
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
-        public async Task LowerOwnerLevelConsumerCannotStartReading()
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
-            {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
-                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
-                {
-                    var partition = (await consumer.GetPartitionIdsAsync()).First();
-                    var firstIteration = true;
-
-                    var higherExclusiveReadOptions = DefaultReadOptions.Clone();
-                    higherExclusiveReadOptions.OwnerLevel = 30;
-
-                    using var cancellationSource = new CancellationTokenSource();
-                    cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
-
-                    await foreach (var higherEvent in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.Latest, higherExclusiveReadOptions, cancellationSource.Token))
-                    {
-                        if (!firstIteration)
-                        {
-                            var lowerExclusiveReadOptions = DefaultReadOptions.Clone();
-                            lowerExclusiveReadOptions.OwnerLevel = 20;
-
-                            Assert.That(async () => await ReadNothingAsync(consumer, partition, EventPosition.Latest, lowerExclusiveReadOptions), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ConsumerDisconnected));
-                            break;
-                        }
-
-                        await Task.Delay(250);
-                        firstIteration = false;
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
-        public async Task LowerOrNoOwnerLevelConsumerCanStartReceivingFromOtherPartitions()
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(3))
-            {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
-                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
-                {
-                    var partitionIds = (await consumer.GetPartitionIdsAsync());
-                    var firstIteration = true;
-
-                    var higherExclusiveReadOptions = DefaultReadOptions.Clone();
-                    higherExclusiveReadOptions.OwnerLevel = 20;
-
-                    var cancellationSource = new CancellationTokenSource();
-                    cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
-
-                    await foreach (var higherEvent in consumer.ReadEventsFromPartitionAsync(partitionIds[0], EventPosition.Latest, higherExclusiveReadOptions, cancellationSource.Token))
-                    {
-                        if (!firstIteration)
-                        {
-                            var lowerExclusiveReadOptions = DefaultReadOptions.Clone();
-                            lowerExclusiveReadOptions.OwnerLevel = 10;
-
-                            Assert.That(async () => await ReadNothingAsync(consumer, partitionIds[1], EventPosition.Latest, lowerExclusiveReadOptions), Throws.Nothing);
-                            Assert.That(async () => await ReadNothingAsync(consumer, partitionIds[2], EventPosition.Latest, DefaultReadOptions), Throws.Nothing);
-
-                            break;
-                        }
-
-                        await Task.Delay(250);
-                        firstIteration = false;
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
-        public async Task LowerOrNoOwnerLevelConsumerCanStartReadingFromOtherConsumerGroups()
-        {
-            var consumerGroups = new[]
-            {
-                "notdefault",
-                "notdefault2"
-            };
-
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(1, consumerGroups))
-            {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
-                await using (var connection = new EventHubConnection(connectionString))
-                {
-                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
-                    var firstIteration = true;
-
-                    using var cancellationSource = new CancellationTokenSource();
-                    cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
-
-                    var higherExclusiveReadOptions = DefaultReadOptions.Clone();
-                    higherExclusiveReadOptions.OwnerLevel = 20;
-
-                    await using var higherExclusiveConsumer = new EventHubConsumerClient(consumerGroups[0], connection);
-                    await foreach (var higherEvent in higherExclusiveConsumer.ReadEventsFromPartitionAsync(partition, EventPosition.Latest, higherExclusiveReadOptions, cancellationSource.Token))
-                    {
-                        if (!firstIteration)
-                        {
-                            var lowerExclusiveReadOptions = DefaultReadOptions.Clone();
-                            lowerExclusiveReadOptions.OwnerLevel = 10;
-
-                            await using var lowerExclusiveConsumer = new EventHubConsumerClient(consumerGroups[1], connection);
-                            Assert.That(async () => await ReadNothingAsync(lowerExclusiveConsumer, partition, EventPosition.Latest, lowerExclusiveReadOptions), Throws.Nothing);
-
-                            await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
-                            Assert.That(async () => await ReadNothingAsync(nonExclusiveConsumer, partition, EventPosition.Latest), Throws.Nothing);
-
-                            break;
-                        }
-
-                        await Task.Delay(250);
-                        firstIteration = false;
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
-        public async Task OwnerConsumerClosesNoOwnerLevelConsumer()
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
-            {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
-                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
-                {
-                    var partition = (await consumer.GetPartitionIdsAsync()).First();
-                    var firstIteration = true;
-
-                    using var cancellationSource = new CancellationTokenSource();
-                    cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
-
-                    // Non-exclusive may read before an exclusive claims.
-
-                    Assert.That(async () => await ReadNothingAsync(consumer, partition, EventPosition.Latest), Throws.Nothing);
-
-                    // Exclusive may read without an issue.
-
-                    var exclusiveReadOptions = DefaultReadOptions.Clone();
-                    exclusiveReadOptions.OwnerLevel = 20;
-
-                    Assert.That(async () => await ReadNothingAsync(consumer, partition, EventPosition.Latest, exclusiveReadOptions), Throws.Nothing);
-
-                    // Once the exclusive is active, ensure that the non-exclusive is denied access.
-
-                    await foreach (var exclusiveEvent in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.Latest, exclusiveReadOptions, cancellationSource.Token))
-                    {
-                        if (!firstIteration)
-                        {
-                            Assert.That(async () => await ReadNothingAsync(consumer, partition, EventPosition.Latest), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ConsumerDisconnected));
-                            break;
-                        }
-
-                        await Task.Delay(250);
-                        firstIteration = false;
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
-        public async Task OwnerConsumerClosesLowerOwnerLevelConsumer()
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
-            {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
-                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
-                {
-                    var partition = (await consumer.GetPartitionIdsAsync()).First();
-                    var firstIteration = true;
-
-                    var higherExclusiveReadOptions = DefaultReadOptions.Clone();
-                    higherExclusiveReadOptions.OwnerLevel = 30;
-
-                    var lowerExclusiveReadOptions = DefaultReadOptions.Clone();
-                    lowerExclusiveReadOptions.OwnerLevel = 20;
-
-                    using var cancellationSource = new CancellationTokenSource();
-                    cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
-
-                    // Non-exclusive may read before an exclusive claims.
-
-                    Assert.That(async () => await ReadNothingAsync(consumer, partition, EventPosition.Latest, lowerExclusiveReadOptions), Throws.Nothing);
-
-                    // Exclusive may read without an issue.
-
-                    Assert.That(async () => await ReadNothingAsync(consumer, partition, EventPosition.Latest, higherExclusiveReadOptions), Throws.Nothing);
-
-                    // Once the exclusive is active, ensure that the non-exclusive is denied access.
-
-                    await foreach (var higherEvent in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.Latest, higherExclusiveReadOptions, cancellationSource.Token))
-                    {
-                        if (!firstIteration)
-                        {
-                            Assert.That(async () => await ReadNothingAsync(consumer, partition, EventPosition.Latest, lowerExclusiveReadOptions), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ConsumerDisconnected));
-                            break;
-                        }
-
-                        await Task.Delay(250);
-                        firstIteration = false;
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
-        public async Task OwnerConsumerDoesNotCloseLowerOrNoOwnerLevelConsumersFromOtherPartitions()
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(3))
-            {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
-                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
-                {
-                    var partitionIds = await consumer.GetPartitionIdsAsync();
-                    var firstIteration = true;
-
-                    using var cancellationSource = new CancellationTokenSource();
-                    cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
-
-                    // Begin reading with the non-exclusive consumer so that it is actively engaged when the others read.
-
-                    await foreach (var nonExclusiveEvent in consumer.ReadEventsFromPartitionAsync(partitionIds[0], EventPosition.Latest, DefaultReadOptions, cancellationSource.Token))
-                    {
-                        if (!firstIteration)
-                        {
-                            // Begin reading with the lower-level exclusive consumer so that it is active connected when the higher level exclusive consumer reads.
-
-                            var innerFirstIteration = true;
-
-                            var lowerExclusiveReadOptions = DefaultReadOptions.Clone();
-                            lowerExclusiveReadOptions.OwnerLevel = 20;
-
-                            await foreach (var lowerExclusiveEvent in consumer.ReadEventsFromPartitionAsync(partitionIds[1], EventPosition.Latest, lowerExclusiveReadOptions, cancellationSource.Token))
-                            {
-                                // Ensure that the higher level consumer can read without interfering with the other active consumers.
-
-                                if (!innerFirstIteration)
-                                {
-                                    var higherExclusiveReadOptions = DefaultReadOptions.Clone();
-                                    higherExclusiveReadOptions.OwnerLevel = 30;
-
-                                    Assert.That(async () => await ReadNothingAsync(consumer, partitionIds[2], EventPosition.Latest, higherExclusiveReadOptions), Throws.Nothing);
-                                    break;
-                                }
-
-                                await Task.Delay(150);
-                                innerFirstIteration = false;
-                            }
-
-                            break;
-                        }
-
-                        await Task.Delay(250);
-                        firstIteration = false;
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
-        public async Task OwnerConsumerDoesNotCloseLowerOrNoOwnerLevelConsumersFromOtherConsumerGroups()
-        {
-            var consumerGroups = new[]
-            {
-                "notdefault",
-                "notdefault2"
-            };
-
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(1, consumerGroups))
-            {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
-                await using (var connection = new EventHubConnection(connectionString))
-                {
-                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
-                    var firstIteration = true;
-
-                    using var cancellationSource = new CancellationTokenSource();
-                    cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
-
-                    await using var nonExclusiveConsumer = new EventHubConsumerClient(consumerGroups[0], connection);
-                    await foreach (var nonExclusiveEvent in nonExclusiveConsumer.ReadEventsFromPartitionAsync(partition, EventPosition.Latest, DefaultReadOptions, cancellationSource.Token))
-                    {
-                        if (!firstIteration)
-                        {
-                            var innerFirstIteration = true;
-
-                            var lowerExclusiveReadOptions = DefaultReadOptions.Clone();
-                            lowerExclusiveReadOptions.OwnerLevel = 10;
-
-                            await using var lowerExclusiveConsumer = new EventHubConsumerClient(consumerGroups[1], connection);
-                            await foreach (var lowerEvent in lowerExclusiveConsumer.ReadEventsFromPartitionAsync(partition, EventPosition.Latest, lowerExclusiveReadOptions, cancellationSource.Token))
-                            {
-                                if (!innerFirstIteration)
-                                {
-                                    var higherExclusiveReadOptions = DefaultReadOptions.Clone();
-                                    higherExclusiveReadOptions.OwnerLevel = 20;
-
-                                    await using var higherExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
-                                    Assert.That(async () => await ReadNothingAsync(higherExclusiveConsumer, partition, EventPosition.Latest, higherExclusiveReadOptions), Throws.Nothing);
-
-                                    break;
-                                }
-
-                                await Task.Delay(150);
-                                innerFirstIteration = false;
-                            }
-
-                            break;
-                        }
-
-                        await Task.Delay(250);
-                        firstIteration = false;
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
-        public async Task FailingToCreateConsumerDoesNotCompromiseReadBehavior()
-        {
-            var customConsumerGroup = "anotherConsumerGroup";
-
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(2, new[] { customConsumerGroup }))
-            {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
-                await using (var defaultGroupConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
-                {
-                    var partitionIds = await defaultGroupConsumer.GetPartitionIdsAsync();
-
-                    using var cancellationSource = new CancellationTokenSource();
-                    cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
-
-                    // Create an exclusive consumer with low priority; this consumer should block a non-exclusive consumer but be trumped by the
-                    // higher exclusive consumer.
-
-                    var firstIteration = true;
-                    var scenariosComplete = false;
-
-                    var lowerExclusiveReadOptions = DefaultReadOptions.Clone();
-                    lowerExclusiveReadOptions.OwnerLevel = 10;
-
-                    try
-                    {
-                        await foreach (var lowerEvent in defaultGroupConsumer.ReadEventsFromPartitionAsync(partitionIds[0], EventPosition.Latest, lowerExclusiveReadOptions, cancellationSource.Token))
-                        {
-                            if (!firstIteration)
-                            {
-                                // Since there is an exclusive consumer reading, the non-exclusive consumer should be rejected.
-
-                                Assert.That(async () => await ReadNothingAsync(defaultGroupConsumer, partitionIds[0], EventPosition.Latest), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ConsumerDisconnected));
-
-                                // Create the higher level exclusive consumer; this should force the lower exclusive consumer to disconnect.
-
-                                var innerFirstIteration = true;
-
-                                var higherExclusiveReadOptions = DefaultReadOptions.Clone();
-                                higherExclusiveReadOptions.OwnerLevel = 20;
-
-                                await foreach (var higherEvent in defaultGroupConsumer.ReadEventsFromPartitionAsync(partitionIds[0], EventPosition.Latest, higherExclusiveReadOptions, cancellationSource.Token))
-                                {
-                                    if (!innerFirstIteration)
-                                    {
-                                        // Consumers for other partitions and consumer groups should be allowed to read without interference.
-
-                                        await using var differentConsumerGroupConsumer = new EventHubConsumerClient(customConsumerGroup, connectionString);
-                                        Assert.That(async () => await ReadNothingAsync(differentConsumerGroupConsumer, partitionIds[0], EventPosition.Latest), Throws.Nothing);
-
-                                        await using var differentGroupAndPartitionConsumer = new EventHubConsumerClient(customConsumerGroup, connectionString);
-                                        Assert.That(async () => await ReadNothingAsync(differentGroupAndPartitionConsumer, partitionIds[1], EventPosition.Latest), Throws.Nothing);
-
-                                        // Exceptions for invalid resources should continue to be thrown.
-
-                                        await using var invalidConsumerGroupConsumer = new EventHubConsumerClient("XYZ", connectionString);
-                                        Assert.That(async () => await ReadNothingAsync(invalidConsumerGroupConsumer, partitionIds[0], EventPosition.Latest), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ResourceNotFound));
-
-                                        await using var invalidPartitionConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString);
-                                        Assert.That(async () => await ReadNothingAsync(invalidPartitionConsumer, "ABC", EventPosition.Latest), Throws.InstanceOf<ArgumentOutOfRangeException>());
-
-                                        scenariosComplete = true;
-                                        break;
-                                    }
-
-                                    await Task.Delay(150);
-                                    innerFirstIteration = false;
-                                }
-
-                                break;
-                            }
-
-                            await Task.Delay(250);
-                            firstIteration = false;
-                        }
-                    }
-                    catch (EventHubsException ex) when (ex.Reason == EventHubsException.FailureReason.ConsumerDisconnected)
-                    {
-                        // This is an possible outcome depending on whether the inner dispose
-                        // completes before the outer iteration ticks.  Since there is an element of
-                        // non-determinism here, allow this.
-                        //
-                        // To ensure that things are in the correct state, validate that the
-                        // scenarios were completed before iteration stopped.
-                    }
-
-                    Assert.That(scenariosComplete, Is.True, "The lower exclusive consumer should not have been disconnected before the scenarios were completed.");
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
-        public async Task FailingToCreateInvalidPartitionConsumerDoesNotCompromiseReadBehavior()
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
-            {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
-                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
-                {
-                    var partition = (await consumer.GetPartitionIdsAsync()).First();
-
-                    using var cancellationSource = new CancellationTokenSource();
-                    cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
-
-                    // Begin with attempting to read from an invalid partition.
-
-                    Assert.That(async () => await ReadNothingAsync(consumer, "XYZ", EventPosition.Latest), Throws.InstanceOf<ArgumentOutOfRangeException>());
-
-                    // It should be possible to create new valid consumers.
-
-                    var exclusiveReadOptions = DefaultReadOptions.Clone();
-                    exclusiveReadOptions.OwnerLevel = 20;
-
-                    Assert.That(async () => await ReadNothingAsync(consumer, partition, EventPosition.Latest, exclusiveReadOptions), Throws.Nothing);
-
-                    // Exceptions should continue to be thrown properly.
-
-                    await foreach (var exclusiveItem in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.Latest, exclusiveReadOptions, cancellationSource.Token))
-                    {
-                        await using var invalidConsumerGroupConsumer = new EventHubConsumerClient("fake", connectionString);
-                        Assert.That(async () => await ReadNothingAsync(invalidConsumerGroupConsumer, partition, EventPosition.Latest), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ResourceNotFound));
-
-                        await using var otherInvalidPartitionConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString);
-                        Assert.That(async () => await ReadNothingAsync(otherInvalidPartitionConsumer, "ABC", EventPosition.Latest), Throws.InstanceOf<ArgumentOutOfRangeException>());
-
-                        await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString);
-                        Assert.That(async () => await ReadNothingAsync(nonExclusiveConsumer, partition, EventPosition.Latest), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ConsumerDisconnected));
-
-                        break;
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
-        public async Task FailingToCreateInvalidConsumerGroupConsumerDoesNotCompromiseReadBehavior()
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
-            {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
-                await using (var connection = new EventHubConnection(connectionString))
-                {
-                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
-
-                    var exclusiveReadOptions = DefaultReadOptions.Clone();
-                    exclusiveReadOptions.OwnerLevel = 20;
-
-                    using var cancellationSource = new CancellationTokenSource();
-                    cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
-
-                    // Begin with attempting to read from an invalid partition.
-
-                    await using var invalidConsumerGroupConsumer = new EventHubConsumerClient("notreal", connection);
-                    Assert.That(async () => await ReadNothingAsync(invalidConsumerGroupConsumer, partition, EventPosition.Latest), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ResourceNotFound));
-
-                    // It should be possible to create new valid consumers.
-
-                    await using var exclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
-                    Assert.That(async () => await ReadNothingAsync(exclusiveConsumer, partition, EventPosition.Latest, exclusiveReadOptions), Throws.Nothing);
-
-                    // Exceptions should continue to be thrown properly.
-
-                    var firstIteration = true;
-
-                    await foreach (var exclusiveItem in exclusiveConsumer.ReadEventsFromPartitionAsync(partition, EventPosition.Latest, exclusiveReadOptions, cancellationSource.Token))
-                    {
-                        if (!firstIteration)
-                        {
-                            await using var otherInvalidConsumerGroupConsumer = new EventHubConsumerClient("XYZ", connection);
-                            Assert.That(async () => await ReadNothingAsync(otherInvalidConsumerGroupConsumer, partition, EventPosition.Latest), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ResourceNotFound));
-
-                            await using var invalidPartitionConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
-                            Assert.That(async () => await ReadNothingAsync(invalidPartitionConsumer, "ABC", EventPosition.Latest), Throws.InstanceOf<ArgumentOutOfRangeException>());
-
-                            await using var nonExclusiveConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
-                            Assert.That(async () => await ReadNothingAsync(nonExclusiveConsumer, partition, EventPosition.Latest), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ConsumerDisconnected));
-
-                            break;
-                        }
-
-                        await Task.Delay(250);
-                        firstIteration = false;
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
-        public async Task ConsumerCannotReadEventsSentToAnotherPartition()
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(2))
-            {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
-                EventData[] eventBatch = new[]
-                {
-                    new EventData(Encoding.UTF8.GetBytes("One")),
-                    new EventData(Encoding.UTF8.GetBytes("Two")),
-                    new EventData(Encoding.UTF8.GetBytes("Three"))
-                };
-
-                await using (var connection = new EventHubConnection(connectionString))
-                {
-                    var partitionIds = await connection.GetPartitionIdsAsync(DefaultRetryPolicy);
-                    var wereEventsPublished = false;
-
-                    await using var producer = new EventHubProducerClient(connection);
-                    await using var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString);
-
-                    using var cancellationSource = new CancellationTokenSource();
-                    cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
-
-                    async Task<bool> PublishEvents()
-                    {
-                        if (!wereEventsPublished)
-                        {
-                            // Send the batches of events.
-
-                            var batches = 3;
-
-                            for (var batchesCount = 0; batchesCount < batches; batchesCount++)
-                            {
-                                await producer.SendAsync(eventBatch, new SendEventOptions { PartitionId = partitionIds[0] });
-                            }
-
-                            await Task.Delay(TimeSpan.FromSeconds(1));
-                            wereEventsPublished = true;
-                        }
-
-                        return false;
-                    }
-
-                    var receivedEvents = await ReadUntilEmptyAsync(consumer, partitionIds[1], EventPosition.Latest, expectedEventCount: eventBatch.Length, iterationCallback: PublishEvents, cancellationToken: cancellationSource.Token);
-                    Assert.That(receivedEvents, Is.Empty, "There should not have been a set of events received.");
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
-        public async Task ConsumersInDifferentConsumerGroupsShouldAllReadEvents()
+        public async Task ConsumerCanReadFromMultipleConsumerGroups()
         {
             var customConsumerGroup = "anotherConsumerGroup";
 
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1, new[] { customConsumerGroup }))
             {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var sourceEvents = EventGenerator.CreateEvents(50).ToList();
 
-                EventData[] eventBatch = new[]
+                await using (var customConsumer = new EventHubConsumerClient(customConsumerGroup, connectionString))
+                await using (var defaultConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                 {
-                    new EventData(Encoding.UTF8.GetBytes("One")),
-                    new EventData(Encoding.UTF8.GetBytes("Two")),
-                    new EventData(Encoding.UTF8.GetBytes("Three"))
-                };
+                    var partition = (await defaultConsumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
+                    await SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
 
-                await using (var connection = new EventHubConnection(connectionString))
-                {
-                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
+                    // Read the events and validate the resulting state.
 
-                    using var cancellationSource = new CancellationTokenSource();
-                    cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
+                    var readState = await Task.WhenAll
+                    (
+                        ReadEventsFromPartitionAsync(customConsumer, partition, sourceEvents.Count, cancellationSource.Token),
+                        ReadEventsFromPartitionAsync(defaultConsumer, partition, sourceEvents.Count, cancellationSource.Token)
+                    );
 
-                    await using var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString);
-                    await using var anotherConsumer = new EventHubConsumerClient(customConsumerGroup, connection);
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
-                    // Send the batch of events.
-
-                    await using var producer = new EventHubProducerClient(connectionString);
-                    await producer.SendAsync(eventBatch, new SendEventOptions { PartitionId = partition });
-
-                    // Read back the events from two different consumer groups.
-
-                    var readOptions = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromSeconds(1) };
-                    var consumerReceivedEvents = await ReadUntilEmptyAsync(consumer, partition, EventPosition.Earliest, readOptions, expectedEventCount: eventBatch.Length, cancellationToken: cancellationSource.Token);
-                    var anotherReceivedEvents = await ReadUntilEmptyAsync(anotherConsumer, partition, EventPosition.Earliest, readOptions, expectedEventCount: eventBatch.Length, cancellationToken: cancellationSource.Token);
-
-                    Assert.That(consumerReceivedEvents.Count, Is.EqualTo(eventBatch.Length), $"The number of received events in consumer group { consumer.ConsumerGroup } did not match the batch size.");
-                    Assert.That(anotherReceivedEvents.Count, Is.EqualTo(eventBatch.Length), $"The number of received events in consumer group { anotherConsumer.ConsumerGroup } did not match the batch size.");
-                }
-            }
-        }
-
-        /// <summary>
-        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
-        ///   connect to the Event Hubs service and perform operations.
-        /// </summary>
-        ///
-        [Test]
-        [TestCase(2)]
-        [TestCase(4)]
-        [TestCase(8)]
-        public async Task ReadStopsWhenMaximumWaitTimeIsReached(int maximumWaitTimeInSecs)
-        {
-            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
-            {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
-                await using (var connection = new EventHubConnection(connectionString))
-                {
-                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
-
-                    using var cancellationSource = new CancellationTokenSource();
-                    cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
-
-                    await using var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connection);
-
-                    var startTime = DateTime.UtcNow;
-                    var elapsedTime = 0.0;
-                    var readOptions = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromSeconds(maximumWaitTimeInSecs) };
-
-                    await foreach (var partitionEvent in consumer.ReadEventsFromPartitionAsync(partition, EventPosition.Latest, readOptions, cancellationSource.Token))
+                    foreach (var sourceEvent in sourceEvents)
                     {
-                        elapsedTime = DateTime.UtcNow.Subtract(startTime).TotalSeconds;
-                        break;
+                        var sourceId = sourceEvent.Properties[EventGenerator.IdPropertyName].ToString();
+                        Assert.That(readState[0].Events.TryGetValue(sourceId, out var customReadEvent), Is.True, $"The event with custom identifier [{ sourceId }] was not processed for the custom consumer group." );
+                        Assert.That(sourceEvent.IsEquivalentTo(customReadEvent.Data), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event for the custom consumer group.");
+
+                        Assert.That(readState[1].Events.TryGetValue(sourceId, out var defaultReadEvent), Is.True, $"The event with custom identifier [{ sourceId }] was not processed for the default consumer group." );
+                        Assert.That(sourceEvent.IsEquivalentTo(defaultReadEvent.Data), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event for the default consumer group.");
                     }
-
-                    Assert.That(elapsedTime, Is.GreaterThan(maximumWaitTimeInSecs - 0.1));
-                    Assert.That(elapsedTime, Is.LessThan(maximumWaitTimeInSecs + 5));
                 }
+
+                cancellationSource.Cancel();
             }
         }
 
@@ -1884,33 +683,750 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task ConsumerCannotReadWhenProxyIsInvalid()
+        public async Task ConsumerCannotReadAcrossPartitions()
+        {
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(2))
+            {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+
+                var credential = new ClientSecretCredential(TestEnvironment.EventHubsTenant, TestEnvironment.EventHubsClient, TestEnvironment.EventHubsSecret);
+                var sourceEvents = EventGenerator.CreateEvents(50).ToList();
+
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, TestEnvironment.FullyQualifiedNamespace, scope.EventHubName, credential))
+                {
+                    var partitions = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).ToArray();
+                    var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+                    await SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partitions[0] }, cancellationSource.Token);
+
+                    // Attempt to read from the empty partition and verify that no events are observed.  Because no events are expected, the
+                    // read operation will not naturally complete; limit the read to only a couple of seconds and trigger cancellation.
+
+                    using var readCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationSource.Token);
+                    readCancellation.CancelAfter(TimeSpan.FromSeconds(5));
+
+                    var readState = await ReadEventsFromPartitionAsync(consumer, partitions[1], sourceEvents.Count, readCancellation.Token);
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The main cancellation token should not have been signaled.");
+
+                    Assert.That(readState.Events.Count, Is.Zero, "No events should have been read from the empty partition.");
+                    Assert.That(readState.EmptyCount, Is.Zero, "No empty ticks should have occurred.");
+                }
+
+                cancellationSource.Cancel();
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ConsumerCannotReadWhenClosed()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var sourceEvents = EventGenerator.CreateEvents(15).ToList();
 
-                await using (var connection = new EventHubConnection(connectionString))
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                 {
-                    var partition = (await connection.GetPartitionIdsAsync(DefaultRetryPolicy)).First();
+                    var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
+                    await SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
 
-                    var options = new EventHubConsumerClientOptions
+                    // Read the events and validate the resulting state.
+
+                    // Create a local function that will close the consumer after five events have
+                    // been read.
+
+                    async Task<bool> closeAfterFiveRead(ReadState state)
                     {
-                        RetryOptions = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromMinutes(2) },
-
-                        ConnectionOptions = new EventHubConnectionOptions
+                        if (state.Events.Count >= 5)
                         {
-                            Proxy = new WebProxy("http://1.2.3.4:9999"),
-                            TransportType = EventHubsTransportType.AmqpWebSockets
+                            await consumer.CloseAsync(cancellationSource.Token).ConfigureAwait(false);
                         }
-                    };
 
-                    await using (var invalidProxyConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString, options))
+                        return true;
+                    }
+
+                    var readTask = ReadEventsFromPartitionAsync(consumer, partition, sourceEvents.Count, cancellationSource.Token, iterationCallback: closeAfterFiveRead);
+
+                    Assert.That(async () => await readTask, Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+                }
+
+                cancellationSource.Cancel();
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ConsumerCannotReadFromInvalidPartition()
+        {
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
+            {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, TestEnvironment.EventHubsConnectionString, scope.EventHubName))
+                {
+                    var invalidPartition = "-1";
+                    var readTask = ReadNothingAsync(consumer, invalidPartition, cancellationSource.Token);
+
+                    Assert.That(async () => await readTask, Throws.InstanceOf<ArgumentOutOfRangeException>());
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+                }
+
+                cancellationSource.Cancel();
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ConsumerCannotReadFromInvalidConsumerGroup()
+        {
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
+            {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+
+                var invalidConsumerGroup = "ThisIsFake";
+
+                await using (var producer = new EventHubProducerClient(TestEnvironment.EventHubsConnectionString, scope.EventHubName))
+                await using (var consumer = new EventHubConsumerClient(invalidConsumerGroup, TestEnvironment.EventHubsConnectionString, scope.EventHubName))
+                {
+                    var partition = (await producer.GetPartitionIdsAsync(cancellationSource.Token)).First();
+                    var readTask = ReadNothingAsync(consumer, partition, cancellationSource.Token);
+
+                    Assert.That(async () => await readTask, Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ResourceNotFound));
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+                }
+
+                cancellationSource.Cancel();
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ConsumerCannotReadWithInvalidProxy()
+        {
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
+            {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+
+                var clientOptions = new EventHubConsumerClientOptions();
+                clientOptions.RetryOptions.TryTimeout = TimeSpan.FromMinutes(2);
+                clientOptions.ConnectionOptions.Proxy = new WebProxy("http://1.2.3.4:9999");
+                clientOptions.ConnectionOptions.TransportType = EventHubsTransportType.AmqpWebSockets;
+
+                await using (var producer = new EventHubProducerClient(TestEnvironment.EventHubsConnectionString, scope.EventHubName))
+                await using (var invalidProxyConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, TestEnvironment.EventHubsConnectionString, scope.EventHubName, clientOptions))
+                {
+                    var partition = (await producer.GetPartitionIdsAsync(cancellationSource.Token)).First();
+
+                    Assert.That(async () => await ReadNothingAsync(invalidProxyConsumer, partition, cancellationSource.Token, iterationCount: 25), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ConsumerCannotReadAsNonExclusiveWhenAnExclusiveReaderIsActive()
+        {
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
+            {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+
+                var exclusiveOptions = DefaultReadOptions.Clone();
+                exclusiveOptions.OwnerLevel = 20;
+
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var sourceEvents = EventGenerator.CreateEvents(200).ToList();
+
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
+                {
+                    var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
+                    await SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
+
+                    var exclusiveMonitor = MonitorReadingEventsFromPartition(consumer, partition, int.MaxValue, cancellationSource.Token, readOptions: exclusiveOptions);
+                    await Task.WhenAny(exclusiveMonitor.StartCompletion.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    var nonExclusiveReadTask = ReadEventsFromPartitionAsync(consumer, partition, int.MaxValue, cancellationSource.Token);
+                    Assert.That(async () => await nonExclusiveReadTask, Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ConsumerDisconnected), "The non-exclusive read should be rejected.");
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    cancellationSource.Cancel();
+                    await exclusiveMonitor.ReadTask;
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ConsumerCannotReadWithLowerOwnerLevelThanActiveReader()
+        {
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
+            {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+
+                var higherOptions = DefaultReadOptions.Clone();
+                higherOptions.OwnerLevel = 40;
+
+                var lowerOptions = DefaultReadOptions.Clone();
+                lowerOptions.OwnerLevel = 20;
+
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var sourceEvents = EventGenerator.CreateEvents(200).ToList();
+
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
+                {
+                    var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
+                    await SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
+
+                    var higherMonitor = MonitorReadingEventsFromPartition(consumer, partition, int.MaxValue, cancellationSource.Token, readOptions: higherOptions);
+                    await Task.WhenAny(higherMonitor.StartCompletion.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    var lowerReadTask = ReadEventsFromPartitionAsync(consumer, partition, int.MaxValue, cancellationSource.Token, readOptions: lowerOptions);
+                    Assert.That(async () => await lowerReadTask, Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ConsumerDisconnected), "The lower-level read should be rejected.");
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    cancellationSource.Cancel();
+                    await higherMonitor.ReadTask;
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ConsumerCanReadFromMultiplePartitionsWithDifferentActiveOwnerLevels()
+        {
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(2))
+            {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+
+                var higherOptions = DefaultReadOptions.Clone();
+                higherOptions.OwnerLevel = 40;
+
+                var lowerOptions = DefaultReadOptions.Clone();
+                lowerOptions.OwnerLevel = 20;
+
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var sourceEvents = EventGenerator.CreateEvents(50).ToList();
+
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
+                {
+                    var partitions = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).Take(2).ToArray();
+
+                    // Send the same set of events to both partitions.
+
+                    await Task.WhenAll
+                    (
+                        SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partitions[0] }, cancellationSource.Token),
+                        SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partitions[1] }, cancellationSource.Token)
+                    );
+
+                    // Read from each partition, allowing the higher level operation to begin first.  Both read operations should be
+                    // successful and read all events from their respective partition.
+
+                    var higherMonitor = MonitorReadingEventsFromPartition(consumer, partitions[0], sourceEvents.Count, cancellationSource.Token, readOptions: higherOptions);
+                    var lowerMonitor = MonitorReadingEventsFromPartition(consumer, partitions[1], sourceEvents.Count, cancellationSource.Token, readOptions: lowerOptions);
+
+                    var readsCompleteTask = Task.WhenAll(higherMonitor.EndCompletion.Task, lowerMonitor.EndCompletion.Task);
+                    await Task.WhenAny(readsCompleteTask, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    cancellationSource.Cancel();
+
+                    var lowerResult = await lowerMonitor.ReadTask;
+                    var higherResult = await higherMonitor.ReadTask;
+
+                    Assert.That(higherResult.Events.Count, Is.EqualTo(sourceEvents.Count), "The higher reader should have read all events.");
+                    Assert.That(lowerResult.Events.Count, Is.EqualTo(sourceEvents.Count), "The lower reader should have read all events.");
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ConsumerCanReadFromMultipleConsumerGroupsWithDifferentActiveOwnerLevels()
+        {
+            var consumerGroups = new[] { "customGroup", "customTwo" };
+
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(1, consumerGroups))
+            {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+
+                var higherOptions = DefaultReadOptions.Clone();
+                higherOptions.OwnerLevel = 40;
+
+                var lowerOptions = DefaultReadOptions.Clone();
+                lowerOptions.OwnerLevel = 20;
+
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var sourceEvents = EventGenerator.CreateEvents(50).ToList();
+
+                await using (var firstGroupConsumer = new EventHubConsumerClient(scope.ConsumerGroups[0], connectionString))
+                await using (var secondGroupConsumer = new EventHubConsumerClient(scope.ConsumerGroups[1], connectionString))
+                {
+                    var partition = (await firstGroupConsumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
+                    await SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
+
+                    // Read from each partition, allowing the higher level operation to begin first.  Both read operations should be
+                    // successful and read all events from their respective partition.
+
+                    var higherMonitor = MonitorReadingEventsFromPartition(firstGroupConsumer, partition, sourceEvents.Count, cancellationSource.Token, readOptions: higherOptions);
+                    var lowerMonitor = MonitorReadingEventsFromPartition(secondGroupConsumer, partition, sourceEvents.Count, cancellationSource.Token, readOptions: lowerOptions);
+
+                    var readsCompleteTask = Task.WhenAll(higherMonitor.EndCompletion.Task, lowerMonitor.EndCompletion.Task);
+                    await Task.WhenAny(readsCompleteTask, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    cancellationSource.Cancel();
+
+                    var lowerResult = await lowerMonitor.ReadTask;
+                    var higherResult = await higherMonitor.ReadTask;
+
+                    Assert.That(higherResult.Events.Count, Is.EqualTo(sourceEvents.Count), "The higher reader should have read all events.");
+                    Assert.That(lowerResult.Events.Count, Is.EqualTo(sourceEvents.Count), "The lower reader should have read all events.");
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ExclusiveConsumerSupercedesNonExclusiveActiveReader()
+        {
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
+            {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+
+                var exclusiveOptions = DefaultReadOptions.Clone();
+                exclusiveOptions.OwnerLevel = 20;
+
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var sourceEvents = EventGenerator.CreateEvents(50).ToList();
+
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
+                {
+                    var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
+                    await SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
+
+                    // Start the non-exclusive read, waiting until at least some events were read before starting the exclusive reader.
+
+                    var nonExclusiveMonitor = MonitorReadingEventsFromPartition(consumer, partition, sourceEvents.Count, cancellationSource.Token);
+
+                    await Task.WhenAny(nonExclusiveMonitor.StartCompletion.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    // The non-exclusive reader has been confirmed to be active; start the exclusive level reader and validate that it supersedes the lower.
+
+                    var exclusiveMonitor = MonitorReadingEventsFromPartition(consumer, partition, sourceEvents.Count, cancellationSource.Token, readOptions: exclusiveOptions);
+                    await Task.WhenAny(exclusiveMonitor.StartCompletion.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+                    Assert.That(async () => await nonExclusiveMonitor.ReadTask, Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ConsumerDisconnected), "The lower-level read should be rejected.");
+
+                    // Wait for the exclusive reader to finish reading events and signal for cancellation to stop it.
+
+                    await Task.WhenAny(exclusiveMonitor.EndCompletion.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+                    cancellationSource.Cancel();
+
+                    var readState = await exclusiveMonitor.ReadTask;
+
+                    foreach (var sourceEvent in sourceEvents)
                     {
-                        var readOptions = new ReadEventOptions { MaximumWaitTime = null };
-                        Assert.That(async () => await ReadNothingAsync(invalidProxyConsumer, partition, EventPosition.Latest, readOptions, 25), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
+                        var sourceId = sourceEvent.Properties[EventGenerator.IdPropertyName].ToString();
+                        Assert.That(readState.Events.TryGetValue(sourceId, out var readEvent), Is.True, $"The event with custom identifier [{ sourceId }] was not processed." );
+                        Assert.That(sourceEvent.IsEquivalentTo(readEvent.Data), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event.");
                     }
                 }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ConsumerWithHigherOwnerLevelSupercedesActiveReader()
+        {
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
+            {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+
+                var higherOptions = DefaultReadOptions.Clone();
+                higherOptions.OwnerLevel = 40;
+
+                var lowerOptions = DefaultReadOptions.Clone();
+                lowerOptions.OwnerLevel = 20;
+
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var sourceEvents = EventGenerator.CreateEvents(50).ToList();
+
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
+                {
+                    var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
+                    await SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
+
+                    // Start the lower level read, waiting until at least some events were read before starting the higher reader.
+
+                    var lowerMonitor = MonitorReadingEventsFromPartition(consumer, partition, sourceEvents.Count, cancellationSource.Token, readOptions: lowerOptions);
+
+                    await Task.WhenAny(lowerMonitor.StartCompletion.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    // The lower reader has been confirmed to be active; start the higher level reader and validate that it supersedes the lower.
+
+                    var higherMonitor = MonitorReadingEventsFromPartition(consumer, partition, sourceEvents.Count, cancellationSource.Token, readOptions: higherOptions);
+                    await Task.WhenAny(higherMonitor.StartCompletion.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+                    Assert.That(async () => await lowerMonitor.ReadTask, Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ConsumerDisconnected), "The lower-level read should be rejected.");
+
+                    // Wait for the higher reader to finish reading events and signal for cancellation.
+
+                    await Task.WhenAny(higherMonitor.EndCompletion.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+                    cancellationSource.Cancel();
+
+                    var readState = await higherMonitor.ReadTask;
+
+                    foreach (var sourceEvent in sourceEvents)
+                    {
+                        var sourceId = sourceEvent.Properties[EventGenerator.IdPropertyName].ToString();
+                        Assert.That(readState.Events.TryGetValue(sourceId, out var readEvent), Is.True, $"The event with custom identifier [{ sourceId }] was not processed." );
+                        Assert.That(sourceEvent.IsEquivalentTo(readEvent.Data), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event.");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ExclusiveConsumerDoesNotSupercedNonExclusiveActiveReaderOnAnotherPartition()
+        {
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(2))
+            {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+
+                var exclusiveOptions = DefaultReadOptions.Clone();
+                exclusiveOptions.OwnerLevel = 20;
+
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var sourceEvents = EventGenerator.CreateEvents(50).ToList();
+
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
+                {
+                    var partitions = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).Take(2).ToArray();
+
+                    // Send the same set of events to both partitions.
+
+                    await Task.WhenAll
+                    (
+                        SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partitions[0] }, cancellationSource.Token),
+                        SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partitions[1] }, cancellationSource.Token)
+                    );
+
+                    // Start the non-exclusive read, waiting until at least some events were read before starting the exclusive reader.
+
+                    var nonExclusiveMonitor = MonitorReadingEventsFromPartition(consumer, partitions[0], sourceEvents.Count, cancellationSource.Token);
+
+                    await Task.WhenAny(nonExclusiveMonitor.StartCompletion.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    // The non-exclusive reader has been confirmed to be active; start the exclusive level reader and ensure that it is active so that
+                    // both readers are confirmed to be running at the same time.
+
+                    var exclusiveMonitor = MonitorReadingEventsFromPartition(consumer, partitions[1], sourceEvents.Count, cancellationSource.Token, readOptions: exclusiveOptions);
+
+                    await Task.WhenAny(exclusiveMonitor.StartCompletion.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    // Wait for both readers to complete and then signal for cancellation.
+
+                    var completionTasks = Task.WhenAll(nonExclusiveMonitor.EndCompletion.Task, exclusiveMonitor.EndCompletion.Task);
+                    await Task.WhenAny(completionTasks, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    cancellationSource.Cancel();
+
+                    var nonExclusiveResult = await nonExclusiveMonitor.ReadTask;
+                    var exclusiveResult = await exclusiveMonitor.ReadTask;
+
+                    Assert.That(nonExclusiveResult.Events.Count, Is.EqualTo(sourceEvents.Count), "The non-exclusive reader should have read all events.");
+                    Assert.That(exclusiveResult.Events.Count, Is.EqualTo(sourceEvents.Count), "The exclusive reader should have read all events.");
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ExclusiveConsumerDoesNotSupercedNonExclusiveActiveReaderOnAnotherConsumerGroup()
+        {
+            var consumerGroups = new[] { "customGroup", "customTwo" };
+
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(1, consumerGroups))
+            {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+
+                var exclusiveOptions = DefaultReadOptions.Clone();
+                exclusiveOptions.OwnerLevel = 20;
+
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var sourceEvents = EventGenerator.CreateEvents(50).ToList();
+
+                await using (var nonExclusiveConsumer = new EventHubConsumerClient(scope.ConsumerGroups[0], connectionString))
+                await using (var exclusiveConsumer = new EventHubConsumerClient(scope.ConsumerGroups[1], connectionString))
+                {
+                    var partition = (await exclusiveConsumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
+                    await SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
+
+                    // Start the non-exclusive read, waiting until at least some events were read before starting the exclusive reader.
+
+                    var nonExclusiveMonitor = MonitorReadingEventsFromPartition(nonExclusiveConsumer, partition, sourceEvents.Count, cancellationSource.Token);
+
+                    await Task.WhenAny(nonExclusiveMonitor.StartCompletion.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    // The non-exclusive reader has been confirmed to be active; start the exclusive level reader and ensure that it is active so that
+                    // both readers are confirmed to be running at the same time.
+
+                    var exclusiveMonitor = MonitorReadingEventsFromPartition(exclusiveConsumer, partition, sourceEvents.Count, cancellationSource.Token, readOptions: exclusiveOptions);
+
+                    await Task.WhenAny(exclusiveMonitor.StartCompletion.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    // Wait for both readers to complete and then signal for cancellation.
+
+                    var completionTasks = Task.WhenAll(nonExclusiveMonitor.EndCompletion.Task, exclusiveMonitor.EndCompletion.Task);
+                    await Task.WhenAny(completionTasks, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    cancellationSource.Cancel();
+
+                    var nonExclusiveResult = await nonExclusiveMonitor.ReadTask;
+                    var exclusiveResult = await exclusiveMonitor.ReadTask;
+
+                    Assert.That(nonExclusiveResult.Events.Count, Is.EqualTo(sourceEvents.Count), "The non-exclusive reader should have read all events.");
+                    Assert.That(exclusiveResult.Events.Count, Is.EqualTo(sourceEvents.Count), "The exclusive reader should have read all events.");
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ConsumerIsNotCompromisedByFailureToReadFromInvalidPartition()
+        {
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
+            {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var sourceEvents = EventGenerator.CreateEvents(50).ToList();
+
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, TestEnvironment.EventHubsConnectionString, scope.EventHubName))
+                {
+                    var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
+                    await SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
+
+                    // Attempt to read from an invalid partition and confirm failure.
+
+                    Assert.That(async () => await ReadNothingAsync(consumer, "-1", cancellationSource.Token), Throws.Exception);
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    // Read from the valid partition and confirm operation is not impacted.
+
+                    var readState = await ReadEventsFromPartitionAsync(consumer, partition, sourceEvents.Count, cancellationSource.Token);
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    foreach (var sourceEvent in sourceEvents)
+                    {
+                        var sourceId = sourceEvent.Properties[EventGenerator.IdPropertyName].ToString();
+                        Assert.That(readState.Events.TryGetValue(sourceId, out var readEvent), Is.True, $"The event with custom identifier [{ sourceId }] was not processed." );
+                        Assert.That(sourceEvent.IsEquivalentTo(readEvent.Data), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event.");
+                    }
+                }
+
+                cancellationSource.Cancel();
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ConsumerIsNotCompromisedByBeingSupercededByAnExclusiveReader()
+        {
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(2))
+            {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+
+                var higherOptions = DefaultReadOptions.Clone();
+                higherOptions.OwnerLevel = 40;
+
+                var lowerOptions = DefaultReadOptions.Clone();
+                lowerOptions.OwnerLevel = 20;
+
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var sourceEvents = EventGenerator.CreateEvents(100).ToList();
+
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
+                {
+                    var partitions = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).Take(2).ToArray();
+
+                    // Send the same set of events to both partitions.
+
+                    await Task.WhenAll
+                    (
+                        SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partitions[0] }, cancellationSource.Token),
+                        SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partitions[1] }, cancellationSource.Token)
+                    );
+
+                    // Start the lower level read, waiting until at least some events were read before starting the higher reader.
+
+                    var lowerMonitor = MonitorReadingEventsFromPartition(consumer, partitions[0], sourceEvents.Count, cancellationSource.Token, readOptions: lowerOptions);
+
+                    await Task.WhenAny(lowerMonitor.StartCompletion.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    // The lower reader has been confirmed to be active; start the higher level reader and validate that it supersedes the lower for the partition.
+
+                    var higherMonitor = MonitorReadingEventsFromPartition(consumer, partitions[0], sourceEvents.Count, cancellationSource.Token, readOptions: higherOptions);
+                    await Task.WhenAny(higherMonitor.StartCompletion.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+                    Assert.That(async () => await lowerMonitor.ReadTask, Throws.Exception, "The lower-level read should be rejected.");
+
+                    // The consumer should be able to read events from another partition after being superseded.  Start a new reader for the other partition,
+                    // using the same lower level.  Wait for both readers to complete and then signal for cancellation.
+
+                    var lowerReadState = await ReadEventsFromPartitionAsync(consumer, partitions[1], sourceEvents.Count, cancellationSource.Token, readOptions: lowerOptions);
+
+                    await Task.WhenAny(higherMonitor.EndCompletion.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+                    cancellationSource.Cancel();
+
+                    var higherReadState = await higherMonitor.ReadTask;
+
+                    foreach (var sourceEvent in sourceEvents)
+                    {
+                        var sourceId = sourceEvent.Properties[EventGenerator.IdPropertyName].ToString();
+                        Assert.That(higherReadState.Events.TryGetValue(sourceId, out var higherEvent), Is.True, $"The event with custom identifier [{ sourceId }] was not processed by the higher reader." );
+                        Assert.That(sourceEvent.IsEquivalentTo(higherEvent.Data), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event for the higher reader.");
+
+                        Assert.That(lowerReadState.Events.TryGetValue(sourceId, out var lowerEvent), Is.True, $"The event with custom identifier [{ sourceId }] was not processed by the lower reader." );
+                        Assert.That(sourceEvent.IsEquivalentTo(lowerEvent.Data), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event for the lower reader.");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ConsumerRespectsTheWaitTimeWhenReading()
+        {
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
+            {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+
+                var credential = new ClientSecretCredential(TestEnvironment.EventHubsTenant, TestEnvironment.EventHubsClient, TestEnvironment.EventHubsSecret);
+
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, TestEnvironment.FullyQualifiedNamespace, scope.EventHubName, credential))
+                {
+                    var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
+                    var options = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(250) };
+                    var desiredEmptyEvents = 8;
+                    var minimumEmptyEvents = 5;
+
+                    var readTime = TimeSpan
+                        .FromSeconds(options.MaximumWaitTime.Value.TotalSeconds * desiredEmptyEvents)
+                        .Add(TimeSpan.FromSeconds(1));
+
+                    // Attempt to read from the empty partition and verify that no events are observed.  Because no events are expected, the
+                    // read operation will not naturally complete; limit the read to only a couple of seconds and trigger cancellation.
+
+                    using var readCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationSource.Token);
+                    readCancellation.CancelAfter(readTime);
+
+                    var readState = await ReadEventsFromPartitionAsync(consumer, partition, int.MaxValue, readCancellation.Token, readOptions: options);
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The main cancellation token should not have been signaled.");
+
+                    Assert.That(readState.Events.Count, Is.Zero, "No events should have been read from the empty partition.");
+                    Assert.That(readState.EmptyCount, Is.AtLeast(minimumEmptyEvents), "The number of empty events read should be consistent with the requested wait time.");
+                }
+
+                cancellationSource.Cancel();
             }
         }
 
@@ -1922,18 +1438,20 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         [TestCase(EventHubsTransportType.AmqpTcp)]
         [TestCase(EventHubsTransportType.AmqpWebSockets)]
-        public async Task ConsumerCanRetrieveEventHubProperties(EventHubsTransportType transportType)
+        public async Task ConsumerCanQueryEventHubProperties(EventHubsTransportType transportType)
         {
             var partitionCount = 4;
+            var clientOptions = new EventHubConsumerClientOptions { ConnectionOptions = new EventHubConnectionOptions { TransportType = transportType } };
 
             await using (EventHubScope scope = await EventHubScope.CreateAsync(partitionCount))
             {
-                var connectionString = TestEnvironment.EventHubsConnectionString;
-                var consumerOptions = new EventHubConsumerClientOptions { ConnectionOptions = new EventHubConnectionOptions { TransportType = transportType } };
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
 
-                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString, scope.EventHubName, consumerOptions))
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, TestEnvironment.EventHubsConnectionString, scope.EventHubName, clientOptions))
                 {
-                    EventHubProperties properties = await consumer.GetEventHubPropertiesAsync();
+                    var properties = await consumer.GetEventHubPropertiesAsync(cancellationSource.Token);
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
                     Assert.That(properties, Is.Not.Null, "A set of properties should have been returned.");
                     Assert.That(properties.Name, Is.EqualTo(scope.EventHubName), "The property Event Hub name should match the scope.");
@@ -1951,21 +1469,25 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         [TestCase(EventHubsTransportType.AmqpTcp)]
         [TestCase(EventHubsTransportType.AmqpWebSockets)]
-        public async Task ConsumerCanRetrievePartitionProperties(EventHubsTransportType transportType)
+        public async Task ConsumerCanQueryPartitionProperties(EventHubsTransportType transportType)
         {
             var partitionCount = 1;
 
             await using (EventHubScope scope = await EventHubScope.CreateAsync(partitionCount))
             {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-                var consumerOptions = new EventHubConsumerClientOptions { ConnectionOptions = new EventHubConnectionOptions { TransportType = transportType } };
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
 
-                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString, scope.EventHubName, consumerOptions))
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var clientOptions = new EventHubConsumerClientOptions { ConnectionOptions = new EventHubConnectionOptions { TransportType = transportType } };
+
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString, scope.EventHubName, clientOptions))
                 {
-                    var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(20));
                     var properties = await consumer.GetEventHubPropertiesAsync();
                     var partition = properties.PartitionIds.First();
-                    var partitionProperties = await consumer.GetPartitionPropertiesAsync(partition, cancellation.Token);
+
+                    var partitionProperties = await consumer.GetPartitionPropertiesAsync(partition, cancellationSource.Token);
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
                     Assert.That(partitionProperties, Is.Not.Null, "A set of partition properties should have been returned.");
                     Assert.That(partitionProperties.Id, Is.EqualTo(partition), "The partition identifier should match.");
@@ -1987,12 +1509,14 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(4))
             {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
 
-                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, TestEnvironment.EventHubsConnectionString, scope.EventHubName))
                 {
-                    EventHubProperties properties = await consumer.GetEventHubPropertiesAsync();
-                    var partitions = await consumer.GetPartitionIdsAsync();
+                    var properties = await consumer.GetEventHubPropertiesAsync(cancellationSource.Token);
+                    var partitions = await consumer.GetPartitionIdsAsync(cancellationSource.Token);
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
                     Assert.That(properties, Is.Not.Null, "A set of properties should have been returned.");
                     Assert.That(properties.PartitionIds, Is.Not.Null, "A set of partition identifiers for the properties should have been returned.");
@@ -2012,21 +1536,24 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
 
-                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, TestEnvironment.EventHubsConnectionString, scope.EventHubName))
                 {
-                    var partition = (await consumer.GetPartitionIdsAsync()).First();
+                    var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
 
-                    Assert.That(async () => await consumer.GetEventHubPropertiesAsync(), Throws.Nothing);
-                    Assert.That(async () => await consumer.GetPartitionPropertiesAsync(partition), Throws.Nothing);
+                    Assert.That(async () => await consumer.GetEventHubPropertiesAsync(cancellationSource.Token), Throws.Nothing);
+                    Assert.That(async () => await consumer.GetPartitionPropertiesAsync(partition, cancellationSource.Token), Throws.Nothing);
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
 
                     await consumer.CloseAsync();
                     await Task.Delay(TimeSpan.FromSeconds(5));
 
-                    Assert.That(async () => await consumer.GetPartitionIdsAsync(), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
-                    Assert.That(async () => await consumer.GetEventHubPropertiesAsync(), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
-                    Assert.That(async () => await consumer.GetPartitionPropertiesAsync(partition), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
+                    Assert.That(async () => await consumer.GetPartitionIdsAsync(cancellationSource.Token), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
+                    Assert.That(async () => await consumer.GetEventHubPropertiesAsync(cancellationSource.Token), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
+                    Assert.That(async () => await consumer.GetPartitionPropertiesAsync(partition, cancellationSource.Token), Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed));
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
                 }
             }
         }
@@ -2041,15 +1568,17 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("-1")]
         [TestCase("1000")]
         [TestCase("-")]
-        public async Task ConsumerCannotRetrievePartitionPropertiesWhenPartitionIdIsInvalid(string invalidPartition)
+        public async Task ConsumerCannotRetrievePartitionPropertiesWithInvalidPartitionId(string invalidPartition)
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
-                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
 
-                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, TestEnvironment.EventHubsConnectionString, scope.EventHubName))
                 {
-                    Assert.That(async () => await consumer.GetPartitionPropertiesAsync(invalidPartition), Throws.TypeOf<ArgumentOutOfRangeException>());
+                    Assert.That(async () => await consumer.GetPartitionPropertiesAsync(invalidPartition, cancellationSource.Token), Throws.TypeOf<ArgumentOutOfRangeException>());
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
                 }
             }
         }
@@ -2060,166 +1589,304 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task ConsumerCannotRetrieveMetadataWhenProxyIsInvalid()
+        public async Task ConsumerCannotRetrieveMetadataWithInvalidProxy()
         {
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
-                var invalidProxyOptions = new EventHubConsumerClientOptions
-                {
-                    RetryOptions = new EventHubsRetryOptions { TryTimeout = TimeSpan.FromMinutes(2) },
-
-                    ConnectionOptions = new EventHubConnectionOptions
-                    {
-                        Proxy = new WebProxy("http://1.2.3.4:9999"),
-                        TransportType = EventHubsTransportType.AmqpWebSockets
-                    }
-                };
+                var invalidProxyOptions = new EventHubConsumerClientOptions();
+                invalidProxyOptions.RetryOptions.TryTimeout = TimeSpan.FromMinutes(2);
+                invalidProxyOptions.ConnectionOptions.Proxy = new WebProxy("http://1.2.3.4:9999");
+                invalidProxyOptions.ConnectionOptions.TransportType = EventHubsTransportType.AmqpWebSockets;
 
                 await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                 await using (var invalidProxyConsumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString, invalidProxyOptions))
                 {
-                    var partition = (await consumer.GetPartitionIdsAsync()).First();
+                    var partition = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).First();
 
-                    Assert.That(async () => await invalidProxyConsumer.GetPartitionIdsAsync(), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
-                    Assert.That(async () => await invalidProxyConsumer.GetEventHubPropertiesAsync(), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
-                    Assert.That(async () => await invalidProxyConsumer.GetPartitionPropertiesAsync(partition), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
+                    Assert.That(async () => await invalidProxyConsumer.GetPartitionIdsAsync(cancellationSource.Token), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
+                    Assert.That(async () => await invalidProxyConsumer.GetEventHubPropertiesAsync(cancellationSource.Token), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
+                    Assert.That(async () => await invalidProxyConsumer.GetPartitionPropertiesAsync(partition, cancellationSource.Token), Throws.InstanceOf<WebSocketException>().Or.InstanceOf<TimeoutException>());
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
                 }
             }
         }
 
         /// <summary>
-        ///   Reads from the requested partition until there are no events available for
-        ///   a number of consecutive iterations.
+        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
         /// </summary>
         ///
-        /// <param name="consumer">The consumer to use for reading.</param>
-        /// <param name="partition">The partition read from.</param>
-        /// <param name="startingPosition">The position in the partition to start reading from.</param>
-        /// <param name="readOptions">The options to apply when reading.</param>
-        /// <param name="expectedEventCount">The expected count of events; when the read count is below this number, the delay will be applied between loop iterations.</param>
-        /// <param name="consecutiveEmptyLimit">The limit for the number of consecutive empty events before reading is terminated.</param>
-        /// <param name="consecutiveEmptyDelayThreshold">The threshold of consecutive empty events to allow before applying the delay or termination; this number should be less than <paramref name="consecutiveEmptyLimit"/>.</param>
-        /// <param name="consecutiveEmptyDelayMilliseconds">The delay, in milliseconds, to apply between iterations when the <paramref name="consecutiveEmptyDelayThreshold"/> is reached and less than the <paramref name="expectedEventCount"/> events have been read.</param>
-        /// <param name="iterationCallback">A callback to invoke at the beginning of each read iteration; if this returns <c>true</c>, reading will be terminated.</param>
-        /// <param name="cancellationToken">The token to consider for cancellation of the operation.</param>
-        ///
-        /// <returns>The set of partition events that were read which contain event data.</returns>
-        ///
-        private async Task<IList<PartitionEvent>> ReadUntilEmptyAsync(EventHubConsumerClient consumer,
-                                                                      string partition,
-                                                                      EventPosition startingPosition,
-                                                                      ReadEventOptions readOptions = default,
-                                                                      int expectedEventCount = int.MaxValue,
-                                                                      int consecutiveEmptyLimit = 30,
-                                                                      int consecutiveEmptyDelayThreshold = 8,
-                                                                      int consecutiveEmptyDelayMilliseconds = 350,
-                                                                      Func<Task<bool>> iterationCallback = default,
-                                                                      CancellationToken cancellationToken = default)
+        [Test]
+        public async Task ConsumerCanReadFromAllPartitions()
         {
-            readOptions ??= DefaultReadOptions;
-
-            var readEvents = new List<PartitionEvent>();
-            var consecutiveEmpties = 0;
-            var readAwaitable = consumer.ReadEventsFromPartitionAsync(partition, startingPosition, readOptions, cancellationToken).ConfigureAwait(false);
-
-            await foreach (var partitionEvent in readAwaitable)
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(4))
             {
-                if (iterationCallback != null)
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var sourceEvents = EventGenerator.CreateEvents(100).ToList();
+
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                 {
-                    if (await iterationCallback().ConfigureAwait(false))
+                    var partitions = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).ToArray();
+
+                    var sendCount = await SendEventsToAllPartitionsAsync(connectionString, sourceEvents, partitions, cancellationSource.Token);
+                    Assert.That(sendCount, Is.EqualTo(sourceEvents.Count), "All of the events should have been sent.");
+
+                    // Read the events and validate the resulting state.
+
+                    var readState = await ReadEventsFromAllPartitionsAsync(consumer, sourceEvents.Count, cancellationSource.Token);
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    foreach (var sourceEvent in sourceEvents)
                     {
-                        break;
+                        var sourceId = sourceEvent.Properties[EventGenerator.IdPropertyName].ToString();
+                        Assert.That(readState.Events.TryGetValue(sourceId, out var readEvent), Is.True, $"The event with custom identifier [{ sourceId }] was not processed." );
+                        Assert.That(sourceEvent.IsEquivalentTo(readEvent.Data), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event.");
                     }
                 }
 
-                if (partitionEvent.Data != null)
-                {
-                    readEvents.Add(partitionEvent);
-                    consecutiveEmpties = 0;
-                }
-                else if (++consecutiveEmpties >= consecutiveEmptyDelayThreshold)
-                {
-                    if (consecutiveEmpties >= consecutiveEmptyLimit)
-                    {
-                        break;
-                    }
-
-                    if (readEvents.Count < expectedEventCount)
-                    {
-                        await Task.Delay(consecutiveEmptyDelayMilliseconds, cancellationToken).ConfigureAwait(false);
-                    }
-                }
+                cancellationSource.Cancel();
             }
-
-            return readEvents;
         }
 
         /// <summary>
-        ///   Reads from all partitions until there are no events available for
-        ///   a number of consecutive iterations.
+        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ConsumerCanReadFromAllPartitionsUsingAnIdentityCredential()
+        {
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(4))
+            {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+
+                var credential = new ClientSecretCredential(TestEnvironment.EventHubsTenant, TestEnvironment.EventHubsClient, TestEnvironment.EventHubsSecret);
+                var sourceEvents = EventGenerator.CreateEvents(100).ToList();
+
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, TestEnvironment.FullyQualifiedNamespace, scope.EventHubName, credential))
+                {
+                    var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                    var partitions = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).ToArray();
+
+                    var sendCount = await SendEventsToAllPartitionsAsync(connectionString, sourceEvents, partitions, cancellationSource.Token);
+                    Assert.That(sendCount, Is.EqualTo(sourceEvents.Count), "All of the events should have been sent.");
+
+                    // Read the events and validate the resulting state.
+
+                    var readState = await ReadEventsFromAllPartitionsAsync(consumer, sourceEvents.Count, cancellationSource.Token);
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+
+                    foreach (var sourceEvent in sourceEvents)
+                    {
+                        var sourceId = sourceEvent.Properties[EventGenerator.IdPropertyName].ToString();
+                        Assert.That(readState.Events.TryGetValue(sourceId, out var readEvent), Is.True, $"The event with custom identifier [{ sourceId }] was not processed." );
+                        Assert.That(sourceEvent.IsEquivalentTo(readEvent.Data), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event.");
+                    }
+                }
+
+                cancellationSource.Cancel();
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConsumerClient" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ConsumerCanReadFromAllPartitionsStartingWithLatest()
+        {
+            await using (EventHubScope scope = await EventHubScope.CreateAsync(4))
+            {
+                using var cancellationSource = new CancellationTokenSource();
+                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var sourceEvents = EventGenerator.CreateEvents(100).ToList();
+
+                await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
+                {
+                    // Send a set of seed events, which should not be read.
+
+                    var partitions = (await consumer.GetPartitionIdsAsync(cancellationSource.Token)).ToArray();
+                    await SendEventsToAllPartitionsAsync(connectionString, EventGenerator.CreateEvents(50), partitions, cancellationSource.Token);
+
+                    // Begin reading though no events have been published.  This is necessary to open the connection and
+                    // ensure that the consumer is watching the partition.
+
+                    var readTask = ReadEventsFromAllPartitionsAsync(consumer, sourceEvents.Count, cancellationSource.Token, startFromEarliest: false);
+
+                    // Give the consumer a moment to ensure that it is established and then send events for it to read.
+
+                    await Task.Delay(250);
+                    await SendEventsToAllPartitionsAsync(connectionString, sourceEvents, partitions, cancellationSource.Token);
+
+                    // Read the events and validate the resulting state.
+
+                    var readState = await readTask;
+                    Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation token should not have been signaled.");
+                    Assert.That(readState.Events.Count, Is.EqualTo(sourceEvents.Count), "Only the source events should have been read.");
+
+                    foreach (var sourceEvent in sourceEvents)
+                    {
+                        var sourceId = sourceEvent.Properties[EventGenerator.IdPropertyName].ToString();
+                        Assert.That(readState.Events.TryGetValue(sourceId, out var readEvent), Is.True, $"The event with custom identifier [{ sourceId }] was not processed." );
+                        Assert.That(sourceEvent.IsEquivalentTo(readEvent.Data), $"The event with custom identifier [{ sourceId }] did not match the corresponding processed event.");
+                    }
+                }
+
+                cancellationSource.Cancel();
+            }
+        }
+
+        /// <summary>
+        ///   Reads the events from a given position, tracking the operation.
         /// </summary>
         ///
         /// <param name="consumer">The consumer to use for reading.</param>
+        /// <param name="partition">The identifier of the partition to read from.</param>
+        /// <param name="expectedEventCount">The expected count of events; when this number of events has been read, reading will cease.</param>
+        /// <param name="cancellationToken">The token used to signal cancellation of the read.</param>
         /// <param name="startingPosition">The position in the partition to start reading from.</param>
         /// <param name="readOptions">The options to apply when reading.</param>
-        /// <param name="startReadingAtFirst"><c>true</c> if reading should begin at the beginning of the event stream; otherwise, reading begins at the end of the stream.</param>
-        /// <param name="expectedEventCount">The expected count of events; when the read count is below this number, the delay will be applied between loop iterations.</param>
-        /// <param name="consecutiveEmptyLimit">The limit for the number of consecutive empty events before reading is terminated.</param>
-        /// <param name="consecutiveEmptyDelayThreshold">The threshold of consecutive empty events to allow before applying the delay or termination; this number should be less than <paramref name="consecutiveEmptyLimit"/>.</param>
-        /// <param name="consecutiveEmptyDelayMilliseconds">The delay, in milliseconds, to apply between iterations when the <paramref name="consecutiveEmptyDelayThreshold"/> is reached and less than the <paramref name="expectedEventCount"/> events have been read.</param>
-        /// <param name="iterationCallback">A callback to invoke at the beginning of each read iteration; if this returns <c>true</c>, reading will be terminated.</param>
-        /// <param name="cancellationToken">The token to consider for cancellation of the operation.</param>
+        /// <param name="iterationCallback">A callback function to invoke each tick of the loop, receiving the current read state and allowing forced termination.</param>
         ///
-        /// <returns>The set of partition events that were read which contain event data.</returns>
+        /// <returns>The final state when reading has ceased.</returns>
         ///
-        private async Task<IList<PartitionEvent>> ReadUntilEmptyAsync(EventHubConsumerClient consumer,
-                                                                      ReadEventOptions readOptions = default,
-                                                                      bool startReadingAtFirst = true,
-                                                                      int expectedEventCount = int.MaxValue,
-                                                                      int consecutiveEmptyLimit = 30,
-                                                                      int consecutiveEmptyDelayThreshold = 8,
-                                                                      int consecutiveEmptyDelayMilliseconds = 350,
-                                                                      Func<Task<bool>> iterationCallback = default,
-                                                                      CancellationToken cancellationToken = default)
+        private async Task<ReadState> ReadEventsFromPartitionAsync(EventHubConsumerClient consumer,
+                                                                   string partition,
+                                                                   int expectedEventCount,
+                                                                   CancellationToken cancellationToken,
+                                                                   EventPosition? startingPosition = default,
+                                                                   ReadEventOptions readOptions = default,
+                                                                   Func<ReadState, Task<bool>> iterationCallback = default)
+        {
+            readOptions ??= DefaultReadOptions;
+            startingPosition ??= EventPosition.Earliest;
+
+            var result = new ReadState();
+
+            try
+            {
+                var readAwaitable = consumer.ReadEventsFromPartitionAsync(partition, startingPosition.Value, readOptions, cancellationToken).ConfigureAwait(false);
+
+                await foreach (var partitionEvent in readAwaitable)
+                {
+                    // Track the events as they are read.
+
+                    if (partitionEvent.Data == null)
+                    {
+                        ++result.EmptyCount;
+                    }
+                    else
+                    {
+                        var eventId = partitionEvent.Data.Properties[EventGenerator.IdPropertyName].ToString();
+
+                        if ((result.Events.TryAdd(eventId, partitionEvent)) && (result.Events.Count >= expectedEventCount))
+                        {
+                            break;
+                        }
+                    }
+
+                    // If there's a callback registered per-tick, invoke it and respect its
+                    // decision on whether iteration should continue.
+
+                    if ((iterationCallback != null) && (!(await iterationCallback(result).ConfigureAwait(false))))
+                    {
+                        break;
+                    }
+                }
+
+                // Delay for a moment before returning the results to ensure that cleanup has registered
+                // with the service and the associated link is no longer alive.
+
+                await Task.Delay(250).ConfigureAwait(false);
+            }
+            catch (TaskCanceledException)
+            {
+                // The test should assert on the cancellation token; treat this as
+                // expected and don't bubble.
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        ///   Reads the events across all partitions from a given position, tracking the operation.
+        /// </summary>
+        ///
+        /// <param name="consumer">The consumer to use for reading.</param>
+        /// <param name="expectedEventCount">The expected count of events; when this number of events has been read, reading will cease.</param>
+        /// <param name="cancellationToken">The token used to signal cancellation of the read.</param>
+        /// <param name="startFromEarliest"><c>true</c> to start reading from the earliest position; otherwise, <c>false</c>.</param>
+        /// <param name="readOptions">The options to apply when reading.</param>
+        /// <param name="iterationCallback">A callback function to invoke each tick of the loop, receiving the current read state and allowing forced termination.</param>
+        ///
+        /// <returns>The final state when reading has ceased.</returns>
+        ///
+        private async Task<ReadState> ReadEventsFromAllPartitionsAsync(EventHubConsumerClient consumer,
+                                                                       int expectedEventCount,
+                                                                       CancellationToken cancellationToken,
+                                                                       bool startFromEarliest = true,
+                                                                       ReadEventOptions readOptions = default,
+                                                                       Func<ReadState, Task<bool>> iterationCallback = default)
         {
             readOptions ??= DefaultReadOptions;
 
-            var readEvents = new List<PartitionEvent>();
-            var consecutiveEmpties = 0;
-            var readAwaitable = consumer.ReadEventsAsync(startReadingAtFirst, readOptions, cancellationToken).ConfigureAwait(false);
+            var result = new ReadState();
 
-            await foreach (var partitionEvent in readAwaitable)
+            try
             {
-                if (iterationCallback != null)
+                var readAwaitable = consumer.ReadEventsAsync(startFromEarliest, readOptions, cancellationToken).ConfigureAwait(false);
+
+                await foreach (var partitionEvent in readAwaitable)
                 {
-                    if (await iterationCallback().ConfigureAwait(false))
+                    // Track the events as they are read.
+
+                    if (partitionEvent.Data == null)
+                    {
+                        ++result.EmptyCount;
+                    }
+                    else
+                    {
+                        var eventId = partitionEvent.Data.Properties[EventGenerator.IdPropertyName].ToString();
+
+                        if ((result.Events.TryAdd(eventId, partitionEvent)) && (result.Events.Count >= expectedEventCount))
+                        {
+                            break;
+                        }
+                    }
+
+                    // If there's a callback registered per-tick, invoke it and respect its
+                    // decision on whether iteration should continue.
+
+                    if ((iterationCallback != null) && (!(await iterationCallback(result).ConfigureAwait(false))))
                     {
                         break;
                     }
                 }
 
-                if (partitionEvent.Data != null)
-                {
-                    readEvents.Add(partitionEvent);
-                    consecutiveEmpties = 0;
-                }
-                else if (++consecutiveEmpties >= consecutiveEmptyDelayThreshold)
-                {
-                    if (consecutiveEmpties >= consecutiveEmptyLimit)
-                    {
-                        break;
-                    }
+                // Delay for a moment before returning the results to ensure that cleanup has registered
+                // with the service and the associated link is no longer alive.
 
-                    if (readEvents.Count < expectedEventCount)
-                    {
-                        await Task.Delay(consecutiveEmptyDelayMilliseconds, cancellationToken).ConfigureAwait(false);
-                    }
-                }
+                await Task.Delay(250).ConfigureAwait(false);
+            }
+            catch (TaskCanceledException)
+            {
+                // The test should assert on the cancellation token; treat this as
+                // expected and don't bubble.
             }
 
-            return readEvents;
+            return result;
         }
 
         /// <summary>
@@ -2227,33 +1894,175 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         /// <param name="consumer">The consumer to use for reading.</param>
-        /// <param name="partition">The partition read from.</param>
+        /// <param name="partition">The identifier of the partition to read from.</param>
+        /// <param name="cancellationToken">The token used to signal cancellation of the read.</param>
         /// <param name="startingPosition">The position in the partition to start reading from.</param>
         /// <param name="iterationCount">The number of iterations to perform.</param>
         /// <param name="readOptions">The options to apply when reading.</param>
         ///
         private async Task ReadNothingAsync(EventHubConsumerClient consumer,
                                             string partition,
-                                            EventPosition startingPosition,
+                                            CancellationToken cancellationToken,
+                                            EventPosition? startingPosition = default,
                                             ReadEventOptions readOptions = default,
                                             int iterationCount = 5)
         {
             readOptions ??= new ReadEventOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(150) };
+            startingPosition ??= EventPosition.Earliest;
 
-            await foreach (var item in consumer.ReadEventsFromPartitionAsync(partition, startingPosition, readOptions))
+            try
             {
-                await Task.Delay(250);
+                var readAwaitable = consumer.ReadEventsFromPartitionAsync(partition, startingPosition.Value, readOptions, cancellationToken).ConfigureAwait(false);
 
-                if (--iterationCount <= 0)
+                await foreach (var item in readAwaitable)
                 {
-                    break;
+                    await Task.Delay(250).ConfigureAwait(false);
+
+                    if (--iterationCount <= 0)
+                    {
+                        break;
+                    }
+                }
+
+                // Delay for a moment to ensure that cleanup has registered with the
+                // service and the associated link is no longer alive.
+
+                await Task.Delay(250).ConfigureAwait(false);
+            }
+            catch (TaskCanceledException)
+            {
+                // The test should assert on the cancellation token; treat this as
+                // expected and don't bubble.
+            }
+        }
+
+        /// <summary>
+        ///   Sends a set of events using a new producer to do so.
+        /// </summary>
+        ///
+        /// <param name="connectionString">The connection string to use when creating the producer.</param>
+        /// <param name="sourceEvents">The set of events to send.</param>
+        /// <param name="batchOptions">The set of options to apply when creating batches.</param>
+        /// <param name="cancellationToken">The token used to signal a cancellation request.</param>
+        ///
+        /// <returns>The count of events that were sent.</returns>
+        ///
+        private async Task<int> SendEventsAsync(string connectionString,
+                                                IEnumerable<EventData> sourceEvents,
+                                                CreateBatchOptions batchOptions = default,
+                                                CancellationToken cancellationToken = default)
+        {
+            var sentCount = 0;
+
+            await using (var producer = new EventHubProducerClient(connectionString))
+            {
+                foreach (var batch in (await EventGenerator.BuildBatchesAsync(sourceEvents, producer, batchOptions, cancellationToken)))
+                {
+                    await producer.SendAsync(batch, cancellationToken).ConfigureAwait(false);
+
+                    sentCount += batch.Count;
+                    batch.Dispose();
                 }
             }
 
-            // Delay for a moment to ensure that cleanup has registered with the
-            // service and the associated link is no longer alive.
+            return sentCount;
+        }
 
-            await Task.Delay(250);
+        /// <summary>
+        ///   Sends a set of events to the desired partitions, using a reasonably even
+        ///   distribution with no guaranteed ordering.
+        /// </summary>
+        ///
+        /// <param name="connectionString">The connection string to use when creating the producer.</param>
+        /// <param name="sourceEvents">The set of events to send.</param>
+        /// <param name="partitionIds">The set of partitions to send events to.</param>
+        /// <param name="cancellationToken">The token used to signal a cancellation request.</param>
+        ///
+        /// <returns>The count of events that were sent.</returns>
+        ///
+        private async Task<int> SendEventsToAllPartitionsAsync(string connectionString,
+                                                               IEnumerable<EventData> sourceEvents,
+                                                               string[] partitionIds,
+                                                               CancellationToken cancellationToken = default)
+        {
+            var sendTasks = sourceEvents
+                .GroupBy(eventData => (eventData.GetHashCode() % partitionIds.Length))
+                .Select(eventGroup =>
+                {
+                    var options = new CreateBatchOptions { PartitionId = partitionIds[eventGroup.Key] };
+                    return SendEventsAsync(connectionString, eventGroup, options, cancellationToken);
+                });
+
+            var sendCounts = await Task.WhenAll(sendTasks).ConfigureAwait(false);
+            return sendCounts.Sum();
+        }
+
+        /// <summary>
+        ///   Begins reading events from a given position, monitoring the status of the operation.
+        /// </summary>
+        ///
+        /// <param name="consumer">The consumer to use for reading.</param>
+        /// <param name="partition">The identifier of the partition to read from.</param>
+        /// <param name="expectedEventCount">The expected count of events; when this number of events has been read, the <see cref="ReadMonitor.EndCompletion" /> will be signaled.</param>
+        /// <param name="cancellationToken">THe token used to signal cancellation of the read.</param>
+        /// <param name="startingPosition">The position in the partition to start reading from.</param>
+        /// <param name="readOptions">The options to apply when reading.</param>
+        ///
+        /// <returns>The set of monitoring primitives to observe the status of the read.</returns>
+        ///
+        /// <remarks>
+        ///   The read operation will not terminate without cancellation; when the <paramref name="expectedEventCount" /> has been reached,
+        ///   the <see cref="ReadMonitor.EndCompletion" /> will be signaled but the operation will be allowed to continue.
+        /// </remarks>
+        ///
+        private ReadMonitor MonitorReadingEventsFromPartition(EventHubConsumerClient consumer,
+                                                              string partition,
+                                                              int expectedEventCount,
+                                                              CancellationToken cancellationToken,
+                                                              EventPosition? startingPosition = default,
+                                                              ReadEventOptions readOptions = default)
+        {
+            var monitor = new ReadMonitor();
+
+            Task<bool> readCallback(ReadState currentState)
+            {
+                if (currentState.Events.Count >= 1)
+                {
+                    monitor.StartCompletion.TrySetResult(true);
+                }
+
+                if (currentState.Events.Count >= expectedEventCount)
+                {
+                    monitor.EndCompletion.TrySetResult(true);
+                }
+
+                return Task.FromResult(true);
+            }
+
+            monitor.ReadTask = ReadEventsFromPartitionAsync(consumer, partition, int.MaxValue, cancellationToken, startingPosition, readOptions, readCallback);
+            return monitor;
+        }
+
+
+        /// <summary>
+        ///   The results of reading events.
+        /// </summary>
+        ///
+        private class ReadState
+        {
+            public readonly ConcurrentDictionary<string, PartitionEvent> Events = new ConcurrentDictionary<string, PartitionEvent>();
+            public long EmptyCount = 0;
+        }
+
+        /// <summary>
+        ///   The set of primitives for monitoring the reading of events.
+        /// </summary>
+        ///
+        private class ReadMonitor
+        {
+            public readonly TaskCompletionSource<bool> StartCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            public readonly TaskCompletionSource<bool> EndCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            public Task<ReadState> ReadTask;
         }
     }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to overhaul the suite of live tests for the `EventHubConsumer` to address areas of timing sensitivity and instability. The refactor moves to a more deterministic approach and ensures that safety cancellation is applied to all tests in order to ensure there are no hangs.

Event generation has also been centralized into a shared helper, with removal of the similar set of helper methods that had existed within the `EventProcessorClient` live test suite.

# Last Upstream Rebase

Thursday, April 9, 1:22pm (EDT)

# References and Related Issues 

- [ Live Tests: Consumer/Receiver Stability and Implementation](https://github.com/Azure/azure-sdk-for-net/issues/11074) (#11074)