### PR TITLE
Update Autorest C#

### DIFF
--- a/eng/CodeGeneration.targets
+++ b/eng/CodeGeneration.targets
@@ -1,13 +1,12 @@
 <Project>
 
   <PropertyGroup>
-    <_AutoRestVersion>https://github.com/Azure/autorest/releases/download/autorest-3.0.6207/autorest-3.0.6207.tgz</_AutoRestVersion>
-    <_AutoRestCoreVersion>3.0.6257</_AutoRestCoreVersion>
-    <_AutoRestCSharpVersion>https://github.com/Azure/autorest.csharp/releases/download/3.0.0-dev.20200402.6/autorest-csharp-v3-3.0.0-dev.20200402.6.tgz</_AutoRestCSharpVersion>
+    <_AutoRestVersion>https://github.com/Azure/autorest/releases/download/autorest-3.0.6221/autorest-3.0.6221.tgz</_AutoRestVersion>
+    <_AutoRestCoreVersion>3.0.6280</_AutoRestCoreVersion>
+    <_AutoRestCSharpVersion>https://github.com/Azure/autorest.csharp/releases/download/3.0.0-dev.20200414.2/autorest-csharp-v3-3.0.0-dev.20200414.2.tgz</_AutoRestCSharpVersion>
     <_SupportsCodeGeneration Condition="'$(IsClientLibrary)' == 'true'">true</_SupportsCodeGeneration>
     <_DefaultInputName Condition="Exists('$(MSBuildProjectDirectory)/autorest.md')">$(MSBuildProjectDirectory)/autorest.md</_DefaultInputName>
     <AutorestInput Condition="'$(AutorestInput)' == ''">$(_DefaultInputName)</AutorestInput>
-    <AutorestConfiguration Condition="'$(AutorestConfiguration)' == '' AND '$(AutorestInput)' != '$(_DefaultInputName)'">$(_DefaultInputName)</AutorestConfiguration>
     <!--
       Allows passing additional AutoRest command line arguments, for example to run in interactive mode 
       use the following command line (remove the space between minus minus): dotnet msbuild /t:GenerateCode /p:AutorestAdditionalParameters="- -interactive"
@@ -21,11 +20,8 @@
   </PropertyGroup>
 
   <Target Name="GenerateCode" Condition="'$(_GenerateCode)' == 'true'" >
-    <PropertyGroup>
-      <_RequireConfigurationArgument Condition="'$(AutorestConfiguration)' != ''">--require=$(AutorestConfiguration)</_RequireConfigurationArgument>
-    </PropertyGroup>
     <RemoveDir Directories="$(MSBuildProjectDirectory)/Generated"/>
-    <Exec Command="npx autorest@$(_AutoRestVersion) --version=$(_AutoRestCoreVersion) $(AutorestInput) $(_RequireConfigurationArgument) $(AutorestAdditionalParameters) --use=$(_AutoRestCSharpVersion) --output-folder=$(MSBuildProjectDirectory) --title=$(RootNamespace) --namespace=$(RootNamespace) --shared-source-folder=$(_SharedCodeDirectory) --verbose" />
+    <Exec Command="npx autorest@$(_AutoRestVersion) --version=$(_AutoRestCoreVersion) $(AutorestInput) $(AutorestAdditionalParameters) --use=$(_AutoRestCSharpVersion) --output-folder=$(MSBuildProjectDirectory) --title=$(RootNamespace) --namespace=$(RootNamespace) --shared-source-folder=$(_SharedCodeDirectory) --verbose" />
   </Target>
 
   <ItemGroup Condition="'$(_GenerateCode)' == 'true'">

--- a/sdk/core/Azure.Core/src/Shared/Autorest/CodeGenMemberAttribute.cs
+++ b/sdk/core/Azure.Core/src/Shared/Autorest/CodeGenMemberAttribute.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System;
 
 namespace Azure.Core
@@ -8,7 +10,22 @@ namespace Azure.Core
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
     internal class CodeGenMemberAttribute : Attribute
     {
-        public string OriginalName { get; }
+        public string? OriginalName { get; }
+
+        /// <summary>
+        /// For collection properties. When set to true empty collection would be treated as undefined and not serialized.
+        /// </summary>
+        public bool EmptyAsUndefined { get; set; }
+
+        /// <summary>
+        /// For collection and model properties. Whether the property would always be initialized on creation/deserialization.
+        /// Requires a parameterless constructor for implementation type.
+        /// </summary>
+        public bool Initialize { get; set; }
+
+        public CodeGenMemberAttribute()
+        {
+        }
 
         public CodeGenMemberAttribute(string originalName)
         {

--- a/sdk/core/Azure.Core/src/Shared/Autorest/CodeGenSuppressAttribute.cs
+++ b/sdk/core/Azure.Core/src/Shared/Autorest/CodeGenSuppressAttribute.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Azure.Core
 {
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Struct)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Struct, AllowMultiple = true)]
     internal class CodeGenSuppressAttribute : Attribute
     {
         public string Member { get; }

--- a/sdk/core/Azure.Core/src/Shared/Autorest/JsonElementExtensions.cs
+++ b/sdk/core/Azure.Core/src/Shared/Autorest/JsonElementExtensions.cs
@@ -73,6 +73,7 @@ namespace Azure.Core
         public static TimeSpan GetTimeSpan(in this JsonElement element, string format) => format switch
         {
             "P" => XmlConvert.ToTimeSpan(element.GetString()),
+            "T" => TimeSpan.ParseExact(element.GetString(), "T", CultureInfo.InvariantCulture),
             _ => throw new ArgumentException($"Format is not supported: '{format}'", nameof(format))
         };
 

--- a/sdk/core/Azure.Core/src/Shared/Autorest/ManagementPipelineBuilder.cs
+++ b/sdk/core/Azure.Core/src/Shared/Autorest/ManagementPipelineBuilder.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.Json;
+using System.Xml;
+using Azure.Core.Pipeline;
+
+namespace Azure.Core
+{
+    internal static class ManagementPipelineBuilder
+    {
+        public static HttpPipeline Build(TokenCredential credential, ClientOptions options)
+        {
+            return HttpPipelineBuilder.Build(options, new BearerTokenAuthenticationPolicy(credential, "https://management.azure.com//.default"));
+        }
+    }
+}

--- a/sdk/core/Azure.Core/src/Shared/Autorest/TypeFormatters.cs
+++ b/sdk/core/Azure.Core/src/Shared/Autorest/TypeFormatters.cs
@@ -28,6 +28,7 @@ namespace Azure.Core
         public static string ToString(TimeSpan value, string format) => format switch
         {
             "P" => XmlConvert.ToString(value),
+            "T" => value.ToString("T", CultureInfo.InvariantCulture),
             _ => throw new ArgumentException($"Format is not supported: '{format}'", nameof(format))
         };
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/AnalyzeResult_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/AnalyzeResult_internal.Serialization.cs
@@ -32,7 +32,14 @@ namespace Azure.AI.FormRecognizer.Models
                     List<ReadResult_internal> array = new List<ReadResult_internal>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(ReadResult_internal.DeserializeReadResult_internal(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(ReadResult_internal.DeserializeReadResult_internal(item));
+                        }
                     }
                     readResults = array;
                     continue;
@@ -46,7 +53,14 @@ namespace Azure.AI.FormRecognizer.Models
                     List<PageResult_internal> array = new List<PageResult_internal>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(PageResult_internal.DeserializePageResult_internal(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(PageResult_internal.DeserializePageResult_internal(item));
+                        }
                     }
                     pageResults = array;
                     continue;
@@ -60,7 +74,14 @@ namespace Azure.AI.FormRecognizer.Models
                     List<DocumentResult_internal> array = new List<DocumentResult_internal>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(DocumentResult_internal.DeserializeDocumentResult_internal(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(DocumentResult_internal.DeserializeDocumentResult_internal(item));
+                        }
                     }
                     documentResults = array;
                     continue;
@@ -74,7 +95,14 @@ namespace Azure.AI.FormRecognizer.Models
                     List<FormRecognizerError> array = new List<FormRecognizerError>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(FormRecognizerError.DeserializeFormRecognizerError(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(FormRecognizerError.DeserializeFormRecognizerError(item));
+                        }
                     }
                     errors = array;
                     continue;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DataTableCell_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DataTableCell_internal.Serialization.cs
@@ -84,7 +84,14 @@ namespace Azure.AI.FormRecognizer.Models
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.GetString());
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(item.GetString());
+                        }
                     }
                     elements = array;
                     continue;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DataTable_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DataTable_internal.Serialization.cs
@@ -35,7 +35,14 @@ namespace Azure.AI.FormRecognizer.Models
                     List<DataTableCell_internal> array = new List<DataTableCell_internal>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(DataTableCell_internal.DeserializeDataTableCell_internal(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(DataTableCell_internal.DeserializeDataTableCell_internal(item));
+                        }
                     }
                     cells = array;
                     continue;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DocumentResult_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/DocumentResult_internal.Serialization.cs
@@ -40,7 +40,14 @@ namespace Azure.AI.FormRecognizer.Models
                     Dictionary<string, FieldValue_internal> dictionary = new Dictionary<string, FieldValue_internal>();
                     foreach (var property0 in property.Value.EnumerateObject())
                     {
-                        dictionary.Add(property0.Name, FieldValue_internal.DeserializeFieldValue_internal(property0.Value));
+                        if (property0.Value.ValueKind == JsonValueKind.Null)
+                        {
+                            dictionary.Add(property0.Name, null);
+                        }
+                        else
+                        {
+                            dictionary.Add(property0.Name, FieldValue_internal.DeserializeFieldValue_internal(property0.Value));
+                        }
                     }
                     fields = dictionary;
                     continue;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/FieldValue_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/FieldValue_internal.Serialization.cs
@@ -99,7 +99,14 @@ namespace Azure.AI.FormRecognizer.Models
                     List<FieldValue_internal> array = new List<FieldValue_internal>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(DeserializeFieldValue_internal(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(DeserializeFieldValue_internal(item));
+                        }
                     }
                     valueArray = array;
                     continue;
@@ -113,7 +120,14 @@ namespace Azure.AI.FormRecognizer.Models
                     Dictionary<string, FieldValue_internal> dictionary = new Dictionary<string, FieldValue_internal>();
                     foreach (var property0 in property.Value.EnumerateObject())
                     {
-                        dictionary.Add(property0.Name, DeserializeFieldValue_internal(property0.Value));
+                        if (property0.Value.ValueKind == JsonValueKind.Null)
+                        {
+                            dictionary.Add(property0.Name, null);
+                        }
+                        else
+                        {
+                            dictionary.Add(property0.Name, DeserializeFieldValue_internal(property0.Value));
+                        }
                     }
                     valueObject = dictionary;
                     continue;
@@ -159,7 +173,14 @@ namespace Azure.AI.FormRecognizer.Models
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.GetString());
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(item.GetString());
+                        }
                     }
                     elements = array;
                     continue;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/GetModelOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/GetModelOptions.cs
@@ -39,7 +39,7 @@ namespace Azure.AI.FormRecognizer.Models
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj) => obj is GetModelOptions other && Equals(other);
         /// <inheritdoc />
-        public bool Equals(GetModelOptions other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+        public bool Equals(GetModelOptions other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
 
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/KeyValueElement_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/KeyValueElement_internal.Serialization.cs
@@ -48,7 +48,14 @@ namespace Azure.AI.FormRecognizer.Models
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.GetString());
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(item.GetString());
+                        }
                     }
                     elements = array;
                     continue;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/KeysResult_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/KeysResult_internal.Serialization.cs
@@ -23,12 +23,26 @@ namespace Azure.AI.FormRecognizer
                     Dictionary<string, IList<string>> dictionary = new Dictionary<string, IList<string>>();
                     foreach (var property0 in property.Value.EnumerateObject())
                     {
-                        List<string> array = new List<string>();
-                        foreach (var item in property0.Value.EnumerateArray())
+                        if (property0.Value.ValueKind == JsonValueKind.Null)
                         {
-                            array.Add(item.GetString());
+                            dictionary.Add(property0.Name, null);
                         }
-                        dictionary.Add(property0.Name, array);
+                        else
+                        {
+                            List<string> array = new List<string>();
+                            foreach (var item in property0.Value.EnumerateArray())
+                            {
+                                if (item.ValueKind == JsonValueKind.Null)
+                                {
+                                    array.Add(null);
+                                }
+                                else
+                                {
+                                    array.Add(item.GetString());
+                                }
+                            }
+                            dictionary.Add(property0.Name, array);
+                        }
                     }
                     clusters = dictionary;
                     continue;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/Language_internal.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/Language_internal.cs
@@ -39,7 +39,7 @@ namespace Azure.AI.FormRecognizer.Models
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj) => obj is Language_internal other && Equals(other);
         /// <inheritdoc />
