### PR TITLE
[EventHubs] Use Invariant vs Current culture

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Storage/BlobsCheckpointStore.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Storage/BlobsCheckpointStore.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -288,11 +289,11 @@ namespace Azure.Messaging.EventHubs.Processor
                     var partitionId = blob.Name.Substring(prefix.Length);
                     var startingPosition = default(EventPosition?);
 
-                    if (blob.Metadata.TryGetValue(BlobMetadataKey.Offset, out var str) && long.TryParse(str, out var result))
+                    if (blob.Metadata.TryGetValue(BlobMetadataKey.Offset, out var str) && long.TryParse(str, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result))
                     {
                         startingPosition = EventPosition.FromOffset(result, false);
                     }
-                    else if (blob.Metadata.TryGetValue(BlobMetadataKey.SequenceNumber, out str) && long.TryParse(str, out result))
+                    else if (blob.Metadata.TryGetValue(BlobMetadataKey.SequenceNumber, out str) && long.TryParse(str, NumberStyles.Integer, CultureInfo.InvariantCulture, out result))
                     {
                         startingPosition = EventPosition.FromSequenceNumber(result, false);
                     }
@@ -363,8 +364,8 @@ namespace Azure.Messaging.EventHubs.Processor
 
             var metadata = new Dictionary<string, string>()
             {
-                { BlobMetadataKey.Offset, eventData.Offset.ToString() },
-                { BlobMetadataKey.SequenceNumber, eventData.SequenceNumber.ToString() }
+                { BlobMetadataKey.Offset, eventData.Offset.ToString(CultureInfo.InvariantCulture) },
+                { BlobMetadataKey.SequenceNumber, eventData.SequenceNumber.ToString(CultureInfo.InvariantCulture) }
             };
 
             Func<CancellationToken, Task> updateCheckpointAsync = async updateCheckpointToken =>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Authorization/SharedAccessSignature.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Authorization/SharedAccessSignature.cs
@@ -289,7 +289,7 @@ namespace Azure.Messaging.EventHubs.Authorization
                     }
                     else if (string.Compare(SignedExpiryToken, token, StringComparison.OrdinalIgnoreCase) == 0)
                     {
-                        if (!long.TryParse(WebUtility.UrlDecode(value), out var unixTime))
+                        if (!long.TryParse(WebUtility.UrlDecode(value), NumberStyles.Integer, CultureInfo.InvariantCulture, out var unixTime))
                         {
                             throw new ArgumentException(Resources.InvalidSharedAccessSignature, nameof(sharedAccessSignature));
                         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpMessageConverter.cs
@@ -231,7 +231,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                 (bool)responseData[AmqpManagement.ResponseMap.PartitionRuntimeInfoPartitionIsEmpty],
                 (long)responseData[AmqpManagement.ResponseMap.PartitionBeginSequenceNumber],
                 (long)responseData[AmqpManagement.ResponseMap.PartitionLastEnqueuedSequenceNumber],
-                long.Parse((string)responseData[AmqpManagement.ResponseMap.PartitionLastEnqueuedOffset]),
+                long.Parse((string)responseData[AmqpManagement.ResponseMap.PartitionLastEnqueuedOffset], NumberStyles.Integer, CultureInfo.InvariantCulture),
                 new DateTimeOffset((DateTime)responseData[AmqpManagement.ResponseMap.PartitionLastEnqueuedTimeUtc], TimeSpan.Zero));
         }
 
@@ -422,7 +422,7 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                 if ((annotations.TryGetValue(AmqpProperty.Offset, out amqpValue))
                     && (TryCreateEventPropertyForAmqpProperty(amqpValue, out propertyValue))
-                    && (long.TryParse((string)propertyValue, out var offset)))
+                    && (long.TryParse((string)propertyValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var offset)))
                 {
                     systemProperties.Offset = offset;
                     processed.Add(AmqpProperty.Offset.ToString());
@@ -473,7 +473,7 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                 if ((source.DeliveryAnnotations.Map.TryGetValue(AmqpProperty.PartitionLastEnqueuedOffset, out amqpValue))
                     && (TryCreateEventPropertyForAmqpProperty(amqpValue, out propertyValue))
-                    && (long.TryParse((string)propertyValue, out var offset)))
+                    && (long.TryParse((string)propertyValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var offset)))
                 {
                     systemProperties.LastOffset = offset;
                 }


### PR DESCRIPTION
By default, the `.Parse` and `.TryParse` methods, as well as `.ToString`
use the current culture. In some of our uses, we don't want to the
behavior to differ based on the culture of the local machine.