### PR TITLE
[Azure Service Bus] ServiceBusProcessor WaitAsync use token

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -480,7 +480,7 @@ namespace Azure.Messaging.ServiceBus
                 {
                     ServiceBusEventSource.Log.StopProcessingStart(Identifier);
 
-                    await ProcessingStartStopSemaphore.WaitAsync().ConfigureAwait(false);
+                    await ProcessingStartStopSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
 
                     cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
@@ -559,7 +559,7 @@ namespace Azure.Messaging.ServiceBus
                 {
                     errorSource = ServiceBusErrorSource.AcceptMessageSession;
                     useThreadLocalReceiver = true;
-                    await MaxConcurrentAcceptSessionsSemaphore.WaitAsync().ConfigureAwait(false);
+                    await MaxConcurrentAcceptSessionsSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
                     try
                     {
                         try


### PR DESCRIPTION
I see no reason why not passing the token to the `WaitAsync`. On the contrary it provides possibility to stop earlier based on the token passed in. The outcome should be the same exception for this one special case when the OperationCanceledException is raised but I guess this is fine