### PR TITLE
[Azure Service Bus] Remove unnecessary LINQ on AmqpReceiver

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -298,7 +298,6 @@ namespace Azure.Messaging.ServiceBus.Amqp
                         lockTokenGuids,
                         timeout,
                         DispositionStatus.Completed,
-                        _isSessionReceiver,
                         SessionId).ConfigureAwait(false);
                     return;
                 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -293,9 +293,10 @@ namespace Azure.Messaging.ServiceBus.Amqp
             var lockTokenGuids = lockTokens.Select(token => new Guid(token)).ToArray();
             foreach (var tokenGuid in lockTokenGuids)
             {
-                if (!requestResponse && _requestResponseLockedMessages.Contains(tokenGuid))
+                if (_requestResponseLockedMessages.Contains(tokenGuid))
                 {
                     requestResponse = true;
+                    break;
                 }
             }
 


### PR DESCRIPTION
Removes LINQ usage from the AmqpReceiver from the hot path to improve speed and allocations

I tried to document reasoning inline

## Results

``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i7-8550U CPU 1.80GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.201
  [Host]    : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  MediumRun : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT

Job=MediumRun  IterationCount=15  LaunchCount=2  
WarmupCount=10  

```
| Method | Elements |       Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |--------- |-----------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
| **Before** |        **1** |   **829.1 ns** |  **50.23 ns** |  **75.18 ns** |  **1.00** |    **0.00** | **0.0362** |     **-** |     **-** |     **152 B** |
|  After |        1 |   454.1 ns |  62.09 ns |  91.01 ns |  0.55 |    0.13 | 0.0286 |     - |     - |     120 B |
|        |          |            |           |           |       |         |        |       |       |           |
| **Before** |        **2** |   **693.1 ns** | **111.54 ns** | **166.95 ns** |  **1.00** |    **0.00** | **0.0401** |     **-** |     **-** |     **168 B** |
|  After |        2 |   567.6 ns |  90.46 ns | 129.74 ns |  0.87 |    0.29 | 0.0324 |     - |     - |     136 B |
|        |          |            |           |           |       |         |        |       |       |           |
| **Before** |        **4** |   **846.9 ns** |  **25.89 ns** |  **38.74 ns** |  **1.00** |    **0.00** | **0.0458** |     **-** |     **-** |     **200 B** |
|  After |        4 |   776.0 ns |  32.62 ns |  44.65 ns |  0.91 |    0.07 | 0.0401 |     - |     - |     168 B |
|        |          |            |           |           |       |         |        |       |       |           |
| **Before** |        **8** | **1,864.3 ns** | **228.77 ns** | **328.10 ns** |  **1.00** |    **0.00** | **0.0610** |     **-** |     **-** |     **264 B** |
|  After |        8 | 1,484.4 ns | 136.14 ns | 186.34 ns |  0.81 |    0.13 | 0.0553 |     - |     - |     232 B |
|        |          |            |           |           |       |         |        |       |       |           |
| **Before** |       **16** | **3,529.6 ns** | **459.86 ns** | **674.05 ns** |  **1.00** |    **0.00** | **0.0916** |     **-** |     **-** |     **392 B** |
|  After |       16 | 3,158.8 ns | 430.75 ns | 631.38 ns |  0.91 |    0.21 | 0.0839 |     - |     - |     360 B |

Benchmark used https://github.com/danielmarbach/MicroBenchmarks/blob/438dac249a7a44e178b758e860cf16ca834b0c79/MicroBenchmarks/Linq/LinqGuidConversionContains.cs
