### PR TITLE
[Event Hubs Client] Additional Resiliency  For AMQP Link Creation

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
@@ -161,14 +161,14 @@ namespace Azure.Messaging.EventHubs.Amqp
 
             ReceiveLink = new FaultTolerantAmqpObject<ReceivingAmqpLink>(
                 timeout =>
-                    ConnectionScope.OpenConsumerLinkAsync(
+                   CreateConsumerLinkAsync(
                         consumerGroup,
                         partitionId,
                         CurrentEventPosition,
-                        timeout,
                         prefetchCount ?? DefaultPrefetchCount,
                         ownerLevel,
                         trackLastEnqueuedEventProperties,
+                        timeout,
                         CancellationToken.None),
                 link =>
                 {
@@ -212,7 +212,12 @@ namespace Azure.Messaging.EventHubs.Amqp
                 {
                     try
                     {
+                        // Creation of the link happens without explicit knowledge of the cancellation token
+                        // used for this operation; validate the token state before attempting link creation and
+                        // again after the operation completes to provide best efforts in respecting it.
+
                         EventHubsEventSource.Log.EventReceiveStart(EventHubName, ConsumerGroup, PartitionId);
+                        cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
                         link = await ReceiveLink.GetOrCreateAsync(UseMinimum(ConnectionScope.SessionTimeout, tryTimeout)).ConfigureAwait(false);
                         cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
@@ -305,6 +310,10 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                 throw new TaskCanceledException();
             }
+            catch (TaskCanceledException)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 EventHubsEventSource.Log.EventReceiveError(EventHubName, ConsumerGroup, PartitionId, ex.Message);
@@ -359,6 +368,52 @@ namespace Azure.Messaging.EventHubs.Amqp
             {
                 EventHubsEventSource.Log.ClientCloseComplete(clientType, EventHubName, clientId);
             }
+        }
+
+        /// <summary>
+        ///   Creates the AMQP link to be used for consumer-related operations.
+        /// </summary>
+        ///
+        /// <param name="consumerGroup">The consumer group of the Event Hub to which the link is bound.</param>
+        /// <param name="partitionId">The identifier of the Event Hub partition to which the link is bound.</param>
+        /// <param name="eventStartingPosition">The place within the partition's event stream to begin consuming events.</param>
+        /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.</param>
+        /// <param name="ownerLevel">The relative priority to associate with the link; for a non-exclusive link, this value should be <c>null</c>.</param>
+        /// <param name="trackLastEnqueuedEventProperties">Indicates whether information on the last enqueued event on the partition is sent as events are received.</param>
+        /// <param name="timeout">The timeout to apply when creating the link.</param>
+        /// <param name="cancellationToken">The cancellation token to consider when creating the link.</param>
+        ///
+        /// <returns>The AMQP link to use for consumer-related operations.</returns>
+        ///
+        private async Task<ReceivingAmqpLink> CreateConsumerLinkAsync(string consumerGroup,
+                                                                      string partitionId,
+                                                                      EventPosition eventStartingPosition,
+                                                                      uint prefetchCount,
+                                                                      long? ownerLevel,
+                                                                      bool trackLastEnqueuedEventProperties,
+                                                                      TimeSpan timeout,
+                                                                      CancellationToken cancellationToken)
+        {
+            var link = default(ReceivingAmqpLink);
+
+            try
+            {
+                link = await ConnectionScope.OpenConsumerLinkAsync(
+                    consumerGroup,
+                    partitionId,
+                    CurrentEventPosition,
+                    timeout,
+                    prefetchCount,
+                    ownerLevel,
+                    trackLastEnqueuedEventProperties,
+                    CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (InvalidOperationException ex)
+            {
+               ExceptionDispatchInfo.Capture(ex.TranslateConnectionCloseDuringLinkCreationException(EventHubName)).Throw();
+            }
+
+            return link;
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -322,10 +323,10 @@ namespace Azure.Messaging.EventHubs.Amqp
         {
             var failedAttemptCount = 0;
             var logPartition = PartitionId ?? partitionKey;
-            var retryDelay = default(TimeSpan?);
             var messageHash = default(string);
             var stopWatch = Stopwatch.StartNew();
 
+            TimeSpan? retryDelay;
             SendingAmqpLink link;
 
             try
@@ -339,7 +340,12 @@ namespace Azure.Messaging.EventHubs.Amqp
                         using AmqpMessage batchMessage = messageFactory();
                         messageHash = batchMessage.GetHashCode().ToString();
 
+                        // Creation of the link happens without explicit knowledge of the cancellation token
+                        // used for this operation; validate the token state before attempting link creation and
+                        // again after the operation completes to provide best efforts in respecting it.
+
                         EventHubsEventSource.Log.EventPublishStart(EventHubName, logPartition, messageHash);
+                        cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
                         link = await SendLink.GetOrCreateAsync(UseMinimum(ConnectionScope.SessionTimeout, tryTimeout)).ConfigureAwait(false);
                         cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
@@ -402,6 +408,10 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                 throw new TaskCanceledException();
             }
+            catch (TaskCanceledException)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 EventHubsEventSource.Log.EventPublishError(EventHubName, logPartition, messageHash, ex.Message);
@@ -437,20 +447,29 @@ namespace Azure.Messaging.EventHubs.Amqp
                                                                                             TimeSpan timeout,
                                                                                             CancellationToken cancellationToken)
         {
-            SendingAmqpLink link = await ConnectionScope.OpenProducerLinkAsync(partitionId, timeout, cancellationToken).ConfigureAwait(false);
+            var link = default(SendingAmqpLink);
 
-            if (!MaximumMessageSize.HasValue)
+            try
             {
-                // This delay is necessary to prevent the link from causing issues for subsequent
-                // operations after creating a batch.  Without it, operations using the link consistently
-                // timeout.  The length of the delay does not appear significant, just the act of introducing
-                // an asynchronous delay.
-                //
-                // For consistency the value used by the legacy Event Hubs client has been brought forward and
-                // used here.
+                link = await ConnectionScope.OpenProducerLinkAsync(partitionId, timeout, cancellationToken).ConfigureAwait(false);
 
-                await Task.Delay(15, cancellationToken).ConfigureAwait(false);
-                MaximumMessageSize = (long)link.Settings.MaxMessageSize;
+                if (!MaximumMessageSize.HasValue)
+                {
+                    // This delay is necessary to prevent the link from causing issues for subsequent
+                    // operations after creating a batch.  Without it, operations using the link consistently
+                    // timeout.  The length of the delay does not appear significant, just the act of introducing
+                    // an asynchronous delay.
+                    //
+                    // For consistency the value used by the legacy Event Hubs client has been brought forward and
+                    // used here.
+
+                    await Task.Delay(15, cancellationToken).ConfigureAwait(false);
+                    MaximumMessageSize = (long)link.Settings.MaxMessageSize;
+                }
+            }
+            catch (InvalidOperationException ex)
+            {
+               ExceptionDispatchInfo.Capture(ex.TranslateConnectionCloseDuringLinkCreationException(EventHubName)).Throw();
             }
 
             return link;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/ExceptionExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/ExceptionExtensions.cs
@@ -48,5 +48,30 @@ namespace Azure.Messaging.EventHubs.Amqp
                     return instance;
             }
         }
+
+        /// <summary>
+        ///   Considers an exception surfaced during the creation of an AMQP link, determining if the cause was a race condition
+        ///   with the connection closing and translating it into the form that should be considered for error handling decisions.
+        /// </summary>
+        ///
+        /// <param name="instance">The instance that this method was invoked on.</param>
+        /// <param name="eventHubName">The name of the Event Hub that the service operation was targeting.</param>
+        ///
+        /// <returns>The <see cref="Exception" /> that corresponds to the <paramref name="instance" /> and which represents the service error.</returns>
+        ///
+        public static Exception TranslateConnectionCloseDuringLinkCreationException(this InvalidOperationException instance,
+                                                                                    string eventHubName)
+        {
+            Argument.AssertNotNull(instance, nameof(instance));
+
+            switch (instance)
+            {
+                case InvalidOperationException _ when (instance.Message.IndexOf("when the connection is closing", StringComparison.InvariantCultureIgnoreCase) >= 0):
+                    return new EventHubsException(true, eventHubName, Resources.CouldNotCreateLink, EventHubsException.FailureReason.ServiceCommunicationProblem, instance);
+
+                default:
+                    return instance;
+            };
+        }
     }
 }


### PR DESCRIPTION
# Summary

Because of the transient nature of AMQP objects, there exists a race condition where an attempt to open a link my happen concurrently to the existing connection closing - either by cancellation or due to the service force-closing the connection due to timeout or other condition.  Currently, this failure is detected and surfaces to callers as an `InvalidOperationException` with an unclear message.

The focus of these changes is to provide resiliency in this scenario, wrapping the service exception into a form that denotes that it is safe to retry and provides
messaging that is more clear for customers.

In addition, because the factory for AMQP links is created as part of class-level state, it is not able to respect the cancellation token provided for individual operations.  This increases the possibility of observing the race condition between link creation and closing of the connection when a cancellation token is signaled.  Additional guards have been put in place to redundantly check the cancellation token before link creation to provide a better chance to respect the token.

# Last Upstream Rebase

Tuesday, April 14, 2:08pm (EDT)