### PR TITLE
Merge design for StartRecognizeCustomForms methods

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FieldText.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FieldText.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+namespace Azure.AI.FormRecognizer.Models
+{
+    /// <summary>
+    /// </summary>
+    public class FieldText : FormContent
+    {
+        /// <summary>
+        /// </summary>
+        /// <param name="textElements"></param>
+        /// <param name="boundingBox"></param>
+        /// <param name="text"></param>
+        internal FieldText(string text, BoundingBox boundingBox, IReadOnlyList<FormContent> textElements)
+            : base(boundingBox, 0, text /* TODO */)
+        {
+            TextContent = textElements;
+        }
+
+        /// <summary>
+        /// </summary>
+        public IReadOnlyList<FormContent> TextContent { get; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="text"></param>
+        public static implicit operator string(FieldText text) => text.Text;
+    }
+}

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FieldValue.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FieldValue.cs
@@ -51,7 +51,7 @@ namespace Azure.AI.FormRecognizer.Models
         }
 
         /// <summary>
-        /// Gets the value of the field as an <see cref="float"/>.
+        /// Gets the value of the field as a <see cref="float"/>.
         /// </summary>
         /// <returns></returns>
         public float AsFloat()
@@ -70,7 +70,7 @@ namespace Azure.AI.FormRecognizer.Models
         }
 
         /// <summary>
-        /// Gets the value of the field as an <see cref="DateTimeOffset"/>.
+        /// Gets the value of the field as a <see cref="DateTimeOffset"/>.
         /// </summary>
         /// <returns></returns>
 #pragma warning disable CA1822
@@ -81,7 +81,7 @@ namespace Azure.AI.FormRecognizer.Models
         }
 
         /// <summary>
