### PR TITLE
Fix #8624: Unable to delete the key when test completed

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
@@ -134,7 +134,7 @@ namespace Azure.Data.AppConfiguration.Tests
                 await service.SetConfigurationSettingAsync(testSettingDiff);
 
                 // Test
-                await service.DeleteConfigurationSettingAsync(testSettingDiff.Key);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSettingDiff.Key));
 
                 //Try to get the non-existing setting
                 RequestFailedException e = Assert.ThrowsAsync<RequestFailedException>(async () =>
@@ -146,7 +146,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label));
             }
         }
 
@@ -165,7 +165,7 @@ namespace Azure.Data.AppConfiguration.Tests
                 await service.SetConfigurationSettingAsync(testSettingDiff);
 
                 // Test
-                await service.DeleteConfigurationSettingAsync(testSettingDiff.Key, testSettingDiff.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSettingDiff.Key, testSettingDiff.Label));
 
                 //Try to get the non-existing setting
                 RequestFailedException e = Assert.ThrowsAsync<RequestFailedException>(async () =>
@@ -177,7 +177,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label));
             }
         }
 
@@ -201,7 +201,7 @@ namespace Azure.Data.AppConfiguration.Tests
             finally
             {
                 await service.SetReadOnlyAsync(testSetting.Key, testSetting.Label, false);
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label));
             }
         }
 
@@ -211,18 +211,8 @@ namespace Azure.Data.AppConfiguration.Tests
             ConfigurationClient service = GetClient();
             ConfigurationSetting testSetting = CreateSetting();
 
-            try
-            {
-                ConfigurationSetting setting = await service.AddConfigurationSettingAsync(testSetting);
-
-                // Test
-                Response response = await service.DeleteConfigurationSettingAsync(setting, onlyIfUnchanged: true);
-                Assert.AreEqual(200, response.Status);
-            }
-            finally
-            {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
-            }
+            ConfigurationSetting setting = await service.AddConfigurationSettingAsync(testSetting);
+            AssertStatus200(await service.DeleteConfigurationSettingAsync(setting, onlyIfUnchanged: true));
         }
 
         [Test]
@@ -245,7 +235,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label));
             }
         }
 
@@ -262,7 +252,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label));
             }
         }
 
@@ -281,7 +271,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label));
             }
         }
 
@@ -306,7 +296,7 @@ namespace Azure.Data.AppConfiguration.Tests
             finally
             {
                 await service.SetReadOnlyAsync(testSetting.Key, testSetting.Label, false);
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label));
             }
         }
 
@@ -329,7 +319,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label));
             }
         }
 
@@ -353,7 +343,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label));
             }
         }
 
@@ -374,7 +364,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(key);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(key));
             }
         }
 
@@ -397,7 +387,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(key, label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(key, label));
             }
         }
 
@@ -415,7 +405,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label));
             }
         }
 
@@ -438,7 +428,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label));
             }
         }
 
@@ -455,7 +445,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label));
             }
         }
 
@@ -475,7 +465,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting.Key));
             }
         }
 
@@ -496,7 +486,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(key);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(key));
             }
         }
 
@@ -519,7 +509,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(key, label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(key, label));
             }
         }
 
@@ -571,8 +561,8 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(setting.Key, setting.Label);
-                await service.DeleteConfigurationSettingAsync(testSettingUpdate.Key, testSettingUpdate.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(setting.Key, setting.Label));
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSettingUpdate.Key, testSettingUpdate.Label));
             }
         }
 
@@ -610,8 +600,8 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(setting.Key, setting.Label);
-                await service.DeleteConfigurationSettingAsync(testSettingUpdate.Key, testSettingUpdate.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(setting.Key, setting.Label));
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSettingUpdate.Key, testSettingUpdate.Label));
             }
         }
 
@@ -634,7 +624,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSettingNoLabel.Key);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSettingNoLabel.Key));
             }
         }
 
@@ -673,8 +663,8 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
-                await service.DeleteConfigurationSettingAsync(testSettingNoLabel.Key);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label));
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSettingNoLabel.Key));
             }
         }
 
@@ -695,7 +685,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label));
             }
         }
 
