### PR TITLE
[Azure Service Bus] Remove cancellation token from CreateProcessor

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
@@ -490,14 +490,11 @@ namespace Azure.Messaging.ServiceBus
         /// <see cref="ServiceBusSessionProcessor"/>.</param>
         /// <param name="sessionId">An optional session ID to scope the <see cref="ServiceBusSessionProcessor"/> to.
         /// If left blank, the next available session returned from the service will be used.</param>
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        ///
         /// <returns>A <see cref="ServiceBusSessionProcessor"/> scoped to the specified queue.</returns>
         public ServiceBusSessionProcessor CreateSessionProcessor(
             string queueName,
             ServiceBusProcessorOptions options = default,
-            string sessionId = default,
-            CancellationToken cancellationToken = default)
+            string sessionId = default)
         {
             ValidateEntityName(queueName);
 
@@ -519,15 +516,12 @@ namespace Azure.Messaging.ServiceBus
         /// <see cref="ServiceBusSessionProcessor"/>.</param>
         /// <param name="sessionId">An optional session ID to scope the <see cref="ServiceBusSessionProcessor"/> to.
         /// If left blank, the next available session returned from the service will be used.</param>
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        ///
         /// <returns>A <see cref="ServiceBusProcessor"/> scoped to the specified topic and subscription.</returns>
         public ServiceBusSessionProcessor CreateSessionProcessor(
             string topicName,
             string subscriptionName,
             ServiceBusProcessorOptions options = default,
-            string sessionId = default,
-            CancellationToken cancellationToken = default)
+            string sessionId = default)
         {
             ValidateEntityName(topicName);
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs
@@ -13,7 +13,7 @@ namespace Azure.Messaging.ServiceBus
     /// A <see cref="ServiceBusSessionProcessor"/> is responsible for processing
     /// <see cref="ServiceBusReceivedMessage" /> from a specific entity using event handlers.
     /// It is constructed by calling
-    ///  <see cref="ServiceBusClient.CreateSessionProcessor(string, ServiceBusProcessorOptions, string, CancellationToken)"/>.
+    ///  <see cref="ServiceBusClient.CreateSessionProcessor(string, ServiceBusProcessorOptions, string)"/>.
     /// The event handler is specified with the <see cref="ProcessMessageAsync"/>
     /// property. The error handler is specified with the <see cref="ProcessErrorAsync"/> property.
     /// To start processing after the handlers have been specified, call <see cref="StartProcessingAsync"/>.


### PR DESCRIPTION
I could not see a reason why a sync factory method would require a cancellation token so I removed it.