### PR TITLE
Read the ClientRequestId off initial request

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.3.0-preview.1 (Unreleased)
 
+- Read client request ID value used for logging and tracing off the initial request object if available.
 
 ## 1.2.0 (2020-04-03)
 

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
@@ -188,7 +188,11 @@ namespace Azure.Core.Pipeline
             public override string ClientRequestId
             {
                 get => _clientRequestId ??= Guid.NewGuid().ToString();
-                set => _clientRequestId = value;
+                set
+                {
+                    Argument.AssertNotNull(value, nameof(value));
+                    _clientRequestId = value;
+                }
             }
 
             protected internal override void AddHeader(string name, string value)

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
@@ -170,11 +170,11 @@ namespace Azure.Core.Pipeline
             private readonly HttpRequestMessage _requestMessage;
 
             private PipelineContentAdapter? _requestContent;
+            private string? _clientRequestId;
 
             public PipelineRequest()
             {
                 _requestMessage = new HttpRequestMessage();
-                ClientRequestId = Guid.NewGuid().ToString();
             }
 
             public override RequestMethod Method
@@ -185,7 +185,11 @@ namespace Azure.Core.Pipeline
 
             public override RequestContent? Content { get; set; }
 
-            public override string ClientRequestId { get; set; }
+            public override string ClientRequestId
+            {
+                get => _clientRequestId ??= Guid.NewGuid().ToString();
+                set => _clientRequestId = value;
+            }
 
             protected internal override void AddHeader(string name, string value)
             {

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipelineBuilder.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipelineBuilder.cs
@@ -48,11 +48,13 @@ namespace Azure.Core.Pipeline
 
             bool isDistributedTracingEnabled = options.Diagnostics.IsDistributedTracingEnabled;
 
-            policies.Add(ClientRequestIdPolicy.Shared);
+            policies.Add(ReadClientRequestIdPolicy.Shared);
 
             policies.AddRange(perCallPolicies);
 
             policies.AddRange(options.PerCallPolicies);
+
+            policies.Add(ClientRequestIdPolicy.Shared);
 
             DiagnosticsOptions diagnostics = options.Diagnostics;
             if (diagnostics.IsTelemetryEnabled)

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipelineBuilder.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipelineBuilder.cs
@@ -48,11 +48,11 @@ namespace Azure.Core.Pipeline
 
             bool isDistributedTracingEnabled = options.Diagnostics.IsDistributedTracingEnabled;
 
+            policies.Add(ClientRequestIdPolicy.Shared);
+
             policies.AddRange(perCallPolicies);
 
             policies.AddRange(options.PerCallPolicies);
-
-            policies.Add(ClientRequestIdPolicy.Shared);
 
             DiagnosticsOptions diagnostics = options.Diagnostics;
             if (diagnostics.IsTelemetryEnabled)

--- a/sdk/core/Azure.Core/src/Pipeline/Internal/ClientRequestIdPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/ClientRequestIdPolicy.cs
@@ -5,8 +5,8 @@ namespace Azure.Core.Pipeline
 {
     internal class ClientRequestIdPolicy : HttpPipelineSynchronousPolicy
     {
-        private const string ClientRequestIdHeader = "x-ms-client-request-id";
-        private const string EchoClientRequestId = "x-ms-return-client-request-id";
+        internal const string ClientRequestIdHeader = "x-ms-client-request-id";
+        internal const string EchoClientRequestId = "x-ms-return-client-request-id";
 
         protected ClientRequestIdPolicy()
         {
@@ -16,15 +16,8 @@ namespace Azure.Core.Pipeline
 
         public override void OnSendingRequest(HttpMessage message)
         {
-            if (message.Request.Headers.TryGetValue(ClientRequestIdHeader, out string? value))
-            {
-                message.Request.ClientRequestId = value;
-            }
-            else
-            {
-                message.Request.Headers.Add(ClientRequestIdHeader, message.Request.ClientRequestId);
-            }
-            message.Request.Headers.Add(EchoClientRequestId, "true");
+            message.Request.Headers.SetValue(ClientRequestIdHeader, message.Request.ClientRequestId);
+            message.Request.Headers.SetValue(EchoClientRequestId, "true");
         }
     }
 }

--- a/sdk/core/Azure.Core/src/Pipeline/Internal/ClientRequestIdPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/ClientRequestIdPolicy.cs
@@ -16,7 +16,14 @@ namespace Azure.Core.Pipeline
 
         public override void OnSendingRequest(HttpMessage message)
         {
-            message.Request.Headers.Add(ClientRequestIdHeader, message.Request.ClientRequestId);
+            if (message.Request.Headers.TryGetValue(ClientRequestIdHeader, out string? value))
+            {
+                message.Request.ClientRequestId = value;
+            }
+            else
+            {
+                message.Request.Headers.Add(ClientRequestIdHeader, message.Request.ClientRequestId);
+            }
             message.Request.Headers.Add(EchoClientRequestId, "true");
         }
     }

--- a/sdk/core/Azure.Core/src/Pipeline/Internal/ReadClientRequestIdPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/ReadClientRequestIdPolicy.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Core.Pipeline
+{
+    internal class ReadClientRequestIdPolicy : HttpPipelineSynchronousPolicy
+    {
+        protected ReadClientRequestIdPolicy()
+        {
+        }
+
+        public static ReadClientRequestIdPolicy Shared { get; } = new ReadClientRequestIdPolicy();
+
+        public override void OnSendingRequest(HttpMessage message)
+        {
+            if (message.Request.Headers.TryGetValue(ClientRequestIdPolicy.ClientRequestIdHeader, out string? value))
+            {
+                message.Request.ClientRequestId = value;
+            }
+        }
+    }
+}

--- a/sdk/core/Azure.Core/tests/ClientRequestIdPolicyTests.cs
+++ b/sdk/core/Azure.Core/tests/ClientRequestIdPolicyTests.cs
@@ -41,7 +41,7 @@ namespace Azure.Core.Tests
                 }).Verifiable();
 
             var transport = new MockTransport(new MockResponse(200));