-        public bool Equals(Language_internal other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+        public bool Equals(Language_internal other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
 
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/Models_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/Models_internal.Serialization.cs
@@ -38,7 +38,14 @@ namespace Azure.AI.FormRecognizer.Training
                     List<ModelInfo_internal> array = new List<ModelInfo_internal>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(ModelInfo_internal.DeserializeModelInfo_internal(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(ModelInfo_internal.DeserializeModelInfo_internal(item));
+                        }
                     }
                     modelList = array;
                     continue;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/PageResult_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/PageResult_internal.Serialization.cs
@@ -44,7 +44,14 @@ namespace Azure.AI.FormRecognizer.Models
                     List<KeyValuePair_internal> array = new List<KeyValuePair_internal>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(KeyValuePair_internal.DeserializeKeyValuePair_internal(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(KeyValuePair_internal.DeserializeKeyValuePair_internal(item));
+                        }
                     }
                     keyValuePairs = array;
                     continue;
@@ -58,7 +65,14 @@ namespace Azure.AI.FormRecognizer.Models
                     List<DataTable_internal> array = new List<DataTable_internal>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(DataTable_internal.DeserializeDataTable_internal(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(DataTable_internal.DeserializeDataTable_internal(item));
+                        }
                     }
                     tables = array;
                     continue;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/ReadResult_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/ReadResult_internal.Serialization.cs
@@ -67,7 +67,14 @@ namespace Azure.AI.FormRecognizer.Models
                     List<TextLine_internal> array = new List<TextLine_internal>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(TextLine_internal.DeserializeTextLine_internal(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(TextLine_internal.DeserializeTextLine_internal(item));
+                        }
                     }
                     lines = array;
                     continue;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TextLine_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TextLine_internal.Serialization.cs
@@ -50,7 +50,14 @@ namespace Azure.AI.FormRecognizer.Models
                     List<TextWord_internal> array = new List<TextWord_internal>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(TextWord_internal.DeserializeTextWord_internal(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(TextWord_internal.DeserializeTextWord_internal(item));
+                        }
                     }
                     words = array;
                     continue;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TrainResult_internal.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TrainResult_internal.Serialization.cs
@@ -27,7 +27,14 @@ namespace Azure.AI.FormRecognizer.Models
                     List<TrainingDocumentInfo> array = new List<TrainingDocumentInfo>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(TrainingDocumentInfo.DeserializeTrainingDocumentInfo(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(TrainingDocumentInfo.DeserializeTrainingDocumentInfo(item));
+                        }
                     }
                     trainingDocuments = array;
                     continue;
@@ -41,7 +48,14 @@ namespace Azure.AI.FormRecognizer.Models
                     List<CustomFormModelField> array = new List<CustomFormModelField>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(CustomFormModelField.DeserializeCustomFormModelField(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(CustomFormModelField.DeserializeCustomFormModelField(item));
+                        }
                     }
                     fields = array;
                     continue;
@@ -64,7 +78,14 @@ namespace Azure.AI.FormRecognizer.Models
                     List<FormRecognizerError> array = new List<FormRecognizerError>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(FormRecognizerError.DeserializeFormRecognizerError(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(FormRecognizerError.DeserializeFormRecognizerError(item));
+                        }
                     }
                     errors = array;
                     continue;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TrainingDocumentInfo.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TrainingDocumentInfo.Serialization.cs
@@ -37,7 +37,14 @@ namespace Azure.AI.FormRecognizer.Training
                     List<FormRecognizerError> array = new List<FormRecognizerError>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(FormRecognizerError.DeserializeFormRecognizerError(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(FormRecognizerError.DeserializeFormRecognizerError(item));
+                        }
                     }
                     errors = array;
                     continue;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Operations/ServiceClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Operations/ServiceClient.cs
@@ -19,8 +19,8 @@ namespace Azure.AI.FormRecognizer
 {
     internal partial class ServiceClient
     {
-        private readonly ClientDiagnostics clientDiagnostics;
-        private readonly HttpPipeline pipeline;
+        private readonly ClientDiagnostics _clientDiagnostics;
+        private readonly HttpPipeline _pipeline;
         internal ServiceRestClient RestClient { get; }
         /// <summary> Initializes a new instance of ServiceClient for mocking. </summary>
         protected ServiceClient()
@@ -30,8 +30,8 @@ namespace Azure.AI.FormRecognizer
         internal ServiceClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string endpoint)
         {
             RestClient = new ServiceRestClient(clientDiagnostics, pipeline, endpoint);
-            this.clientDiagnostics = clientDiagnostics;
-            this.pipeline = pipeline;
+            _clientDiagnostics = clientDiagnostics;
+            _pipeline = pipeline;
         }
 
         /// <summary> Create and train a custom model. The request must include a source parameter that is either an externally accessible Azure storage blob container Uri (preferably a Shared Access Signature Uri) or valid path to a data folder in a locally mounted drive. When local paths are specified, they must follow the Linux/Unix path format and be an absolute path rooted to the input mount configuration setting value e.g., if &apos;{Mounts:Input}&apos; configuration setting value is &apos;/input&apos; then a valid source path would be &apos;/input/contosodataset&apos;. All data to be trained is expected to be under the source folder or sub folders under it. Models are trained using documents that are of the following content type - &apos;application/pdf&apos;, &apos;image/jpeg&apos;, &apos;image/png&apos;, &apos;image/tiff&apos;. Other type of content is ignored. </summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Operations/ServiceRestClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Operations/ServiceRestClient.cs
@@ -21,8 +21,8 @@ namespace Azure.AI.FormRecognizer
     internal partial class ServiceRestClient
     {
         private string endpoint;
-        private ClientDiagnostics clientDiagnostics;
-        private HttpPipeline pipeline;
+        private ClientDiagnostics _clientDiagnostics;
+        private HttpPipeline _pipeline;
 
         /// <summary> Initializes a new instance of ServiceRestClient. </summary>
         public ServiceRestClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string endpoint)
@@ -33,13 +33,13 @@ namespace Azure.AI.FormRecognizer
             }
 
             this.endpoint = endpoint;
-            this.clientDiagnostics = clientDiagnostics;
-            this.pipeline = pipeline;
+            _clientDiagnostics = clientDiagnostics;
+            _pipeline = pipeline;
         }
 
         internal HttpMessage CreateTrainCustomModelAsyncRequest(TrainRequest_internal trainRequest)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
@@ -64,19 +64,19 @@ namespace Azure.AI.FormRecognizer
                 throw new ArgumentNullException(nameof(trainRequest));
             }
 
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.TrainCustomModelAsync");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.TrainCustomModelAsync");
             scope.Start();
             try
             {
                 using var message = CreateTrainCustomModelAsyncRequest(trainRequest);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 var headers = new ServiceTrainCustomModelAsyncHeaders(message.Response);
                 switch (message.Response.Status)
                 {
                     case 201:
                         return ResponseWithHeaders.FromValue(headers, message.Response);
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -96,19 +96,19 @@ namespace Azure.AI.FormRecognizer
                 throw new ArgumentNullException(nameof(trainRequest));
             }
 
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.TrainCustomModelAsync");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.TrainCustomModelAsync");
             scope.Start();
             try
             {
                 using var message = CreateTrainCustomModelAsyncRequest(trainRequest);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 var headers = new ServiceTrainCustomModelAsyncHeaders(message.Response);
                 switch (message.Response.Status)
                 {
                     case 201:
                         return ResponseWithHeaders.FromValue(headers, message.Response);
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -120,7 +120,7 @@ namespace Azure.AI.FormRecognizer
 
         internal HttpMessage CreateGetCustomModelsRequest(GetModelOptions? op)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
@@ -140,23 +140,30 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<Models_internal>> GetCustomModelsAsync(GetModelOptions? op = null, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.GetCustomModels");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.GetCustomModels");
             scope.Start();
             try
             {
                 using var message = CreateGetCustomModelsRequest(op);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             Models_internal value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = Models_internal.DeserializeModels_internal(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = Models_internal.DeserializeModels_internal(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -171,23 +178,30 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<Models_internal> GetCustomModels(GetModelOptions? op = null, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.GetCustomModels");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.GetCustomModels");
             scope.Start();
             try
             {
                 using var message = CreateGetCustomModelsRequest(op);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             Models_internal value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = Models_internal.DeserializeModels_internal(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = Models_internal.DeserializeModels_internal(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -199,7 +213,7 @@ namespace Azure.AI.FormRecognizer
 
         internal HttpMessage CreateGetCustomModelRequest(Guid modelId, bool? includeKeys)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
@@ -221,23 +235,30 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<Model_internal>> GetCustomModelAsync(Guid modelId, bool? includeKeys = null, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.GetCustomModel");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.GetCustomModel");
             scope.Start();
             try
             {
                 using var message = CreateGetCustomModelRequest(modelId, includeKeys);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             Model_internal value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = Model_internal.DeserializeModel_internal(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = Model_internal.DeserializeModel_internal(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -253,23 +274,30 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<Model_internal> GetCustomModel(Guid modelId, bool? includeKeys = null, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.GetCustomModel");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.GetCustomModel");
             scope.Start();
             try
             {
                 using var message = CreateGetCustomModelRequest(modelId, includeKeys);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             Model_internal value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = Model_internal.DeserializeModel_internal(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = Model_internal.DeserializeModel_internal(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -281,7 +309,7 @@ namespace Azure.AI.FormRecognizer
 
         internal HttpMessage CreateDeleteCustomModelRequest(Guid modelId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Delete;
             var uri = new RawRequestUriBuilder();
@@ -298,18 +326,18 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> DeleteCustomModelAsync(Guid modelId, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.DeleteCustomModel");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.DeleteCustomModel");
             scope.Start();
             try
             {
                 using var message = CreateDeleteCustomModelRequest(modelId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 204:
                         return message.Response;
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -324,18 +352,18 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response DeleteCustomModel(Guid modelId, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.DeleteCustomModel");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.DeleteCustomModel");
             scope.Start();
             try
             {
                 using var message = CreateDeleteCustomModelRequest(modelId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 204:
                         return message.Response;
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -347,7 +375,7 @@ namespace Azure.AI.FormRecognizer
 
         internal HttpMessage CreateAnalyzeWithCustomModelRequest(Guid modelId, ContentType contentType, Stream fileStream, bool? includeTextDetails)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
@@ -379,19 +407,19 @@ namespace Azure.AI.FormRecognizer
                 throw new ArgumentNullException(nameof(fileStream));
             }
 
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.AnalyzeWithCustomModel");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.AnalyzeWithCustomModel");
             scope.Start();
             try
             {
                 using var message = CreateAnalyzeWithCustomModelRequest(modelId, contentType, fileStream, includeTextDetails);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 var headers = new ServiceAnalyzeWithCustomModelHeaders(message.Response);
                 switch (message.Response.Status)
                 {
                     case 202:
                         return ResponseWithHeaders.FromValue(headers, message.Response);
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -414,19 +442,19 @@ namespace Azure.AI.FormRecognizer
                 throw new ArgumentNullException(nameof(fileStream));
             }
 
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.AnalyzeWithCustomModel");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.AnalyzeWithCustomModel");
             scope.Start();
             try
             {
                 using var message = CreateAnalyzeWithCustomModelRequest(modelId, contentType, fileStream, includeTextDetails);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 var headers = new ServiceAnalyzeWithCustomModelHeaders(message.Response);
                 switch (message.Response.Status)
                 {
                     case 202:
                         return ResponseWithHeaders.FromValue(headers, message.Response);
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -438,7 +466,7 @@ namespace Azure.AI.FormRecognizer
 
         internal HttpMessage CreateAnalyzeWithCustomModelRequest(Guid modelId, bool? includeTextDetails, SourcePath_internal fileStream)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
@@ -469,19 +497,19 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<ResponseWithHeaders<ServiceAnalyzeWithCustomModelHeaders>> AnalyzeWithCustomModelAsync(Guid modelId, bool? includeTextDetails = null, SourcePath_internal fileStream = null, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.AnalyzeWithCustomModel");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.AnalyzeWithCustomModel");
             scope.Start();
             try
             {
                 using var message = CreateAnalyzeWithCustomModelRequest(modelId, includeTextDetails, fileStream);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 var headers = new ServiceAnalyzeWithCustomModelHeaders(message.Response);
                 switch (message.Response.Status)
                 {
                     case 202:
                         return ResponseWithHeaders.FromValue(headers, message.Response);
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -498,19 +526,19 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public ResponseWithHeaders<ServiceAnalyzeWithCustomModelHeaders> AnalyzeWithCustomModel(Guid modelId, bool? includeTextDetails = null, SourcePath_internal fileStream = null, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.AnalyzeWithCustomModel");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.AnalyzeWithCustomModel");
             scope.Start();
             try
             {
                 using var message = CreateAnalyzeWithCustomModelRequest(modelId, includeTextDetails, fileStream);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 var headers = new ServiceAnalyzeWithCustomModelHeaders(message.Response);
                 switch (message.Response.Status)
                 {
                     case 202:
                         return ResponseWithHeaders.FromValue(headers, message.Response);
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -522,7 +550,7 @@ namespace Azure.AI.FormRecognizer
 
         internal HttpMessage CreateGetAnalyzeFormResultRequest(Guid modelId, Guid resultId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
@@ -542,23 +570,30 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<AnalyzeOperationResult_internal>> GetAnalyzeFormResultAsync(Guid modelId, Guid resultId, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.GetAnalyzeFormResult");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.GetAnalyzeFormResult");
             scope.Start();
             try
             {
                 using var message = CreateGetAnalyzeFormResultRequest(modelId, resultId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             AnalyzeOperationResult_internal value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = AnalyzeOperationResult_internal.DeserializeAnalyzeOperationResult_internal(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = AnalyzeOperationResult_internal.DeserializeAnalyzeOperationResult_internal(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -574,23 +609,30 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<AnalyzeOperationResult_internal> GetAnalyzeFormResult(Guid modelId, Guid resultId, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.GetAnalyzeFormResult");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.GetAnalyzeFormResult");
             scope.Start();
             try
             {
                 using var message = CreateGetAnalyzeFormResultRequest(modelId, resultId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             AnalyzeOperationResult_internal value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = AnalyzeOperationResult_internal.DeserializeAnalyzeOperationResult_internal(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = AnalyzeOperationResult_internal.DeserializeAnalyzeOperationResult_internal(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -602,7 +644,7 @@ namespace Azure.AI.FormRecognizer
 
         internal HttpMessage CreateAnalyzeReceiptAsyncRequest(ContentType contentType, Stream fileStream, bool? includeTextDetails)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
@@ -631,19 +673,19 @@ namespace Azure.AI.FormRecognizer
                 throw new ArgumentNullException(nameof(fileStream));
             }
 
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.AnalyzeReceiptAsync");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.AnalyzeReceiptAsync");
             scope.Start();
             try
             {
                 using var message = CreateAnalyzeReceiptAsyncRequest(contentType, fileStream, includeTextDetails);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 var headers = new ServiceAnalyzeReceiptAsyncHeaders(message.Response);
                 switch (message.Response.Status)
                 {
                     case 202:
                         return ResponseWithHeaders.FromValue(headers, message.Response);
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -665,19 +707,19 @@ namespace Azure.AI.FormRecognizer
                 throw new ArgumentNullException(nameof(fileStream));
             }
 
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.AnalyzeReceiptAsync");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.AnalyzeReceiptAsync");
             scope.Start();
             try
             {
                 using var message = CreateAnalyzeReceiptAsyncRequest(contentType, fileStream, includeTextDetails);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 var headers = new ServiceAnalyzeReceiptAsyncHeaders(message.Response);
                 switch (message.Response.Status)
                 {
                     case 202:
                         return ResponseWithHeaders.FromValue(headers, message.Response);
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -689,7 +731,7 @@ namespace Azure.AI.FormRecognizer
 
         internal HttpMessage CreateAnalyzeReceiptAsyncRequest(bool? includeTextDetails, SourcePath_internal fileStream)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
@@ -717,19 +759,19 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<ResponseWithHeaders<ServiceAnalyzeReceiptAsyncHeaders>> AnalyzeReceiptAsyncAsync(bool? includeTextDetails = null, SourcePath_internal fileStream = null, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.AnalyzeReceiptAsync");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.AnalyzeReceiptAsync");
             scope.Start();
             try
             {
                 using var message = CreateAnalyzeReceiptAsyncRequest(includeTextDetails, fileStream);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 var headers = new ServiceAnalyzeReceiptAsyncHeaders(message.Response);
                 switch (message.Response.Status)
                 {
                     case 202:
                         return ResponseWithHeaders.FromValue(headers, message.Response);
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -745,19 +787,19 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public ResponseWithHeaders<ServiceAnalyzeReceiptAsyncHeaders> AnalyzeReceiptAsync(bool? includeTextDetails = null, SourcePath_internal fileStream = null, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.AnalyzeReceiptAsync");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.AnalyzeReceiptAsync");
             scope.Start();
             try
             {
                 using var message = CreateAnalyzeReceiptAsyncRequest(includeTextDetails, fileStream);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 var headers = new ServiceAnalyzeReceiptAsyncHeaders(message.Response);
                 switch (message.Response.Status)
                 {
                     case 202:
                         return ResponseWithHeaders.FromValue(headers, message.Response);
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -769,7 +811,7 @@ namespace Azure.AI.FormRecognizer
 
         internal HttpMessage CreateGetAnalyzeReceiptResultRequest(Guid resultId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
@@ -786,23 +828,30 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<AnalyzeOperationResult_internal>> GetAnalyzeReceiptResultAsync(Guid resultId, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.GetAnalyzeReceiptResult");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.GetAnalyzeReceiptResult");
             scope.Start();
             try
             {
                 using var message = CreateGetAnalyzeReceiptResultRequest(resultId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             AnalyzeOperationResult_internal value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = AnalyzeOperationResult_internal.DeserializeAnalyzeOperationResult_internal(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = AnalyzeOperationResult_internal.DeserializeAnalyzeOperationResult_internal(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -817,23 +866,30 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<AnalyzeOperationResult_internal> GetAnalyzeReceiptResult(Guid resultId, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.GetAnalyzeReceiptResult");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.GetAnalyzeReceiptResult");
             scope.Start();
             try
             {
                 using var message = CreateGetAnalyzeReceiptResultRequest(resultId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             AnalyzeOperationResult_internal value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = AnalyzeOperationResult_internal.DeserializeAnalyzeOperationResult_internal(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = AnalyzeOperationResult_internal.DeserializeAnalyzeOperationResult_internal(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -845,7 +901,7 @@ namespace Azure.AI.FormRecognizer
 
         internal HttpMessage CreateAnalyzeLayoutAsyncRequest(ContentType contentType, Stream fileStream)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
@@ -869,19 +925,19 @@ namespace Azure.AI.FormRecognizer
                 throw new ArgumentNullException(nameof(fileStream));
             }
 
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.AnalyzeLayoutAsync");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.AnalyzeLayoutAsync");
             scope.Start();
             try
             {
                 using var message = CreateAnalyzeLayoutAsyncRequest(contentType, fileStream);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 var headers = new ServiceAnalyzeLayoutAsyncHeaders(message.Response);
                 switch (message.Response.Status)
                 {
                     case 202:
                         return ResponseWithHeaders.FromValue(headers, message.Response);
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -902,19 +958,19 @@ namespace Azure.AI.FormRecognizer
                 throw new ArgumentNullException(nameof(fileStream));
             }
 
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.AnalyzeLayoutAsync");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.AnalyzeLayoutAsync");
             scope.Start();
             try
             {
                 using var message = CreateAnalyzeLayoutAsyncRequest(contentType, fileStream);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 var headers = new ServiceAnalyzeLayoutAsyncHeaders(message.Response);
                 switch (message.Response.Status)
                 {
                     case 202:
                         return ResponseWithHeaders.FromValue(headers, message.Response);
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -926,7 +982,7 @@ namespace Azure.AI.FormRecognizer
 
         internal HttpMessage CreateAnalyzeLayoutAsyncRequest(SourcePath_internal fileStream)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
@@ -949,19 +1005,19 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<ResponseWithHeaders<ServiceAnalyzeLayoutAsyncHeaders>> AnalyzeLayoutAsyncAsync(SourcePath_internal fileStream = null, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.AnalyzeLayoutAsync");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.AnalyzeLayoutAsync");
             scope.Start();
             try
             {
                 using var message = CreateAnalyzeLayoutAsyncRequest(fileStream);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 var headers = new ServiceAnalyzeLayoutAsyncHeaders(message.Response);
                 switch (message.Response.Status)
                 {
                     case 202:
                         return ResponseWithHeaders.FromValue(headers, message.Response);
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -976,19 +1032,19 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public ResponseWithHeaders<ServiceAnalyzeLayoutAsyncHeaders> AnalyzeLayoutAsync(SourcePath_internal fileStream = null, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.AnalyzeLayoutAsync");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.AnalyzeLayoutAsync");
             scope.Start();
             try
             {
                 using var message = CreateAnalyzeLayoutAsyncRequest(fileStream);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 var headers = new ServiceAnalyzeLayoutAsyncHeaders(message.Response);
                 switch (message.Response.Status)
                 {
                     case 202:
                         return ResponseWithHeaders.FromValue(headers, message.Response);
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -1000,7 +1056,7 @@ namespace Azure.AI.FormRecognizer
 
         internal HttpMessage CreateGetAnalyzeLayoutResultRequest(Guid resultId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
@@ -1017,23 +1073,30 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<AnalyzeOperationResult_internal>> GetAnalyzeLayoutResultAsync(Guid resultId, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.GetAnalyzeLayoutResult");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.GetAnalyzeLayoutResult");
             scope.Start();
             try
             {
                 using var message = CreateGetAnalyzeLayoutResultRequest(resultId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             AnalyzeOperationResult_internal value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = AnalyzeOperationResult_internal.DeserializeAnalyzeOperationResult_internal(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = AnalyzeOperationResult_internal.DeserializeAnalyzeOperationResult_internal(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -1048,23 +1111,30 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<AnalyzeOperationResult_internal> GetAnalyzeLayoutResult(Guid resultId, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.GetAnalyzeLayoutResult");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.GetAnalyzeLayoutResult");
             scope.Start();
             try
             {
                 using var message = CreateGetAnalyzeLayoutResultRequest(resultId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             AnalyzeOperationResult_internal value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = AnalyzeOperationResult_internal.DeserializeAnalyzeOperationResult_internal(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = AnalyzeOperationResult_internal.DeserializeAnalyzeOperationResult_internal(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -1076,7 +1146,7 @@ namespace Azure.AI.FormRecognizer
 
         internal HttpMessage CreateGetCustomModelsNextPageRequest(string nextLink, GetModelOptions? op)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
@@ -1096,23 +1166,30 @@ namespace Azure.AI.FormRecognizer
                 throw new ArgumentNullException(nameof(nextLink));
             }
 
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.GetCustomModels");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.GetCustomModels");
             scope.Start();
             try
             {
                 using var message = CreateGetCustomModelsNextPageRequest(nextLink, op);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             Models_internal value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = Models_internal.DeserializeModels_internal(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = Models_internal.DeserializeModels_internal(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -1133,23 +1210,30 @@ namespace Azure.AI.FormRecognizer
                 throw new ArgumentNullException(nameof(nextLink));
             }
 
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.GetCustomModels");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.GetCustomModels");
             scope.Start();
             try
             {
                 using var message = CreateGetCustomModelsNextPageRequest(nextLink, op);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             Models_internal value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = Models_internal.DeserializeModels_internal(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = Models_internal.DeserializeModels_internal(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/AnalyzeResult.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/AnalyzeResult.Serialization.cs
@@ -23,7 +23,14 @@ namespace Azure.Search.Documents.Models
                     List<TokenInfo> array = new List<TokenInfo>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(TokenInfo.DeserializeTokenInfo(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(TokenInfo.DeserializeTokenInfo(item));
+                        }
                     }
                     tokens = array;
                     continue;

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/Analyzer.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/Analyzer.Serialization.cs
@@ -34,13 +34,13 @@ namespace Azure.Search.Documents.Models
                     case "#Microsoft.Azure.Search.StopAnalyzer": return StopAnalyzer.DeserializeStopAnalyzer(element);
                 }
             }
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -49,7 +49,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new Analyzer(odatatype, name);
+            return new Analyzer(odataType, name);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/Analyzer.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/Analyzer.cs
@@ -30,7 +30,7 @@ namespace Azure.Search.Documents.Models
         /// <param name="name"> The name of the analyzer. It must only contain letters, digits, spaces, dashes or underscores, can only start and end with alphanumeric characters, and is limited to 128 characters. </param>
         internal Analyzer(string oDataType, string name)
         {
-            ODataType = oDataType ?? null;
+            ODataType = oDataType;
             Name = name;
         }
 

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/AnalyzerName.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/AnalyzerName.cs
@@ -312,7 +312,7 @@ namespace Azure.Search.Documents.Models
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj) => obj is AnalyzerName other && Equals(other);
         /// <inheritdoc />
-        public bool Equals(AnalyzerName other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+        public bool Equals(AnalyzerName other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
 
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/AsciiFoldingTokenFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/AsciiFoldingTokenFilter.Serialization.cs
@@ -30,7 +30,7 @@ namespace Azure.Search.Documents.Models
         internal static AsciiFoldingTokenFilter DeserializeAsciiFoldingTokenFilter(JsonElement element)
         {
             bool? preserveOriginal = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -45,7 +45,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -54,7 +54,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new AsciiFoldingTokenFilter(odatatype, name, preserveOriginal);
+            return new AsciiFoldingTokenFilter(odataType, name, preserveOriginal);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/AutocompleteResults.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/AutocompleteResults.Serialization.cs
@@ -15,7 +15,7 @@ namespace Azure.Search.Documents.Models
     {
         internal static AutocompleteResults DeserializeAutocompleteResults(JsonElement element)
         {
-            double? searchcoverage = default;
+            double? searchCoverage = default;
             IReadOnlyList<Autocompletion> value = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -25,7 +25,7 @@ namespace Azure.Search.Documents.Models
                     {
                         continue;
                     }
-                    searchcoverage = property.Value.GetDouble();
+                    searchCoverage = property.Value.GetDouble();
                     continue;
                 }
                 if (property.NameEquals("value"))
@@ -33,13 +33,20 @@ namespace Azure.Search.Documents.Models
                     List<Autocompletion> array = new List<Autocompletion>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(Autocompletion.DeserializeAutocompletion(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(Autocompletion.DeserializeAutocompletion(item));
+                        }
                     }
                     value = array;
                     continue;
                 }
             }
-            return new AutocompleteResults(searchcoverage, value);
+            return new AutocompleteResults(searchCoverage, value);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/CharFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/CharFilter.Serialization.cs
@@ -32,13 +32,13 @@ namespace Azure.Search.Documents.Models
                     case "#Microsoft.Azure.Search.PatternReplaceCharFilter": return PatternReplaceCharFilter.DeserializePatternReplaceCharFilter(element);
                 }
             }
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -47,7 +47,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new CharFilter(odatatype, name);
+            return new CharFilter(odataType, name);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/CharFilter.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/CharFilter.cs
@@ -30,7 +30,7 @@ namespace Azure.Search.Documents.Models
         /// <param name="name"> The name of the char filter. It must only contain letters, digits, spaces, dashes or underscores, can only start and end with alphanumeric characters, and is limited to 128 characters. </param>
         internal CharFilter(string oDataType, string name)
         {
-            ODataType = oDataType ?? null;
+            ODataType = oDataType;
             Name = name;
         }
 

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/CjkBigramTokenFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/CjkBigramTokenFilter.Serialization.cs
@@ -42,7 +42,7 @@ namespace Azure.Search.Documents.Models
         {
             IList<CjkBigramTokenFilterScripts> ignoreScripts = default;
             bool? outputUnigrams = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -71,7 +71,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -80,7 +80,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new CjkBigramTokenFilter(odatatype, name, ignoreScripts, outputUnigrams);
+            return new CjkBigramTokenFilter(odataType, name, ignoreScripts, outputUnigrams);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/ClassicTokenizer.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/ClassicTokenizer.Serialization.cs
@@ -30,7 +30,7 @@ namespace Azure.Search.Documents.Models
         internal static ClassicTokenizer DeserializeClassicTokenizer(JsonElement element)
         {
             int? maxTokenLength = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -45,7 +45,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -54,7 +54,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new ClassicTokenizer(odatatype, name, maxTokenLength);
+            return new ClassicTokenizer(odataType, name, maxTokenLength);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/CognitiveServicesAccount.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/CognitiveServicesAccount.Serialization.cs
@@ -35,13 +35,13 @@ namespace Azure.Search.Documents.Models
                     case "#Microsoft.Azure.Search.DefaultCognitiveServices": return DefaultCognitiveServicesAccount.DeserializeDefaultCognitiveServicesAccount(element);
                 }
             }
-            string odatatype = default;
+            string odataType = default;
             string description = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("description"))
@@ -54,7 +54,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new CognitiveServicesAccount(odatatype, description);
+            return new CognitiveServicesAccount(odataType, description);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/CognitiveServicesAccount.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/CognitiveServicesAccount.cs
@@ -21,7 +21,7 @@ namespace Azure.Search.Documents.Models
         /// <param name="description"> Description of the cognitive service resource attached to a skillset. </param>
         internal CognitiveServicesAccount(string oDataType, string description)
         {
-            ODataType = oDataType ?? null;
+            ODataType = oDataType;
             Description = description;
         }
 

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/CognitiveServicesAccountKey.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/CognitiveServicesAccountKey.Serialization.cs
@@ -30,7 +30,7 @@ namespace Azure.Search.Documents.Models
         internal static CognitiveServicesAccountKey DeserializeCognitiveServicesAccountKey(JsonElement element)
         {
             string key = default;
-            string odatatype = default;
+            string odataType = default;
             string description = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -41,7 +41,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("description"))
@@ -54,7 +54,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new CognitiveServicesAccountKey(odatatype, description, key);
+            return new CognitiveServicesAccountKey(odataType, description, key);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/CommonGramTokenFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/CommonGramTokenFilter.Serialization.cs
@@ -45,7 +45,7 @@ namespace Azure.Search.Documents.Models
             IList<string> commonWords = default;
             bool? ignoreCase = default;
             bool? queryMode = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -54,7 +54,14 @@ namespace Azure.Search.Documents.Models
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.GetString());
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(item.GetString());
+                        }
                     }
                     commonWords = array;
                     continue;
@@ -79,7 +86,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -88,7 +95,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new CommonGramTokenFilter(odatatype, name, commonWords, ignoreCase, queryMode);
+            return new CommonGramTokenFilter(odataType, name, commonWords, ignoreCase, queryMode);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/ConditionalSkill.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/ConditionalSkill.Serialization.cs
@@ -42,9 +42,9 @@ namespace Azure.Search.Documents.Models
             writer.WriteEndArray();
             writer.WritePropertyName("outputs");
             writer.WriteStartArray();
-            foreach (var item0 in Outputs)
+            foreach (var item in Outputs)
             {
-                writer.WriteObjectValue(item0);
+                writer.WriteObjectValue(item);
             }
             writer.WriteEndArray();
             writer.WriteEndObject();
@@ -52,7 +52,7 @@ namespace Azure.Search.Documents.Models
 
         internal static ConditionalSkill DeserializeConditionalSkill(JsonElement element)
         {
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             string description = default;
             string context = default;
@@ -62,7 +62,7 @@ namespace Azure.Search.Documents.Models
             {
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -97,7 +97,14 @@ namespace Azure.Search.Documents.Models
                     List<InputFieldMappingEntry> array = new List<InputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        }
                     }
                     inputs = array;
                     continue;
@@ -107,13 +114,20 @@ namespace Azure.Search.Documents.Models
                     List<OutputFieldMappingEntry> array = new List<OutputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        }
                     }
                     outputs = array;
                     continue;
                 }
             }
-            return new ConditionalSkill(odatatype, name, description, context, inputs, outputs);
+            return new ConditionalSkill(odataType, name, description, context, inputs, outputs);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/CorsOptions.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/CorsOptions.Serialization.cs
@@ -42,7 +42,14 @@ namespace Azure.Search.Documents.Models
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.GetString());
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(item.GetString());
+                        }
                     }
                     allowedOrigins = array;
                     continue;

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/CustomAnalyzer.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/CustomAnalyzer.Serialization.cs
@@ -50,7 +50,7 @@ namespace Azure.Search.Documents.Models
             TokenizerName tokenizer = default;
             IList<TokenFilterName> tokenFilters = default;
             IList<string> charFilters = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -82,14 +82,21 @@ namespace Azure.Search.Documents.Models
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.GetString());
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(item.GetString());
+                        }
                     }
                     charFilters = array;
                     continue;
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -98,7 +105,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new CustomAnalyzer(odatatype, name, tokenizer, tokenFilters, charFilters);
+            return new CustomAnalyzer(odataType, name, tokenizer, tokenFilters, charFilters);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/DataChangeDetectionPolicy.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/DataChangeDetectionPolicy.Serialization.cs
@@ -30,16 +30,16 @@ namespace Azure.Search.Documents.Models
                     case "#Microsoft.Azure.Search.SqlIntegratedChangeTrackingPolicy": return SqlIntegratedChangeTrackingPolicy.DeserializeSqlIntegratedChangeTrackingPolicy(element);
                 }
             }
-            string odatatype = default;
+            string odataType = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
             }
-            return new DataChangeDetectionPolicy(odatatype);
+            return new DataChangeDetectionPolicy(odataType);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/DataChangeDetectionPolicy.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/DataChangeDetectionPolicy.cs
@@ -20,7 +20,7 @@ namespace Azure.Search.Documents.Models
         /// <param name="oDataType"> Identifies the concrete type of the data change detection policy. </param>
         internal DataChangeDetectionPolicy(string oDataType)
         {
-            ODataType = oDataType ?? null;
+            ODataType = oDataType;
         }
 
         /// <summary> Identifies the concrete type of the data change detection policy. </summary>

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/DataDeletionDetectionPolicy.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/DataDeletionDetectionPolicy.Serialization.cs
@@ -29,16 +29,16 @@ namespace Azure.Search.Documents.Models
                     case "#Microsoft.Azure.Search.SoftDeleteColumnDeletionDetectionPolicy": return SoftDeleteColumnDeletionDetectionPolicy.DeserializeSoftDeleteColumnDeletionDetectionPolicy(element);
                 }
             }
-            string odatatype = default;
+            string odataType = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
             }
-            return new DataDeletionDetectionPolicy(odatatype);
+            return new DataDeletionDetectionPolicy(odataType);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/DataDeletionDetectionPolicy.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/DataDeletionDetectionPolicy.cs
@@ -20,7 +20,7 @@ namespace Azure.Search.Documents.Models
         /// <param name="oDataType"> Identifies the concrete type of the data deletion detection policy. </param>
         internal DataDeletionDetectionPolicy(string oDataType)
         {
-            ODataType = oDataType ?? null;
+            ODataType = oDataType;
         }
 
         /// <summary> Identifies the concrete type of the data deletion detection policy. </summary>

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/DataSource.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/DataSource.Serialization.cs
@@ -55,7 +55,7 @@ namespace Azure.Search.Documents.Models
             DataContainer container = default;
             DataChangeDetectionPolicy dataChangeDetectionPolicy = default;
             DataDeletionDetectionPolicy dataDeletionDetectionPolicy = default;
-            string odataetag = default;
+            string odataEtag = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("name"))
@@ -111,11 +111,11 @@ namespace Azure.Search.Documents.Models
                     {
                         continue;
                     }
-                    odataetag = property.Value.GetString();
+                    odataEtag = property.Value.GetString();
                     continue;
                 }
             }
-            return new DataSource(name, description, type, credentials, container, dataChangeDetectionPolicy, dataDeletionDetectionPolicy, odataetag);
+            return new DataSource(name, description, type, credentials, container, dataChangeDetectionPolicy, dataDeletionDetectionPolicy, odataEtag);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/DataSourceType.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/DataSourceType.cs
@@ -48,7 +48,7 @@ namespace Azure.Search.Documents.Models
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj) => obj is DataSourceType other && Equals(other);
         /// <inheritdoc />
-        public bool Equals(DataSourceType other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+        public bool Equals(DataSourceType other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
 
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/DataType.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/DataType.cs
@@ -40,7 +40,7 @@ namespace Azure.Search.Documents.Models
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj) => obj is DataType other && Equals(other);
         /// <inheritdoc />
-        public bool Equals(DataType other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+        public bool Equals(DataType other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
 
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/DefaultCognitiveServicesAccount.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/DefaultCognitiveServicesAccount.Serialization.cs
@@ -27,13 +27,13 @@ namespace Azure.Search.Documents.Models
 
         internal static DefaultCognitiveServicesAccount DeserializeDefaultCognitiveServicesAccount(JsonElement element)
         {
-            string odatatype = default;
+            string odataType = default;
             string description = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("description"))
@@ -46,7 +46,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new DefaultCognitiveServicesAccount(odatatype, description);
+            return new DefaultCognitiveServicesAccount(odataType, description);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/DictionaryDecompounderTokenFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/DictionaryDecompounderTokenFilter.Serialization.cs
@@ -57,7 +57,7 @@ namespace Azure.Search.Documents.Models
             int? minSubwordSize = default;
             int? maxSubwordSize = default;
             bool? onlyLongestMatch = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -66,7 +66,14 @@ namespace Azure.Search.Documents.Models
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.GetString());
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(item.GetString());
+                        }
                     }
                     wordList = array;
                     continue;
@@ -109,7 +116,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -118,7 +125,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new DictionaryDecompounderTokenFilter(odatatype, name, wordList, minWordSize, minSubwordSize, maxSubwordSize, onlyLongestMatch);
+            return new DictionaryDecompounderTokenFilter(odataType, name, wordList, minWordSize, minSubwordSize, maxSubwordSize, onlyLongestMatch);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/EdgeNGramTokenFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/EdgeNGramTokenFilter.Serialization.cs
@@ -42,7 +42,7 @@ namespace Azure.Search.Documents.Models
             int? minGram = default;
             int? maxGram = default;
             EdgeNGramTokenFilterSide? side = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -75,7 +75,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -84,7 +84,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new EdgeNGramTokenFilter(odatatype, name, minGram, maxGram, side);
+            return new EdgeNGramTokenFilter(odataType, name, minGram, maxGram, side);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/EdgeNGramTokenFilterV2.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/EdgeNGramTokenFilterV2.Serialization.cs
@@ -42,7 +42,7 @@ namespace Azure.Search.Documents.Models
             int? minGram = default;
             int? maxGram = default;
             EdgeNGramTokenFilterSide? side = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -75,7 +75,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -84,7 +84,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new EdgeNGramTokenFilterV2(odatatype, name, minGram, maxGram, side);
+            return new EdgeNGramTokenFilterV2(odataType, name, minGram, maxGram, side);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/EdgeNGramTokenizer.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/EdgeNGramTokenizer.Serialization.cs
@@ -48,7 +48,7 @@ namespace Azure.Search.Documents.Models
             int? minGram = default;
             int? maxGram = default;
             IList<TokenCharacterKind> tokenChars = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -86,7 +86,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -95,7 +95,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new EdgeNGramTokenizer(odatatype, name, minGram, maxGram, tokenChars);
+            return new EdgeNGramTokenizer(odataType, name, minGram, maxGram, tokenChars);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/ElisionTokenFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/ElisionTokenFilter.Serialization.cs
@@ -36,7 +36,7 @@ namespace Azure.Search.Documents.Models
         internal static ElisionTokenFilter DeserializeElisionTokenFilter(JsonElement element)
         {
             IList<string> articles = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -49,14 +49,21 @@ namespace Azure.Search.Documents.Models
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.GetString());
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(item.GetString());
+                        }
                     }
                     articles = array;
                     continue;
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -65,7 +72,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new ElisionTokenFilter(odatatype, name, articles);
+            return new ElisionTokenFilter(odataType, name, articles);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/EntityRecognitionSkill.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/EntityRecognitionSkill.Serialization.cs
@@ -67,9 +67,9 @@ namespace Azure.Search.Documents.Models
             writer.WriteEndArray();
             writer.WritePropertyName("outputs");
             writer.WriteStartArray();
-            foreach (var item0 in Outputs)
+            foreach (var item in Outputs)
             {
-                writer.WriteObjectValue(item0);
+                writer.WriteObjectValue(item);
             }
             writer.WriteEndArray();
             writer.WriteEndObject();
@@ -81,7 +81,7 @@ namespace Azure.Search.Documents.Models
             EntityRecognitionSkillLanguage? defaultLanguageCode = default;
             bool? includeTypelessEntities = default;
             double? minimumPrecision = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             string description = default;
             string context = default;
@@ -132,7 +132,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -167,7 +167,14 @@ namespace Azure.Search.Documents.Models
                     List<InputFieldMappingEntry> array = new List<InputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        }
                     }
                     inputs = array;
                     continue;
@@ -177,13 +184,20 @@ namespace Azure.Search.Documents.Models
                     List<OutputFieldMappingEntry> array = new List<OutputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        }
                     }
                     outputs = array;
                     continue;
                 }
             }
-            return new EntityRecognitionSkill(odatatype, name, description, context, inputs, outputs, categories, defaultLanguageCode, includeTypelessEntities, minimumPrecision);
+            return new EntityRecognitionSkill(odataType, name, description, context, inputs, outputs, categories, defaultLanguageCode, includeTypelessEntities, minimumPrecision);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/EntityRecognitionSkillLanguage.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/EntityRecognitionSkillLanguage.cs
@@ -102,7 +102,7 @@ namespace Azure.Search.Documents.Models
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj) => obj is EntityRecognitionSkillLanguage other && Equals(other);
         /// <inheritdoc />
-        public bool Equals(EntityRecognitionSkillLanguage other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+        public bool Equals(EntityRecognitionSkillLanguage other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
 
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/FacetResult.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/FacetResult.Serialization.cs
@@ -17,7 +17,7 @@ namespace Azure.Search.Documents.Models
         {
             long? count = default;
             IReadOnlyDictionary<string, object> additionalProperties = default;
-            Dictionary<string, object> additionalPropertiesDictionary = new Dictionary<string, object>();
+            Dictionary<string, object> additionalPropertiesDictionary = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("count"))
@@ -29,7 +29,15 @@ namespace Azure.Search.Documents.Models
                     count = property.Value.GetInt64();
                     continue;
                 }
-                additionalPropertiesDictionary.Add(property.Name, property.Value.GetObject());
+                additionalPropertiesDictionary ??= new Dictionary<string, object>();
+                if (property.Value.ValueKind == JsonValueKind.Null)
+                {
+                    additionalPropertiesDictionary.Add(property.Name, null);
+                }
+                else
+                {
+                    additionalPropertiesDictionary.Add(property.Name, property.Value.GetObject());
+                }
             }
             additionalProperties = additionalPropertiesDictionary;
             return new FacetResult(count, additionalProperties);

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/FacetResult.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/FacetResult.cs
@@ -25,7 +25,7 @@ namespace Azure.Search.Documents.Models
         internal FacetResult(long? count, IReadOnlyDictionary<string, object> additionalProperties)
         {
             Count = count;
-            AdditionalProperties = additionalProperties;
+            AdditionalProperties = additionalProperties ?? new Dictionary<string, object>();
         }
 
         /// <summary> The approximate count of documents falling within the bucket described by this facet. </summary>

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/FieldMappingFunction.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/FieldMappingFunction.Serialization.cs
@@ -52,7 +52,14 @@ namespace Azure.Search.Documents.Models
                     Dictionary<string, object> dictionary = new Dictionary<string, object>();
                     foreach (var property0 in property.Value.EnumerateObject())
                     {
-                        dictionary.Add(property0.Name, property0.Value.GetObject());
+                        if (property0.Value.ValueKind == JsonValueKind.Null)
+                        {
+                            dictionary.Add(property0.Name, null);
+                        }
+                        else
+                        {
+                            dictionary.Add(property0.Name, property0.Value.GetObject());
+                        }
                     }
                     parameters = dictionary;
                     continue;

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/HighWaterMarkChangeDetectionPolicy.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/HighWaterMarkChangeDetectionPolicy.Serialization.cs
@@ -25,7 +25,7 @@ namespace Azure.Search.Documents.Models
         internal static HighWaterMarkChangeDetectionPolicy DeserializeHighWaterMarkChangeDetectionPolicy(JsonElement element)
         {
             string highWaterMarkColumnName = default;
-            string odatatype = default;
+            string odataType = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("highWaterMarkColumnName"))
@@ -35,11 +35,11 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
             }
-            return new HighWaterMarkChangeDetectionPolicy(odatatype, highWaterMarkColumnName);
+            return new HighWaterMarkChangeDetectionPolicy(odataType, highWaterMarkColumnName);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/ImageAnalysisSkill.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/ImageAnalysisSkill.Serialization.cs
@@ -67,9 +67,9 @@ namespace Azure.Search.Documents.Models
             writer.WriteEndArray();
             writer.WritePropertyName("outputs");
             writer.WriteStartArray();
-            foreach (var item0 in Outputs)
+            foreach (var item in Outputs)
             {
-                writer.WriteObjectValue(item0);
+                writer.WriteObjectValue(item);
             }
             writer.WriteEndArray();
             writer.WriteEndObject();
@@ -80,7 +80,7 @@ namespace Azure.Search.Documents.Models
             ImageAnalysisSkillLanguage? defaultLanguageCode = default;
             IList<VisualFeature> visualFeatures = default;
             IList<ImageDetail> details = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             string description = default;
             string context = default;
@@ -127,7 +127,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -162,7 +162,14 @@ namespace Azure.Search.Documents.Models
                     List<InputFieldMappingEntry> array = new List<InputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        }
                     }
                     inputs = array;
                     continue;
@@ -172,13 +179,20 @@ namespace Azure.Search.Documents.Models
                     List<OutputFieldMappingEntry> array = new List<OutputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        }
                     }
                     outputs = array;
                     continue;
                 }
             }
-            return new ImageAnalysisSkill(odatatype, name, description, context, inputs, outputs, defaultLanguageCode, visualFeatures, details);
+            return new ImageAnalysisSkill(odataType, name, description, context, inputs, outputs, defaultLanguageCode, visualFeatures, details);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/ImageAnalysisSkillLanguage.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/ImageAnalysisSkillLanguage.cs
@@ -48,7 +48,7 @@ namespace Azure.Search.Documents.Models
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj) => obj is ImageAnalysisSkillLanguage other && Equals(other);
         /// <inheritdoc />
-        public bool Equals(ImageAnalysisSkillLanguage other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+        public bool Equals(ImageAnalysisSkillLanguage other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
 
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/IndexAction.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/IndexAction.cs
@@ -25,7 +25,7 @@ namespace Azure.Search.Documents.Models
         internal IndexAction(IndexActionType? actionType, IDictionary<string, object> additionalProperties)
         {
             ActionType = actionType;
-            AdditionalProperties = additionalProperties;
+            AdditionalProperties = additionalProperties ?? new Dictionary<string, object>();
         }
 
         /// <summary> The operation to perform on a document in an indexing batch. </summary>

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/IndexDocumentsResult.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/IndexDocumentsResult.Serialization.cs
@@ -23,7 +23,14 @@ namespace Azure.Search.Documents.Models
                     List<IndexingResult> array = new List<IndexingResult>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(IndexingResult.DeserializeIndexingResult(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(IndexingResult.DeserializeIndexingResult(item));
+                        }
                     }
                     value = array;
                     continue;

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/IndexerExecutionInfo.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/IndexerExecutionInfo.Serialization.cs
@@ -40,7 +40,14 @@ namespace Azure.Search.Documents.Models
                     List<IndexerExecutionResult> array = new List<IndexerExecutionResult>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(IndexerExecutionResult.DeserializeIndexerExecutionResult(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(IndexerExecutionResult.DeserializeIndexerExecutionResult(item));
+                        }
                     }
                     executionHistory = array;
                     continue;

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/IndexerExecutionResult.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/IndexerExecutionResult.Serialization.cs
@@ -65,7 +65,14 @@ namespace Azure.Search.Documents.Models
                     List<ItemError> array = new List<ItemError>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(ItemError.DeserializeItemError(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(ItemError.DeserializeItemError(item));
+                        }
                     }
                     errors = array;
                     continue;
@@ -75,7 +82,14 @@ namespace Azure.Search.Documents.Models
                     List<ItemWarning> array = new List<ItemWarning>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(ItemWarning.DeserializeItemWarning(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(ItemWarning.DeserializeItemWarning(item));
+                        }
                     }
                     warnings = array;
                     continue;

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/IndexingParameters.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/IndexingParameters.Serialization.cs
@@ -89,7 +89,14 @@ namespace Azure.Search.Documents.Models
                     Dictionary<string, object> dictionary = new Dictionary<string, object>();
                     foreach (var property0 in property.Value.EnumerateObject())
                     {
-                        dictionary.Add(property0.Name, property0.Value.GetObject());
+                        if (property0.Value.ValueKind == JsonValueKind.Null)
+                        {
+                            dictionary.Add(property0.Name, null);
+                        }
+                        else
+                        {
+                            dictionary.Add(property0.Name, property0.Value.GetObject());
+                        }
                     }
                     configuration = dictionary;
                     continue;

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/InputFieldMappingEntry.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/InputFieldMappingEntry.Serialization.cs
@@ -81,7 +81,14 @@ namespace Azure.Search.Documents.Models
                     List<InputFieldMappingEntry> array = new List<InputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(DeserializeInputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(DeserializeInputFieldMappingEntry(item));
+                        }
                     }
                     inputs = array;
                     continue;

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/KeepTokenFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/KeepTokenFilter.Serialization.cs
@@ -39,7 +39,7 @@ namespace Azure.Search.Documents.Models
         {
             IList<string> keepWords = default;
             bool? keepWordsCase = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -48,7 +48,14 @@ namespace Azure.Search.Documents.Models
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.GetString());
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(item.GetString());
+                        }
                     }
                     keepWords = array;
                     continue;
@@ -64,7 +71,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -73,7 +80,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new KeepTokenFilter(odatatype, name, keepWords, keepWordsCase);
+            return new KeepTokenFilter(odataType, name, keepWords, keepWordsCase);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/KeyPhraseExtractionSkill.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/KeyPhraseExtractionSkill.Serialization.cs
@@ -52,9 +52,9 @@ namespace Azure.Search.Documents.Models
             writer.WriteEndArray();
             writer.WritePropertyName("outputs");
             writer.WriteStartArray();
-            foreach (var item0 in Outputs)
+            foreach (var item in Outputs)
             {
-                writer.WriteObjectValue(item0);
+                writer.WriteObjectValue(item);
             }
             writer.WriteEndArray();
             writer.WriteEndObject();
@@ -64,7 +64,7 @@ namespace Azure.Search.Documents.Models
         {
             KeyPhraseExtractionSkillLanguage? defaultLanguageCode = default;
             int? maxKeyPhraseCount = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             string description = default;
             string context = default;
@@ -92,7 +92,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -127,7 +127,14 @@ namespace Azure.Search.Documents.Models
                     List<InputFieldMappingEntry> array = new List<InputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        }
                     }
                     inputs = array;
                     continue;
@@ -137,13 +144,20 @@ namespace Azure.Search.Documents.Models
                     List<OutputFieldMappingEntry> array = new List<OutputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        }
                     }
                     outputs = array;
                     continue;
                 }
             }
-            return new KeyPhraseExtractionSkill(odatatype, name, description, context, inputs, outputs, defaultLanguageCode, maxKeyPhraseCount);
+            return new KeyPhraseExtractionSkill(odataType, name, description, context, inputs, outputs, defaultLanguageCode, maxKeyPhraseCount);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/KeyPhraseExtractionSkillLanguage.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/KeyPhraseExtractionSkillLanguage.cs
@@ -81,7 +81,7 @@ namespace Azure.Search.Documents.Models
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj) => obj is KeyPhraseExtractionSkillLanguage other && Equals(other);
         /// <inheritdoc />
-        public bool Equals(KeyPhraseExtractionSkillLanguage other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+        public bool Equals(KeyPhraseExtractionSkillLanguage other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
 
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/KeywordMarkerTokenFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/KeywordMarkerTokenFilter.Serialization.cs
@@ -39,7 +39,7 @@ namespace Azure.Search.Documents.Models
         {
             IList<string> keywords = default;
             bool? ignoreCase = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -48,7 +48,14 @@ namespace Azure.Search.Documents.Models
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.GetString());
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(item.GetString());
+                        }
                     }
                     keywords = array;
                     continue;
@@ -64,7 +71,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -73,7 +80,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new KeywordMarkerTokenFilter(odatatype, name, keywords, ignoreCase);
+            return new KeywordMarkerTokenFilter(odataType, name, keywords, ignoreCase);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/KeywordTokenizer.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/KeywordTokenizer.Serialization.cs
@@ -30,7 +30,7 @@ namespace Azure.Search.Documents.Models
         internal static KeywordTokenizer DeserializeKeywordTokenizer(JsonElement element)
         {
             int? bufferSize = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -45,7 +45,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -54,7 +54,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new KeywordTokenizer(odatatype, name, bufferSize);
+            return new KeywordTokenizer(odataType, name, bufferSize);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/KeywordTokenizerV2.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/KeywordTokenizerV2.Serialization.cs
@@ -30,7 +30,7 @@ namespace Azure.Search.Documents.Models
         internal static KeywordTokenizerV2 DeserializeKeywordTokenizerV2(JsonElement element)
         {
             int? maxTokenLength = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -45,7 +45,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -54,7 +54,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new KeywordTokenizerV2(odatatype, name, maxTokenLength);
+            return new KeywordTokenizerV2(odataType, name, maxTokenLength);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/LanguageDetectionSkill.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/LanguageDetectionSkill.Serialization.cs
@@ -42,9 +42,9 @@ namespace Azure.Search.Documents.Models
             writer.WriteEndArray();
             writer.WritePropertyName("outputs");
             writer.WriteStartArray();
-            foreach (var item0 in Outputs)
+            foreach (var item in Outputs)
             {
-                writer.WriteObjectValue(item0);
+                writer.WriteObjectValue(item);
             }
             writer.WriteEndArray();
             writer.WriteEndObject();
@@ -52,7 +52,7 @@ namespace Azure.Search.Documents.Models
 
         internal static LanguageDetectionSkill DeserializeLanguageDetectionSkill(JsonElement element)
         {
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             string description = default;
             string context = default;
@@ -62,7 +62,7 @@ namespace Azure.Search.Documents.Models
             {
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -97,7 +97,14 @@ namespace Azure.Search.Documents.Models
                     List<InputFieldMappingEntry> array = new List<InputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        }
                     }
                     inputs = array;
                     continue;
@@ -107,13 +114,20 @@ namespace Azure.Search.Documents.Models
                     List<OutputFieldMappingEntry> array = new List<OutputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        }
                     }
                     outputs = array;
                     continue;
                 }
             }
-            return new LanguageDetectionSkill(odatatype, name, description, context, inputs, outputs);
+            return new LanguageDetectionSkill(odataType, name, description, context, inputs, outputs);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/LengthTokenFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/LengthTokenFilter.Serialization.cs
@@ -36,7 +36,7 @@ namespace Azure.Search.Documents.Models
         {
             int? min = default;
             int? max = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -60,7 +60,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -69,7 +69,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new LengthTokenFilter(odatatype, name, min, max);
+            return new LengthTokenFilter(odataType, name, min, max);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/LimitTokenFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/LimitTokenFilter.Serialization.cs
@@ -36,7 +36,7 @@ namespace Azure.Search.Documents.Models
         {
             int? maxTokenCount = default;
             bool? consumeAllTokens = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -60,7 +60,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -69,7 +69,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new LimitTokenFilter(odatatype, name, maxTokenCount, consumeAllTokens);
+            return new LimitTokenFilter(odataType, name, maxTokenCount, consumeAllTokens);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/ListDataSourcesResult.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/ListDataSourcesResult.Serialization.cs
@@ -23,7 +23,14 @@ namespace Azure.Search.Documents.Models
                     List<DataSource> array = new List<DataSource>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(DataSource.DeserializeDataSource(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(DataSource.DeserializeDataSource(item));
+                        }
                     }
                     value = array;
                     continue;

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/ListIndexersResult.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/ListIndexersResult.Serialization.cs
@@ -23,7 +23,14 @@ namespace Azure.Search.Documents.Models
                     List<SearchIndexer> array = new List<SearchIndexer>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(SearchIndexer.DeserializeSearchIndexer(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(SearchIndexer.DeserializeSearchIndexer(item));
+                        }
                     }
                     value = array;
                     continue;

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/ListIndexesResult.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/ListIndexesResult.Serialization.cs
@@ -23,7 +23,14 @@ namespace Azure.Search.Documents.Models
                     List<SearchIndex> array = new List<SearchIndex>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(SearchIndex.DeserializeSearchIndex(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(SearchIndex.DeserializeSearchIndex(item));
+                        }
                     }
                     value = array;
                     continue;

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/ListSkillsetsResult.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/ListSkillsetsResult.Serialization.cs
@@ -23,7 +23,14 @@ namespace Azure.Search.Documents.Models
                     List<Skillset> array = new List<Skillset>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(Skillset.DeserializeSkillset(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(Skillset.DeserializeSkillset(item));
+                        }
                     }
                     value = array;
                     continue;

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/ListSynonymMapsResult.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/ListSynonymMapsResult.Serialization.cs
@@ -23,7 +23,14 @@ namespace Azure.Search.Documents.Models
                     List<SynonymMap> array = new List<SynonymMap>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(SynonymMap.DeserializeSynonymMap(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(SynonymMap.DeserializeSynonymMap(item));
+                        }
                     }
                     value = array;
                     continue;

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/MappingCharFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/MappingCharFilter.Serialization.cs
@@ -33,7 +33,7 @@ namespace Azure.Search.Documents.Models
         internal static MappingCharFilter DeserializeMappingCharFilter(JsonElement element)
         {
             IList<string> mappings = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -42,14 +42,21 @@ namespace Azure.Search.Documents.Models
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.GetString());
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(item.GetString());
+                        }
                     }
                     mappings = array;
                     continue;
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -58,7 +65,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new MappingCharFilter(odatatype, name, mappings);
+            return new MappingCharFilter(odataType, name, mappings);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/MergeSkill.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/MergeSkill.Serialization.cs
@@ -52,9 +52,9 @@ namespace Azure.Search.Documents.Models
             writer.WriteEndArray();
             writer.WritePropertyName("outputs");
             writer.WriteStartArray();
-            foreach (var item0 in Outputs)
+            foreach (var item in Outputs)
             {
-                writer.WriteObjectValue(item0);
+                writer.WriteObjectValue(item);
             }
             writer.WriteEndArray();
             writer.WriteEndObject();
@@ -64,7 +64,7 @@ namespace Azure.Search.Documents.Models
         {
             string insertPreTag = default;
             string insertPostTag = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             string description = default;
             string context = default;
@@ -92,7 +92,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -127,7 +127,14 @@ namespace Azure.Search.Documents.Models
                     List<InputFieldMappingEntry> array = new List<InputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        }
                     }
                     inputs = array;
                     continue;
@@ -137,13 +144,20 @@ namespace Azure.Search.Documents.Models
                     List<OutputFieldMappingEntry> array = new List<OutputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        }
                     }
                     outputs = array;
                     continue;
                 }
             }
-            return new MergeSkill(odatatype, name, description, context, inputs, outputs, insertPreTag, insertPostTag);
+            return new MergeSkill(odataType, name, description, context, inputs, outputs, insertPreTag, insertPostTag);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/MicrosoftLanguageStemmingTokenizer.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/MicrosoftLanguageStemmingTokenizer.Serialization.cs
@@ -42,7 +42,7 @@ namespace Azure.Search.Documents.Models
             int? maxTokenLength = default;
             bool? isSearchTokenizer = default;
             MicrosoftStemmingTokenizerLanguage? language = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -75,7 +75,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -84,7 +84,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new MicrosoftLanguageStemmingTokenizer(odatatype, name, maxTokenLength, isSearchTokenizer, language);
+            return new MicrosoftLanguageStemmingTokenizer(odataType, name, maxTokenLength, isSearchTokenizer, language);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/MicrosoftLanguageTokenizer.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/MicrosoftLanguageTokenizer.Serialization.cs
@@ -42,7 +42,7 @@ namespace Azure.Search.Documents.Models
             int? maxTokenLength = default;
             bool? isSearchTokenizer = default;
             MicrosoftTokenizerLanguage? language = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -75,7 +75,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -84,7 +84,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new MicrosoftLanguageTokenizer(odatatype, name, maxTokenLength, isSearchTokenizer, language);
+            return new MicrosoftLanguageTokenizer(odataType, name, maxTokenLength, isSearchTokenizer, language);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/NGramTokenFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/NGramTokenFilter.Serialization.cs
@@ -36,7 +36,7 @@ namespace Azure.Search.Documents.Models
         {
             int? minGram = default;
             int? maxGram = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -60,7 +60,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -69,7 +69,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new NGramTokenFilter(odatatype, name, minGram, maxGram);
+            return new NGramTokenFilter(odataType, name, minGram, maxGram);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/NGramTokenFilterV2.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/NGramTokenFilterV2.Serialization.cs
@@ -36,7 +36,7 @@ namespace Azure.Search.Documents.Models
         {
             int? minGram = default;
             int? maxGram = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -60,7 +60,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -69,7 +69,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new NGramTokenFilterV2(odatatype, name, minGram, maxGram);
+            return new NGramTokenFilterV2(odataType, name, minGram, maxGram);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/NGramTokenizer.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/NGramTokenizer.Serialization.cs
@@ -48,7 +48,7 @@ namespace Azure.Search.Documents.Models
             int? minGram = default;
             int? maxGram = default;
             IList<TokenCharacterKind> tokenChars = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -86,7 +86,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -95,7 +95,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new NGramTokenizer(odatatype, name, minGram, maxGram, tokenChars);
+            return new NGramTokenizer(odataType, name, minGram, maxGram, tokenChars);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/OcrSkill.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/OcrSkill.Serialization.cs
@@ -57,9 +57,9 @@ namespace Azure.Search.Documents.Models
             writer.WriteEndArray();
             writer.WritePropertyName("outputs");
             writer.WriteStartArray();
-            foreach (var item0 in Outputs)
+            foreach (var item in Outputs)
             {
-                writer.WriteObjectValue(item0);
+                writer.WriteObjectValue(item);
             }
             writer.WriteEndArray();
             writer.WriteEndObject();
@@ -70,7 +70,7 @@ namespace Azure.Search.Documents.Models
             TextExtractionAlgorithm? textExtractionAlgorithm = default;
             OcrSkillLanguage? defaultLanguageCode = default;
             bool? detectOrientation = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             string description = default;
             string context = default;
@@ -107,7 +107,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -142,7 +142,14 @@ namespace Azure.Search.Documents.Models
                     List<InputFieldMappingEntry> array = new List<InputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        }
                     }
                     inputs = array;
                     continue;
@@ -152,13 +159,20 @@ namespace Azure.Search.Documents.Models
                     List<OutputFieldMappingEntry> array = new List<OutputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        }
                     }
                     outputs = array;
                     continue;
                 }
             }
