### PR TITLE
[Event Hubs Client] Event Batch Tweaks

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpEventBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpEventBatch.cs
@@ -28,6 +28,9 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// <summary>The maximum number of bytes that a message may be to be considered small.</summary>
         private const byte MaximumBytesSmallMessage = 255;
 
+        /// <summary>The size of the batch, in bytes, to reserve for the AMQP message overhead.</summary>
+        private readonly long ReservedSize;
+
         /// <summary>A flag that indicates whether or not the instance has been disposed.</summary>
         private bool _disposed = false;
 
@@ -93,7 +96,9 @@ namespace Azure.Messaging.EventHubs.Amqp
             // Initialize the size by reserving space for the batch envelope.
 
             using AmqpMessage envelope = messageConverter.CreateBatchFromEvents(Enumerable.Empty<EventData>(), options.PartitionKey);
-            _sizeBytes = envelope.SerializedMessageSize;
+            ReservedSize = envelope.SerializedMessageSize;
+            _sizeBytes = ReservedSize;
+
         }
 
         /// <summary>
@@ -140,6 +145,17 @@ namespace Azure.Messaging.EventHubs.Amqp
         }
 
         /// <summary>
+        ///   Clears the batch, removing all events and resetting the
+        ///   available size.
+        /// </summary>
+        ///
+        public override void Clear()
+        {
+            BatchEvents.Clear();
+            _sizeBytes = ReservedSize;
+        }
+
+        /// <summary>
         ///   Represents the batch as an enumerable set of transport-specific
         ///   representations of an event.
         /// </summary>
@@ -165,9 +181,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         public override void Dispose()
         {
             _disposed = true;
-
-            BatchEvents.Clear();
-            _sizeBytes = 0;
+            Clear();
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
@@ -881,6 +881,15 @@ namespace Azure.Messaging.EventHubs.Consumer
                         activeException = (cancellationToken.IsCancellationRequested) ? null : ex;
                         break;
                     }