-            var pipeline = new HttpPipeline(transport, new[] { ClientRequestIdPolicy.Shared, policy.Object });
+            var pipeline = new HttpPipeline(transport, new[] { ReadClientRequestIdPolicy.Shared, policy.Object });
 
             using (Request request = pipeline.CreateRequest())
             {

--- a/sdk/core/Azure.Core/tests/ClientRequestIdPolicyTests.cs
+++ b/sdk/core/Azure.Core/tests/ClientRequestIdPolicyTests.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Pipeline;
 using Azure.Core.Testing;
+using Moq;
 using NUnit.Framework;
 
 namespace Azure.Core.Tests
@@ -22,6 +25,33 @@ namespace Azure.Core.Tests
             Assert.True(request.TryGetHeader("x-ms-return-client-request-id", out string returnRequestId));
             Assert.AreEqual(request.ClientRequestId, requestId);
             Assert.AreEqual("true", returnRequestId);
+        }
+
+        [Test]
+        public async Task ReadsRequestIdValueOfRequest()
+        {
+            var policy = new Mock<HttpPipelineSynchronousPolicy>();
+            policy.CallBase = true;
+            policy.Setup(p => p.OnReceivedResponse(It.IsAny<HttpMessage>()))
+                .Callback<HttpMessage>(message =>
+                {
+                    Assert.AreEqual("ExternalClientId",message.Request.ClientRequestId);
+                    Assert.True(message.Request.TryGetHeader("x-ms-client-request-id", out string requestId));
+                    Assert.AreEqual("ExternalClientId", requestId);
+                }).Verifiable();
+
+            var transport = new MockTransport(new MockResponse(200));
+            var pipeline = new HttpPipeline(transport, new[] { ClientRequestIdPolicy.Shared, policy.Object });
+
+            using (Request request = pipeline.CreateRequest())
+            {
+                request.Method = RequestMethod.Get;
+                request.Uri.Reset(new Uri("http://example.com"));
+                request.Headers.Add("x-ms-client-request-id", "ExternalClientId");
+                await pipeline.SendRequestAsync(request, CancellationToken.None);
+            }
+
+            policy.Verify();
         }
     }
 }

--- a/sdk/core/Azure.Core/tests/HttpClientTransportTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpClientTransportTests.cs
@@ -703,6 +703,14 @@ namespace Azure.Core.Tests
             Assert.True(disposeTrackingContent.IsDisposed);
         }
 
+        [Test]
+        public void ClientRequestIdSetterThrowsOnNull()
+        {
+            var transport = new HttpClientTransport();
+            var request = transport.CreateRequest();
+            Assert.Throws<ArgumentNullException>(() => request.ClientRequestId = null);
+        }
+
         public class DisposeTrackingContent : RequestContent
         {
             public override Task WriteToAsync(Stream stream, CancellationToken cancellation)


### PR DESCRIPTION
I had to move the policy to be the first one in the pipeline so everyone can read the correct value of the Request.ClientRequestId. I couldn't come up with a scenario where it's breaking.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/11198