### PR TITLE
[FormRecognizer] Preview: Design Changes (renaming and finishing Content-related types)

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ExtractedField.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ExtractedField.cs
@@ -102,7 +102,7 @@ namespace Azure.AI.FormRecognizer.Custom
 
             // TODO: Support case where text reference is lines only, without word segment
             // https://github.com/Azure/azure-sdk-for-net/issues/10364
-            return new RawExtractedWord(readResult.Lines.ToList()[lineIndex].Words.ToList()[wordIndex], readResult.Page);
+            return new FormWord(readResult.Lines.ToList()[lineIndex].Words.ToList()[wordIndex], readResult.Page);
 
             // Code from Chris Stone below
             //if (!string.IsNullOrEmpty(reference) && reference.Length > 2 && reference[0] == '#')
@@ -163,7 +163,7 @@ namespace Azure.AI.FormRecognizer.Custom
 
             // TODO: Support case where text reference is lines only, without word segment
             // https://github.com/Azure/azure-sdk-for-net/issues/10364
-            return new RawExtractedWord(readResults[pageIndex].Lines[lineIndex].Words[wordIndex], readResults[pageIndex].Page);
+            return new FormWord(readResults[pageIndex].Lines[lineIndex].Words[wordIndex], readResults[pageIndex].Page);
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ExtractedLabeledForm.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ExtractedLabeledForm.cs
@@ -99,7 +99,7 @@ namespace Azure.AI.FormRecognizer.Custom
             {
                 foreach (var table in pageResult.Tables)
                 {
-                    tables.Add(new ExtractedLabeledTable(table, readResults[pageResult.Page - 1], pageResult.Page));
+                    tables.Add(new ExtractedLabeledTable(table, readResults[pageResult.Page - 1]));
                 }
             }
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ExtractedLabeledTable.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ExtractedLabeledTable.cs
@@ -1,25 +1,17 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Azure.AI.FormRecognizer.Models;
 
 namespace Azure.AI.FormRecognizer.Custom
 {
     /// <summary>
     /// </summary>
-    public class ExtractedLabeledTable : ExtractedTable
+    public class ExtractedLabeledTable : FormTable
     {
-        internal ExtractedLabeledTable(DataTable_internal table, ReadResult_internal readResult, int pageNumber)
+        internal ExtractedLabeledTable(DataTable_internal table, ReadResult_internal readResult)
             :  base(table, readResult)
         {
-            PageNumber = pageNumber;
         }
-
-        /// <summary>
-        /// </summary>
-        public int PageNumber { get; }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ExtractedLayoutPage.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ExtractedLayoutPage.cs
@@ -26,19 +26,19 @@ namespace Azure.AI.FormRecognizer.Models
 
         /// <summary>
         /// </summary>
-        public IReadOnlyList<ExtractedTable> Tables { get; }
+        public IReadOnlyList<FormTable> Tables { get; }
 
         /// <summary>
         /// </summary>
         public RawExtractedPage RawExtractedPage { get; }
 
-        internal static IReadOnlyList<ExtractedTable> ConvertTables(IReadOnlyList<DataTable_internal> tablesResult, ReadResult_internal readResult)
+        internal static IReadOnlyList<FormTable> ConvertTables(IReadOnlyList<DataTable_internal> tablesResult, ReadResult_internal readResult)
         {
-            List<ExtractedTable> tables = new List<ExtractedTable>();
+            List<FormTable> tables = new List<FormTable>();
 
             foreach (var result in tablesResult)
             {
-                tables.Add(new ExtractedTable(result, readResult));
+                tables.Add(new FormTable(result, readResult));
             }
 
             return tables;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ExtractedPage.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ExtractedPage.cs
@@ -42,7 +42,7 @@ namespace Azure.AI.FormRecognizer.Custom
         /// <summary>
         /// </summary>
 
-        public IReadOnlyList<ExtractedTable> Tables { get; }
+        public IReadOnlyList<FormTable> Tables { get; }
 
         /// <summary>
         /// </summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormContent.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormContent.cs
@@ -12,6 +12,7 @@ namespace Azure.AI.FormRecognizer.Models
         public BoundingBox BoundingBox { get; }
 
         /// <summary>
+        /// The 1-based page number in the input document.
         /// </summary>
         public int PageNumber { get; }
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormContent.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormContent.cs
@@ -7,6 +7,13 @@ namespace Azure.AI.FormRecognizer.Models
     /// </summary>
     public abstract class FormContent
     {
+        internal FormContent(BoundingBox boundingBox, int pageNumber, string text)
+        {
+            BoundingBox = boundingBox;
+            PageNumber = pageNumber;
+            Text = text;
+        }
+
         /// <summary>
         /// </summary>
         public BoundingBox BoundingBox { get; }
@@ -19,12 +26,5 @@ namespace Azure.AI.FormRecognizer.Models
         /// <summary>
         /// </summary>
         public string Text { get; }
-
-        internal FormContent(BoundingBox boundingBox, int pageNumber, string text)
-        {
-            BoundingBox = boundingBox;
-            PageNumber = pageNumber;
-            Text = text;
-        }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormLine.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormLine.cs
@@ -15,15 +15,15 @@ namespace Azure.AI.FormRecognizer.Models
         }
 
         /// <summary> List of words in the text line. </summary>
-        public IReadOnlyList<RawExtractedWord> Words { get; internal set; }
+        public IReadOnlyList<FormWord> Words { get; internal set; }
 
-        private static IReadOnlyList<RawExtractedWord> ConvertWords(IReadOnlyList<TextWord_internal> textWords, int pageNumber)
+        private static IReadOnlyList<FormWord> ConvertWords(IReadOnlyList<TextWord_internal> textWords, int pageNumber)
         {
-            List<RawExtractedWord> rawWords = new List<RawExtractedWord>();
+            List<FormWord> rawWords = new List<FormWord>();
 
             foreach (TextWord_internal textWord in textWords)
             {
-                rawWords.Add(new RawExtractedWord(textWord, pageNumber));
+                rawWords.Add(new FormWord(textWord, pageNumber));
             }
 
             return rawWords;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormLine.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormLine.cs
@@ -9,7 +9,8 @@ namespace Azure.AI.FormRecognizer.Models
     /// </summary>
     public class FormLine : FormContent
     {
-        internal FormLine(TextLine_internal textLine, int pageNumber) : base(new BoundingBox(textLine.BoundingBox), pageNumber, textLine.Text)
+        internal FormLine(TextLine_internal textLine, int pageNumber)
+            : base(new BoundingBox(textLine.BoundingBox), pageNumber, textLine.Text)
         {
             Words = ConvertWords(textLine.Words, pageNumber);
         }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormLine.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormLine.cs
@@ -7,9 +7,9 @@ namespace Azure.AI.FormRecognizer.Models
 {
     /// <summary>
     /// </summary>
-    public class RawExtractedLine : FormContent
+    public class FormLine : FormContent
     {
-        internal RawExtractedLine(TextLine_internal textLine, int pageNumber) : base(new BoundingBox(textLine.BoundingBox), pageNumber, textLine.Text)
+        internal FormLine(TextLine_internal textLine, int pageNumber) : base(new BoundingBox(textLine.BoundingBox), pageNumber, textLine.Text)
         {
             Words = ConvertWords(textLine.Words, pageNumber);
         }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormPage.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormPage.cs
@@ -9,6 +9,22 @@ namespace Azure.AI.FormRecognizer.Models
     /// </summary>
     public class FormPage : FormContent
     {
+        internal FormPage(IReadOnlyList<DataTable_internal> tablesResult, ReadResult_internal readResult)
+            : base(null, readResult.Page, null) // TODO: retrieve text and bounding box.
+        {
+            TextAngle = readResult.Angle;
+            Width = readResult.Width;
+            Height = readResult.Height;
+            Unit = readResult.Unit;
+
+            if (readResult.Lines != null)
+            {
+                Lines = RawExtractedPage.ConvertLines(readResult.Lines, PageNumber);
+            }
+
+            Tables = ExtractedLayoutPage.ConvertTables(tablesResult, readResult);
+        }
+
         /// <summary>
         /// The general orientation of the text in clockwise direction, measured in degrees between (-180, 180].
         /// </summary>
@@ -41,21 +57,5 @@ namespace Azure.AI.FormRecognizer.Models
         /// <summary>
         /// </summary>
         public IReadOnlyList<ExtractedTable> Tables { get; }
-
-        internal FormPage(IReadOnlyList<DataTable_internal> tablesResult, ReadResult_internal readResult)
-            : base(null, readResult.Page, null) // TODO: retrieve text and bounding box.
-        {
-            TextAngle = readResult.Angle;
-            Width = readResult.Width;
-            Height = readResult.Height;
-            Unit = readResult.Unit;
-
-            if (readResult.Lines != null)
-            {
-                Lines = RawExtractedPage.ConvertLines(readResult.Lines, PageNumber);
-            }
-
-            Tables = ExtractedLayoutPage.ConvertTables(tablesResult, readResult);
-        }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormPage.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormPage.cs
@@ -52,7 +52,7 @@ namespace Azure.AI.FormRecognizer.Models
         /// treated with higher priority. As the sorting order depends on the detected text, it may change across images
         /// and OCR version updates. Thus, business logic should be built upon the actual line location instead of order.
         /// </summary>
-        public ICollection<RawExtractedLine> Lines { get; set; }
+        public ICollection<FormLine> Lines { get; set; }
 
         /// <summary>
         /// </summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormPage.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormPage.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+namespace Azure.AI.FormRecognizer.Models
+{
+    /// <summary>
+    /// </summary>
+    public class FormPage : FormContent
+    {
+        /// <summary>
+        /// The general orientation of the text in clockwise direction, measured in degrees between (-180, 180].
+        /// </summary>
+        public float TextAngle { get; set; }
+
+        /// <summary>
+        /// The width of the image/PDF in pixels/inches, respectively.
+        /// </summary>
+        public float Width { get; set; }
+
+        /// <summary>
+        /// The height of the image/PDF in pixels/inches, respectively.
+        /// </summary>
+        public float Height { get; set; }
+
+        /// <summary>
+        /// The unit used by the width, height and boundingBox properties. For images, the unit is &quot;pixel&quot;.
+        /// For PDF, the unit is &quot;inch&quot;.
+        /// </summary>
+        public LengthUnit Unit { get; set; }
+
+        /// <summary>
+        /// When includeTextDetails is set to true, a list of recognized text lines. The maximum number of lines returned
+        /// is 300 per page. The lines are sorted top to bottom, left to right, although in certain cases proximity is
+        /// treated with higher priority. As the sorting order depends on the detected text, it may change across images
+        /// and OCR version updates. Thus, business logic should be built upon the actual line location instead of order.
+        /// </summary>
+        public ICollection<RawExtractedLine> Lines { get; set; }
+
+        /// <summary>
+        /// </summary>
+        public IReadOnlyList<ExtractedTable> Tables { get; }
+
+        internal FormPage(IReadOnlyList<DataTable_internal> tablesResult, ReadResult_internal readResult)
+            : base(null, readResult.Page, null) // TODO: retrieve text and bounding box.
+        {
+            TextAngle = readResult.Angle;
+            Width = readResult.Width;
+            Height = readResult.Height;
+            Unit = readResult.Unit;
+
+            if (readResult.Lines != null)
+            {
+                Lines = RawExtractedPage.ConvertLines(readResult.Lines, PageNumber);
+            }
+
+            Tables = ExtractedLayoutPage.ConvertTables(tablesResult, readResult);
+        }
+    }
+}

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormPage.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormPage.cs
@@ -56,6 +56,6 @@ namespace Azure.AI.FormRecognizer.Models
 
         /// <summary>
         /// </summary>
-        public IReadOnlyList<ExtractedTable> Tables { get; }
+        public IReadOnlyList<FormTable> Tables { get; }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTable.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTable.cs
@@ -37,7 +37,7 @@ namespace Azure.AI.FormRecognizer.Models
         /// <summary>
         /// </summary>
 #pragma warning disable CA1822 // Mark as static
-        public FormTableCell this[int row, int column]
+        internal FormTableCell this[int row, int column]
 #pragma warning restore CA1822 // Mark as static
         {
             get

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTable.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTable.cs
@@ -20,7 +20,7 @@ namespace Azure.AI.FormRecognizer.Models
 
         /// <summary>
         /// </summary>
-        public IReadOnlyList<ExtractedTableCell> Cells { get; }
+        public IReadOnlyList<FormTableCell> Cells { get; }
 
         /// <summary>
         /// </summary>
@@ -37,7 +37,7 @@ namespace Azure.AI.FormRecognizer.Models
         /// <summary>
         /// </summary>
 #pragma warning disable CA1822 // Mark as static
-        public ExtractedTableCell this[int row, int column]
+        public FormTableCell this[int row, int column]
 #pragma warning restore CA1822 // Mark as static
         {
             get
@@ -53,12 +53,12 @@ namespace Azure.AI.FormRecognizer.Models
             }
         }
 
-        private static IReadOnlyList<ExtractedTableCell> ConvertCells(IReadOnlyList<DataTableCell_internal> cellsResult, ReadResult_internal readResult)
+        private static IReadOnlyList<FormTableCell> ConvertCells(IReadOnlyList<DataTableCell_internal> cellsResult, ReadResult_internal readResult)
         {
-            List<ExtractedTableCell> cells = new List<ExtractedTableCell>();
+            List<FormTableCell> cells = new List<FormTableCell>();
             foreach (var result in cellsResult)
             {
-                cells.Add(new ExtractedTableCell(result, readResult, result.Elements));
+                cells.Add(new FormTableCell(result, readResult, result.Elements));
             }
 
             return cells;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTable.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTable.cs
@@ -8,9 +8,10 @@ namespace Azure.AI.FormRecognizer.Models
 {
     /// <summary>
     /// </summary>
-    public class ExtractedTable
+    public class FormTable : FormContent
     {
-        internal ExtractedTable(DataTable_internal table, ReadResult_internal readResult)
+        internal FormTable(DataTable_internal table, ReadResult_internal readResult)
+            : base(null, readResult.Page, null) // TODO: retrieve text and bounding box.
         {
             ColumnCount = table.Columns;
             RowCount = table.Rows;
@@ -32,7 +33,6 @@ namespace Azure.AI.FormRecognizer.Models
         // TODO: implement table indexer
         // TODO: Handling column-span?
         // https://github.com/Azure/azure-sdk-for-net/issues/9975
-
 
         /// <summary>
         /// </summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTableCell.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTableCell.cs
@@ -8,11 +8,11 @@ namespace Azure.AI.FormRecognizer.Models
 {
     /// <summary>
     /// </summary>
-    public class ExtractedTableCell
+    public class FormTableCell : FormContent
     {
-        internal ExtractedTableCell(DataTableCell_internal dataTableCell, ReadResult_internal readResult, IReadOnlyList<string> references)
+        internal FormTableCell(DataTableCell_internal dataTableCell, ReadResult_internal readResult, IReadOnlyList<string> references)
+            : base(new BoundingBox(dataTableCell.BoundingBox), readResult.Page, dataTableCell.Text)
         {
-            BoundingBox = new BoundingBox(dataTableCell.BoundingBox);
             ColumnIndex = dataTableCell.ColumnIndex;
             ColumnSpan = dataTableCell.ColumnSpan ?? 1;
             Confidence = dataTableCell.Confidence;
@@ -20,17 +20,12 @@ namespace Azure.AI.FormRecognizer.Models
             IsHeader = dataTableCell.IsHeader ?? false;
             RowIndex = dataTableCell.RowIndex;
             RowSpan = dataTableCell.RowSpan ?? 1;
-            Text = dataTableCell.Text;
 
             if (references != null)
             {
-                RawExtractedItems = ExtractedField.ConvertTextReferences(readResult, references);
+                TextContent = ExtractedField.ConvertTextReferences(readResult, references);
             }
         }
-
-        /// <summary>
-        /// </summary>
-        public BoundingBox BoundingBox { get; }
 
         /// <summary>
         /// </summary>
@@ -62,10 +57,6 @@ namespace Azure.AI.FormRecognizer.Models
 
         /// <summary>
         /// </summary>
-        public string Text { get; }
-
-        /// <summary>
-        /// </summary>
-        public IReadOnlyList<FormContent> RawExtractedItems { get; internal set; }
+        public IReadOnlyList<FormContent> TextContent { get; }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormWord.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormWord.cs
@@ -5,9 +5,9 @@ namespace Azure.AI.FormRecognizer.Models
 {
     /// <summary>
     /// </summary>
-    public class RawExtractedWord : FormContent
+    public class FormWord : FormContent
     {
-        internal RawExtractedWord(TextWord_internal textWord, int pageNumber) : base(new BoundingBox(textWord.BoundingBox), pageNumber, textWord.Text)
+        internal FormWord(TextWord_internal textWord, int pageNumber) : base(new BoundingBox(textWord.BoundingBox), pageNumber, textWord.Text)
         {
             Confidence = textWord.Confidence;
         }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormWord.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormWord.cs
@@ -7,7 +7,8 @@ namespace Azure.AI.FormRecognizer.Models
     /// </summary>
     public class FormWord : FormContent
     {
-        internal FormWord(TextWord_internal textWord, int pageNumber) : base(new BoundingBox(textWord.BoundingBox), pageNumber, textWord.Text)
+        internal FormWord(TextWord_internal textWord, int pageNumber)
+            : base(new BoundingBox(textWord.BoundingBox), pageNumber, textWord.Text)
         {
             Confidence = textWord.Confidence;
         }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RawExtractedPage.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RawExtractedPage.cs
@@ -39,15 +39,15 @@ namespace Azure.AI.FormRecognizer.Models
         public LengthUnit Unit { get; set; }
 
         /// <summary> When includeTextDetails is set to true, a list of recognized text lines. The maximum number of lines returned is 300 per page. The lines are sorted top to bottom, left to right, although in certain cases proximity is treated with higher priority. As the sorting order depends on the detected text, it may change across images and OCR version updates. Thus, business logic should be built upon the actual line location instead of order. </summary>
-        public ICollection<RawExtractedLine> Lines { get; set; }
+        public ICollection<FormLine> Lines { get; set; }
 
-        internal static ICollection<RawExtractedLine> ConvertLines(IReadOnlyList<TextLine_internal> textLines, int pageNumber)
+        internal static ICollection<FormLine> ConvertLines(IReadOnlyList<TextLine_internal> textLines, int pageNumber)
         {
-            List<RawExtractedLine> rawLines = new List<RawExtractedLine>();
+            List<FormLine> rawLines = new List<FormLine>();
 
             foreach (TextLine_internal textLine in textLines)
             {
-                rawLines.Add(new RawExtractedLine(textLine, pageNumber));
+                rawLines.Add(new FormLine(textLine, pageNumber));
             }
 
             return rawLines;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RawExtractedPage.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RawExtractedPage.cs
@@ -41,7 +41,7 @@ namespace Azure.AI.FormRecognizer.Models
         /// <summary> When includeTextDetails is set to true, a list of recognized text lines. The maximum number of lines returned is 300 per page. The lines are sorted top to bottom, left to right, although in certain cases proximity is treated with higher priority. As the sorting order depends on the detected text, it may change across images and OCR version updates. Thus, business logic should be built upon the actual line location instead of order. </summary>
         public ICollection<RawExtractedLine> Lines { get; set; }
 
-        private static ICollection<RawExtractedLine> ConvertLines(IReadOnlyList<TextLine_internal> textLines, int pageNumber)
+        internal static ICollection<RawExtractedLine> ConvertLines(IReadOnlyList<TextLine_internal> textLines, int pageNumber)
         {
             List<RawExtractedLine> rawLines = new List<RawExtractedLine>();
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeContentOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeContentOperation.cs
@@ -15,7 +15,7 @@ namespace Azure.AI.FormRecognizer.Models
     /// <summary>
     /// Tracks the status of a long-running operation for recognizing layout elements from forms.
     /// </summary>
-    public class RecognizeContentOperation : Operation<IReadOnlyList<ExtractedLayoutPage>>
+    public class RecognizeContentOperation : Operation<IReadOnlyList<FormPage>>
     {
         /// <summary>Provides communication with the Form Recognizer Azure Cognitive Service through its REST API.</summary>
         private readonly ServiceClient _serviceClient;
@@ -24,7 +24,7 @@ namespace Azure.AI.FormRecognizer.Models
         private Response _response;
 
         /// <summary>The result of the long-running operation. <c>null</c> until result is received on status update.</summary>
-        private IReadOnlyList<ExtractedLayoutPage> _value;
+        private IReadOnlyList<FormPage> _value;
 
         /// <summary><c>true</c> if the long-running operation has completed. Otherwise, <c>false</c>.</summary>
         private bool _hasCompleted;
@@ -33,7 +33,7 @@ namespace Azure.AI.FormRecognizer.Models
         public override string Id { get; }
 
         /// <inheritdoc/>
-        public override IReadOnlyList<ExtractedLayoutPage> Value => OperationHelpers.GetValue(ref _value);
+        public override IReadOnlyList<FormPage> Value => OperationHelpers.GetValue(ref _value);
 
         /// <inheritdoc/>
         public override bool HasCompleted => _hasCompleted;
@@ -73,11 +73,11 @@ namespace Azure.AI.FormRecognizer.Models
         public override Response GetRawResponse() => _response;
 
         /// <inheritdoc/>
-        public override ValueTask<Response<IReadOnlyList<ExtractedLayoutPage>>> WaitForCompletionAsync(CancellationToken cancellationToken = default) =>
+        public override ValueTask<Response<IReadOnlyList<FormPage>>> WaitForCompletionAsync(CancellationToken cancellationToken = default) =>
             this.DefaultWaitForCompletionAsync(cancellationToken);
 
         /// <inheritdoc/>
-        public override ValueTask<Response<IReadOnlyList<ExtractedLayoutPage>>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) =>
+        public override ValueTask<Response<IReadOnlyList<FormPage>>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) =>
             this.DefaultWaitForCompletionAsync(pollingInterval, cancellationToken);
 
         /// <inheritdoc/>
@@ -118,16 +118,16 @@ namespace Azure.AI.FormRecognizer.Models
             return GetRawResponse();
         }
 
-        private static IReadOnlyList<ExtractedLayoutPage> ConvertValue(IReadOnlyList<PageResult_internal> pageResults, IReadOnlyList<ReadResult_internal> readResults)
+        private static IReadOnlyList<FormPage> ConvertValue(IReadOnlyList<PageResult_internal> pageResults, IReadOnlyList<ReadResult_internal> readResults)
         {
             Debug.Assert(pageResults.Count == readResults.Count);
 
-            List<ExtractedLayoutPage> pages = new List<ExtractedLayoutPage>();
+            List<FormPage> pages = new List<FormPage>();
             List<ReadResult_internal> rawPages = readResults.ToList();
 
-            foreach (var page in pageResults)
+            foreach (var pageResult in pageResults)
             {
-                pages.Add(new ExtractedLayoutPage(page, rawPages[page.Page - 1]));
+                pages.Add(new FormPage(pageResult.Tables, rawPages[pageResult.Page - 1]));
             }
 
             return pages;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
@@ -117,7 +117,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 Assert.GreaterOrEqual(cell.Confidence, 0, $"Cell with text {cell.Text} should have confidence greater than or equal to zero.");
                 Assert.LessOrEqual(cell.RowIndex, 1, $"Cell with text {cell.Text} should have confidence less than or equal to one.");
 
-                Assert.Greater(cell.RawExtractedItems.Count, 0, $"Cell with text {cell.Text} should have at least one extracted item.");
+                Assert.Greater(cell.TextContent.Count, 0, $"Cell with text {cell.Text} should have text content.");
             }
         }
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
@@ -37,10 +37,10 @@ namespace Azure.AI.FormRecognizer.Tests
         [Test]
         [TestCase(true)]
         [TestCase(false)]
-        public async Task StartRecognizeContentPopulatesExtractedLayoutPage(bool useStream)
+        public async Task StartRecognizeContentPopulatesFormPage(bool useStream)
         {
             var client = CreateInstrumentedClient();
-            Operation<IReadOnlyList<ExtractedLayoutPage>> operation;
+            Operation<IReadOnlyList<FormPage>> operation;
 
             if (useStream)
             {
@@ -57,23 +57,19 @@ namespace Azure.AI.FormRecognizer.Tests
 
             Assert.IsTrue(operation.HasValue);
 
-            var layoutPage = operation.Value.Single();
+            var formPage = operation.Value.Single();
 
             // The expected values are based on the values returned by the service, and not the actual
             // values present in the form. We are not testing the service here, but the SDK.
 
-            Assert.AreEqual(1, layoutPage.PageNumber);
+            Assert.AreEqual(1, formPage.PageNumber);
+            Assert.AreEqual(LengthUnit.Inch, formPage.Unit);
+            Assert.AreEqual(8.5, formPage.Width);
+            Assert.AreEqual(11, formPage.Height);
+            Assert.AreEqual(0, formPage.TextAngle);
+            Assert.AreEqual(18, formPage.Lines.Count);
 
-            var rawPage = layoutPage.RawExtractedPage;
-
-            Assert.AreEqual(1, rawPage.Page);
-            Assert.AreEqual(LengthUnit.Inch, rawPage.Unit);
-            Assert.AreEqual(8.5, rawPage.Width);
-            Assert.AreEqual(11, rawPage.Height);
-            Assert.AreEqual(0, rawPage.TextAngle);
-            Assert.AreEqual(18, rawPage.Lines.Count);
-
-            var lines = rawPage.Lines.ToList();
+            var lines = formPage.Lines.ToList();
 
             for (var lineIndex = 0; lineIndex < lines.Count; lineIndex++)
             {
@@ -84,7 +80,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 Assert.AreEqual(4, line.BoundingBox.Points.Count(), $"There should be exactly 4 points in the bounding box in line {lineIndex}.");
             }
 
-            var table = layoutPage.Tables.Single();
+            var table = formPage.Tables.Single();
 
             Assert.AreEqual(2, table.RowCount);
             Assert.AreEqual(6, table.ColumnCount);


### PR DESCRIPTION
### Summary

This PR is one of the multiple set of changes needed to update the FormRecognizer clients to their new API for the next preview. The current plan consists in breaking #11048 into smaller chunks for easier review and to avoid big merge conflicts.

With these changes, all the Content-related types will be in accordance with the new design, but missing a little bit of functionality. Corresponding methods in the `FormRecognizerClient` still need to have their signatures updated (`StartRecognizeContent` methods).

### Changes

- Created `FormPage` type by merging contents from `RawExtractedPage` and `ExtractedLayoutPage`. Both original classes were not removed in order to keep changes to other operations (Receipt and Custom) to a minimum. These files will eventually be removed when the new API is in place.
- Updated `RawExtractedLine` to `FormLine`.
- Updated `RawExtractedWord` to `FormWord`.
- Updated `ExtractedTable` to `FormTable`.
- Updated `ExtractedTableCell` to `FormTableCell`.
- Updated tests accordingly.