-            return new OcrSkill(odatatype, name, description, context, inputs, outputs, textExtractionAlgorithm, defaultLanguageCode, detectOrientation);
+            return new OcrSkill(odataType, name, description, context, inputs, outputs, textExtractionAlgorithm, defaultLanguageCode, detectOrientation);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/OcrSkillLanguage.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/OcrSkillLanguage.cs
@@ -111,7 +111,7 @@ namespace Azure.Search.Documents.Models
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj) => obj is OcrSkillLanguage other && Equals(other);
         /// <inheritdoc />
-        public bool Equals(OcrSkillLanguage other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+        public bool Equals(OcrSkillLanguage other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
 
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/PathHierarchyTokenizerV2.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/PathHierarchyTokenizerV2.Serialization.cs
@@ -54,7 +54,7 @@ namespace Azure.Search.Documents.Models
             int? maxTokenLength = default;
             bool? reverse = default;
             int? skip = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -105,7 +105,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -114,7 +114,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new PathHierarchyTokenizerV2(odatatype, name, delimiter, replacement, maxTokenLength, reverse, skip);
+            return new PathHierarchyTokenizerV2(odataType, name, delimiter, replacement, maxTokenLength, reverse, skip);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/PatternAnalyzer.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/PatternAnalyzer.Serialization.cs
@@ -54,7 +54,7 @@ namespace Azure.Search.Documents.Models
             string pattern = default;
             RegexFlags? flags = default;
             IList<string> stopwords = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -94,14 +94,21 @@ namespace Azure.Search.Documents.Models
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.GetString());
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(item.GetString());
+                        }
                     }
                     stopwords = array;
                     continue;
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -110,7 +117,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new PatternAnalyzer(odatatype, name, lowercase, pattern, flags, stopwords);
+            return new PatternAnalyzer(odataType, name, lowercase, pattern, flags, stopwords);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/PatternCaptureTokenFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/PatternCaptureTokenFilter.Serialization.cs
@@ -39,7 +39,7 @@ namespace Azure.Search.Documents.Models
         {
             IList<string> patterns = default;
             bool? preserveOriginal = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -48,7 +48,14 @@ namespace Azure.Search.Documents.Models
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.GetString());
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(item.GetString());
+                        }
                     }
                     patterns = array;
                     continue;
