### PR TITLE
[Event Hubs Client] Set Processor to Project Reference

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This library extends its Event Processor with durable storage for checkpoint information using Azure Blob storage.  For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
     <Version>5.1.0-preview.2</Version>
@@ -12,7 +12,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.1.0-preview.1" />
+    <!-- TEMP :: Restore the package reference when the Event Processor <T> preview moves to GA -->
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj "/>
+    <!--
+    <PackageReference Include="Azure.Messaging.EventHubs" />
+    -->
+    <!-- END TEMP -->
+
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />


### PR DESCRIPTION
# Summary

The focus of these changes is to reset the reference override in the `Azure.Messaging.EventHubs.Processor` library and temporarily use a project reference to the `Azure.Messaging.EventHubs` core library until the needed preview features _(`EventProcessor<T>`)_ have reached GA status.

# Last Upstream Rebase

Thursday, April 9, 6:16pm (EDT)