### PR TITLE
Fix Key Vault live tests

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample3_GetKeys.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample3_GetKeys.cs
@@ -50,6 +50,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
             IEnumerable<KeyProperties> keys = client.GetPropertiesOfKeys();
             foreach (KeyProperties key in keys)
             {
+                /*@@*/ if (key.Managed) continue;
                 KeyVaultKey keyWithType = client.GetKey(key.Name);
                 Debug.WriteLine($"Key is returned with name {keyWithType.Name} and type {keyWithType.KeyType}");
             }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample3_GetKeysAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/samples/Sample3_GetKeysAsync.cs
@@ -52,6 +52,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
             // So, for each returned key we call GetKey to get the actual key.
             await foreach (KeyProperties key in client.GetPropertiesOfKeysAsync())
             {
+                /*@@*/ if (key.Managed) continue;
                 KeyVaultKey keyWithType = await client.GetKeyAsync(key.Name);
                 Debug.WriteLine($"Key is returned with name {keyWithType.Name} and type {keyWithType.KeyType}");
             }

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample3_GetSecrets.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample3_GetSecrets.cs
@@ -47,6 +47,7 @@ namespace Azure.Security.KeyVault.Secrets.Samples
             IEnumerable<SecretProperties> secrets = client.GetPropertiesOfSecrets();
             foreach (SecretProperties secret in secrets)
             {
+                /*@@*/ if (secret.Managed) continue;
                 // Getting a disabled secret will fail, so skip disabled secrets.
                 if (!secret.Enabled.GetValueOrDefault())
                 {

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample3_GetSecretsAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample3_GetSecretsAsync.cs
@@ -41,6 +41,7 @@ namespace Azure.Security.KeyVault.Secrets.Samples
 
             await foreach (SecretProperties secret in client.GetPropertiesOfSecretsAsync())
             {
+                /*@@*/ if (secret.Managed) continue;
                 // Getting a disabled secret will fail, so skip disabled secrets.
                 if (!secret.Enabled.GetValueOrDefault())
                 {


### PR DESCRIPTION
Occasional issue with live tests caused by test assemblies running
concurrently. We need to skip managed keys and secrets (only secrets was
actually failing, but keys could as well) since certificates may be
getting deleted simultaneously.