+                    catch (InvalidOperationException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        // If cancellation was requested, there is a race condition in which publishing may
+                        // try to communicate with the service as the connection is being closed.  This is not
+                        // a failure condition.
+
+                        activeException = null;
+                        break;
+                    }
                     catch (OperationCanceledException ex)
                     {
                         activeException = new TaskCanceledException(ex.Message, ex);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventBatch.cs
@@ -48,6 +48,13 @@ namespace Azure.Messaging.EventHubs.Core
         public abstract bool TryAdd(EventData eventData);
 
         /// <summary>
+        ///   Clears the batch, removing all events and resetting the
+        ///   available size.
+        /// </summary>
+        ///
+        public abstract void Clear();
+
+        /// <summary>
         ///   Represents the batch as an enumerable set of transport-specific
         ///   representations of an event.
         /// </summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
@@ -14,10 +14,18 @@ namespace Azure.Messaging.EventHubs.Producer
     ///   intended to be sent to the Event Hubs service as a single batch.
     /// </summary>
     ///
+    /// <remarks>
+    ///   The operations for this class are thread-safe and will prevent changes when
+    ///   actively being published to the Event Hubs service.
+    /// </remarks>
+    ///
     public sealed class EventDataBatch : IDisposable
     {
+        /// <summary>An object instance to use as the synchronization root for ensuring the thread-safety of operations.</summary>
+        private readonly object SyncGuard = new object();
+
         /// <summary>A flag indicating that the batch is locked, such as when in use during a publish operation.</summary>
-        private volatile bool _locked = false;
+        private bool _locked = false;
 
         /// <summary>
         ///   The maximum size allowed for the batch, in bytes.  This includes the events in the batch as
@@ -118,34 +126,55 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         public bool TryAdd(EventData eventData)
         {
-            if (_locked)
+            lock (SyncGuard)
             {
-                throw new InvalidOperationException(Resources.EventBatchIsLocked);
-            }
+                AssertNotLocked();
 
-            bool instrumented = EventDataInstrumentation.InstrumentEvent(eventData, FullyQualifiedNamespace, EventHubName);
-            bool added = InnerBatch.TryAdd(eventData);
+                bool instrumented = EventDataInstrumentation.InstrumentEvent(eventData, FullyQualifiedNamespace, EventHubName);
+                bool added = InnerBatch.TryAdd(eventData);
 
-            if (added)
-            {
-                if (EventDataInstrumentation.TryExtractDiagnosticId(eventData, out string diagnosticId))
+                if (added)
                 {
-                    EventDiagnosticIdentifiers.Add(diagnosticId);
+                    if (EventDataInstrumentation.TryExtractDiagnosticId(eventData, out string diagnosticId))
+                    {
+                        EventDiagnosticIdentifiers.Add(diagnosticId);
+                    }
                 }
-            }
-            else if (instrumented)
-            {
-                EventDataInstrumentation.ResetEvent(eventData);
-            }
+                else if (instrumented)
+                {
+                    EventDataInstrumentation.ResetEvent(eventData);
+                }
 
-            return added;
+                return added;
+            }
         }
 
         /// <summary>
         ///   Performs the task needed to clean up resources used by the <see cref="EventDataBatch" />.
         /// </summary>
         ///
-        public void Dispose() => InnerBatch.Dispose();
+        public void Dispose()
+        {
+            lock (SyncGuard)
+            {
+                AssertNotLocked();
+                InnerBatch.Dispose();
+            }
+        }
+
+        /// <summary>
+        ///   Clears the batch, removing all events and resetting the
+        ///   available size.
+        /// </summary>
+        ///
+        internal void Clear()
+        {
+            lock (SyncGuard)
+            {
+                AssertNotLocked();
+                InnerBatch.Clear();
+            }
+        }
 
         /// <summary>
         ///   Represents the batch as an enumerable set of specific representations of an event.
@@ -170,12 +199,39 @@ namespace Azure.Messaging.EventHubs.Producer
         ///   operation is active.
         /// </summary>
         ///
-        internal void Lock() => _locked = true;
+        internal void Lock()
+        {
+            lock (SyncGuard)
+            {
+                _locked = true;
+            }
+        }
 
         /// <summary>
         ///   Unlocks the batch, allowing new events to be added.
         /// </summary>
         ///
-        internal void Unlock() => _locked = false;
+        internal void Unlock()
+        {
+            lock (SyncGuard)
+            {
+                _locked = false;
+            }
+        }
+
+        /// <summary>
+        ///   Validates that the batch is not in a locked state, triggering an
+        ///   invalid operation if it is.
+        /// </summary>
+        ///
+        /// <exception cref="InvalidOperationException">Occurs when the batch is locked.</exception>
+        ///
+        private void AssertNotLocked()
+        {
+            if (_locked)
+            {
+                throw new InvalidOperationException(Resources.EventBatchIsLocked);
+            }
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
@@ -480,7 +480,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task SendManageLockingTheBatch()
+        public async Task SendInvokesTheTransportProducerWithABatch()
         {
             var batchOptions = new CreateBatchOptions { PartitionKey = "testKey" };
             var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions.ToSendOptions());
@@ -497,7 +497,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task SendInvokesTheTransportProducerWithABatch()
+        public async Task SendManagesLockingTheBatch()
         {
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
@@ -826,6 +826,7 @@ namespace Azure.Messaging.EventHubs.Tests
             public override int Count { get; }
             public override bool TryAdd(EventData eventData) => throw new NotImplementedException();
             public override IEnumerable<T> AsEnumerable<T>() => throw new NotImplementedException();
+            public override void Clear() => throw new NotImplementedException();
             public override void Dispose() => throw new NotImplementedException();
         }
     }


### PR DESCRIPTION
# Summary

The focus of these changes is to add thread safety to the core batch operations, ensuring that `TryAdd`, `Clear`, and `Dispose` are safe to call concurrently.  Also fixed behavior with Dispose where the "locked during send" semantics were not properly respected.

An internal-facing `Clear` operation was added, allowing the batch state to be reset, in anticipation of architect approval, at which point things will be public.

# Last Upstream Rebase

Thursday, April 9, 3:44pm (EDT)