### PR TITLE
Include tracking ID in exceptions

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpExceptionHelper.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpExceptionHelper.cs
@@ -1,19 +1,19 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Azure.Amqp;
+using Microsoft.Azure.Amqp.Encoding;
+using Microsoft.Azure.Amqp.Framing;
+
 namespace Azure.Messaging.ServiceBus.Amqp
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Globalization;
-    using System.IO;
-    using System.Net.Sockets;
-    using System.Text;
-    using System.Threading.Tasks;
-    using Microsoft.Azure.Amqp;
-    using Microsoft.Azure.Amqp.Encoding;
-    using Microsoft.Azure.Amqp.Framing;
-
     internal static class AmqpExceptionHelper
     {
         private static readonly Dictionary<string, AmqpResponseStatusCode> s_conditionToStatusMap = new Dictionary<string, AmqpResponseStatusCode>
@@ -76,9 +76,9 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
         public static Exception ToMessagingContractException(this AmqpMessage responseMessage, AmqpResponseStatusCode statusCode)
         {
-            AmqpSymbol errorCondition = AmqpExceptionHelper.GetResponseErrorCondition(responseMessage, statusCode);
+            AmqpSymbol errorCondition = GetResponseErrorCondition(responseMessage, statusCode);
             var statusDescription = responseMessage.ApplicationProperties.Map[ManagementConstants.Response.StatusDescription] as string ?? errorCondition.Value;
-            return AmqpExceptionHelper.ToMessagingContractException(errorCondition.Value, statusDescription);
+            return ToMessagingContractException(errorCondition.Value, statusDescription);
         }
 
         public static Exception ToMessagingContractException(this Error error, bool connectionError = false)
@@ -239,7 +239,9 @@ namespace Azure.Messaging.ServiceBus.Amqp
         public static string GetTrackingId(this AmqpLink link)
         {
             if (link.Settings.Properties != null &&
-                link.Settings.Properties.TryGetValue<string>(AmqpClientConstants.TrackingIdName, out var trackingContext))
+                link.Settings.Properties.TryGetValue<string>(
+                    AmqpClientConstants.TrackingIdName,
+                    out var trackingContext))
             {
                 return trackingContext;
             }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -142,24 +142,23 @@ namespace Azure.Messaging.ServiceBus.Amqp
                         sessionId: sessionId,
                         isSessionReceiver: isSessionReceiver,
                         cancellationToken: CancellationToken.None),
-                link =>
-                {
-                    CloseLink(link);
-                });
+                link => CloseLink(link));
 
             _managementLink = new FaultTolerantAmqpObject<RequestResponseAmqpLink>(
                 timeout => _connectionScope.OpenManagementLinkAsync(
                     _entityPath,
                     timeout,
                     CancellationToken.None),
-                link =>
-                {
-                    link.Session?.SafeClose();
-                    link.SafeClose();
-                });
+                link => CloseLink(link));
         }
 
         private void CloseLink(ReceivingAmqpLink link)
+        {
+            link.Session?.SafeClose();
+            link.SafeClose();
+        }
+
+        private void CloseLink(RequestResponseAmqpLink link)
         {
             link.Session?.SafeClose();
             link.SafeClose();
@@ -215,44 +214,53 @@ namespace Azure.Messaging.ServiceBus.Amqp
             var link = default(ReceivingAmqpLink);
             var amqpMessages = default(IEnumerable<AmqpMessage>);
             var receivedMessages = new List<ServiceBusReceivedMessage>();
-
             var stopWatch = Stopwatch.StartNew();
 
-            link = await _receiveLink.GetOrCreateAsync(UseMinimum(_connectionScope.SessionTimeout, timeout)).ConfigureAwait(false);
-            cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
-
-            var messagesReceived = await Task.Factory.FromAsync
-            (
-                (callback, state) => link.BeginReceiveRemoteMessages(
-                    maxMessages,
-                    TimeSpan.FromMilliseconds(20),
-                    maxWaitTime ?? timeout,
-                    callback,
-                    state),
-                (asyncResult) => link.EndReceiveMessages(asyncResult, out amqpMessages),
-                TaskCreationOptions.RunContinuationsAsynchronously
-            ).ConfigureAwait(false);
-
-            cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
-
-            // If event messages were received, then package them for consumption and
-            // return them.
-
-            if ((messagesReceived) && (amqpMessages != null))
+            try
             {
-                foreach (AmqpMessage message in amqpMessages)
-                {
-                    if (_receiveMode == ReceiveMode.ReceiveAndDelete)
-                    {
-                        link.DisposeDelivery(message, true, AmqpConstants.AcceptedOutcome);
-                    }
-                    receivedMessages.Add(AmqpMessageConverter.AmqpMessageToSBMessage(message));
-                    message.Dispose();
-                }
-            }
+                link = await _receiveLink.GetOrCreateAsync(UseMinimum(_connectionScope.SessionTimeout, timeout)).ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
-            stopWatch.Stop();
-            return receivedMessages;
+                var messagesReceived = await Task.Factory.FromAsync
+                (
+                    (callback, state) => link.BeginReceiveRemoteMessages(
+                        maxMessages,
+                        TimeSpan.FromMilliseconds(20),
+                        maxWaitTime ?? timeout,
+                        callback,
+                        state),
+                    (asyncResult) => link.EndReceiveMessages(asyncResult, out amqpMessages),
+                    TaskCreationOptions.RunContinuationsAsynchronously
+                ).ConfigureAwait(false);
+
+                cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+                // If event messages were received, then package them for consumption and
+                // return them.
+
+                if ((messagesReceived) && (amqpMessages != null))
+                {
+                    foreach (AmqpMessage message in amqpMessages)
+                    {
+                        if (_receiveMode == ReceiveMode.ReceiveAndDelete)
+                        {
+                            link.DisposeDelivery(message, true, AmqpConstants.AcceptedOutcome);
+                        }
+                        receivedMessages.Add(AmqpMessageConverter.AmqpMessageToSBMessage(message));
+                        message.Dispose();
+                    }
+                }
+
+                stopWatch.Stop();
+                return receivedMessages;
+            }
+            catch (Exception exception)
+            {
+                throw AmqpExceptionHelper.TranslateException(
+                    exception,
+                    link?.GetTrackingId(),
+                    null,
+                    link?.IsClosing() ?? false);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Adds the tracking ID to exceptions generated from send/receive/schedule/cancel scheduled to match what is done in Track 1.