### PR TITLE
[Cross-Service Samples] IoT Hub => Event Hub Connection String Translation

### DIFF
--- a/samples/iothub-connect-to-eventhubs/IotHubConnection.cs
+++ b/samples/iothub-connect-to-eventhubs/IotHubConnection.cs
@@ -1,0 +1,281 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Azure.Amqp;
+using Microsoft.Azure.Amqp.Framing;
+using Microsoft.Azure.Amqp.Sasl;
+using Microsoft.Azure.Amqp.Transport;
+using Microsoft.Azure.Devices;
+
+namespace IotHubToEventHubsSample
+{
+    /// <summary>
+    ///   A transient connection to the IoT Hub service, providing a set of utility-type operations that
+    ///   span the service client and device roles.
+    /// </summary>
+    ///
+    public static class IotHubConnection
+    {
+        /// <summary>
+        ///   Requests connection string for the built-in Event Hubs messaging endpoint of the associated IoT Hub.
+        /// </summary>
+        ///
+        /// <param name="iotHubConnectionString">The connection string for the IoT Hub instance to request the Event Hubs connection string from.</param>
+        /// <param name="timeout">The maximum amount of time that the request and translation should be allowed to take.  If not provided, a default of 60 seconds will be assumed.</param>
+        ///
+        /// <returns>A connection string which can be used to connect to the Event Hubs service and interact with the IoT Hub messaging endpoint.</returns>
+        ///
+        /// <exception cref="InvalidOperationException">The Event Hubs host information was not returned by the IoT Hub service.</exception>
+        ///
+        /// <seealso href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-endpoints" />
+        /// <seealso href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-read-builtin" />
+        /// <seealso href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-amqp-support#receive-telemetry-messages-service-client" />
+        ///
+        public static async Task<string> RequestEventHubsConnectionStringAsync(string iotHubConnectionString,
+                                                                               TimeSpan? timeout = default)
+        {
+            timeout ??= TimeSpan.FromMinutes(1);
+
+            if (string.IsNullOrEmpty(iotHubConnectionString))
+            {
+                throw new ArgumentException("The IoT Hub connection string must be provided.", nameof(iotHubConnectionString));
+            }
+
+            // Parse the connection string into the necessary components, and ensure the information is available.
+
+            var parsedConnectionString = IotHubConnectionStringBuilder.Create(iotHubConnectionString);
+            var iotHubName = parsedConnectionString.HostName?.Substring(0, parsedConnectionString.HostName.IndexOf('.'));
+
+            if ((string.IsNullOrEmpty(parsedConnectionString.HostName)) || (string.IsNullOrEmpty(parsedConnectionString.SharedAccessKeyName)) || (string.IsNullOrEmpty(parsedConnectionString.SharedAccessKey)))
+            {
+                throw new ArgumentException("The IoT Hub connection string is not valid; it must contain the host, shared access key, and shared access key name.", nameof(iotHubConnectionString));
+            }
+
+            if (string.IsNullOrEmpty(iotHubName))
+            {
+                throw new ArgumentException("Unable to parse the IoT Hub name from the connection string.", nameof(iotHubConnectionString));
+            }
+
+            // Establish the IoT Hub connection via link to the necessary endpoint, which will trigger a redirect exception
+            // from which the Event Hubs connection string can be built.
+
+            var stopWatch = Stopwatch.StartNew();
+            var serviceEndpoint = new Uri($"{ AmqpConstants.SchemeAmqps }://{ parsedConnectionString.HostName }/messages/events");
+            var connection = default(AmqpConnection);
+            var link = default(AmqpLink);
+            var eventHubsHost = default(string);
+
+            try
+            {
+                connection = await CreateAndOpenConnectionAsync(serviceEndpoint, iotHubName, parsedConnectionString.SharedAccessKeyName, parsedConnectionString.SharedAccessKey, timeout.Value).ConfigureAwait(false);
+                link = await CreateRedirectLinkAsync(connection, serviceEndpoint, timeout.Value.Subtract(stopWatch.Elapsed)).ConfigureAwait(false);
+
+                await link.OpenAsync(timeout.Value.Subtract(stopWatch.Elapsed)).ConfigureAwait(false);
+            }
+            catch (AmqpException ex)
+                when ((ex?.Error?.Condition.Value == AmqpErrorCode.LinkRedirect.Value) && (ex?.Error?.Info != null))
+            {
+                ex.Error.Info.TryGetValue("hostname", out eventHubsHost);
+            }
+            finally
+            {
+                stopWatch.Stop();
+
+                link?.Session?.SafeClose();
+                link?.SafeClose();
+                connection?.SafeClose();
+            }
+
+            // Attempt to assemble the Event Hubs connection string using the IoT Hub components.
+
+            if (string.IsNullOrEmpty(eventHubsHost))
+            {
+                throw new InvalidOperationException("The Event Hubs host was not returned by the IoT Hub service.");
+            }
+
+            return $"Endpoint=sb://{ eventHubsHost }/;EntityPath={ iotHubName };SharedAccessKeyName={ parsedConnectionString.SharedAccessKeyName };SharedAccessKey={ parsedConnectionString.SharedAccessKey }";
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to build and open a connection to the IoT Hub
+        ///   service.
+        /// </summary>
+        ///
+        /// <param name="serviceEndpoint">The endpoint of the IoT Hub service to connect to.</param>
+        /// <param name="iotHubName">The name of the IoT Hub to connect to.</param>
+        /// <param name="sharedAccessKeyName">The name of the shared access key being used for authentication.</param>
+        /// <param name="sharedAccessKey">The shared access key being used for authentication.</param>
+        /// <param name="timeout">The maximum amount of time that establishing the connection should be allowed to take.</param>
+        ///
+        /// <returns>An <see cref="AmqpConnection" /> to the requested IoT Hub.</returns>
+        ///
+        /// <seealso href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-amqp-support"/>
+        ///
+        private static async Task<AmqpConnection> CreateAndOpenConnectionAsync(Uri serviceEndpoint,
+                                                                               string iotHubName,
+                                                                               string sharedAccessKeyName,
+                                                                               string sharedAccessKey,
+                                                                               TimeSpan timeout)
+        {
+            var hostName = serviceEndpoint.Host;
+            var userName = $"{ sharedAccessKeyName }@sas.root.{ iotHubName }";
+            var signature = BuildSignature($"{ hostName }{ serviceEndpoint.AbsolutePath }", sharedAccessKeyName, sharedAccessKey, TimeSpan.FromMinutes(5));
+            var port = 5671;
+
+            // Create the layers of settings needed to establish the connection.
+
+            var amqpVersion = new Version(1, 0, 0, 0);
+
+            var tcpSettings = new TcpTransportSettings
+            {
+                Host = hostName,
+                Port = port,
+                ReceiveBufferSize = AmqpConstants.TransportBufferSize,
+                SendBufferSize = AmqpConstants.TransportBufferSize
+            };
+
+            var transportSettings = new TlsTransportSettings(tcpSettings)
+            {
+                TargetHost = hostName,
+            };
+
+            var connectionSettings = new AmqpConnectionSettings
+            {
+                IdleTimeOut = (uint)TimeSpan.FromMinutes(1).TotalMilliseconds,
+                MaxFrameSize = AmqpConstants.DefaultMaxFrameSize,
+                ContainerId = Guid.NewGuid().ToString(),
+                HostName = hostName
+            };
+
+            var saslProvider = new SaslTransportProvider();
+            saslProvider.Versions.Add(new AmqpVersion(amqpVersion));
+            saslProvider.AddHandler(new SaslPlainHandler { AuthenticationIdentity = userName, Password = signature });
+
+            var amqpProvider = new AmqpTransportProvider();
+            amqpProvider.Versions.Add(new AmqpVersion(amqpVersion));
+
+            var amqpSettings = new AmqpSettings();
+            amqpSettings.TransportProviders.Add(saslProvider);
+            amqpSettings.TransportProviders.Add(amqpProvider);
+
+            // Create and open the connection, respecting the timeout constraint
+            // that was received.
+
+            var stopWatch = Stopwatch.StartNew();
+            var initiator = new AmqpTransportInitiator(amqpSettings, transportSettings);
+            var transport = await initiator.ConnectTaskAsync(timeout).ConfigureAwait(false);
+
+            try
+            {
+                var connection = new AmqpConnection(transport, amqpSettings, connectionSettings);
+                await connection.OpenAsync(timeout.Subtract(stopWatch.Elapsed)).ConfigureAwait(false);
+
+                return connection;
+            }
+            catch
+            {
+                transport.Abort();
+                throw;
+            }
+            finally
+            {
+                stopWatch.Stop();
+            }
+        }
+
+        /// <summary>
+        ///   Creates the AMQP link used to trigger a redirection response from the
+        ///   IoT Hub service.
+        /// </summary>
+        ///
+        /// <param name="connection">The connection to the IoT Hub service to associate the link with.</param>
+        /// <param name="serviceEndpoint">The endpoint of the IoT Hub service that the connection was made to.</param>
+        /// <param name="timeout">The maximum amount of time that creating the link should be allowed to take.</param>
+        ///
+        /// <returns>An <see cref="AmqpLink" /> to an IoT Hub resource that will trigger redirection when opened.</returns>
+        ///
+        /// <remarks>
+        ///   The link is not opened by this method; callers are required to open the link in order to trigger
+        ///   the redirection error.
+        /// </remarks>
+        ///
+        /// <seealso href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-amqp-support"/>
+        ///
+        private static async Task<AmqpLink> CreateRedirectLinkAsync(AmqpConnection connection,
+                                                                    Uri serviceEndpoint,
+                                                                    TimeSpan timeout)
+        {
+            var linkPath = $"{ serviceEndpoint.AbsolutePath }/$management";
+            var session = default(AmqpSession);
+
+            try
+            {
+                var sessionSettings = new AmqpSessionSettings { Properties = new Fields() };
+                session = connection.CreateSession(sessionSettings);
+
+                await session.OpenAsync(timeout).ConfigureAwait(false);
+
+                var linkSettings = new AmqpLinkSettings
+                {
+                    Role = true,
+                    TotalLinkCredit = 1,
+                    AutoSendFlow = true,
+                    SettleType = SettleMode.SettleOnSend,
+                    Source = new Source { Address = linkPath },
+                    Target = new Target { Address = serviceEndpoint.AbsoluteUri }
+                };
+
+                var link = new ReceivingAmqpLink(linkSettings);
+                linkSettings.LinkName = $"{ nameof(IotHubConnection) };{ connection.Identifier }:{ session.Identifier }:{ link.Identifier }";
+                link.AttachTo(session);
+
+                return link;
+            }
+            catch
+            {
+                session?.Abort();
+                throw;
+            }
+        }
+        /// <summary>
+        ///   Builds a shared access signature to use for authentication with the IoT Hub
+        ///   service.
+        /// </summary>
+        ///
+        /// <param name="resourceUri">The address of the resource the signature is intended to authenticate for.</param>
+        /// <param name="keyName">Name of the shared access key to base the signature on.</param>
+        /// <param name="keyValue">The value of the shared access key to base the signature on.</param>
+        /// <param name="validityDuration">The amount of time that the signature should be considered valid; after this time a new signature would be needed.</param>
+        ///
+        /// <returns>The shared access signature, encoded and suitable for use as a credential in service communication.</returns>
+        ///
+        /// <seealso href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-security#security-tokens" />
+        ///
+        private static string BuildSignature(string resourceUri,
+                                             string keyName,
+                                             string keyValue,
+                                             TimeSpan validityDuration)
+        {
+            using var hmac = new HMACSHA256(Convert.FromBase64String(keyValue));
+
+            var epoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            var expirationTime = Convert.ToInt64((DateTimeOffset.UtcNow.Add(validityDuration) - epoch).TotalSeconds);
+            var encodedAudience = WebUtility.UrlEncode(resourceUri);
+            var expiration = Convert.ToString(expirationTime, CultureInfo.InvariantCulture);
+            var signature = Convert.ToBase64String(hmac.ComputeHash(Encoding.UTF8.GetBytes($"{ encodedAudience }\n{ expiration }")));
+
+            return string.Format(CultureInfo.InvariantCulture, "SharedAccessSignature sr={0}&sig={1}&se={2}&skn={3}",
+                encodedAudience,
+                WebUtility.UrlEncode(signature),
+                WebUtility.UrlEncode(expiration),
+                WebUtility.UrlEncode(keyName));
+        }
+    }
+}

--- a/samples/iothub-connect-to-eventhubs/IotHubToEventHubsSample.csproj
+++ b/samples/iothub-connect-to-eventhubs/IotHubToEventHubsSample.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="README.md" />
+    <None Remove="sample-resources.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.3" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.20.1" />
+  </ItemGroup>
+</Project>

--- a/samples/iothub-connect-to-eventhubs/IotHubToEventHubsSample.sln
+++ b/samples/iothub-connect-to-eventhubs/IotHubToEventHubsSample.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29709.97
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IotHubToEventHubsSample", "IotHubToEventHubsSample.csproj", "{4FCB4E25-9C31-4F79-B0A7-16E03A15F949}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4FCB4E25-9C31-4F79-B0A7-16E03A15F949}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4FCB4E25-9C31-4F79-B0A7-16E03A15F949}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4FCB4E25-9C31-4F79-B0A7-16E03A15F949}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4FCB4E25-9C31-4F79-B0A7-16E03A15F949}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {78FCF9C4-3E40-446A-A112-F7412465BE44}
+	EndGlobalSection
+EndGlobal