@@ -718,7 +708,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label));
             }
         }
 
@@ -750,7 +740,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label));
             }
         }
 
@@ -774,7 +764,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSettingNoLabel.Key);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSettingNoLabel.Key));
             }
         }
 
@@ -794,7 +784,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting));
             }
         }
 
@@ -840,7 +830,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label));
             }
         }
 
@@ -869,7 +859,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label));
             }
         }
 
@@ -892,7 +882,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label));
             }
         }
 
@@ -919,7 +909,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label));
             }
         }
 
@@ -954,7 +944,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(setting.Key, setting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(setting.Key, setting.Label));
             }
         }
 
@@ -987,7 +977,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(setting.Key, setting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(setting.Key, setting.Label));
             }
         }
 
@@ -1024,7 +1014,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(setting.Key, setting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(setting.Key, setting.Label));
             }
         }
 
@@ -1049,7 +1039,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting));
             }
         }
 
@@ -1077,7 +1067,7 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label));
             }
         }
 
@@ -1104,8 +1094,8 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(abcSetting.Key);
-                await service.DeleteConfigurationSettingAsync(xyzSetting.Key);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(abcSetting.Key));
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(xyzSetting.Key));
             }
         }
 
@@ -1130,8 +1120,8 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(abcSetting.Key);
-                await service.DeleteConfigurationSettingAsync(xyzSetting.Key);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(abcSetting.Key));
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(xyzSetting.Key));
             }
         }
 
@@ -1158,8 +1148,8 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(abcSetting.Key);
-                await service.DeleteConfigurationSettingAsync(xyzSetting.Key);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(abcSetting.Key));
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(xyzSetting.Key));
             }
         }
 
@@ -1186,8 +1176,8 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(abcSetting.Key, abcSetting.Label);
-                await service.DeleteConfigurationSettingAsync(xyzSetting.Key, xyzSetting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(abcSetting.Key, abcSetting.Label));
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(xyzSetting.Key, xyzSetting.Label));
             }
         }
 
@@ -1206,27 +1196,17 @@ namespace Azure.Data.AppConfiguration.Tests
             finally
             {
                 await service.SetReadOnlyAsync(testSetting.Key, testSetting.Label, false);
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label));
             }
         }
 
         [Test]
-        public async Task SetReadOnlySettingNotFound()
+        public void SetReadOnlySettingNotFound()
         {
             ConfigurationClient service = GetClient();
             ConfigurationSetting testSetting = CreateSetting();
 
-            try
-            {
-                Assert.ThrowsAsync<RequestFailedException>(async () =>
-                {
-                    await service.SetReadOnlyAsync(testSetting.Key, true);
-                });
-            }
-            finally
-            {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
-            }
+            Assert.ThrowsAsync<RequestFailedException>(async () => { await service.SetReadOnlyAsync(testSetting.Key, true); });
         }
 
         [Test]
@@ -1243,27 +1223,17 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting));
             }
         }
 
         [Test]
-        public async Task ClearReadOnlySettingNotFound()
+        public void ClearReadOnlySettingNotFound()
         {
             ConfigurationClient service = GetClient();
             ConfigurationSetting testSetting = CreateSetting();
 
-            try
-            {
-                var exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
-                {
-                    await service.SetReadOnlyAsync(testSetting.Key, true);
-                });
-            }
-            finally
-            {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
-            }
+            Assert.ThrowsAsync<RequestFailedException>(async () => { await service.SetReadOnlyAsync(testSetting.Key, true); });
         }
 
         [Test]
@@ -1279,8 +1249,10 @@ namespace Azure.Data.AppConfiguration.Tests
             }
             finally
             {
-                await service.DeleteConfigurationSettingAsync(testSetting.Key, testSetting.Label);
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(testSetting));
             }
         }