@@ -64,7 +71,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -73,7 +80,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new PatternCaptureTokenFilter(odatatype, name, patterns, preserveOriginal);
+            return new PatternCaptureTokenFilter(odataType, name, patterns, preserveOriginal);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/PatternReplaceCharFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/PatternReplaceCharFilter.Serialization.cs
@@ -30,7 +30,7 @@ namespace Azure.Search.Documents.Models
         {
             string pattern = default;
             string replacement = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -46,7 +46,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -55,7 +55,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new PatternReplaceCharFilter(odatatype, name, pattern, replacement);
+            return new PatternReplaceCharFilter(odataType, name, pattern, replacement);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/PatternReplaceTokenFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/PatternReplaceTokenFilter.Serialization.cs
@@ -30,7 +30,7 @@ namespace Azure.Search.Documents.Models
         {
             string pattern = default;
             string replacement = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -46,7 +46,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -55,7 +55,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new PatternReplaceTokenFilter(odatatype, name, pattern, replacement);
+            return new PatternReplaceTokenFilter(odataType, name, pattern, replacement);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/PatternTokenizer.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/PatternTokenizer.Serialization.cs
@@ -42,7 +42,7 @@ namespace Azure.Search.Documents.Models
             string pattern = default;
             RegexFlags? flags = default;
             int? group = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -75,7 +75,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -84,7 +84,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new PatternTokenizer(odatatype, name, pattern, flags, group);
+            return new PatternTokenizer(odataType, name, pattern, flags, group);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/PhoneticTokenFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/PhoneticTokenFilter.Serialization.cs
@@ -36,7 +36,7 @@ namespace Azure.Search.Documents.Models
         {
             PhoneticEncoder? encoder = default;
             bool? replace = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -60,7 +60,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -69,7 +69,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new PhoneticTokenFilter(odatatype, name, encoder, replace);
+            return new PhoneticTokenFilter(odataType, name, encoder, replace);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/RegexFlags.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/RegexFlags.cs
@@ -57,7 +57,7 @@ namespace Azure.Search.Documents.Models
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj) => obj is RegexFlags other && Equals(other);
         /// <inheritdoc />
-        public bool Equals(RegexFlags other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+        public bool Equals(RegexFlags other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
 
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/ScoringFunction.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/ScoringFunction.cs
@@ -20,7 +20,7 @@ namespace Azure.Search.Documents.Models
         /// <param name="interpolation"> A value indicating how boosting will be interpolated across document scores; defaults to &quot;Linear&quot;. </param>
         internal ScoringFunction(string type, string fieldName, double boost, ScoringFunctionInterpolation? interpolation)
         {
-            Type = type ?? null;
+            Type = type;
             FieldName = fieldName;
             Boost = boost;
             Interpolation = interpolation;

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/ScoringProfile.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/ScoringProfile.Serialization.cs
@@ -72,7 +72,14 @@ namespace Azure.Search.Documents.Models
                     List<ScoringFunction> array = new List<ScoringFunction>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(ScoringFunction.DeserializeScoringFunction(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(ScoringFunction.DeserializeScoringFunction(item));
+                        }
                     }
                     functions = array;
                     continue;

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SearchDocumentsResult.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SearchDocumentsResult.Serialization.cs
@@ -16,12 +16,12 @@ namespace Azure.Search.Documents.Models
     {
         internal static SearchDocumentsResult DeserializeSearchDocumentsResult(JsonElement element)
         {
-            long? odatacount = default;
-            double? searchcoverage = default;
-            IReadOnlyDictionary<string, IList<FacetResult>> searchfacets = default;
-            SearchOptions searchnextPageParameters = default;
+            long? odataCount = default;
+            double? searchCoverage = default;
+            IReadOnlyDictionary<string, IList<FacetResult>> searchFacets = default;
+            SearchOptions searchNextPageParameters = default;
             IReadOnlyList<SearchResult> value = default;
-            string odatanextLink = default;
+            string odataNextLink = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("@odata.count"))
@@ -30,7 +30,7 @@ namespace Azure.Search.Documents.Models
                     {
                         continue;
                     }
-                    odatacount = property.Value.GetInt64();
+                    odataCount = property.Value.GetInt64();
                     continue;
                 }
                 if (property.NameEquals("@search.coverage"))
@@ -39,7 +39,7 @@ namespace Azure.Search.Documents.Models
                     {
                         continue;
                     }
-                    searchcoverage = property.Value.GetDouble();
+                    searchCoverage = property.Value.GetDouble();
                     continue;
                 }
                 if (property.NameEquals("@search.facets"))
@@ -51,14 +51,28 @@ namespace Azure.Search.Documents.Models
                     Dictionary<string, IList<FacetResult>> dictionary = new Dictionary<string, IList<FacetResult>>();
                     foreach (var property0 in property.Value.EnumerateObject())
                     {
-                        List<FacetResult> array = new List<FacetResult>();
-                        foreach (var item in property0.Value.EnumerateArray())
+                        if (property0.Value.ValueKind == JsonValueKind.Null)
                         {
-                            array.Add(FacetResult.DeserializeFacetResult(item));
+                            dictionary.Add(property0.Name, null);
                         }
-                        dictionary.Add(property0.Name, array);
+                        else
+                        {
+                            List<FacetResult> array = new List<FacetResult>();
+                            foreach (var item in property0.Value.EnumerateArray())
+                            {
+                                if (item.ValueKind == JsonValueKind.Null)
+                                {
+                                    array.Add(null);
+                                }
+                                else
+                                {
+                                    array.Add(FacetResult.DeserializeFacetResult(item));
+                                }
+                            }
+                            dictionary.Add(property0.Name, array);
+                        }
                     }
-                    searchfacets = dictionary;
+                    searchFacets = dictionary;
                     continue;
                 }
                 if (property.NameEquals("@search.nextPageParameters"))
@@ -67,7 +81,7 @@ namespace Azure.Search.Documents.Models
                     {
                         continue;
                     }
-                    searchnextPageParameters = SearchOptions.DeserializeSearchOptions(property.Value);
+                    searchNextPageParameters = SearchOptions.DeserializeSearchOptions(property.Value);
                     continue;
                 }
                 if (property.NameEquals("value"))
@@ -75,7 +89,14 @@ namespace Azure.Search.Documents.Models
                     List<SearchResult> array = new List<SearchResult>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(SearchResult.DeserializeSearchResult(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(SearchResult.DeserializeSearchResult(item));
+                        }
                     }
                     value = array;
                     continue;
@@ -86,11 +107,11 @@ namespace Azure.Search.Documents.Models
                     {
                         continue;
                     }
-                    odatanextLink = property.Value.GetString();
+                    odataNextLink = property.Value.GetString();
                     continue;
                 }
             }
-            return new SearchDocumentsResult(odatacount, searchcoverage, searchfacets, searchnextPageParameters, value, odatanextLink);
+            return new SearchDocumentsResult(odataCount, searchCoverage, searchFacets, searchNextPageParameters, value, odataNextLink);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SearchError.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SearchError.Serialization.cs
@@ -43,7 +43,14 @@ namespace Azure.Search.Documents.Models
                     List<SearchError> array = new List<SearchError>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(DeserializeSearchError(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(DeserializeSearchError(item));
+                        }
                     }
                     details = array;
                     continue;

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SearchField.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SearchField.Serialization.cs
@@ -212,7 +212,14 @@ namespace Azure.Search.Documents.Models
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.GetString());
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(item.GetString());
+                        }
                     }
                     synonymMaps = array;
                     continue;
@@ -226,7 +233,14 @@ namespace Azure.Search.Documents.Models
                     List<SearchField> array = new List<SearchField>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(DeserializeSearchField(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(DeserializeSearchField(item));
+                        }
                     }
                     fields = array;
                     continue;

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SearchIndex.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SearchIndex.Serialization.cs
@@ -127,7 +127,7 @@ namespace Azure.Search.Documents.Models
             IList<TokenFilter> tokenFilters = default;
             IList<CharFilter> charFilters = default;
             EncryptionKey encryptionKey = default;
-            string odataetag = default;
+            string odataEtag = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("name"))
@@ -148,7 +148,14 @@ namespace Azure.Search.Documents.Models
                     List<SearchField> array = new List<SearchField>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(SearchField.DeserializeSearchField(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(SearchField.DeserializeSearchField(item));
+                        }
                     }
                     fields = array;
                     continue;
@@ -162,7 +169,14 @@ namespace Azure.Search.Documents.Models
                     List<ScoringProfile> array = new List<ScoringProfile>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(ScoringProfile.DeserializeScoringProfile(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(ScoringProfile.DeserializeScoringProfile(item));
+                        }
                     }
                     scoringProfiles = array;
                     continue;
@@ -194,7 +208,14 @@ namespace Azure.Search.Documents.Models
                     List<Suggester> array = new List<Suggester>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(Suggester.DeserializeSuggester(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(Suggester.DeserializeSuggester(item));
+                        }
                     }
                     suggesters = array;
                     continue;