--- a/samples/iothub-connect-to-eventhubs/Program.cs
+++ b/samples/iothub-connect-to-eventhubs/Program.cs
@@ -1,0 +1,91 @@
+﻿
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Consumer;
+
+namespace IotHubToEventHubsSample
+{
+    /// <summary>
+    ///   Serves as the main entry point for the application.
+    /// </summary>
+    ///
+    public static class Program
+    {
+        /// <summary>
+        ///   The method invoked as the main entry point for execution.
+        /// </summary>
+        ///
+        /// <param name="args">The arguments passed to the application on the command line.</param>
+        ///
+        /// <remarks>
+        ///   If arguments are passed, the first argument is assumed to be the IoT Hub connection string; the rest
+        ///   are ignored.  If no arguments were present, an interactive prompt will collect the IoT Hub connection.
+        /// </remarks>
+        ///
+        public static async Task Main(string[] args)
+        {
+            var connectionString = default(string);
+
+            try
+            {
+                // If there were arguments passed, assume the first is the connection string.
+
+                if (args.Length > 0)
+                {
+                    connectionString = args[0];
+                }
+
+                // If there was no connection string provided, then prompt for one.
+
+                while (string.IsNullOrEmpty(connectionString))
+                {
+                    Console.Write("Please provide the connection string for the IoT Hub that you'd like to use and then press Enter: ");
+                    connectionString = Console.ReadLine().Trim();
+                    Console.WriteLine();
+                }
+
+                // Translate the connection string.
+
+                Console.WriteLine();
+                Console.WriteLine("Requesting Event Hubs connection string...");
+                var eventHubsConnectionString = await IotHubConnection.RequestEventHubsConnectionStringAsync(connectionString);
+
+                Console.WriteLine("Connection string obtained.  Connecting to Event Hubs...");
+                await using var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, eventHubsConnectionString);
+
+                // Read events from any partition of the Event Hub; once no events are read after a couple of seconds, stop
+                // reading.
+
+                Console.WriteLine();
+                Console.WriteLine("Reading events...");
+                var consecutiveEmpties = 0;
+
+                await foreach (var partitionEvent in consumer.ReadEventsAsync(new ReadEventOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(500) }))
+                {
+                    if (partitionEvent.Data != null)
+                    {
+                        Console.WriteLine($"\tRead an event from partition { partitionEvent.Partition.PartitionId }");
+                        consecutiveEmpties = 0;
+                    }
+                    else if (++consecutiveEmpties > 5)
+                    {
+                        Console.WriteLine("\tNo events are available. No longer reading...");
+                        break;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"An exception of type { ex.GetType().Name } occurred.  Message:");
+                Console.WriteLine($"\t{ ex.Message }");
+            }
+
+            Console.WriteLine();
+            Console.WriteLine();
+            Console.WriteLine("Exiting...");
+        }
+    }
+}

