### PR TITLE
[FIX] ValidationException: 'maxNumOfCandidatesReturned' exceeds maxim…

### DIFF
--- a/sdk/cognitiveservices/Vision.Face/src/Generated/Models/IdentifyRequest.cs
+++ b/sdk/cognitiveservices/Vision.Face/src/Generated/Models/IdentifyRequest.cs
@@ -144,9 +144,9 @@ namespace Microsoft.Azure.CognitiveServices.Vision.Face.Models
                     throw new ValidationException(ValidationRules.Pattern, "LargePersonGroupId", "^[a-z0-9-_]+$");
                 }
             }
-            if (MaxNumOfCandidatesReturned > 5)
+            if (MaxNumOfCandidatesReturned > 100)
             {
-                throw new ValidationException(ValidationRules.InclusiveMaximum, "MaxNumOfCandidatesReturned", 5);
+                throw new ValidationException(ValidationRules.InclusiveMaximum, "MaxNumOfCandidatesReturned", 100);
             }
             if (MaxNumOfCandidatesReturned < 1)
             {


### PR DESCRIPTION
_FaceClient.Face.IdentifyAsync_ does not accept a higher value than **5** to maxNumOfCandidatesReturned, although documentation says it can be **100**.

### ValidationException: 'maxNumOfCandidatesReturned' exceeds maximum value of '5'.

Face API - v1.0
Face - Identify [See Docs](https://westus.dev.cognitive.microsoft.com/docs/services/563879b61984550e40cbbe8d/operations/563879b61984550f30395239)
maxNumOfCandidatesReturned (optional) | Number | The range of maxNumOfCandidatesReturned is between 1 and 100 (default is 10).
-- | -- | --
closes #11251