@@ -208,7 +229,14 @@ namespace Azure.Search.Documents.Models
                     List<Analyzer> array = new List<Analyzer>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(Analyzer.DeserializeAnalyzer(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(Analyzer.DeserializeAnalyzer(item));
+                        }
                     }
                     analyzers = array;
                     continue;
@@ -222,7 +250,14 @@ namespace Azure.Search.Documents.Models
                     List<Tokenizer> array = new List<Tokenizer>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(Tokenizer.DeserializeTokenizer(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(Tokenizer.DeserializeTokenizer(item));
+                        }
                     }
                     tokenizers = array;
                     continue;
@@ -236,7 +271,14 @@ namespace Azure.Search.Documents.Models
                     List<TokenFilter> array = new List<TokenFilter>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(TokenFilter.DeserializeTokenFilter(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(TokenFilter.DeserializeTokenFilter(item));
+                        }
                     }
                     tokenFilters = array;
                     continue;
@@ -250,7 +292,14 @@ namespace Azure.Search.Documents.Models
                     List<CharFilter> array = new List<CharFilter>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(CharFilter.DeserializeCharFilter(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(CharFilter.DeserializeCharFilter(item));
+                        }
                     }
                     charFilters = array;
                     continue;
@@ -270,11 +319,11 @@ namespace Azure.Search.Documents.Models
                     {
                         continue;
                     }
-                    odataetag = property.Value.GetString();
+                    odataEtag = property.Value.GetString();
                     continue;
                 }
             }
-            return new SearchIndex(name, fields, scoringProfiles, defaultScoringProfile, corsOptions, suggesters, analyzers, tokenizers, tokenFilters, charFilters, encryptionKey, odataetag);
+            return new SearchIndex(name, fields, scoringProfiles, defaultScoringProfile, corsOptions, suggesters, analyzers, tokenizers, tokenFilters, charFilters, encryptionKey, odataEtag);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SearchIndexer.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SearchIndexer.Serialization.cs
@@ -87,7 +87,7 @@ namespace Azure.Search.Documents.Models
             IList<FieldMapping> fieldMappings = default;
             IList<FieldMapping> outputFieldMappings = default;
             bool? disabled = default;
-            string odataetag = default;
+            string odataEtag = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("name"))
@@ -150,7 +150,14 @@ namespace Azure.Search.Documents.Models
                     List<FieldMapping> array = new List<FieldMapping>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(FieldMapping.DeserializeFieldMapping(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(FieldMapping.DeserializeFieldMapping(item));
+                        }
                     }
                     fieldMappings = array;
                     continue;
@@ -164,7 +171,14 @@ namespace Azure.Search.Documents.Models
                     List<FieldMapping> array = new List<FieldMapping>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(FieldMapping.DeserializeFieldMapping(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(FieldMapping.DeserializeFieldMapping(item));
+                        }
                     }
                     outputFieldMappings = array;
                     continue;
@@ -184,11 +198,11 @@ namespace Azure.Search.Documents.Models
                     {
                         continue;
                     }
-                    odataetag = property.Value.GetString();
+                    odataEtag = property.Value.GetString();
                     continue;
                 }
             }
-            return new SearchIndexer(name, description, dataSourceName, skillsetName, targetIndexName, schedule, parameters, fieldMappings, outputFieldMappings, disabled, odataetag);
+            return new SearchIndexer(name, description, dataSourceName, skillsetName, targetIndexName, schedule, parameters, fieldMappings, outputFieldMappings, disabled, odataEtag);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SearchOptions.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SearchOptions.Serialization.cs
@@ -154,7 +154,14 @@ namespace Azure.Search.Documents
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.GetString());
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(item.GetString());
+                        }
                     }
                     facets = array;
                     continue;
@@ -231,7 +238,14 @@ namespace Azure.Search.Documents
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.GetString());
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(item.GetString());
+                        }
                     }
                     scoringParameters = array;
                     continue;

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SearchResult.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SearchResult.Serialization.cs
@@ -15,15 +15,15 @@ namespace Azure.Search.Documents.Models
     {
         internal static SearchResult DeserializeSearchResult(JsonElement element)
         {
-            double searchscore = default;
-            IReadOnlyDictionary<string, IList<string>> searchhighlights = default;
+            double searchScore = default;
+            IReadOnlyDictionary<string, IList<string>> searchHighlights = default;
             IReadOnlyDictionary<string, object> additionalProperties = default;
-            Dictionary<string, object> additionalPropertiesDictionary = new Dictionary<string, object>();
+            Dictionary<string, object> additionalPropertiesDictionary = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("@search.score"))
                 {
-                    searchscore = property.Value.GetDouble();
+                    searchScore = property.Value.GetDouble();
                     continue;
                 }
                 if (property.NameEquals("@search.highlights"))
@@ -35,20 +35,42 @@ namespace Azure.Search.Documents.Models
                     Dictionary<string, IList<string>> dictionary = new Dictionary<string, IList<string>>();
                     foreach (var property0 in property.Value.EnumerateObject())
                     {
-                        List<string> array = new List<string>();
-                        foreach (var item in property0.Value.EnumerateArray())
+                        if (property0.Value.ValueKind == JsonValueKind.Null)
                         {
-                            array.Add(item.GetString());
+                            dictionary.Add(property0.Name, null);
                         }
-                        dictionary.Add(property0.Name, array);
+                        else
+                        {
+                            List<string> array = new List<string>();
+                            foreach (var item in property0.Value.EnumerateArray())
+                            {
+                                if (item.ValueKind == JsonValueKind.Null)
+                                {
+                                    array.Add(null);
+                                }
+                                else
+                                {
+                                    array.Add(item.GetString());
+                                }
+                            }
+                            dictionary.Add(property0.Name, array);
+                        }
                     }
-                    searchhighlights = dictionary;
+                    searchHighlights = dictionary;
                     continue;
                 }
-                additionalPropertiesDictionary.Add(property.Name, property.Value.GetObject());
+                additionalPropertiesDictionary ??= new Dictionary<string, object>();
+                if (property.Value.ValueKind == JsonValueKind.Null)
+                {
+                    additionalPropertiesDictionary.Add(property.Name, null);
+                }
+                else
+                {
+                    additionalPropertiesDictionary.Add(property.Name, property.Value.GetObject());
+                }
             }
             additionalProperties = additionalPropertiesDictionary;
-            return new SearchResult(searchscore, searchhighlights, additionalProperties);
+            return new SearchResult(searchScore, searchHighlights, additionalProperties);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SearchResult.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SearchResult.cs
@@ -29,7 +29,7 @@ namespace Azure.Search.Documents.Models
         {
             Score = score;
             Highlights = highlights;
-            AdditionalProperties = additionalProperties;
+            AdditionalProperties = additionalProperties ?? new Dictionary<string, object>();
         }
 
         /// <summary> The relevance score of the document compared to other documents returned by the query. </summary>

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SearchServiceError.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SearchServiceError.Serialization.cs
@@ -43,7 +43,14 @@ namespace Azure.Search.Documents.Models
                     List<SearchServiceError> array = new List<SearchServiceError>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(DeserializeSearchServiceError(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(DeserializeSearchServiceError(item));
+                        }
                     }
                     details = array;
                     continue;

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SentimentSkill.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SentimentSkill.Serialization.cs
@@ -47,9 +47,9 @@ namespace Azure.Search.Documents.Models
             writer.WriteEndArray();
             writer.WritePropertyName("outputs");
             writer.WriteStartArray();
-            foreach (var item0 in Outputs)
+            foreach (var item in Outputs)
             {
-                writer.WriteObjectValue(item0);
+                writer.WriteObjectValue(item);
             }
             writer.WriteEndArray();
             writer.WriteEndObject();
@@ -58,7 +58,7 @@ namespace Azure.Search.Documents.Models
         internal static SentimentSkill DeserializeSentimentSkill(JsonElement element)
         {
             SentimentSkillLanguage? defaultLanguageCode = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             string description = default;
             string context = default;
@@ -77,7 +77,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -112,7 +112,14 @@ namespace Azure.Search.Documents.Models
                     List<InputFieldMappingEntry> array = new List<InputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        }
                     }
                     inputs = array;
                     continue;
@@ -122,13 +129,20 @@ namespace Azure.Search.Documents.Models
                     List<OutputFieldMappingEntry> array = new List<OutputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        }
                     }
                     outputs = array;
                     continue;
                 }
             }
-            return new SentimentSkill(odatatype, name, description, context, inputs, outputs, defaultLanguageCode);
+            return new SentimentSkill(odataType, name, description, context, inputs, outputs, defaultLanguageCode);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SentimentSkillLanguage.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SentimentSkillLanguage.cs
@@ -78,7 +78,7 @@ namespace Azure.Search.Documents.Models
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj) => obj is SentimentSkillLanguage other && Equals(other);
         /// <inheritdoc />
-        public bool Equals(SentimentSkillLanguage other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+        public bool Equals(SentimentSkillLanguage other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
 
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/ShaperSkill.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/ShaperSkill.Serialization.cs
@@ -42,9 +42,9 @@ namespace Azure.Search.Documents.Models
             writer.WriteEndArray();
             writer.WritePropertyName("outputs");
             writer.WriteStartArray();
-            foreach (var item0 in Outputs)
+            foreach (var item in Outputs)
             {
-                writer.WriteObjectValue(item0);
+                writer.WriteObjectValue(item);
             }
             writer.WriteEndArray();
             writer.WriteEndObject();
@@ -52,7 +52,7 @@ namespace Azure.Search.Documents.Models
 
         internal static ShaperSkill DeserializeShaperSkill(JsonElement element)
         {
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             string description = default;
             string context = default;
@@ -62,7 +62,7 @@ namespace Azure.Search.Documents.Models
             {
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -97,7 +97,14 @@ namespace Azure.Search.Documents.Models
                     List<InputFieldMappingEntry> array = new List<InputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        }
                     }
                     inputs = array;
                     continue;
@@ -107,13 +114,20 @@ namespace Azure.Search.Documents.Models
                     List<OutputFieldMappingEntry> array = new List<OutputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        }
                     }
                     outputs = array;
                     continue;
                 }
             }
-            return new ShaperSkill(odatatype, name, description, context, inputs, outputs);
+            return new ShaperSkill(odataType, name, description, context, inputs, outputs);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/ShingleTokenFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/ShingleTokenFilter.Serialization.cs
@@ -60,7 +60,7 @@ namespace Azure.Search.Documents.Models
             bool? outputUnigramsIfNoShingles = default;
             string tokenSeparator = default;
             string filterToken = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -120,7 +120,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -129,7 +129,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new ShingleTokenFilter(odatatype, name, maxShingleSize, minShingleSize, outputUnigrams, outputUnigramsIfNoShingles, tokenSeparator, filterToken);
+            return new ShingleTokenFilter(odataType, name, maxShingleSize, minShingleSize, outputUnigrams, outputUnigramsIfNoShingles, tokenSeparator, filterToken);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/Skill.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/Skill.Serialization.cs
@@ -42,9 +42,9 @@ namespace Azure.Search.Documents.Models
             writer.WriteEndArray();
             writer.WritePropertyName("outputs");
             writer.WriteStartArray();
-            foreach (var item0 in Outputs)
+            foreach (var item in Outputs)
             {
-                writer.WriteObjectValue(item0);
+                writer.WriteObjectValue(item);
             }
             writer.WriteEndArray();
             writer.WriteEndObject();
@@ -70,7 +70,7 @@ namespace Azure.Search.Documents.Models
                     case "#Microsoft.Skills.Vision.OcrSkill": return OcrSkill.DeserializeOcrSkill(element);
                 }
             }
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             string description = default;
             string context = default;
@@ -80,7 +80,7 @@ namespace Azure.Search.Documents.Models
             {
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -115,7 +115,14 @@ namespace Azure.Search.Documents.Models
                     List<InputFieldMappingEntry> array = new List<InputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        }
                     }
                     inputs = array;
                     continue;
@@ -125,13 +132,20 @@ namespace Azure.Search.Documents.Models
                     List<OutputFieldMappingEntry> array = new List<OutputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        }
                     }
                     outputs = array;
                     continue;
                 }
             }
-            return new Skill(odatatype, name, description, context, inputs, outputs);
+            return new Skill(odataType, name, description, context, inputs, outputs);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/Skill.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/Skill.cs
@@ -42,7 +42,7 @@ namespace Azure.Search.Documents.Models
         /// <param name="outputs"> The output of a skill is either a field in a search index, or a value that can be consumed as an input by another skill. </param>
         internal Skill(string oDataType, string name, string description, string context, IList<InputFieldMappingEntry> inputs, IList<OutputFieldMappingEntry> outputs)
         {
-            ODataType = oDataType ?? null;
+            ODataType = oDataType;
             Name = name;
             Description = description;
             Context = context;

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/Skillset.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/Skillset.Serialization.cs
@@ -46,7 +46,7 @@ namespace Azure.Search.Documents.Models
             string description = default;
             IList<Skill> skills = default;
             CognitiveServicesAccount cognitiveServices = default;
-            string odataetag = default;
+            string odataEtag = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("name"))
@@ -64,7 +64,14 @@ namespace Azure.Search.Documents.Models
                     List<Skill> array = new List<Skill>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(Skill.DeserializeSkill(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(Skill.DeserializeSkill(item));
+                        }
                     }
                     skills = array;
                     continue;
@@ -84,11 +91,11 @@ namespace Azure.Search.Documents.Models
                     {
                         continue;
                     }
-                    odataetag = property.Value.GetString();
+                    odataEtag = property.Value.GetString();
                     continue;
                 }
             }
-            return new Skillset(name, description, skills, cognitiveServices, odataetag);
+            return new Skillset(name, description, skills, cognitiveServices, odataEtag);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SnowballTokenFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SnowballTokenFilter.Serialization.cs
@@ -27,7 +27,7 @@ namespace Azure.Search.Documents.Models
         internal static SnowballTokenFilter DeserializeSnowballTokenFilter(JsonElement element)
         {
             SnowballTokenFilterLanguage language = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -38,7 +38,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -47,7 +47,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new SnowballTokenFilter(odatatype, name, language);
+            return new SnowballTokenFilter(odataType, name, language);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SoftDeleteColumnDeletionDetectionPolicy.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SoftDeleteColumnDeletionDetectionPolicy.Serialization.cs
@@ -34,7 +34,7 @@ namespace Azure.Search.Documents.Models
         {
             string softDeleteColumnName = default;
             string softDeleteMarkerValue = default;
-            string odatatype = default;
+            string odataType = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("softDeleteColumnName"))
@@ -57,11 +57,11 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
             }
-            return new SoftDeleteColumnDeletionDetectionPolicy(odatatype, softDeleteColumnName, softDeleteMarkerValue);
+            return new SoftDeleteColumnDeletionDetectionPolicy(odataType, softDeleteColumnName, softDeleteMarkerValue);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SplitSkill.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SplitSkill.Serialization.cs
@@ -57,9 +57,9 @@ namespace Azure.Search.Documents.Models
             writer.WriteEndArray();
             writer.WritePropertyName("outputs");
             writer.WriteStartArray();
-            foreach (var item0 in Outputs)
+            foreach (var item in Outputs)
             {
-                writer.WriteObjectValue(item0);
+                writer.WriteObjectValue(item);
             }
             writer.WriteEndArray();
             writer.WriteEndObject();
@@ -70,7 +70,7 @@ namespace Azure.Search.Documents.Models
             SplitSkillLanguage? defaultLanguageCode = default;
             TextSplitMode? textSplitMode = default;
             int? maximumPageLength = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             string description = default;
             string context = default;
@@ -107,7 +107,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -142,7 +142,14 @@ namespace Azure.Search.Documents.Models
                     List<InputFieldMappingEntry> array = new List<InputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        }
                     }
                     inputs = array;
                     continue;
@@ -152,13 +159,20 @@ namespace Azure.Search.Documents.Models
                     List<OutputFieldMappingEntry> array = new List<OutputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        }
                     }
                     outputs = array;
                     continue;
                 }
             }
-            return new SplitSkill(odatatype, name, description, context, inputs, outputs, defaultLanguageCode, textSplitMode, maximumPageLength);
+            return new SplitSkill(odataType, name, description, context, inputs, outputs, defaultLanguageCode, textSplitMode, maximumPageLength);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SplitSkillLanguage.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SplitSkillLanguage.cs
@@ -60,7 +60,7 @@ namespace Azure.Search.Documents.Models
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj) => obj is SplitSkillLanguage other && Equals(other);
         /// <inheritdoc />
-        public bool Equals(SplitSkillLanguage other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+        public bool Equals(SplitSkillLanguage other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
 
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SqlIntegratedChangeTrackingPolicy.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SqlIntegratedChangeTrackingPolicy.Serialization.cs
@@ -22,16 +22,16 @@ namespace Azure.Search.Documents.Models
 
         internal static SqlIntegratedChangeTrackingPolicy DeserializeSqlIntegratedChangeTrackingPolicy(JsonElement element)
         {
-            string odatatype = default;
+            string odataType = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
             }
-            return new SqlIntegratedChangeTrackingPolicy(odatatype);
+            return new SqlIntegratedChangeTrackingPolicy(odataType);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/StandardAnalyzer.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/StandardAnalyzer.Serialization.cs
@@ -42,7 +42,7 @@ namespace Azure.Search.Documents.Models
         {
             int? maxTokenLength = default;
             IList<string> stopwords = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -64,14 +64,21 @@ namespace Azure.Search.Documents.Models
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.GetString());
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(item.GetString());
+                        }
                     }
                     stopwords = array;
                     continue;
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -80,7 +87,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new StandardAnalyzer(odatatype, name, maxTokenLength, stopwords);
+            return new StandardAnalyzer(odataType, name, maxTokenLength, stopwords);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/StandardTokenizer.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/StandardTokenizer.Serialization.cs
@@ -30,7 +30,7 @@ namespace Azure.Search.Documents.Models
         internal static StandardTokenizer DeserializeStandardTokenizer(JsonElement element)
         {
             int? maxTokenLength = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -45,7 +45,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -54,7 +54,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new StandardTokenizer(odatatype, name, maxTokenLength);
+            return new StandardTokenizer(odataType, name, maxTokenLength);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/StandardTokenizerV2.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/StandardTokenizerV2.Serialization.cs
@@ -30,7 +30,7 @@ namespace Azure.Search.Documents.Models
         internal static StandardTokenizerV2 DeserializeStandardTokenizerV2(JsonElement element)
         {
             int? maxTokenLength = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -45,7 +45,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -54,7 +54,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new StandardTokenizerV2(odatatype, name, maxTokenLength);
+            return new StandardTokenizerV2(odataType, name, maxTokenLength);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/StemmerOverrideTokenFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/StemmerOverrideTokenFilter.Serialization.cs
@@ -33,7 +33,7 @@ namespace Azure.Search.Documents.Models
         internal static StemmerOverrideTokenFilter DeserializeStemmerOverrideTokenFilter(JsonElement element)
         {
             IList<string> rules = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -42,14 +42,21 @@ namespace Azure.Search.Documents.Models
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.GetString());
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(item.GetString());
+                        }
                     }
                     rules = array;
                     continue;
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -58,7 +65,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new StemmerOverrideTokenFilter(odatatype, name, rules);
+            return new StemmerOverrideTokenFilter(odataType, name, rules);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/StemmerTokenFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/StemmerTokenFilter.Serialization.cs
@@ -27,7 +27,7 @@ namespace Azure.Search.Documents.Models
         internal static StemmerTokenFilter DeserializeStemmerTokenFilter(JsonElement element)
         {
             StemmerTokenFilterLanguage language = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -38,7 +38,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -47,7 +47,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new StemmerTokenFilter(odatatype, name, language);
+            return new StemmerTokenFilter(odataType, name, language);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/StopAnalyzer.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/StopAnalyzer.Serialization.cs
@@ -36,7 +36,7 @@ namespace Azure.Search.Documents.Models
         internal static StopAnalyzer DeserializeStopAnalyzer(JsonElement element)
         {
             IList<string> stopwords = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -49,14 +49,21 @@ namespace Azure.Search.Documents.Models
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.GetString());
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(item.GetString());
+                        }
                     }
                     stopwords = array;
                     continue;
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -65,7 +72,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new StopAnalyzer(odatatype, name, stopwords);
+            return new StopAnalyzer(odataType, name, stopwords);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/StopwordsTokenFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/StopwordsTokenFilter.Serialization.cs
@@ -54,7 +54,7 @@ namespace Azure.Search.Documents.Models
             StopwordsList? stopwordsList = default;
             bool? ignoreCase = default;
             bool? removeTrailing = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -67,7 +67,14 @@ namespace Azure.Search.Documents.Models
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.GetString());
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(item.GetString());
+                        }
                     }
                     stopwords = array;
                     continue;
@@ -101,7 +108,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -110,7 +117,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new StopwordsTokenFilter(odatatype, name, stopwords, stopwordsList, ignoreCase, removeTrailing);
+            return new StopwordsTokenFilter(odataType, name, stopwords, stopwordsList, ignoreCase, removeTrailing);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SuggestDocumentsResult.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SuggestDocumentsResult.Serialization.cs
@@ -16,7 +16,7 @@ namespace Azure.Search.Documents.Models
         internal static SuggestDocumentsResult DeserializeSuggestDocumentsResult(JsonElement element)
         {
             IReadOnlyList<SuggestResult> value = default;
-            double? searchcoverage = default;
+            double? searchCoverage = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("value"))
@@ -24,7 +24,14 @@ namespace Azure.Search.Documents.Models
                     List<SuggestResult> array = new List<SuggestResult>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(SuggestResult.DeserializeSuggestResult(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(SuggestResult.DeserializeSuggestResult(item));
+                        }
                     }
                     value = array;
                     continue;
@@ -35,11 +42,11 @@ namespace Azure.Search.Documents.Models
                     {
                         continue;
                     }
