### PR TITLE
Increase duration of OnMessageExceptionHandlerCalled to make more reliable

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
@@ -283,7 +283,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
         }
 
         [Test]
-        public async Task OnMessageExceptionHandlerCalledTest()
+        public async Task OnMessageExceptionHandlerCalled()
         {
             var invalidQueueName = "nonexistentqueuename";
             var exceptionReceivedHandlerCalled = false;
@@ -324,7 +324,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
             {
                 await processor.StartProcessingAsync();
                 var stopwatch = Stopwatch.StartNew();
-                while (stopwatch.Elapsed.TotalSeconds <= 10)
+                while (stopwatch.Elapsed.TotalSeconds <= 20)
                 {
                     if (exceptionReceivedHandlerCalled)
                     {


### PR DESCRIPTION
Attempting to fix https://dev.azure.com/azure-sdk/internal/_build/results?buildId=357301&view=ms.vss-test-web.build-test-results-tab&runId=10265842&resultId=100043&paneView=debug