### PR TITLE
[Event Hubs Client] Assorted Small Improvements

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
@@ -28,6 +28,9 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// <summary>The default prefetch count to use for the consumer.</summary>
         private const uint DefaultPrefetchCount = 300;
 
+        /// <summary>An empty set of events which can be dispatched when no events are available.</summary>
+        private static readonly IReadOnlyList<EventData> EmptyEventSet = Array.Empty<EventData>();
+
         /// <summary>Indicates whether or not this instance has been closed.</summary>
         private bool _closed = false;
 
@@ -267,7 +270,7 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                         // No events were available.
 
-                        return new List<EventData>(0);
+                        return EmptyEventSet;
                     }
                     catch (EventHubsException ex) when (ex.Reason == EventHubsException.FailureReason.ServiceTimeout)
                     {
@@ -275,7 +278,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                         // amount of time to wait for events, a timeout isn't considered an error condition,
                         // rather a sign that no events were available in the requested period.
 
-                        return new List<EventData>(0);
+                        return EmptyEventSet;
                     }
                     catch (Exception ex)
                     {
@@ -406,7 +409,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                     prefetchCount,
                     ownerLevel,
                     trackLastEnqueuedEventProperties,
-                    CancellationToken.None).ConfigureAwait(false);
+                    cancellationToken).ConfigureAwait(false);
             }
             catch (InvalidOperationException ex)
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -276,5 +276,27 @@ namespace Azure.Messaging.EventHubs
         ///
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override string ToString() => base.ToString();
+
+        /// <summary>
+        ///   Creates a new copy of the current <see cref="EventData" />, cloning its attributes into a new instance.
+        /// </summary>
+        ///
+        /// <returns>A new copy of <see cref="EventData" />.</returns>
+        ///
+        internal EventData Clone() =>
+            new EventData
+            (
+                Body,
+                new Dictionary<string, object>(Properties),
+                SystemProperties,
+                SequenceNumber,
+                Offset,
+                EnqueuedTime,
+                PartitionKey,
+                LastPartitionSequenceNumber,
+                LastPartitionOffset,
+                LastPartitionEnqueuedTime,
+                LastPartitionPropertiesRetrievalTime
+            );
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
@@ -130,19 +130,14 @@ namespace Azure.Messaging.EventHubs.Producer
             {
                 AssertNotLocked();
 
-                bool instrumented = EventDataInstrumentation.InstrumentEvent(eventData, FullyQualifiedNamespace, EventHubName);
-                bool added = InnerBatch.TryAdd(eventData);
+                eventData = eventData.Clone();
+                EventDataInstrumentation.InstrumentEvent(eventData, FullyQualifiedNamespace, EventHubName);
 
-                if (added)
+                var added = InnerBatch.TryAdd(eventData);
+
+                if ((added) && (EventDataInstrumentation.TryExtractDiagnosticId(eventData, out string diagnosticId)))
                 {
-                    if (EventDataInstrumentation.TryExtractDiagnosticId(eventData, out string diagnosticId))
-                    {
-                        EventDiagnosticIdentifiers.Add(diagnosticId);
-                    }
-                }
-                else if (instrumented)
-                {
-                    EventDataInstrumentation.ResetEvent(eventData);
+                    EventDiagnosticIdentifiers.Add(diagnosticId);
                 }
 
                 return added;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -480,9 +480,9 @@ namespace Azure.Messaging.EventHubs.Producer
             Argument.AssertNotNull(eventBatch, nameof(eventBatch));
             AssertSinglePartitionReference(eventBatch.SendOptions.PartitionId, eventBatch.SendOptions.PartitionKey);
 
-            int attempts = 0;
             using DiagnosticScope scope = CreateDiagnosticScope(eventBatch.GetEventDiagnosticIdentifiers());
 
+            var attempts = 0;
             var pooledProducer = PartitionProducerPool.GetPooledProducer(eventBatch.SendOptions.PartitionId, PartitionProducerLifespan);
 
             while (!cancellationToken.IsCancellationRequested)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventDataTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/EventDataTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework;
 
@@ -51,6 +52,34 @@ namespace Azure.Messaging.EventHubs.Tests
             var streamData = bodyStream.ToArray();
             Assert.That(streamData, Is.Not.Null, "There should have been data in the stream.");
             Assert.That(streamData.Length, Is.EqualTo(0), "The stream should have contained no data.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventData.Clone" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CloneProducesACopy()
+        {
+            var sourceEvent = new EventData(
+                new byte[] { 0x21, 0x22 },
+                new Dictionary<string, object> { {"Test", 123 } },
+                new Dictionary<string, object> { { "System", "Hello" }},
+                33334444,
+                666777,
+                DateTimeOffset.Parse("2015-10-27T00:00:00Z"),
+                "TestKey",
+                111222,
+                999888,
+                DateTimeOffset.Parse("2012-03-04T09:00:00Z"),
+                DateTimeOffset.Parse("2003-09-27T15:00:00Z"));
+
+            var clone = sourceEvent.Clone();
+            Assert.That(clone, Is.Not.Null, "The clone should not be null.");
+            Assert.That(clone.IsEquivalentTo(sourceEvent, true), Is.True, "The clone should be equivalent to the source event.");
+            Assert.That(clone, Is.Not.SameAs(sourceEvent), "The clone should be a distinct reference.");
+            Assert.That(object.ReferenceEquals(clone.Properties, sourceEvent.Properties), Is.False, "The clone's property bag should be a distinct reference.");
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
@@ -15,7 +15,6 @@ using Azure.Messaging.EventHubs.Diagnostics;
 using Azure.Messaging.EventHubs.Primitives;
 using Azure.Messaging.EventHubs.Producer;
 using Moq;
-using Moq.Protected;
 using NUnit.Framework;
 
 namespace Azure.Messaging.EventHubs.Tests
@@ -92,18 +91,21 @@ namespace Azure.Messaging.EventHubs.Tests
             using var testListener = new ClientDiagnosticListener(EventDataInstrumentation.DiagnosticNamespace);
             var activity = new Activity("SomeActivity").Start();
 
+            var eventCount = 0;
             var eventHubName = "SomeName";
             var endpoint = "endpoint";
+            var batchEvent = default(EventData);
             var fakeConnection = new MockConnection(endpoint, eventHubName);
-            var eventCount = 0;
             var batchTransportMock = new Mock<TransportEventBatch>();
+
 
             batchTransportMock
                 .Setup(m => m.TryAdd(It.IsAny<EventData>()))
+                .Callback<EventData>(addedEvent => batchEvent = addedEvent)
                 .Returns(() =>
                 {
                     eventCount++;
-                    return eventCount <= 3;
+                    return eventCount <= 1;
                 });
 
             var transportMock = new Mock<TransportProducer>();
@@ -119,11 +121,10 @@ namespace Azure.Messaging.EventHubs.Tests
             var producer = new EventHubProducerClient(fakeConnection, transportMock.Object);
 
             var eventData = new EventData(ReadOnlyMemory<byte>.Empty);
-            EventDataBatch batch = await producer.CreateBatchAsync();
+            var batch = await producer.CreateBatchAsync();
             Assert.True(batch.TryAdd(eventData));
 
             await producer.SendAsync(batch);
-
             activity.Stop();
 
             ClientDiagnosticListener.ProducedDiagnosticScope sendScope = testListener.AssertScope(DiagnosticProperty.ProducerActivityName,
@@ -136,7 +137,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 new KeyValuePair<string, string>(DiagnosticProperty.EventHubAttribute, eventHubName),
                 new KeyValuePair<string, string>(DiagnosticProperty.EndpointAttribute, endpoint));
 
-            Assert.That(eventData.Properties[DiagnosticProperty.DiagnosticIdAttribute], Is.EqualTo(messageScope.Activity.Id), "The diagnostics identifier should match.");
+            Assert.That(batchEvent.Properties[DiagnosticProperty.DiagnosticIdAttribute], Is.EqualTo(messageScope.Activity.Id), "The diagnostics identifier should match.");
             Assert.That(messageScope.Activity, Is.Not.SameAs(sendScope.Activity), "The activities should not be the same instance.");
             Assert.That(sendScope.Activity.ParentId, Is.EqualTo(activity.Id), "The send scope's parent identifier should match the activity in the active scope.");
             Assert.That(messageScope.Activity.ParentId, Is.EqualTo(activity.Id), "The message scope's parent identifier should match the activity in the active scope.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventDataBatchTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventDataBatchTests.cs
@@ -111,7 +111,24 @@ namespace Azure.Messaging.EventHubs.Tests
             var eventData = new EventData(new byte[] { 0x21 });
 
             Assert.That(batch.TryAdd(eventData), Is.True, "The event should have been accepted.");
-            Assert.That(mockBatch.TryAddCalledWith, Is.SameAs(eventData), "The event data should have been passed with delegation.");
+            Assert.That(mockBatch.TryAddCalledWith.IsEquivalentTo(eventData), Is.True, "The event data should have been passed with delegation.");
+        }
+
+        /// <summary>
+        ///   Verifies property accessors for the <see cref="EventDataBatch.TryAdd" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void TryAddClonesTheEvent()
+        {
+            var mockBatch = new MockTransportBatch();
+            var batch = new EventDataBatch(mockBatch, "ns", "eh", new SendEventOptions());
+            var eventData = new EventData(new byte[] { 0x21 });
+
+            Assert.That(batch.TryAdd(eventData), Is.True, "The event should have been accepted.");
+            Assert.That(mockBatch.TryAddCalledWith.IsEquivalentTo(eventData), Is.True, "The event data should have been passed with delegation.");
+            Assert.That(mockBatch.TryAddCalledWith, Is.Not.SameAs(eventData), "The event data should have been cloned.");
         }
 
         /// <summary>


### PR DESCRIPTION
# Summary

The focus of these changes is to collect a set of smaller miscellaneous changes to improve performance and ensure data integrity.  The prominent changes are:

  - Centralized an empty read-only set of events to be returned when an attempt to read finds no events in the partition; previously, a new set was allocated for each call.

  - Making a shallow copy of an event when added to a batch to ensure that changes made to the event's property bag while the event is in a batch does not result in the ability to exceed the size of the batch.

# Last Upstream Rebase

Friday, April 174, 2:43pm (EDT)