-                    searchcoverage = property.Value.GetDouble();
+                    searchCoverage = property.Value.GetDouble();
                     continue;
                 }
             }
-            return new SuggestDocumentsResult(value, searchcoverage);
+            return new SuggestDocumentsResult(value, searchCoverage);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SuggestResult.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SuggestResult.Serialization.cs
@@ -15,20 +15,28 @@ namespace Azure.Search.Documents.Models
     {
         internal static SuggestResult DeserializeSuggestResult(JsonElement element)
         {
-            string searchtext = default;
+            string searchText = default;
             IReadOnlyDictionary<string, object> additionalProperties = default;
-            Dictionary<string, object> additionalPropertiesDictionary = new Dictionary<string, object>();
+            Dictionary<string, object> additionalPropertiesDictionary = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("@search.text"))
                 {
-                    searchtext = property.Value.GetString();
+                    searchText = property.Value.GetString();
                     continue;
                 }
-                additionalPropertiesDictionary.Add(property.Name, property.Value.GetObject());
+                additionalPropertiesDictionary ??= new Dictionary<string, object>();
+                if (property.Value.ValueKind == JsonValueKind.Null)
+                {
+                    additionalPropertiesDictionary.Add(property.Name, null);
+                }
+                else
+                {
+                    additionalPropertiesDictionary.Add(property.Name, property.Value.GetObject());
+                }
             }
             additionalProperties = additionalPropertiesDictionary;
-            return new SuggestResult(searchtext, additionalProperties);
+            return new SuggestResult(searchText, additionalProperties);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SuggestResult.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SuggestResult.cs
@@ -33,7 +33,7 @@ namespace Azure.Search.Documents.Models
         internal SuggestResult(string text, IReadOnlyDictionary<string, object> additionalProperties)
         {
             Text = text;
-            AdditionalProperties = additionalProperties;
+            AdditionalProperties = additionalProperties ?? new Dictionary<string, object>();
         }
 
         /// <summary> The text of the suggestion result. </summary>

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/Suggester.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/Suggester.Serialization.cs
@@ -59,7 +59,14 @@ namespace Azure.Search.Documents.Models
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.GetString());
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(item.GetString());
+                        }
                     }
                     sourceFields = array;
                     continue;

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SynonymMap.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SynonymMap.Serialization.cs
@@ -49,7 +49,7 @@ namespace Azure.Search.Documents.Models
             string format = default;
             string synonyms = default;
             EncryptionKey encryptionKey = default;
-            string odataetag = default;
+            string odataEtag = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("name"))
@@ -94,11 +94,11 @@ namespace Azure.Search.Documents.Models
                     {
                         continue;
                     }
-                    odataetag = property.Value.GetString();
+                    odataEtag = property.Value.GetString();
                     continue;
                 }
             }
-            return new SynonymMap(name, format, synonyms, encryptionKey, odataetag);
+            return new SynonymMap(name, format, synonyms, encryptionKey, odataEtag);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SynonymMap.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SynonymMap.cs
@@ -12,24 +12,6 @@ namespace Azure.Search.Documents.Models
     /// <summary> Represents a synonym map definition. </summary>
     public partial class SynonymMap
     {
-        /// <summary> Initializes a new instance of SynonymMap. </summary>
-        /// <param name="name"> The name of the synonym map. </param>
-        /// <param name="synonyms"> A series of synonym rules in the specified synonym map format. The rules must be separated by newlines. </param>
-        public SynonymMap(string name, string synonyms)
-        {
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
-            if (synonyms == null)
-            {
-                throw new ArgumentNullException(nameof(synonyms));
-            }
-
-            Name = name;
-            Format = "solr";
-            Synonyms = synonyms;
-        }
 
         /// <summary> Initializes a new instance of SynonymMap. </summary>
         /// <param name="name"> The name of the synonym map. </param>

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SynonymMap.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SynonymMap.cs
@@ -15,7 +15,7 @@ namespace Azure.Search.Documents.Models
         /// <summary> Initializes a new instance of SynonymMap. </summary>
         /// <param name="name"> The name of the synonym map. </param>
         /// <param name="synonyms"> A series of synonym rules in the specified synonym map format. The rules must be separated by newlines. </param>
-        private SynonymMap(string name, string synonyms)
+        public SynonymMap(string name, string synonyms)
         {
             if (name == null)
             {

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SynonymTokenFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SynonymTokenFilter.Serialization.cs
@@ -45,7 +45,7 @@ namespace Azure.Search.Documents.Models
             IList<string> synonyms = default;
             bool? ignoreCase = default;
             bool? expand = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -54,7 +54,14 @@ namespace Azure.Search.Documents.Models
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.GetString());
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(item.GetString());
+                        }
                     }
                     synonyms = array;
                     continue;
@@ -79,7 +86,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -88,7 +95,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new SynonymTokenFilter(odatatype, name, synonyms, ignoreCase, expand);
+            return new SynonymTokenFilter(odataType, name, synonyms, ignoreCase, expand);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/TextTranslationSkill.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/TextTranslationSkill.Serialization.cs
@@ -54,9 +54,9 @@ namespace Azure.Search.Documents.Models
             writer.WriteEndArray();
             writer.WritePropertyName("outputs");
             writer.WriteStartArray();
-            foreach (var item0 in Outputs)
+            foreach (var item in Outputs)
             {
-                writer.WriteObjectValue(item0);
+                writer.WriteObjectValue(item);
             }
             writer.WriteEndArray();
             writer.WriteEndObject();
@@ -67,7 +67,7 @@ namespace Azure.Search.Documents.Models
             TextTranslationSkillLanguage defaultToLanguageCode = default;
             TextTranslationSkillLanguage? defaultFromLanguageCode = default;
             TextTranslationSkillLanguage? suggestedFrom = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             string description = default;
             string context = default;
@@ -100,7 +100,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -135,7 +135,14 @@ namespace Azure.Search.Documents.Models
                     List<InputFieldMappingEntry> array = new List<InputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        }
                     }
                     inputs = array;
                     continue;
@@ -145,13 +152,20 @@ namespace Azure.Search.Documents.Models
                     List<OutputFieldMappingEntry> array = new List<OutputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        }
                     }
                     outputs = array;
                     continue;
                 }
             }
-            return new TextTranslationSkill(odatatype, name, description, context, inputs, outputs, defaultToLanguageCode, defaultFromLanguageCode, suggestedFrom);
+            return new TextTranslationSkill(odataType, name, description, context, inputs, outputs, defaultToLanguageCode, defaultFromLanguageCode, suggestedFrom);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/TextTranslationSkillLanguage.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/TextTranslationSkillLanguage.cs
@@ -222,7 +222,7 @@ namespace Azure.Search.Documents.Models
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj) => obj is TextTranslationSkillLanguage other && Equals(other);
         /// <inheritdoc />
-        public bool Equals(TextTranslationSkillLanguage other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+        public bool Equals(TextTranslationSkillLanguage other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
 
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/TokenFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/TokenFilter.Serialization.cs
@@ -55,13 +55,13 @@ namespace Azure.Search.Documents.Models
                     case "#Microsoft.Azure.Search.WordDelimiterTokenFilter": return WordDelimiterTokenFilter.DeserializeWordDelimiterTokenFilter(element);
                 }
             }
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -70,7 +70,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new TokenFilter(odatatype, name);
+            return new TokenFilter(odataType, name);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/TokenFilter.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/TokenFilter.cs
@@ -30,7 +30,7 @@ namespace Azure.Search.Documents.Models
         /// <param name="name"> The name of the token filter. It must only contain letters, digits, spaces, dashes or underscores, can only start and end with alphanumeric characters, and is limited to 128 characters. </param>
         internal TokenFilter(string oDataType, string name)
         {
-            ODataType = oDataType ?? null;
+            ODataType = oDataType;
             Name = name;
         }
 

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/TokenFilterName.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/TokenFilterName.cs
@@ -135,7 +135,7 @@ namespace Azure.Search.Documents.Models
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj) => obj is TokenFilterName other && Equals(other);
         /// <inheritdoc />
-        public bool Equals(TokenFilterName other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+        public bool Equals(TokenFilterName other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
 
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/Tokenizer.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/Tokenizer.Serialization.cs
@@ -42,13 +42,13 @@ namespace Azure.Search.Documents.Models
                     case "#Microsoft.Azure.Search.UaxUrlEmailTokenizer": return UaxUrlEmailTokenizer.DeserializeUaxUrlEmailTokenizer(element);
                 }
             }
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -57,7 +57,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new Tokenizer(odatatype, name);
+            return new Tokenizer(odataType, name);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/Tokenizer.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/Tokenizer.cs
@@ -30,7 +30,7 @@ namespace Azure.Search.Documents.Models
         /// <param name="name"> The name of the tokenizer. It must only contain letters, digits, spaces, dashes or underscores, can only start and end with alphanumeric characters, and is limited to 128 characters. </param>
         internal Tokenizer(string oDataType, string name)
         {
-            ODataType = oDataType ?? null;
+            ODataType = oDataType;
             Name = name;
         }
 

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/TokenizerName.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/TokenizerName.cs
@@ -72,7 +72,7 @@ namespace Azure.Search.Documents.Models
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj) => obj is TokenizerName other && Equals(other);
         /// <inheritdoc />
-        public bool Equals(TokenizerName other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+        public bool Equals(TokenizerName other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
 
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/TruncateTokenFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/TruncateTokenFilter.Serialization.cs
@@ -30,7 +30,7 @@ namespace Azure.Search.Documents.Models
         internal static TruncateTokenFilter DeserializeTruncateTokenFilter(JsonElement element)
         {
             int? length = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -45,7 +45,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -54,7 +54,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new TruncateTokenFilter(odatatype, name, length);
+            return new TruncateTokenFilter(odataType, name, length);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/UaxUrlEmailTokenizer.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/UaxUrlEmailTokenizer.Serialization.cs
@@ -30,7 +30,7 @@ namespace Azure.Search.Documents.Models
         internal static UaxUrlEmailTokenizer DeserializeUaxUrlEmailTokenizer(JsonElement element)
         {
             int? maxTokenLength = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -45,7 +45,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -54,7 +54,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new UaxUrlEmailTokenizer(odatatype, name, maxTokenLength);
+            return new UaxUrlEmailTokenizer(odataType, name, maxTokenLength);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/UniqueTokenFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/UniqueTokenFilter.Serialization.cs
@@ -30,7 +30,7 @@ namespace Azure.Search.Documents.Models
         internal static UniqueTokenFilter DeserializeUniqueTokenFilter(JsonElement element)
         {
             bool? onlyOnSamePosition = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -45,7 +45,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -54,7 +54,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new UniqueTokenFilter(odatatype, name, onlyOnSamePosition);
+            return new UniqueTokenFilter(odataType, name, onlyOnSamePosition);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/WebApiSkill.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/WebApiSkill.Serialization.cs
@@ -76,9 +76,9 @@ namespace Azure.Search.Documents.Models
             writer.WriteEndArray();
             writer.WritePropertyName("outputs");
             writer.WriteStartArray();
-            foreach (var item0 in Outputs)
+            foreach (var item in Outputs)
             {
-                writer.WriteObjectValue(item0);
+                writer.WriteObjectValue(item);
             }
             writer.WriteEndArray();
             writer.WriteEndObject();
@@ -92,7 +92,7 @@ namespace Azure.Search.Documents.Models
             TimeSpan? timeout = default;
             int? batchSize = default;
             int? degreeOfParallelism = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             string description = default;
             string context = default;
@@ -114,7 +114,14 @@ namespace Azure.Search.Documents.Models
                     Dictionary<string, string> dictionary = new Dictionary<string, string>();
                     foreach (var property0 in property.Value.EnumerateObject())
                     {
-                        dictionary.Add(property0.Name, property0.Value.GetString());
+                        if (property0.Value.ValueKind == JsonValueKind.Null)
+                        {
+                            dictionary.Add(property0.Name, null);
+                        }
+                        else
+                        {
+                            dictionary.Add(property0.Name, property0.Value.GetString());
+                        }
                     }
                     httpHeaders = dictionary;
                     continue;
@@ -157,7 +164,7 @@ namespace Azure.Search.Documents.Models
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -192,7 +199,14 @@ namespace Azure.Search.Documents.Models
                     List<InputFieldMappingEntry> array = new List<InputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(InputFieldMappingEntry.DeserializeInputFieldMappingEntry(item));
+                        }
                     }
                     inputs = array;
                     continue;
@@ -202,13 +216,20 @@ namespace Azure.Search.Documents.Models
                     List<OutputFieldMappingEntry> array = new List<OutputFieldMappingEntry>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(OutputFieldMappingEntry.DeserializeOutputFieldMappingEntry(item));
+                        }
                     }
                     outputs = array;
                     continue;
                 }
             }
-            return new WebApiSkill(odatatype, name, description, context, inputs, outputs, uri, httpHeaders, httpMethod, timeout, batchSize, degreeOfParallelism);
+            return new WebApiSkill(odataType, name, description, context, inputs, outputs, uri, httpHeaders, httpMethod, timeout, batchSize, degreeOfParallelism);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/WordDelimiterTokenFilter.Serialization.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/WordDelimiterTokenFilter.Serialization.cs
@@ -90,7 +90,7 @@ namespace Azure.Search.Documents.Models
             bool? splitOnNumerics = default;
             bool? stemEnglishPossessive = default;
             IList<string> protectedWords = default;
-            string odatatype = default;
+            string odataType = default;
             string name = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -184,14 +184,21 @@ namespace Azure.Search.Documents.Models
                     List<string> array = new List<string>();
                     foreach (var item in property.Value.EnumerateArray())
                     {
-                        array.Add(item.GetString());
+                        if (item.ValueKind == JsonValueKind.Null)
+                        {
+                            array.Add(null);
+                        }
+                        else
+                        {
+                            array.Add(item.GetString());
+                        }
                     }
                     protectedWords = array;
                     continue;
                 }
                 if (property.NameEquals("@odata.type"))
                 {
-                    odatatype = property.Value.GetString();
+                    odataType = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("name"))
@@ -200,7 +207,7 @@ namespace Azure.Search.Documents.Models
                     continue;
                 }
             }
-            return new WordDelimiterTokenFilter(odatatype, name, generateWordParts, generateNumberParts, catenateWords, catenateNumbers, catenateAll, splitOnCaseChange, preserveOriginal, splitOnNumerics, stemEnglishPossessive, protectedWords);
+            return new WordDelimiterTokenFilter(odataType, name, generateWordParts, generateNumberParts, catenateWords, catenateNumbers, catenateAll, splitOnCaseChange, preserveOriginal, splitOnNumerics, stemEnglishPossessive, protectedWords);
         }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Operations/DataSourcesClient.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Operations/DataSourcesClient.cs