+
+        private static void AssertStatus200(Response response) => Assert.AreEqual(200, response.Status);
     }
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/SessionRecords/ConfigurationLiveTests/GetBatchSettingSpecialCharacters.json
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/SessionRecords/ConfigurationLiveTests/GetBatchSettingSpecialCharacters.json
@@ -105,7 +105,7 @@
       }
     },
     {
-      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/~%60%21%40%23%24%5E%26%28%29_%2B%3D%5B%5D%7B%7D%7C%3B%22%27%3C%3E.%2F--563777872?api-version=1.0",
+      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/~%60%21%40%23%24%5E%26%28%29_%2B%3D%5B%5D%7B%7D%7C%3B%22%27%3C%3E.%2F--563777872?label=label-~%60%21%40%23%24%5E%26%28%29_%2B%3D%5B%5D%7B%7D%7C%3B%22%27%3C%3E.%2F-&api-version=1.0",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
@@ -121,7 +121,7 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
-      "StatusCode": 204,
+      "StatusCode": 200,
       "ResponseHeaders": {
         "Access-Control-Allow-Credentials": "true",
         "Access-Control-Allow-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/SessionRecords/ConfigurationLiveTests/GetBatchSettingSpecialCharactersAsync.json
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/SessionRecords/ConfigurationLiveTests/GetBatchSettingSpecialCharactersAsync.json
@@ -105,7 +105,7 @@
       }
     },
     {
-      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/~%60%21%40%23%24%5E%26%28%29_%2B%3D%5B%5D%7B%7D%7C%3B%22%27%3C%3E.%2F--1930085505?api-version=1.0",
+      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/~%60%21%40%23%24%5E%26%28%29_%2B%3D%5B%5D%7B%7D%7C%3B%22%27%3C%3E.%2F--1930085505?label=label-~%60%21%40%23%24%5E%26%28%29_%2B%3D%5B%5D%7B%7D%7C%3B%22%27%3C%3E.%2F-&api-version=1.0",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
@@ -121,7 +121,7 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
-      "StatusCode": 204,
+      "StatusCode": 200,
       "ResponseHeaders": {
         "Access-Control-Allow-Credentials": "true",
         "Access-Control-Allow-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/SessionRecords/ConfigurationLiveTests/GetSettingSpecialCharactersWithLabel.json
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/SessionRecords/ConfigurationLiveTests/GetSettingSpecialCharactersWithLabel.json
@@ -105,7 +105,7 @@
       }
     },
     {
-      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/~%60%21%40%23%24%5E%26%28%29_%2B%3D%5B%5D%7B%7D%7C%3B%22%27%3C%3E.%2F--409765984?api-version=1.0",
+      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/~%60%21%40%23%24%5E%26%28%29_%2B%3D%5B%5D%7B%7D%7C%3B%22%27%3C%3E.%2F--409765984?label=label-~%60%21%40%23%24%5E%26%28%29_%2B%3D%5B%5D%7B%7D%7C%3B%22%27%3C%3E.%2F-&api-version=1.0",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
@@ -121,7 +121,7 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
-      "StatusCode": 204,
+      "StatusCode": 200,
       "ResponseHeaders": {
         "Access-Control-Allow-Credentials": "true",
         "Access-Control-Allow-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/SessionRecords/ConfigurationLiveTests/GetSettingSpecialCharactersWithLabelAsync.json
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/SessionRecords/ConfigurationLiveTests/GetSettingSpecialCharactersWithLabelAsync.json
@@ -105,7 +105,7 @@
       }
     },
     {
-      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/~%60%21%40%23%24%5E%26%28%29_%2B%3D%5B%5D%7B%7D%7C%3B%22%27%3C%3E.%2F--498393529?api-version=1.0",
+      "RequestUri": "https://pakrym-azconfig-ui.azconfig.io/kv/~%60%21%40%23%24%5E%26%28%29_%2B%3D%5B%5D%7B%7D%7C%3B%22%27%3C%3E.%2F--498393529?label=label-~%60%21%40%23%24%5E%26%28%29_%2B%3D%5B%5D%7B%7D%7C%3B%22%27%3C%3E.%2F-&api-version=1.0",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Authorization": "Sanitized",
@@ -121,7 +121,7 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
-      "StatusCode": 204,
+      "StatusCode": 200,
       "ResponseHeaders": {
         "Access-Control-Allow-Credentials": "true",
         "Access-Control-Allow-Headers": "DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate",


### PR DESCRIPTION
No product change is required, tests are updated to ensure that settings created in test are deleted.