### PR TITLE
Remove setting FileSystemId property, that is to be removed

### DIFF
--- a/sdk/netapp/Microsoft.Azure.Management.NetApp/tests/Helpers/ResourceUtils.cs
+++ b/sdk/netapp/Microsoft.Azure.Management.NetApp/tests/Helpers/ResourceUtils.cs
@@ -210,7 +210,6 @@ namespace NetApp.Tests.Helpers
                 snapshot = new Snapshot
                 {
                     Location = location,
-                    FileSystemId = volume?.FileSystemId
                 };
             }
             else


### PR DESCRIPTION
Remove line from tests where we are setting value of FileSystemID property in Snapshot. 
This property is to be removed in the next api version 2020-02-01 and this line causes test pipeline to fail on https://github.com/Azure/azure-rest-api-specs/pull/8986 due to it trying to set this property that does not exist.