@@ -16,8 +16,8 @@ namespace Azure.Search.Documents
 {
     internal partial class DataSourcesClient
     {
-        private readonly ClientDiagnostics clientDiagnostics;
-        private readonly HttpPipeline pipeline;
+        private readonly ClientDiagnostics _clientDiagnostics;
+        private readonly HttpPipeline _pipeline;
         internal DataSourcesRestClient RestClient { get; }
         /// <summary> Initializes a new instance of DataSourcesClient for mocking. </summary>
         protected DataSourcesClient()
@@ -27,8 +27,8 @@ namespace Azure.Search.Documents
         internal DataSourcesClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string endpoint, string apiVersion = "2019-05-06-Preview")
         {
             RestClient = new DataSourcesRestClient(clientDiagnostics, pipeline, endpoint, apiVersion);
-            this.clientDiagnostics = clientDiagnostics;
-            this.pipeline = pipeline;
+            _clientDiagnostics = clientDiagnostics;
+            _pipeline = pipeline;
         }
 
         /// <summary> Creates a new datasource or updates a datasource if it already exists. </summary>

--- a/sdk/search/Azure.Search.Documents/src/Generated/Operations/DocumentsClient.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Operations/DocumentsClient.cs
@@ -17,8 +17,8 @@ namespace Azure.Search.Documents
 {
     internal partial class DocumentsClient
     {
-        private readonly ClientDiagnostics clientDiagnostics;
-        private readonly HttpPipeline pipeline;
+        private readonly ClientDiagnostics _clientDiagnostics;
+        private readonly HttpPipeline _pipeline;
         internal DocumentsRestClient RestClient { get; }
         /// <summary> Initializes a new instance of DocumentsClient for mocking. </summary>
         protected DocumentsClient()
@@ -28,8 +28,8 @@ namespace Azure.Search.Documents
         internal DocumentsClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string endpoint, string indexName, string apiVersion = "2019-05-06-Preview")
         {
             RestClient = new DocumentsRestClient(clientDiagnostics, pipeline, endpoint, indexName, apiVersion);
-            this.clientDiagnostics = clientDiagnostics;
-            this.pipeline = pipeline;
+            _clientDiagnostics = clientDiagnostics;
+            _pipeline = pipeline;
         }
 
         /// <summary> Queries the number of documents in the index. </summary>

--- a/sdk/search/Azure.Search.Documents/src/Generated/Operations/DocumentsRestClient.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Operations/DocumentsRestClient.cs
@@ -22,8 +22,8 @@ namespace Azure.Search.Documents
         private string endpoint;
         private string indexName;
         private string apiVersion;
-        private ClientDiagnostics clientDiagnostics;
-        private HttpPipeline pipeline;
+        private ClientDiagnostics _clientDiagnostics;
+        private HttpPipeline _pipeline;
 
         /// <summary> Initializes a new instance of DocumentsRestClient. </summary>
         public DocumentsRestClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string endpoint, string indexName, string apiVersion = "2019-05-06-Preview")
@@ -44,13 +44,13 @@ namespace Azure.Search.Documents
             this.endpoint = endpoint;
             this.indexName = indexName;
             this.apiVersion = apiVersion;
-            this.clientDiagnostics = clientDiagnostics;
-            this.pipeline = pipeline;
+            _clientDiagnostics = clientDiagnostics;
+            _pipeline = pipeline;
         }
 
         internal HttpMessage CreateCountRequest(Guid? xMsClientRequestId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
@@ -73,12 +73,12 @@ namespace Azure.Search.Documents
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<long>> CountAsync(Guid? xMsClientRequestId = null, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("DocumentsClient.Count");
+            using var scope = _clientDiagnostics.CreateScope("DocumentsClient.Count");
             scope.Start();
             try
             {
                 using var message = CreateCountRequest(xMsClientRequestId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
@@ -89,7 +89,7 @@ namespace Azure.Search.Documents
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -104,12 +104,12 @@ namespace Azure.Search.Documents
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<long> Count(Guid? xMsClientRequestId = null, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("DocumentsClient.Count");
+            using var scope = _clientDiagnostics.CreateScope("DocumentsClient.Count");
             scope.Start();
             try
             {
                 using var message = CreateCountRequest(xMsClientRequestId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
@@ -120,7 +120,7 @@ namespace Azure.Search.Documents
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -132,7 +132,7 @@ namespace Azure.Search.Documents
 
         internal HttpMessage CreateSearchPostRequest(SearchOptions searchRequest, Guid? xMsClientRequestId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
@@ -165,23 +165,30 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(searchRequest));
             }
 
-            using var scope = clientDiagnostics.CreateScope("DocumentsClient.SearchPost");
+            using var scope = _clientDiagnostics.CreateScope("DocumentsClient.SearchPost");
             scope.Start();
             try
             {
                 using var message = CreateSearchPostRequest(searchRequest, xMsClientRequestId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             SearchDocumentsResult value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = SearchDocumentsResult.DeserializeSearchDocumentsResult(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SearchDocumentsResult.DeserializeSearchDocumentsResult(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -202,23 +209,30 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(searchRequest));
             }
 
-            using var scope = clientDiagnostics.CreateScope("DocumentsClient.SearchPost");
+            using var scope = _clientDiagnostics.CreateScope("DocumentsClient.SearchPost");
             scope.Start();
             try
             {
                 using var message = CreateSearchPostRequest(searchRequest, xMsClientRequestId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             SearchDocumentsResult value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = SearchDocumentsResult.DeserializeSearchDocumentsResult(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SearchDocumentsResult.DeserializeSearchDocumentsResult(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -230,7 +244,7 @@ namespace Azure.Search.Documents
 
         internal HttpMessage CreateGetRequest(string key, IEnumerable<string> selectedFields, Guid? xMsClientRequestId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
@@ -266,28 +280,42 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(key));
             }
 
-            using var scope = clientDiagnostics.CreateScope("DocumentsClient.Get");
+            using var scope = _clientDiagnostics.CreateScope("DocumentsClient.Get");
             scope.Start();
             try
             {
                 using var message = CreateGetRequest(key, selectedFields, xMsClientRequestId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             IReadOnlyDictionary<string, object> value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            Dictionary<string, object> dictionary = new Dictionary<string, object>();
-                            foreach (var property in document.RootElement.EnumerateObject())
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
                             {
-                                dictionary.Add(property.Name, property.Value.GetObject());
+                                value = null;
                             }
-                            value = dictionary;
+                            else
+                            {
+                                Dictionary<string, object> dictionary = new Dictionary<string, object>();
+                                foreach (var property in document.RootElement.EnumerateObject())
+                                {
+                                    if (property.Value.ValueKind == JsonValueKind.Null)
+                                    {
+                                        dictionary.Add(property.Name, null);
+                                    }
+                                    else
+                                    {
+                                        dictionary.Add(property.Name, property.Value.GetObject());
+                                    }
+                                }
+                                value = dictionary;
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -309,28 +337,42 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(key));
             }
 
-            using var scope = clientDiagnostics.CreateScope("DocumentsClient.Get");
+            using var scope = _clientDiagnostics.CreateScope("DocumentsClient.Get");
             scope.Start();
             try
             {
                 using var message = CreateGetRequest(key, selectedFields, xMsClientRequestId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             IReadOnlyDictionary<string, object> value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            Dictionary<string, object> dictionary = new Dictionary<string, object>();
-                            foreach (var property in document.RootElement.EnumerateObject())
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
                             {
-                                dictionary.Add(property.Name, property.Value.GetObject());
+                                value = null;
                             }
-                            value = dictionary;
+                            else
+                            {
+                                Dictionary<string, object> dictionary = new Dictionary<string, object>();
+                                foreach (var property in document.RootElement.EnumerateObject())
+                                {
+                                    if (property.Value.ValueKind == JsonValueKind.Null)
+                                    {
+                                        dictionary.Add(property.Name, null);
+                                    }
+                                    else
+                                    {
+                                        dictionary.Add(property.Name, property.Value.GetObject());
+                                    }
+                                }
+                                value = dictionary;
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -342,7 +384,7 @@ namespace Azure.Search.Documents
 
         internal HttpMessage CreateSuggestPostRequest(SuggestOptions suggestRequest, Guid? xMsClientRequestId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
@@ -375,23 +417,30 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(suggestRequest));
             }
 
-            using var scope = clientDiagnostics.CreateScope("DocumentsClient.SuggestPost");
+            using var scope = _clientDiagnostics.CreateScope("DocumentsClient.SuggestPost");
             scope.Start();
             try
             {
                 using var message = CreateSuggestPostRequest(suggestRequest, xMsClientRequestId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             SuggestDocumentsResult value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = SuggestDocumentsResult.DeserializeSuggestDocumentsResult(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SuggestDocumentsResult.DeserializeSuggestDocumentsResult(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -412,23 +461,30 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(suggestRequest));
             }
 
-            using var scope = clientDiagnostics.CreateScope("DocumentsClient.SuggestPost");
+            using var scope = _clientDiagnostics.CreateScope("DocumentsClient.SuggestPost");
             scope.Start();
             try
             {
                 using var message = CreateSuggestPostRequest(suggestRequest, xMsClientRequestId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             SuggestDocumentsResult value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = SuggestDocumentsResult.DeserializeSuggestDocumentsResult(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SuggestDocumentsResult.DeserializeSuggestDocumentsResult(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -440,7 +496,7 @@ namespace Azure.Search.Documents
 
         internal HttpMessage CreateIndexRequest(IndexBatch batch, Guid? xMsClientRequestId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
@@ -473,12 +529,12 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(batch));
             }
 
-            using var scope = clientDiagnostics.CreateScope("DocumentsClient.Index");
+            using var scope = _clientDiagnostics.CreateScope("DocumentsClient.Index");
             scope.Start();
             try
             {
                 using var message = CreateIndexRequest(batch, xMsClientRequestId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
@@ -486,11 +542,18 @@ namespace Azure.Search.Documents
                         {
                             IndexDocumentsResult value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = IndexDocumentsResult.DeserializeIndexDocumentsResult(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = IndexDocumentsResult.DeserializeIndexDocumentsResult(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -511,12 +574,12 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(batch));
             }
 
-            using var scope = clientDiagnostics.CreateScope("DocumentsClient.Index");
+            using var scope = _clientDiagnostics.CreateScope("DocumentsClient.Index");
             scope.Start();
             try
             {
                 using var message = CreateIndexRequest(batch, xMsClientRequestId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
@@ -524,11 +587,18 @@ namespace Azure.Search.Documents
                         {
                             IndexDocumentsResult value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = IndexDocumentsResult.DeserializeIndexDocumentsResult(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = IndexDocumentsResult.DeserializeIndexDocumentsResult(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -540,7 +610,7 @@ namespace Azure.Search.Documents
 
         internal HttpMessage CreateAutocompletePostRequest(AutocompleteOptions autocompleteRequest, Guid? xMsClientRequestId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
@@ -573,23 +643,30 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(autocompleteRequest));
             }
 
-            using var scope = clientDiagnostics.CreateScope("DocumentsClient.AutocompletePost");
+            using var scope = _clientDiagnostics.CreateScope("DocumentsClient.AutocompletePost");
             scope.Start();
             try
             {
                 using var message = CreateAutocompletePostRequest(autocompleteRequest, xMsClientRequestId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             AutocompleteResults value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = AutocompleteResults.DeserializeAutocompleteResults(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = AutocompleteResults.DeserializeAutocompleteResults(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -610,23 +687,30 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(autocompleteRequest));
             }
 
-            using var scope = clientDiagnostics.CreateScope("DocumentsClient.AutocompletePost");
+            using var scope = _clientDiagnostics.CreateScope("DocumentsClient.AutocompletePost");
             scope.Start();
             try
             {
                 using var message = CreateAutocompletePostRequest(autocompleteRequest, xMsClientRequestId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             AutocompleteResults value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = AutocompleteResults.DeserializeAutocompleteResults(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = AutocompleteResults.DeserializeAutocompleteResults(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)

--- a/sdk/search/Azure.Search.Documents/src/Generated/Operations/IndexersClient.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Operations/IndexersClient.cs
@@ -16,8 +16,8 @@ namespace Azure.Search.Documents
 {
     internal partial class IndexersClient
     {
-        private readonly ClientDiagnostics clientDiagnostics;
-        private readonly HttpPipeline pipeline;
+        private readonly ClientDiagnostics _clientDiagnostics;
+        private readonly HttpPipeline _pipeline;
         internal IndexersRestClient RestClient { get; }
         /// <summary> Initializes a new instance of IndexersClient for mocking. </summary>
         protected IndexersClient()
@@ -27,8 +27,8 @@ namespace Azure.Search.Documents
         internal IndexersClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string endpoint, string apiVersion = "2019-05-06-Preview")
         {
             RestClient = new IndexersRestClient(clientDiagnostics, pipeline, endpoint, apiVersion);
-            this.clientDiagnostics = clientDiagnostics;
-            this.pipeline = pipeline;
+            _clientDiagnostics = clientDiagnostics;
+            _pipeline = pipeline;
         }
 
         /// <summary> Resets the change tracking state associated with an indexer. </summary>

--- a/sdk/search/Azure.Search.Documents/src/Generated/Operations/IndexersRestClient.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Operations/IndexersRestClient.cs
@@ -20,8 +20,8 @@ namespace Azure.Search.Documents
     {
         private string endpoint;
         private string apiVersion;
-        private ClientDiagnostics clientDiagnostics;
-        private HttpPipeline pipeline;
+        private ClientDiagnostics _clientDiagnostics;
+        private HttpPipeline _pipeline;
 
         /// <summary> Initializes a new instance of IndexersRestClient. </summary>
         public IndexersRestClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string endpoint, string apiVersion = "2019-05-06-Preview")
@@ -37,13 +37,13 @@ namespace Azure.Search.Documents
 
             this.endpoint = endpoint;
             this.apiVersion = apiVersion;
-            this.clientDiagnostics = clientDiagnostics;
-            this.pipeline = pipeline;
+            _clientDiagnostics = clientDiagnostics;
+            _pipeline = pipeline;
         }
 
         internal HttpMessage CreateResetRequest(string indexerName, Guid? xMsClientRequestId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
@@ -71,18 +71,18 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(indexerName));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexersClient.Reset");
+            using var scope = _clientDiagnostics.CreateScope("IndexersClient.Reset");
             scope.Start();
             try
             {
                 using var message = CreateResetRequest(indexerName, xMsClientRequestId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 204:
                         return message.Response;
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -103,18 +103,18 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(indexerName));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexersClient.Reset");
+            using var scope = _clientDiagnostics.CreateScope("IndexersClient.Reset");
             scope.Start();
             try
             {
                 using var message = CreateResetRequest(indexerName, xMsClientRequestId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 204:
                         return message.Response;
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -126,7 +126,7 @@ namespace Azure.Search.Documents
 
         internal HttpMessage CreateRunRequest(string indexerName, Guid? xMsClientRequestId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
@@ -154,18 +154,18 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(indexerName));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexersClient.Run");
+            using var scope = _clientDiagnostics.CreateScope("IndexersClient.Run");
             scope.Start();
             try
             {
                 using var message = CreateRunRequest(indexerName, xMsClientRequestId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 202:
                         return message.Response;
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -186,18 +186,18 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(indexerName));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexersClient.Run");
+            using var scope = _clientDiagnostics.CreateScope("IndexersClient.Run");
             scope.Start();
             try
             {
                 using var message = CreateRunRequest(indexerName, xMsClientRequestId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 202:
                         return message.Response;
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -209,7 +209,7 @@ namespace Azure.Search.Documents
 
         internal HttpMessage CreateCreateOrUpdateRequest(string indexerName, SearchIndexer indexer, Guid? xMsClientRequestId, string ifMatch, string ifNoneMatch)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Put;
             var uri = new RawRequestUriBuilder();
@@ -257,12 +257,12 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(indexer));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexersClient.CreateOrUpdate");
+            using var scope = _clientDiagnostics.CreateScope("IndexersClient.CreateOrUpdate");
             scope.Start();
             try
             {
                 using var message = CreateCreateOrUpdateRequest(indexerName, indexer, xMsClientRequestId, ifMatch, ifNoneMatch);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
@@ -270,11 +270,18 @@ namespace Azure.Search.Documents
                         {
                             SearchIndexer value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = SearchIndexer.DeserializeSearchIndexer(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SearchIndexer.DeserializeSearchIndexer(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -302,12 +309,12 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(indexer));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexersClient.CreateOrUpdate");
+            using var scope = _clientDiagnostics.CreateScope("IndexersClient.CreateOrUpdate");
             scope.Start();
             try
             {
                 using var message = CreateCreateOrUpdateRequest(indexerName, indexer, xMsClientRequestId, ifMatch, ifNoneMatch);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
@@ -315,11 +322,18 @@ namespace Azure.Search.Documents
                         {
                             SearchIndexer value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = SearchIndexer.DeserializeSearchIndexer(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SearchIndexer.DeserializeSearchIndexer(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -331,7 +345,7 @@ namespace Azure.Search.Documents
 
         internal HttpMessage CreateDeleteRequest(string indexerName, Guid? xMsClientRequestId, string ifMatch, string ifNoneMatch)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Delete;
             var uri = new RawRequestUriBuilder();
@@ -369,19 +383,19 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(indexerName));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexersClient.Delete");
+            using var scope = _clientDiagnostics.CreateScope("IndexersClient.Delete");
             scope.Start();
             try
             {
                 using var message = CreateDeleteRequest(indexerName, xMsClientRequestId, ifMatch, ifNoneMatch);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 204:
                     case 404:
                         return message.Response;
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -404,19 +418,19 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(indexerName));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexersClient.Delete");
+            using var scope = _clientDiagnostics.CreateScope("IndexersClient.Delete");
             scope.Start();
             try
             {
                 using var message = CreateDeleteRequest(indexerName, xMsClientRequestId, ifMatch, ifNoneMatch);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 204:
                     case 404:
                         return message.Response;
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -428,7 +442,7 @@ namespace Azure.Search.Documents
 
         internal HttpMessage CreateGetRequest(string indexerName, Guid? xMsClientRequestId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
@@ -456,23 +470,30 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(indexerName));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexersClient.Get");
+            using var scope = _clientDiagnostics.CreateScope("IndexersClient.Get");
             scope.Start();
             try
             {
                 using var message = CreateGetRequest(indexerName, xMsClientRequestId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             SearchIndexer value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = SearchIndexer.DeserializeSearchIndexer(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SearchIndexer.DeserializeSearchIndexer(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -493,23 +514,30 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(indexerName));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexersClient.Get");
+            using var scope = _clientDiagnostics.CreateScope("IndexersClient.Get");
             scope.Start();
             try
             {
                 using var message = CreateGetRequest(indexerName, xMsClientRequestId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             SearchIndexer value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = SearchIndexer.DeserializeSearchIndexer(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SearchIndexer.DeserializeSearchIndexer(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -521,7 +549,7 @@ namespace Azure.Search.Documents
 
         internal HttpMessage CreateListRequest(string select, Guid? xMsClientRequestId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
@@ -546,23 +574,30 @@ namespace Azure.Search.Documents
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ListIndexersResult>> ListAsync(string select = null, Guid? xMsClientRequestId = null, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("IndexersClient.List");
+            using var scope = _clientDiagnostics.CreateScope("IndexersClient.List");
             scope.Start();
             try
             {
                 using var message = CreateListRequest(select, xMsClientRequestId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             ListIndexersResult value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = ListIndexersResult.DeserializeListIndexersResult(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = ListIndexersResult.DeserializeListIndexersResult(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -578,23 +613,30 @@ namespace Azure.Search.Documents
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ListIndexersResult> List(string select = null, Guid? xMsClientRequestId = null, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("IndexersClient.List");
+            using var scope = _clientDiagnostics.CreateScope("IndexersClient.List");
             scope.Start();
             try
             {
                 using var message = CreateListRequest(select, xMsClientRequestId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             ListIndexersResult value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = ListIndexersResult.DeserializeListIndexersResult(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = ListIndexersResult.DeserializeListIndexersResult(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -606,7 +648,7 @@ namespace Azure.Search.Documents
 
         internal HttpMessage CreateCreateRequest(SearchIndexer indexer, Guid? xMsClientRequestId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
@@ -636,23 +678,30 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(indexer));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexersClient.Create");
+            using var scope = _clientDiagnostics.CreateScope("IndexersClient.Create");
             scope.Start();
             try
             {
                 using var message = CreateCreateRequest(indexer, xMsClientRequestId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 201:
                         {
                             SearchIndexer value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = SearchIndexer.DeserializeSearchIndexer(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SearchIndexer.DeserializeSearchIndexer(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -673,23 +722,30 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(indexer));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexersClient.Create");
+            using var scope = _clientDiagnostics.CreateScope("IndexersClient.Create");
             scope.Start();
             try
             {
                 using var message = CreateCreateRequest(indexer, xMsClientRequestId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 201:
                         {
                             SearchIndexer value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = SearchIndexer.DeserializeSearchIndexer(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SearchIndexer.DeserializeSearchIndexer(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -701,7 +757,7 @@ namespace Azure.Search.Documents
 
         internal HttpMessage CreateGetStatusRequest(string indexerName, Guid? xMsClientRequestId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
@@ -729,23 +785,30 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(indexerName));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexersClient.GetStatus");
+            using var scope = _clientDiagnostics.CreateScope("IndexersClient.GetStatus");
             scope.Start();
             try
             {
                 using var message = CreateGetStatusRequest(indexerName, xMsClientRequestId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             IndexerExecutionInfo value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = IndexerExecutionInfo.DeserializeIndexerExecutionInfo(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = IndexerExecutionInfo.DeserializeIndexerExecutionInfo(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -766,23 +829,30 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(indexerName));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexersClient.GetStatus");
+            using var scope = _clientDiagnostics.CreateScope("IndexersClient.GetStatus");
             scope.Start();
             try
             {
                 using var message = CreateGetStatusRequest(indexerName, xMsClientRequestId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             IndexerExecutionInfo value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = IndexerExecutionInfo.DeserializeIndexerExecutionInfo(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = IndexerExecutionInfo.DeserializeIndexerExecutionInfo(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)

--- a/sdk/search/Azure.Search.Documents/src/Generated/Operations/IndexesClient.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Operations/IndexesClient.cs
@@ -16,8 +16,8 @@ namespace Azure.Search.Documents
 {
     internal partial class IndexesClient
     {
-        private readonly ClientDiagnostics clientDiagnostics;
-        private readonly HttpPipeline pipeline;
+        private readonly ClientDiagnostics _clientDiagnostics;
+        private readonly HttpPipeline _pipeline;
         internal IndexesRestClient RestClient { get; }
         /// <summary> Initializes a new instance of IndexesClient for mocking. </summary>
         protected IndexesClient()
@@ -27,8 +27,8 @@ namespace Azure.Search.Documents
         internal IndexesClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string endpoint, string apiVersion = "2019-05-06-Preview")
         {
             RestClient = new IndexesRestClient(clientDiagnostics, pipeline, endpoint, apiVersion);
-            this.clientDiagnostics = clientDiagnostics;
-            this.pipeline = pipeline;
+            _clientDiagnostics = clientDiagnostics;
+            _pipeline = pipeline;
         }
 
         /// <summary> Creates a new search index. </summary>

--- a/sdk/search/Azure.Search.Documents/src/Generated/Operations/IndexesRestClient.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Operations/IndexesRestClient.cs
@@ -20,8 +20,8 @@ namespace Azure.Search.Documents
     {
         private string endpoint;
         private string apiVersion;
-        private ClientDiagnostics clientDiagnostics;
-        private HttpPipeline pipeline;
+        private ClientDiagnostics _clientDiagnostics;
+        private HttpPipeline _pipeline;
 
         /// <summary> Initializes a new instance of IndexesRestClient. </summary>
         public IndexesRestClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string endpoint, string apiVersion = "2019-05-06-Preview")
@@ -37,13 +37,13 @@ namespace Azure.Search.Documents
 
             this.endpoint = endpoint;
             this.apiVersion = apiVersion;
-            this.clientDiagnostics = clientDiagnostics;
-            this.pipeline = pipeline;
+            _clientDiagnostics = clientDiagnostics;
+            _pipeline = pipeline;
         }
 
         internal HttpMessage CreateCreateRequest(SearchIndex index, Guid? xMsClientRequestId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
@@ -73,23 +73,30 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(index));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexesClient.Create");
+            using var scope = _clientDiagnostics.CreateScope("IndexesClient.Create");
             scope.Start();
             try
             {
                 using var message = CreateCreateRequest(index, xMsClientRequestId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 201:
                         {
                             SearchIndex value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = SearchIndex.DeserializeSearchIndex(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SearchIndex.DeserializeSearchIndex(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -110,23 +117,30 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(index));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexesClient.Create");
+            using var scope = _clientDiagnostics.CreateScope("IndexesClient.Create");
             scope.Start();
             try
             {
                 using var message = CreateCreateRequest(index, xMsClientRequestId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 201:
                         {
                             SearchIndex value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = SearchIndex.DeserializeSearchIndex(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SearchIndex.DeserializeSearchIndex(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -138,7 +152,7 @@ namespace Azure.Search.Documents
 
         internal HttpMessage CreateListRequest(string select, Guid? xMsClientRequestId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
@@ -163,23 +177,30 @@ namespace Azure.Search.Documents
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ListIndexesResult>> ListAsync(string select = null, Guid? xMsClientRequestId = null, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("IndexesClient.List");
+            using var scope = _clientDiagnostics.CreateScope("IndexesClient.List");
             scope.Start();
             try
             {
                 using var message = CreateListRequest(select, xMsClientRequestId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             ListIndexesResult value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = ListIndexesResult.DeserializeListIndexesResult(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = ListIndexesResult.DeserializeListIndexesResult(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -195,23 +216,30 @@ namespace Azure.Search.Documents
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ListIndexesResult> List(string select = null, Guid? xMsClientRequestId = null, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("IndexesClient.List");
+            using var scope = _clientDiagnostics.CreateScope("IndexesClient.List");
             scope.Start();
             try
             {
                 using var message = CreateListRequest(select, xMsClientRequestId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             ListIndexesResult value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = ListIndexesResult.DeserializeListIndexesResult(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = ListIndexesResult.DeserializeListIndexesResult(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -223,7 +251,7 @@ namespace Azure.Search.Documents
 
         internal HttpMessage CreateCreateOrUpdateRequest(string indexName, SearchIndex index, bool? allowIndexDowntime, Guid? xMsClientRequestId, string ifMatch, string ifNoneMatch)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Put;
             var uri = new RawRequestUriBuilder();
@@ -276,12 +304,12 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(index));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexesClient.CreateOrUpdate");
+            using var scope = _clientDiagnostics.CreateScope("IndexesClient.CreateOrUpdate");
             scope.Start();
             try
             {
                 using var message = CreateCreateOrUpdateRequest(indexName, index, allowIndexDowntime, xMsClientRequestId, ifMatch, ifNoneMatch);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
@@ -289,11 +317,18 @@ namespace Azure.Search.Documents
                         {
                             SearchIndex value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = SearchIndex.DeserializeSearchIndex(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SearchIndex.DeserializeSearchIndex(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -322,12 +357,12 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(index));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexesClient.CreateOrUpdate");
+            using var scope = _clientDiagnostics.CreateScope("IndexesClient.CreateOrUpdate");
             scope.Start();
             try
             {
                 using var message = CreateCreateOrUpdateRequest(indexName, index, allowIndexDowntime, xMsClientRequestId, ifMatch, ifNoneMatch);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
@@ -335,11 +370,18 @@ namespace Azure.Search.Documents
                         {
                             SearchIndex value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = SearchIndex.DeserializeSearchIndex(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SearchIndex.DeserializeSearchIndex(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -351,7 +393,7 @@ namespace Azure.Search.Documents
 
         internal HttpMessage CreateDeleteRequest(string indexName, Guid? xMsClientRequestId, string ifMatch, string ifNoneMatch)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Delete;
             var uri = new RawRequestUriBuilder();
@@ -389,19 +431,19 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(indexName));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexesClient.Delete");
+            using var scope = _clientDiagnostics.CreateScope("IndexesClient.Delete");
             scope.Start();
             try
             {
                 using var message = CreateDeleteRequest(indexName, xMsClientRequestId, ifMatch, ifNoneMatch);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 204:
                     case 404:
                         return message.Response;
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -424,19 +466,19 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(indexName));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexesClient.Delete");
+            using var scope = _clientDiagnostics.CreateScope("IndexesClient.Delete");
             scope.Start();
             try
             {
                 using var message = CreateDeleteRequest(indexName, xMsClientRequestId, ifMatch, ifNoneMatch);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 204:
                     case 404:
                         return message.Response;
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -448,7 +490,7 @@ namespace Azure.Search.Documents
 
         internal HttpMessage CreateGetRequest(string indexName, Guid? xMsClientRequestId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
@@ -476,23 +518,30 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(indexName));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexesClient.Get");
+            using var scope = _clientDiagnostics.CreateScope("IndexesClient.Get");
             scope.Start();
             try
             {
                 using var message = CreateGetRequest(indexName, xMsClientRequestId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             SearchIndex value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = SearchIndex.DeserializeSearchIndex(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SearchIndex.DeserializeSearchIndex(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -513,23 +562,30 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(indexName));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexesClient.Get");
+            using var scope = _clientDiagnostics.CreateScope("IndexesClient.Get");
             scope.Start();
             try
             {
                 using var message = CreateGetRequest(indexName, xMsClientRequestId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             SearchIndex value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = SearchIndex.DeserializeSearchIndex(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SearchIndex.DeserializeSearchIndex(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -541,7 +597,7 @@ namespace Azure.Search.Documents
 
         internal HttpMessage CreateGetStatisticsRequest(string indexName, Guid? xMsClientRequestId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
@@ -569,23 +625,30 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(indexName));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexesClient.GetStatistics");
+            using var scope = _clientDiagnostics.CreateScope("IndexesClient.GetStatistics");
             scope.Start();
             try
             {
                 using var message = CreateGetStatisticsRequest(indexName, xMsClientRequestId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             SearchIndexStatistics value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = SearchIndexStatistics.DeserializeSearchIndexStatistics(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SearchIndexStatistics.DeserializeSearchIndexStatistics(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -606,23 +669,30 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(indexName));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexesClient.GetStatistics");
+            using var scope = _clientDiagnostics.CreateScope("IndexesClient.GetStatistics");
             scope.Start();
             try
             {
                 using var message = CreateGetStatisticsRequest(indexName, xMsClientRequestId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             SearchIndexStatistics value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = SearchIndexStatistics.DeserializeSearchIndexStatistics(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SearchIndexStatistics.DeserializeSearchIndexStatistics(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -634,7 +704,7 @@ namespace Azure.Search.Documents
 
         internal HttpMessage CreateAnalyzeRequest(string indexName, AnalyzeRequest request, Guid? xMsClientRequestId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request0 = message.Request;
             request0.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
@@ -671,23 +741,30 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(request));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexesClient.Analyze");
+            using var scope = _clientDiagnostics.CreateScope("IndexesClient.Analyze");
             scope.Start();
             try
             {
                 using var message = CreateAnalyzeRequest(indexName, request, xMsClientRequestId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             AnalyzeResult value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = AnalyzeResult.DeserializeAnalyzeResult(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = AnalyzeResult.DeserializeAnalyzeResult(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -713,23 +790,30 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(request));
             }
 
-            using var scope = clientDiagnostics.CreateScope("IndexesClient.Analyze");
+            using var scope = _clientDiagnostics.CreateScope("IndexesClient.Analyze");
             scope.Start();
             try
             {
                 using var message = CreateAnalyzeRequest(indexName, request, xMsClientRequestId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             AnalyzeResult value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = AnalyzeResult.DeserializeAnalyzeResult(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = AnalyzeResult.DeserializeAnalyzeResult(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)

--- a/sdk/search/Azure.Search.Documents/src/Generated/Operations/ServiceClient.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Operations/ServiceClient.cs
@@ -16,8 +16,8 @@ namespace Azure.Search.Documents
 {
     internal partial class ServiceClient
     {
-        private readonly ClientDiagnostics clientDiagnostics;
-        private readonly HttpPipeline pipeline;
+        private readonly ClientDiagnostics _clientDiagnostics;
+        private readonly HttpPipeline _pipeline;
         internal ServiceRestClient RestClient { get; }
         /// <summary> Initializes a new instance of ServiceClient for mocking. </summary>
         protected ServiceClient()
@@ -27,8 +27,8 @@ namespace Azure.Search.Documents
         internal ServiceClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string endpoint, string apiVersion = "2019-05-06-Preview")
         {
             RestClient = new ServiceRestClient(clientDiagnostics, pipeline, endpoint, apiVersion);
-            this.clientDiagnostics = clientDiagnostics;
-            this.pipeline = pipeline;
+            _clientDiagnostics = clientDiagnostics;
+            _pipeline = pipeline;
         }
 
         /// <summary> Gets service level statistics for a search service. </summary>

--- a/sdk/search/Azure.Search.Documents/src/Generated/Operations/ServiceRestClient.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Operations/ServiceRestClient.cs
@@ -20,8 +20,8 @@ namespace Azure.Search.Documents
     {
         private string endpoint;
         private string apiVersion;
-        private ClientDiagnostics clientDiagnostics;
-        private HttpPipeline pipeline;
+        private ClientDiagnostics _clientDiagnostics;
+        private HttpPipeline _pipeline;
 
         /// <summary> Initializes a new instance of ServiceRestClient. </summary>
         public ServiceRestClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string endpoint, string apiVersion = "2019-05-06-Preview")
@@ -37,13 +37,13 @@ namespace Azure.Search.Documents
 
             this.endpoint = endpoint;
             this.apiVersion = apiVersion;
-            this.clientDiagnostics = clientDiagnostics;
-            this.pipeline = pipeline;
+            _clientDiagnostics = clientDiagnostics;
+            _pipeline = pipeline;
         }
 
         internal HttpMessage CreateGetServiceStatisticsRequest(Guid? xMsClientRequestId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
@@ -63,23 +63,30 @@ namespace Azure.Search.Documents
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<SearchServiceStatistics>> GetServiceStatisticsAsync(Guid? xMsClientRequestId = null, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.GetServiceStatistics");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.GetServiceStatistics");
             scope.Start();
             try
             {
                 using var message = CreateGetServiceStatisticsRequest(xMsClientRequestId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             SearchServiceStatistics value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = SearchServiceStatistics.DeserializeSearchServiceStatistics(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SearchServiceStatistics.DeserializeSearchServiceStatistics(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -94,23 +101,30 @@ namespace Azure.Search.Documents
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<SearchServiceStatistics> GetServiceStatistics(Guid? xMsClientRequestId = null, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.GetServiceStatistics");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.GetServiceStatistics");
             scope.Start();
             try
             {
                 using var message = CreateGetServiceStatisticsRequest(xMsClientRequestId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             SearchServiceStatistics value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = SearchServiceStatistics.DeserializeSearchServiceStatistics(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SearchServiceStatistics.DeserializeSearchServiceStatistics(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)

--- a/sdk/search/Azure.Search.Documents/src/Generated/Operations/SkillsetsClient.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Operations/SkillsetsClient.cs
@@ -16,8 +16,8 @@ namespace Azure.Search.Documents
 {
     internal partial class SkillsetsClient
     {
-        private readonly ClientDiagnostics clientDiagnostics;
-        private readonly HttpPipeline pipeline;
+        private readonly ClientDiagnostics _clientDiagnostics;
+        private readonly HttpPipeline _pipeline;
         internal SkillsetsRestClient RestClient { get; }
         /// <summary> Initializes a new instance of SkillsetsClient for mocking. </summary>
         protected SkillsetsClient()
@@ -27,8 +27,8 @@ namespace Azure.Search.Documents
         internal SkillsetsClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string endpoint, string apiVersion = "2019-05-06-Preview")
         {
             RestClient = new SkillsetsRestClient(clientDiagnostics, pipeline, endpoint, apiVersion);
-            this.clientDiagnostics = clientDiagnostics;
-            this.pipeline = pipeline;
+            _clientDiagnostics = clientDiagnostics;
+            _pipeline = pipeline;
         }
 
         /// <summary> Creates a new skillset in a search service or updates the skillset if it already exists. </summary>

--- a/sdk/search/Azure.Search.Documents/src/Generated/Operations/SynonymMapsClient.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Operations/SynonymMapsClient.cs
@@ -16,8 +16,8 @@ namespace Azure.Search.Documents
 {
     internal partial class SynonymMapsClient
     {
-        private readonly ClientDiagnostics clientDiagnostics;
-        private readonly HttpPipeline pipeline;
+        private readonly ClientDiagnostics _clientDiagnostics;
+        private readonly HttpPipeline _pipeline;
         internal SynonymMapsRestClient RestClient { get; }
         /// <summary> Initializes a new instance of SynonymMapsClient for mocking. </summary>
         protected SynonymMapsClient()
@@ -27,8 +27,8 @@ namespace Azure.Search.Documents
         internal SynonymMapsClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string endpoint, string apiVersion = "2019-05-06-Preview")
         {
             RestClient = new SynonymMapsRestClient(clientDiagnostics, pipeline, endpoint, apiVersion);
-            this.clientDiagnostics = clientDiagnostics;
-            this.pipeline = pipeline;
+            _clientDiagnostics = clientDiagnostics;
+            _pipeline = pipeline;
         }
 
         /// <summary> Creates a new synonym map or updates a synonym map if it already exists. </summary>

--- a/sdk/search/Azure.Search.Documents/src/Generated/Operations/SynonymMapsRestClient.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Operations/SynonymMapsRestClient.cs
@@ -20,8 +20,8 @@ namespace Azure.Search.Documents
     {
         private string endpoint;
         private string apiVersion;
-        private ClientDiagnostics clientDiagnostics;
-        private HttpPipeline pipeline;
+        private ClientDiagnostics _clientDiagnostics;
+        private HttpPipeline _pipeline;
 
         /// <summary> Initializes a new instance of SynonymMapsRestClient. </summary>
         public SynonymMapsRestClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string endpoint, string apiVersion = "2019-05-06-Preview")
@@ -37,13 +37,13 @@ namespace Azure.Search.Documents
 
             this.endpoint = endpoint;
             this.apiVersion = apiVersion;
-            this.clientDiagnostics = clientDiagnostics;
-            this.pipeline = pipeline;
+            _clientDiagnostics = clientDiagnostics;
+            _pipeline = pipeline;
         }
 
         internal HttpMessage CreateCreateOrUpdateRequest(string synonymMapName, SynonymMap synonymMap, Guid? xMsClientRequestId, string ifMatch, string ifNoneMatch)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Put;
             var uri = new RawRequestUriBuilder();
@@ -91,12 +91,12 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(synonymMap));
             }
 
-            using var scope = clientDiagnostics.CreateScope("SynonymMapsClient.CreateOrUpdate");
+            using var scope = _clientDiagnostics.CreateScope("SynonymMapsClient.CreateOrUpdate");
             scope.Start();
             try
             {
                 using var message = CreateCreateOrUpdateRequest(synonymMapName, synonymMap, xMsClientRequestId, ifMatch, ifNoneMatch);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
@@ -104,11 +104,18 @@ namespace Azure.Search.Documents
                         {
                             SynonymMap value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = SynonymMap.DeserializeSynonymMap(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SynonymMap.DeserializeSynonymMap(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -136,12 +143,12 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(synonymMap));
             }
 
-            using var scope = clientDiagnostics.CreateScope("SynonymMapsClient.CreateOrUpdate");
+            using var scope = _clientDiagnostics.CreateScope("SynonymMapsClient.CreateOrUpdate");
             scope.Start();
             try
             {
                 using var message = CreateCreateOrUpdateRequest(synonymMapName, synonymMap, xMsClientRequestId, ifMatch, ifNoneMatch);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
@@ -149,11 +156,18 @@ namespace Azure.Search.Documents
                         {
                             SynonymMap value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = SynonymMap.DeserializeSynonymMap(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SynonymMap.DeserializeSynonymMap(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -165,7 +179,7 @@ namespace Azure.Search.Documents
 
         internal HttpMessage CreateDeleteRequest(string synonymMapName, Guid? xMsClientRequestId, string ifMatch, string ifNoneMatch)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Delete;
             var uri = new RawRequestUriBuilder();
@@ -203,19 +217,19 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(synonymMapName));
             }
 
-            using var scope = clientDiagnostics.CreateScope("SynonymMapsClient.Delete");
+            using var scope = _clientDiagnostics.CreateScope("SynonymMapsClient.Delete");
             scope.Start();
             try
             {
                 using var message = CreateDeleteRequest(synonymMapName, xMsClientRequestId, ifMatch, ifNoneMatch);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 204:
                     case 404:
                         return message.Response;
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -238,19 +252,19 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(synonymMapName));
             }
 
-            using var scope = clientDiagnostics.CreateScope("SynonymMapsClient.Delete");
+            using var scope = _clientDiagnostics.CreateScope("SynonymMapsClient.Delete");
             scope.Start();
             try
             {
                 using var message = CreateDeleteRequest(synonymMapName, xMsClientRequestId, ifMatch, ifNoneMatch);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 204:
                     case 404:
                         return message.Response;
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -262,7 +276,7 @@ namespace Azure.Search.Documents
 
         internal HttpMessage CreateGetRequest(string synonymMapName, Guid? xMsClientRequestId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
@@ -290,23 +304,30 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(synonymMapName));
             }
 
-            using var scope = clientDiagnostics.CreateScope("SynonymMapsClient.Get");
+            using var scope = _clientDiagnostics.CreateScope("SynonymMapsClient.Get");
             scope.Start();
             try
             {
                 using var message = CreateGetRequest(synonymMapName, xMsClientRequestId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             SynonymMap value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = SynonymMap.DeserializeSynonymMap(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SynonymMap.DeserializeSynonymMap(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -327,23 +348,30 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(synonymMapName));
             }
 
-            using var scope = clientDiagnostics.CreateScope("SynonymMapsClient.Get");
+            using var scope = _clientDiagnostics.CreateScope("SynonymMapsClient.Get");
             scope.Start();
             try
             {
                 using var message = CreateGetRequest(synonymMapName, xMsClientRequestId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             SynonymMap value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = SynonymMap.DeserializeSynonymMap(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SynonymMap.DeserializeSynonymMap(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -355,7 +383,7 @@ namespace Azure.Search.Documents
 
         internal HttpMessage CreateListRequest(string select, Guid? xMsClientRequestId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Get;
             var uri = new RawRequestUriBuilder();
@@ -380,23 +408,30 @@ namespace Azure.Search.Documents
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ListSynonymMapsResult>> ListAsync(string select = null, Guid? xMsClientRequestId = null, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("SynonymMapsClient.List");
+            using var scope = _clientDiagnostics.CreateScope("SynonymMapsClient.List");
             scope.Start();
             try
             {
                 using var message = CreateListRequest(select, xMsClientRequestId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             ListSynonymMapsResult value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = ListSynonymMapsResult.DeserializeListSynonymMapsResult(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = ListSynonymMapsResult.DeserializeListSynonymMapsResult(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -412,23 +447,30 @@ namespace Azure.Search.Documents
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ListSynonymMapsResult> List(string select = null, Guid? xMsClientRequestId = null, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("SynonymMapsClient.List");
+            using var scope = _clientDiagnostics.CreateScope("SynonymMapsClient.List");
             scope.Start();
             try
             {
                 using var message = CreateListRequest(select, xMsClientRequestId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             ListSynonymMapsResult value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = ListSynonymMapsResult.DeserializeListSynonymMapsResult(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = ListSynonymMapsResult.DeserializeListSynonymMapsResult(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)
@@ -440,7 +482,7 @@ namespace Azure.Search.Documents
 
         internal HttpMessage CreateCreateRequest(SynonymMap synonymMap, Guid? xMsClientRequestId)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Post;
             var uri = new RawRequestUriBuilder();
@@ -470,23 +512,30 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(synonymMap));
             }
 
-            using var scope = clientDiagnostics.CreateScope("SynonymMapsClient.Create");
+            using var scope = _clientDiagnostics.CreateScope("SynonymMapsClient.Create");
             scope.Start();
             try
             {
                 using var message = CreateCreateRequest(synonymMap, xMsClientRequestId);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 201:
                         {
                             SynonymMap value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = SynonymMap.DeserializeSynonymMap(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SynonymMap.DeserializeSynonymMap(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -507,23 +556,30 @@ namespace Azure.Search.Documents
                 throw new ArgumentNullException(nameof(synonymMap));
             }
 
-            using var scope = clientDiagnostics.CreateScope("SynonymMapsClient.Create");
+            using var scope = _clientDiagnostics.CreateScope("SynonymMapsClient.Create");
             scope.Start();
             try
             {
                 using var message = CreateCreateRequest(synonymMap, xMsClientRequestId);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 201:
                         {
                             SynonymMap value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = SynonymMap.DeserializeSynonymMap(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = SynonymMap.DeserializeSynonymMap(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)

--- a/sdk/search/Azure.Search.Documents/src/Models/SynonymMap.cs
+++ b/sdk/search/Azure.Search.Documents/src/Models/SynonymMap.cs
@@ -7,6 +7,7 @@ using Azure.Core;
 
 namespace Azure.Search.Documents.Models
 {
+    [CodeGenSuppress(nameof(SynonymMap), typeof(string), typeof(string))]
     public partial class SynonymMap
     {
         private const string DefaultFormat = "soln";

--- a/sdk/template/Azure.Template/src/Generated/Models/DaysOfWeek.cs
+++ b/sdk/template/Azure.Template/src/Generated/Models/DaysOfWeek.cs
@@ -54,7 +54,7 @@ namespace Azure.Template.Models
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj) => obj is DaysOfWeek other && Equals(other);
         /// <inheritdoc />
-        public bool Equals(DaysOfWeek other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+        public bool Equals(DaysOfWeek other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
 
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/template/Azure.Template/src/Generated/Models/Fruit.cs
+++ b/sdk/template/Azure.Template/src/Generated/Models/Fruit.cs
@@ -39,7 +39,7 @@ namespace Azure.Template.Models
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj) => obj is Fruit other && Equals(other);
         /// <inheritdoc />
-        public bool Equals(Fruit other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+        public bool Equals(Fruit other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
 
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/sdk/template/Azure.Template/src/Generated/Operations/ServiceRestClient.cs
+++ b/sdk/template/Azure.Template/src/Generated/Operations/ServiceRestClient.cs
@@ -19,8 +19,8 @@ namespace Azure.Template
     internal partial class ServiceRestClient
     {
         private string host;
-        private ClientDiagnostics clientDiagnostics;
-        private HttpPipeline pipeline;
+        private ClientDiagnostics _clientDiagnostics;
+        private HttpPipeline _pipeline;
 
         /// <summary> Initializes a new instance of ServiceRestClient. </summary>
         public ServiceRestClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string host = "http://localhost:3000")
@@ -31,13 +31,13 @@ namespace Azure.Template
             }
 
             this.host = host;
-            this.clientDiagnostics = clientDiagnostics;
-            this.pipeline = pipeline;
+            _clientDiagnostics = clientDiagnostics;
+            _pipeline = pipeline;
         }
 
         internal HttpMessage CreateOperationRequest(Model body)
         {
-            var message = pipeline.CreateMessage();
+            var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Patch;
             var uri = new RawRequestUriBuilder();
@@ -58,23 +58,30 @@ namespace Azure.Template
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<Model>> OperationAsync(Model body = null, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.Operation");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.Operation");
             scope.Start();
             try
             {
                 using var message = CreateOperationRequest(body);
-                await pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
+                await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             Model value = default;
                             using var document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                            value = Model.DeserializeModel(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = Model.DeserializeModel(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw await clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
+                        throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(message.Response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -88,23 +95,30 @@ namespace Azure.Template
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<Model> Operation(Model body = null, CancellationToken cancellationToken = default)
         {
-            using var scope = clientDiagnostics.CreateScope("ServiceClient.Operation");
+            using var scope = _clientDiagnostics.CreateScope("ServiceClient.Operation");
             scope.Start();
             try
             {
                 using var message = CreateOperationRequest(body);
-                pipeline.Send(message, cancellationToken);
+                _pipeline.Send(message, cancellationToken);
                 switch (message.Response.Status)
                 {
                     case 200:
                         {
                             Model value = default;
                             using var document = JsonDocument.Parse(message.Response.ContentStream);
-                            value = Model.DeserializeModel(document.RootElement);
+                            if (document.RootElement.ValueKind == JsonValueKind.Null)
+                            {
+                                value = null;
+                            }
+                            else
+                            {
+                                value = Model.DeserializeModel(document.RootElement);
+                            }
                             return Response.FromValue(value, message.Response);
                         }
                     default:
-                        throw clientDiagnostics.CreateRequestFailedException(message.Response);
+                        throw _clientDiagnostics.CreateRequestFailedException(message.Response);
                 }
             }
             catch (Exception e)

--- a/sdk/template/Azure.Template/src/Generated/Operations/TemplateClient.cs
+++ b/sdk/template/Azure.Template/src/Generated/Operations/TemplateClient.cs
@@ -15,8 +15,8 @@ namespace Azure.Template
 {
     public partial class TemplateClient
     {
-        private readonly ClientDiagnostics clientDiagnostics;
-        private readonly HttpPipeline pipeline;
+        private readonly ClientDiagnostics _clientDiagnostics;
+        private readonly HttpPipeline _pipeline;
         internal ServiceRestClient RestClient { get; }
         /// <summary> Initializes a new instance of TemplateClient for mocking. </summary>
         protected TemplateClient()
@@ -26,8 +26,8 @@ namespace Azure.Template
         internal TemplateClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string host = "http://localhost:3000")
         {
             RestClient = new ServiceRestClient(clientDiagnostics, pipeline, host);
-            this.clientDiagnostics = clientDiagnostics;
-            this.pipeline = pipeline;
+            _clientDiagnostics = clientDiagnostics;
+            _pipeline = pipeline;
         }
 
         /// <param name="body"> The Model to use. </param>


### PR DESCRIPTION
Minor naming and serialization changes.
Additional CodeGenMember attributes:

- Initialize - to always initialize members see https://github.com/Azure/autorest.csharp/blob/feature/v3/test/TestProjects/SerializationCustomization/AlwaysInitializeTestClass.cs#L11

- EmptyAsUndefined to avoid serializing empty collections https://github.com/Azure/autorest.csharp/blob/feature/v3/test/TestProjects/SerializationCustomization/EmptyAsUndefinedTestModel.cs#L11

Bug fix for FormRecognizer overloads.
Time type support.