--- a/samples/iothub-connect-to-eventhubs/README.md
+++ b/samples/iothub-connect-to-eventhubs/README.md
@@ -1,0 +1,39 @@
+---
+page_type: sample
+languages:
+- csharp
+products:
+- azure
+- azure-iot-hub
+- azure-event-hubs
+urlFragment: iothub-connect-to-eventhubs
+name: How to request the IoT Hub built-in Event Hubs-compatible endpoint connection string
+description: This sample illustrates the flow of querying an IoT instance to obtain a connection string that can be used with the Event Hub instance to which IoT Hub is currently publishing as its "built-in" endpoint.
+---
+# How to request the IoT Hub built-in Event Hubs-compatible endpoint connection string
+
+IoT Hub is a managed service that acts as a central message hub for bi-directional communication between an IoT application and the devices it manages. IoT Hub supports communications both from the device to the cloud and from the cloud to the device. IoT Hub supports multiple messaging patterns and may be integrated with other Azure services to build complete, end-to-end solutions.
+
+A common pattern is for users of IoT Hub to consume information from an Event Hub instance that is provisioned and owned by the IoT Hub service. The [IoT Hub documentation](https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-endpoints) refers to this Event Hub instance as the "built-in Event Hub-compatible endpoint that IoT Hub exposes", making it an important part of the IoT Hub story.  One of the features supported by IoT Hub is a fail-over scenario, which may be initiated by customers, and which is likely to result in IoT Hub changing the Event Hub instance to which it publishes events. Because this Event Hub instance association is owned by IoT Hub, developers cannot assume a static connection string to access it, but instead must query the IoT Hub service for the active instance.
+
+This sample illustrates querying the IoT Hub service to obtain the connection string of the Event Hub instance to which IoT Hub is currently publishing as its "built-in" endpoint.
+
+## Getting started
+
+- **Azure Subscription:**  To use Azure services, including Azure Event Hubs, you'll need a subscription.  If you do not have an existing Azure account, you may sign up for a [free trial](https://azure.microsoft.com/free) or use your [Visual Studio Subscription](https://visualstudio.microsoft.com/subscriptions/) benefits when you [create an account](https://account.windowsazure.com/Home/Index).
+
+- **.NET Core 3.1:** This sample targets [.NET Core 3.1](https://docs.microsoft.com/dotnet/standard/frameworks#how-to-specify-target-frameworks) and makes use of language features that were introduced in C# 8.0.  In order to build and run the sample without modifications, you will need the [.NET Core SDK](https://dotnet.microsoft.com/download) available.  If you are using Visual Studio, versions prior to Visual Studio 2019 are not compatible with the tools needed to build C# 8.0 projects nor target .NET Core 3.1.  Visual Studio 2019, including the free Community edition, can be downloaded [here](https://visualstudio.microsoft.com/vs/).
+
+- **IoT Hub:** To interact with Azure IoT Hub, you'll also need to have an IoT Hub instance available.  If you are not familiar with creating Azure resources, you may wish to follow the step-by-step guide for [creating an IoT hub using the Azure portal](https://docs.microsoft.com/azure/iot-hub/iot-hub-create-through-portal).  There, you can also find detailed instructions for using the [Azure CLI](https://docs.microsoft.com/azure/iot-hub/iot-hub-create-using-cli), [Azure PowerShell](https://docs.microsoft.com/azure/iot-hub/iot-hub-create-using-powershell), or [Azure Resource Manager (ARM) templates](https://docs.microsoft.com/azure/iot-hub/iot-hub-rm-template-powershell) to create an IoT Hub.
+
+To quickly create the needed IoT Hub resource in Azure and to receive a connection string for it, you can deploy our sample template by clicking:
+
+[![](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fgithub.com%2FAzure%2Fazure-sdk-for-net%2Ftree%2Fmaster%2Fsamples%2F%2Fiothub-connect-to-eventhubs%2Fsample-resources.json)
+
+## References
+
+- [What is Azure IoT Hub?](https://docs.microsoft.com/azure/iot-hub/about-iot-hub)
+- [IoT Hub - Endpoints documentation](https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-endpoints)
+- [IoT Hub - Read device-to-cloud messages from the built-in endpoint](https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messages-read-builtin)
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsamples%2F%2Fiothub-connect-to-eventhubs%2FREADME.png)

--- a/samples/iothub-connect-to-eventhubs/sample-resources.json
+++ b/samples/iothub-connect-to-eventhubs/sample-resources.json
@@ -1,0 +1,45 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "hubname": {
+            "type": "string"
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]"
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "apiVersion": "2020-03-01",
+            "type": "Microsoft.Devices/IotHubs",
+            "name": "[parameters('hubname')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "eventHubEndpoints": {
+                    "events": {
+                        "retentionTimeInDays": 1,
+                        "partitionCount": "4"
+                    }
+                },
+                "features": "None"
+            },
+            "sku": {
+                "name": "B1",
+                "capacity": "5"
+            }
+        }
+    ],
+    "outputs": {
+        "IoTHubConnectionString": {
+            "type": "string",
+            "value": "[concat('HostName=', reference(resourceId('Microsoft.Devices/IoTHubs', parameters('hubname')), providers('Microsoft.Devices', 'IoTHubs').apiVersions[0]).hostName, ';SharedAccessKeyName=iothubowner;SharedAccessKey=', listKeys(resourceId('Microsoft.Devices/IotHubs', parameters('hubname')), providers('Microsoft.Devices', 'IoTHubs').apiVersions[0]).value[0].primaryKey)]"
+        },
+        "IoTHubName": {
+            "type": "string",
+            "value": "[parameters('hubname')]"
+        }
+    }
+}


### PR DESCRIPTION
# Summary

The focus of these changes is to introduce a new sample that illustrates how to query IoT Hub for the connection string to its "built-in Event Hub endpoint" used
for sharing device telemetry.

**Note:** These changes do not include integration into the nightly smoke tests; this will follow as an independent unit of work.

# Last Upstream Rebase

Thursday, April 16, 11:36am (EDT)

# References and Related Issues 

- [IoT Hub Connection String Translation Sample](https://github.com/Azure/azure-sdk-for-net/issues/11072) (#11072)
- [IoT Hub: Connection String Translator Proposal](https://gist.github.com/jsquire/189ab66346407c7453600e0f43074190)