-        /// Gets the value of the field as an <see cref="DateTimeOffset"/>.
+        /// Gets the value of the field as a <see cref="TimeSpan"/>.
         /// </summary>
         /// <returns></returns>
 #pragma warning disable CA1822

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FieldValue.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FieldValue.cs
@@ -1,0 +1,130 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Azure.AI.FormRecognizer.Models
+{
+    /// <summary>
+    /// </summary>
+    public struct FieldValue
+    {
+#pragma warning disable CS0649 // Add readonly modifier
+        private FieldValue_internal _fieldValue;
+#pragma warning restore CS0649 // Add readonly modifier
+
+        /// <summary> Type of field value. </summary>
+        public FieldValueType Type { get; internal set; }
+
+        /// <summary>
+        /// Gets the value of the field as a <see cref="string"/>.
+        /// </summary>
+        /// <returns></returns>
+        public string AsString()
+        {
+            if (Type != FieldValueType.String)
+            {
+                throw new InvalidOperationException($"Cannot get field as String.  Field value's type is {Type}.");
+            }
+
+            return _fieldValue.ValueString;
+        }
+
+        /// <summary>
+        /// Gets the value of the field as an <see cref="int"/>.
+        /// </summary>
+        /// <returns></returns>
+        public int AsInt32()
+        {
+            if (Type != FieldValueType.Integer)
+            {
+                throw new InvalidOperationException($"Cannot get field as Integer.  Field value's type is {Type}.");
+            }
+
+            if (!_fieldValue.ValueInteger.HasValue)
+            {
+                throw new InvalidOperationException($"Field value is null.");
+            }
+
+            return _fieldValue.ValueInteger.Value;
+        }
+
+        /// <summary>
+        /// Gets the value of the field as an <see cref="float"/>.
+        /// </summary>
+        /// <returns></returns>
+        public float AsFloat()
+        {
+            if (Type != FieldValueType.Number)
+            {
+                throw new InvalidOperationException($"Cannot get field as Float.  Field value's type is {Type}.");
+            }
+
+            if (!_fieldValue.ValueNumber.HasValue)
+            {
+                throw new InvalidOperationException($"Field value is null.");
+            }
+
+            return _fieldValue.ValueNumber.Value;
+        }
+
+        /// <summary>
+        /// Gets the value of the field as an <see cref="DateTimeOffset"/>.
+        /// </summary>
+        /// <returns></returns>
+#pragma warning disable CA1822
+        public DateTime AsDate()
+#pragma warning restore CA1822
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Gets the value of the field as an <see cref="DateTimeOffset"/>.
+        /// </summary>
+        /// <returns></returns>
+#pragma warning disable CA1822
+        public TimeSpan AsTime()
+#pragma warning restore CA1822
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Gets the value of the field as a phone number <see cref="string"/>.
+        /// </summary>
+        /// <returns></returns>
+#pragma warning disable CA1822
+        public string AsPhoneNumber()
+#pragma warning restore CA1822
+        {
+            if (Type != FieldValueType.PhoneNumber)
+            {
+                throw new InvalidOperationException($"Cannot get field as PhoneNumber.  Field value's type is {Type}.");
+            }
+
+            return _fieldValue.ValuePhoneNumber;
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <returns></returns>
+#pragma warning disable CA1822
+        public IReadOnlyList<FieldValue> AsList()
+#pragma warning restore CA1822
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <returns></returns>
+#pragma warning disable CA1822
+        public IReadOnlyDictionary<string, FieldValue> AsDictionary()
+#pragma warning restore CA1822
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormField.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormField.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.AI.FormRecognizer.Models
+{
+    /// <summary>
+    /// </summary>
+    public class FormField
+    {
+#pragma warning disable CA1801
+        internal FormField(KeyValuePair_internal field, ReadResult_internal readResult)
+        {
+#pragma warning restore CA1801
+            //Confidence = field.Confidence;
+
+            //Name = field.Key.Text;
+            //NameBoundingBox = new BoundingBox(field.Key.BoundingBox);
+
+            //if (field.Key.Elements != null)
+            //{
+            //    NameTextElements = ConvertTextReferences(readResult, field.Key.Elements);
+            //}
+
+            //Value = field.Value.Text;
+            //ValueBoundingBox = new BoundingBox(field.Value.BoundingBox);
+
+            //if (field.Value.Elements != null)
+            //{
+            //    ValueTextElements = ConvertTextReferences(readResult, field.Value.Elements);
+            //}
+        }
+
+        /// <summary>
+        /// Canonical name; uniquely identifieds field within the form.
+        /// </summary>
+        public string Name { get; internal set; }
+
+        /// <summary>
+        /// Text from the form that labels the form field.
+        /// </summary>
+        public FieldText FieldLabel { get; internal set; }
+
+        /// <summary>
+        /// </summary>
+        public FieldText ValueText { get; internal set; }
+
+        /// <summary>
+        /// </summary>
+        public FieldValue Value { get; internal set; }
+
+        /// <summary>
+        /// </summary>
+        public float? Confidence { get; }
+    }
+}

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormField.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormField.cs
@@ -31,7 +31,7 @@ namespace Azure.AI.FormRecognizer.Models
         }
 
         /// <summary>
-        /// Canonical name; uniquely identifieds field within the form.
+        /// Canonical name; uniquely identifies a field within the form.
         /// </summary>
         public string Name { get; internal set; }
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormField{T}.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormField{T}.cs
@@ -14,7 +14,7 @@ namespace Azure.AI.FormRecognizer.Models
         }
 
         /// <summary>
-        /// Canonical name; uniquely identifieds field within the form.
+        /// Canonical name; uniquely identifies a field within the form.
         /// </summary>
         public string Name { get; internal set; }
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormField{T}.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormField{T}.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.AI.FormRecognizer.Models
+{
+    /// <summary>
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class FormField<T>
+    {
+        internal FormField(T value)
+        {
+            Value = value;
+        }
+
+        /// <summary>
+        /// Canonical name; uniquely identifieds field within the form.
+        /// </summary>
+        public string Name { get; internal set; }
+
+        /// <summary>
+        /// Text from the form that labels the form field.
+        /// </summary>
+        public FieldText FieldLabel { get; internal set; }
+
+        /// <summary>
+        /// </summary>
+        public FieldText ValueText { get; internal set; }
+
+        /// <summary>
+        /// </summary>
+        public T Value { get; internal set; }
+
+        /// <summary>
+        /// </summary>
+        public float? Confidence { get; }
+
+        /// <summary>
+        /// </summary>
+        public int? PageNumber { get; internal set; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="field"></param>
+        public static implicit operator T(FormField<T> field) => field.Value;
+    }
+}

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormPageRange.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormPageRange.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Azure.AI.FormRecognizer.Models
+{
+    /// <summary>
+    /// </summary>
+    public class FormPageRange
+    {
+        internal FormPageRange(IList<int> pageRange)
+        {
+            // TODO: validate that PageRange.Length == 2.
+            // https://github.com/Azure/azure-sdk-for-net/issues/10547
+            FirstPageNumber = pageRange.First();
+            LastPageNumber = pageRange.Last();
+        }
+
+        /// <summary>
+        /// </summary>
+        public int FirstPageNumber { get; internal set; }
+
+        /// <summary>
+        /// </summary>
+        public int LastPageNumber { get; internal set; }
+    }
+}

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
@@ -193,6 +193,7 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="RecognizeCustomFormsOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeCustomFormsOperation"/>.Value upon successful
         /// completion will contain extracted pages from the input document.</returns>
+        [ForwardsClientCalls]
         public virtual RecognizeCustomFormsOperation StartRecognizeCustomForms(string modelId, Stream formFileStream, /* ContentType contentType, */ RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
@@ -212,6 +213,7 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="RecognizeCustomFormsOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeCustomFormsOperation"/>.Value upon successful
         /// completion will contain extracted pages from the input document.</returns>
+        [ForwardsClientCalls]
         public virtual RecognizeCustomFormsOperation StartRecognizeCustomFormsFromUri(string modelId, Uri formFileUri, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
@@ -229,6 +231,7 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="RecognizeCustomFormsOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeCustomFormsOperation"/>.Value upon successful
         /// completion will contain extracted pages from the input document.</returns>
+        [ForwardsClientCalls]
         public virtual async Task<RecognizeCustomFormsOperation> StartRecognizeCustomFormsAsync(string modelId, Stream formFileStream, /* ContentType contentType, */ RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
         {
             await Task.Run(() => { }).ConfigureAwait(false);
@@ -249,6 +252,7 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="RecognizeCustomFormsOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeCustomFormsOperation"/>.Value upon successful
         /// completion will contain extracted pages from the input document.</returns>
+        [ForwardsClientCalls]
         public virtual async Task<RecognizeCustomFormsOperation> StartRecognizeCustomFormsFromUriAsync(string modelId, Uri formFileUri, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
         {
             await Task.Run(() => { }).ConfigureAwait(false);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
@@ -182,6 +182,85 @@ namespace Azure.AI.FormRecognizer
 
         #endregion
 
+        #region Custom Forms
+
+        /// <summary>
+        /// Extract pages from one or more forms, using a model trained without labels.
+        /// </summary>
+        /// <param name="modelId">The id of the model to use for extracting form values.</param>
+        /// <param name="formFileStream">The stream containing one or more forms to extract elements from.</param>
+        /// <param name="recognizeOptions">Whether or not to include raw page extractions in addition to layout elements.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
+        /// <returns>A <see cref="RecognizeCustomFormsOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeCustomFormsOperation"/>.Value upon successful
+        /// completion will contain extracted pages from the input document.</returns>
+        public virtual RecognizeCustomFormsOperation StartRecognizeCustomForms(string modelId, Stream formFileStream, /* ContentType contentType, */ RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+
+            //// TODO: automate content-type detection
+            //// https://github.com/Azure/azure-sdk-for-net/issues/10329
+            //ResponseWithHeaders<AnalyzeWithCustomModelHeaders> response = ServiceClient.AnalyzeWithCustomModel(new Guid(modelId), includeTextDetails: includeTextElements, formFileStream, contentType, cancellationToken);
+            //return new RecognizeFormsOperation(ServiceClient, modelId, response.Headers.OperationLocation);
+        }
+
+        /// <summary>
+        /// Extract pages from one or more forms, using a model trained without labels.
+        /// </summary>
+        /// <param name="modelId">The id of the model to use for extracting form values.</param>
+        /// <param name="formFileUri">The absolute URI of the remote file to extract elements from.</param>
+        /// <param name="recognizeOptions">Whether or not to include raw page extractions in addition to layout elements.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
+        /// <returns>A <see cref="RecognizeCustomFormsOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeCustomFormsOperation"/>.Value upon successful
+        /// completion will contain extracted pages from the input document.</returns>
+        public virtual RecognizeCustomFormsOperation StartRecognizeCustomFormsFromUri(string modelId, Uri formFileUri, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+            //SourcePath_internal sourcePath = new SourcePath_internal() { Source = formFileUri.ToString() };
+            //ResponseWithHeaders<AnalyzeWithCustomModelHeaders> response = ServiceClient.RestClient.AnalyzeWithCustomModel(new Guid(modelId), includeTextDetails: includeTextElements, sourcePath, cancellationToken);
+            //return new RecognizeCustomFormsOperation(ServiceClient, modelId, response.Headers.OperationLocation);
+        }
+
+        /// <summary>
+        /// Extract pages from one or more forms, using a model trained without labels.
+        /// </summary>
+        /// <param name="modelId">The id of the model to use for extracting form values.</param>
+        /// <param name="formFileStream">The stream containing one or more forms to extract elements from.</param>
+        /// <param name="recognizeOptions">Whether or not to include raw page extractions in addition to layout elements.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
+        /// <returns>A <see cref="RecognizeCustomFormsOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeCustomFormsOperation"/>.Value upon successful
+        /// completion will contain extracted pages from the input document.</returns>
+        public virtual async Task<RecognizeCustomFormsOperation> StartRecognizeCustomFormsAsync(string modelId, Stream formFileStream, /* ContentType contentType, */ RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
+        {
+            await Task.Run(() => { }).ConfigureAwait(false);
+            throw new NotImplementedException();
+
+            //// TODO: automate content-type detection
+            //// https://github.com/Azure/azure-sdk-for-net/issues/10329
+            //ResponseWithHeaders<AnalyzeWithCustomModelHeaders> response = await ServiceClient.AnalyzeWithCustomModelAsync(new Guid(modelId), includeTextDetails: includeTextElements, formFileStream, contentType, cancellationToken).ConfigureAwait(false);
+            //return new RecognizeFormsOperation(ServiceClient, modelId, response.Headers.OperationLocation);
+        }
+
+        /// <summary>
+        /// Extract pages from one or more forms, using a model trained without labels.
+        /// </summary>
+        /// <param name="modelId">The id of the model to use for extracting form values.</param>
+        /// <param name="formFileUri">The absolute URI of the remote file to extract elements from.</param>
+        /// <param name="recognizeOptions">Whether or not to include raw page extractions in addition to layout elements.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
+        /// <returns>A <see cref="RecognizeCustomFormsOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeCustomFormsOperation"/>.Value upon successful
+        /// completion will contain extracted pages from the input document.</returns>
+        public virtual async Task<RecognizeCustomFormsOperation> StartRecognizeCustomFormsFromUriAsync(string modelId, Uri formFileUri, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
+        {
+            await Task.Run(() => { }).ConfigureAwait(false);
+            throw new NotImplementedException();
+
+            //SourcePath_internal sourcePath = new SourcePath_internal() { Source = formFileUri.ToString() };
+            //ResponseWithHeaders<AnalyzeWithCustomModelHeaders> response = await ServiceClient.RestClient.AnalyzeWithCustomModelAsync(new Guid(modelId), includeTextDetails: includeTextElements, sourcePath, cancellationToken).ConfigureAwait(false);
+            //return new RecognizeCustomFormsOperation(ServiceClient, modelId, response.Headers.OperationLocation);
+        }
+
+        #endregion
+
         #region Training client
         /// <summary>
         /// </summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
@@ -185,11 +185,11 @@ namespace Azure.AI.FormRecognizer
         #region Custom Forms
 
         /// <summary>
-        /// Extract pages from one or more forms, using a model trained without labels.
+        /// Recognizes pages from one or more forms, using a model trained without labels.
         /// </summary>
-        /// <param name="modelId">The id of the model to use for extracting form values.</param>
-        /// <param name="formFileStream">The stream containing one or more forms to extract elements from.</param>
-        /// <param name="recognizeOptions">Whether or not to include raw page extractions in addition to layout elements.</param>
+        /// <param name="modelId">The id of the model to use for recognizing form values.</param>
+        /// <param name="formFileStream">The stream containing one or more forms to recognize elements from.</param>
+        /// <param name="recognizeOptions">Whether or not to include raw page recognition in addition to layout elements.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="RecognizeCustomFormsOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeCustomFormsOperation"/>.Value upon successful
         /// completion will contain extracted pages from the input document.</returns>
@@ -205,11 +205,11 @@ namespace Azure.AI.FormRecognizer
         }
 
         /// <summary>
-        /// Extract pages from one or more forms, using a model trained without labels.
+        /// Recognizes pages from one or more forms, using a model trained without labels.
         /// </summary>
-        /// <param name="modelId">The id of the model to use for extracting form values.</param>
-        /// <param name="formFileUri">The absolute URI of the remote file to extract elements from.</param>
-        /// <param name="recognizeOptions">Whether or not to include raw page extractions in addition to layout elements.</param>
+        /// <param name="modelId">The id of the model to use for recognizing form values.</param>
+        /// <param name="formFileUri">The absolute URI of the remote file to recognize elements from.</param>
+        /// <param name="recognizeOptions">Whether or not to include raw page recognition in addition to layout elements.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="RecognizeCustomFormsOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeCustomFormsOperation"/>.Value upon successful
         /// completion will contain extracted pages from the input document.</returns>
@@ -223,11 +223,11 @@ namespace Azure.AI.FormRecognizer
         }
 
         /// <summary>
-        /// Extract pages from one or more forms, using a model trained without labels.
+        /// Recognizes pages from one or more forms, using a model trained without labels.
         /// </summary>
-        /// <param name="modelId">The id of the model to use for extracting form values.</param>
-        /// <param name="formFileStream">The stream containing one or more forms to extract elements from.</param>
-        /// <param name="recognizeOptions">Whether or not to include raw page extractions in addition to layout elements.</param>
+        /// <param name="modelId">The id of the model to use for recognizing form values.</param>
+        /// <param name="formFileStream">The stream containing one or more forms to recognize elements from.</param>
+        /// <param name="recognizeOptions">Whether or not to include raw page recognition in addition to layout elements.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="RecognizeCustomFormsOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeCustomFormsOperation"/>.Value upon successful
         /// completion will contain extracted pages from the input document.</returns>
@@ -244,11 +244,11 @@ namespace Azure.AI.FormRecognizer
         }
 
         /// <summary>
-        /// Extract pages from one or more forms, using a model trained without labels.
+        /// Recognizes pages from one or more forms, using a model trained without labels.
         /// </summary>
-        /// <param name="modelId">The id of the model to use for extracting form values.</param>
-        /// <param name="formFileUri">The absolute URI of the remote file to extract elements from.</param>
-        /// <param name="recognizeOptions">Whether or not to include raw page extractions in addition to layout elements.</param>
+        /// <param name="modelId">The id of the model to use for recognizing form values.</param>
+        /// <param name="formFileUri">The absolute URI of the remote file to recognize elements from.</param>
+        /// <param name="recognizeOptions">Whether or not to include raw page recognition in addition to layout elements.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="RecognizeCustomFormsOperation"/> to wait on this long-running operation.  Its <see cref="RecognizeCustomFormsOperation"/>.Value upon successful
         /// completion will contain extracted pages from the input document.</returns>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RawExtractedPage.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RawExtractedPage.cs
@@ -7,9 +7,10 @@ namespace Azure.AI.FormRecognizer.Models
 {
     /// <summary>
     /// </summary>
-    public class RawExtractedPage
+    public class RawExtractedPage : FormContent
     {
         internal RawExtractedPage(ReadResult_internal readResult)
+            : base(default, readResult.Page, default /* TODO */ )
         {
             Page = readResult.Page;
             TextAngle = readResult.Angle;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeCustomFormsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeCustomFormsOperation.cs
@@ -6,40 +6,46 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.AI.FormRecognizer.Models;
 using Azure.Core;
 using Azure.Core.Pipeline;
 
-namespace Azure.AI.FormRecognizer.Custom
+namespace Azure.AI.FormRecognizer.Models
 {
     /// <summary>
     /// </summary>
-    internal class ExtractPagesOperation : Operation<IReadOnlyList<ExtractedPage>>
+    public class RecognizeCustomFormsOperation : Operation<IReadOnlyList<RecognizedForm>>
     {
         private Response _response;
-        private IReadOnlyList<ExtractedPage> _value;
+        private IReadOnlyList<RecognizedForm> _value;
         private bool _hasCompleted;
 
         private readonly string _modelId;
-        private readonly ServiceClient _operations;
+        private readonly ServiceClient _serviceClient;
 
+        // TODO: use this.
+        private CancellationToken _cancellationToken;
+
+        /// <inheritdoc/>
         public override string Id { get; }
 
-        public override IReadOnlyList<ExtractedPage> Value => OperationHelpers.GetValue(ref _value);
+        /// <inheritdoc/>
+        public override IReadOnlyList<RecognizedForm> Value => OperationHelpers.GetValue(ref _value);
 
+        /// <inheritdoc/>
         public override bool HasCompleted => _hasCompleted;
 
+        /// <inheritdoc/>
         public override bool HasValue => _value != null;
 
         /// <inheritdoc/>
         public override Response GetRawResponse() => _response;
 
         /// <inheritdoc/>
-        public override ValueTask<Response<IReadOnlyList<ExtractedPage>>> WaitForCompletionAsync(CancellationToken cancellationToken = default) =>
+        public override ValueTask<Response<IReadOnlyList<RecognizedForm>>> WaitForCompletionAsync(CancellationToken cancellationToken = default) =>
             this.DefaultWaitForCompletionAsync(cancellationToken);
 
         /// <inheritdoc/>
-        public override ValueTask<Response<IReadOnlyList<ExtractedPage>>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) =>
+        public override ValueTask<Response<IReadOnlyList<RecognizedForm>>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) =>
             this.DefaultWaitForCompletionAsync(pollingInterval, cancellationToken);
 
         /// <summary>
@@ -47,14 +53,27 @@ namespace Azure.AI.FormRecognizer.Custom
         /// <param name="operations"></param>
         /// <param name="modelId"></param>
         /// <param name="operationLocation"></param>
-        internal ExtractPagesOperation(ServiceClient operations, string modelId, string operationLocation)
+        internal RecognizeCustomFormsOperation(ServiceClient operations, string modelId, string operationLocation)
         {
-            _operations = operations;
+            _serviceClient = operations;
             _modelId = modelId;
 
             // TODO: Add validation here
             // https://github.com/Azure/azure-sdk-for-net/issues/10385
             Id = operationLocation.Split('/').Last();
+        }
+
+        /// <summary>
+        /// Initializes a new <see cref="RecognizeCustomFormsOperation"/> instance.
+        /// </summary>
+        /// <param name="operationId">The ID of this operation.</param>
+        /// <param name="client">The client used to check for completion.</param>
+        /// <param name="cancellationToken"></param>
+        public RecognizeCustomFormsOperation(string operationId, FormRecognizerClient client, CancellationToken cancellationToken = default)
+        {
+            Id = operationId;
+            _serviceClient = client.ServiceClient;
+            _cancellationToken = cancellationToken;
         }
 
         /// <inheritdoc/>
@@ -70,8 +89,8 @@ namespace Azure.AI.FormRecognizer.Custom
             if (!_hasCompleted)
             {
                 Response<AnalyzeOperationResult_internal> update = async
-                    ? await _operations.GetAnalyzeFormResultAsync(new Guid(_modelId), new Guid(Id), cancellationToken).ConfigureAwait(false)
-                    : _operations.GetAnalyzeFormResult(new Guid(_modelId), new Guid(Id), cancellationToken);
+                    ? await _serviceClient.GetAnalyzeFormResultAsync(new Guid(_modelId), new Guid(Id), cancellationToken).ConfigureAwait(false)
+                    : _serviceClient.GetAnalyzeFormResult(new Guid(_modelId), new Guid(Id), cancellationToken);
 
                 // TODO: Handle correctly according to returned status code
                 // https://github.com/Azure/azure-sdk-for-net/issues/10386
@@ -80,7 +99,7 @@ namespace Azure.AI.FormRecognizer.Custom
                 if (update.Value.Status == OperationStatus.Succeeded || update.Value.Status == OperationStatus.Failed)
                 {
                     _hasCompleted = true;
-                    _value = ConvertToExtractedPages(update.Value.AnalyzeResult.PageResults, update.Value.AnalyzeResult.ReadResults);
+                    _value = ConvertToRecognizedForms(update.Value.AnalyzeResult.PageResults, update.Value.AnalyzeResult.ReadResults);
                 }
 
                 _response = update.GetRawResponse();
@@ -89,12 +108,15 @@ namespace Azure.AI.FormRecognizer.Custom
             return GetRawResponse();
         }
 
-        private static IReadOnlyList<ExtractedPage> ConvertToExtractedPages(IReadOnlyList<PageResult_internal> pageResults, IReadOnlyList<ReadResult_internal> readResults)
+#pragma warning disable CA1801 // Remove unused parameter
+        private static IReadOnlyList<RecognizedForm> ConvertToRecognizedForms(IReadOnlyList<PageResult_internal> pageResults, IReadOnlyList<ReadResult_internal> readResults)
+#pragma warning disable CA1801 // Remove unused parameter
         {
-            List<ExtractedPage> pages = new List<ExtractedPage>();
+            List<RecognizedForm> pages = new List<RecognizedForm>();
             for (int i = 0; i < pageResults.Count; i++)
             {
-                pages.Add(new ExtractedPage(pageResults[i], readResults[i]));
+                // TODO: Implement
+                //pages.Add(new RecognizedForm(pageResults[i], readResults[i]));
             }
             return pages;
         }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeOptions.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.AI.FormRecognizer.Models
+{
+    /// <summary>
+    /// </summary>
+    public class RecognizeOptions
+    {
+        /// <summary>
+        /// </summary>
+        public RecognizeOptions()
+        {
+        }
+
+        /// <summary>
+        /// </summary>
+        public bool IncludeTextContent { get; set; } = false;
+
+    }
+}

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizedForm.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizedForm.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+namespace Azure.AI.FormRecognizer.Models
+{
+    /// <summary>
+    /// </summary>
+    public class RecognizedForm
+    {
+#pragma warning disable CA1801 // Remove unused parameter
+        internal RecognizedForm(DocumentResult_internal documentResult, IList<PageResult_internal> pageResults, IList<ReadResult_internal> readResults)
+#pragma warning restore CA1801 // Remove unused parameter
+        {
+            // Supervised
+            FormType = documentResult.DocType;
+            //PageRange = new FormPageRange(documentResult.PageRange);
+
+            //Fields = ConvertFields(documentResult.Fields, readResults);
+            //Tables = ConvertLabeledTables(pageResults, readResults);
+
+            //// TODO: Populate CheckBoxes
+
+            //if (readResults != null)
+            //{
+            //    PageText = ConvertPageText(readResults);
+            //}
+        }
+
+        /// <summary>
+        /// </summary>
+        // Convert clusterId to a string (ex. "FormType1").
+        public string FormType { get; }
+
+        /// <summary>
+        /// </summary>
+        public FormPageRange PageRange { get; }
+
+        /// <summary>
+        /// </summary>
+        public IReadOnlyDictionary<string, FormField> Fields { get; }
+
+        /// <summary>
+        /// </summary>
+        public IReadOnlyList<RawExtractedPage> Pages { get; }
+    }
+}


### PR DESCRIPTION
This is an effort to merge the changes from PR: #11048

The `FieldValueType` properties names differ from the original PR while I figure out https://github.com/Azure/azure-sdk-for-net/issues/11221

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/11222