### PR TITLE
[Event Hubs Client] Live Test Improvements

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Processor/EventProcessorClientLiveTests.cs
@@ -50,7 +50,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
             using var cancellationSource = new CancellationTokenSource();
-            cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+           cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
             // Send a set of events.
 
@@ -100,7 +100,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
             using var cancellationSource = new CancellationTokenSource();
-            cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+           cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
             // Send a set of events.
 
@@ -217,7 +217,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
             using var cancellationSource = new CancellationTokenSource();
-            cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+           cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
             // Discover the partitions.
 
@@ -282,7 +282,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
             using var cancellationSource = new CancellationTokenSource();
-            cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+           cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
             // Send a set of events.
 
@@ -363,7 +363,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
             using var cancellationSource = new CancellationTokenSource();
-            cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+           cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
             // Send a set of events.
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CONTRIBUTING.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CONTRIBUTING.md
@@ -45,6 +45,9 @@ The Live tests read information from the following environment variables:
 
 `EVENT_HUBS_SECRET`  
  The client secret (password) of the Azure Active Directory application that is associated with the service principal
+ 
+`EVENT_HUBS_PER_TEST_LIMIT_MINUTES`
+The maximum duration, in minutes, that a single test is permitted to run before it is considered at-risk for being hung.  If not provided, a default suitable for local runs is assumed.
 
 To make setting up your environment easier, a [PowerShell script](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/assets/live-tests-azure-setup.ps1) is included in the repository and will create and/or configure the needed Azure resources.  To use this script, open a PowerShell instance and login to your Azure account using `Login-AzAccount`, then execute the script.  You will need to provide some information, after which the script will configure the Azure resources and then output the set of environment variables with the correct values for running tests.
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
@@ -49,7 +49,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+               cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
@@ -80,7 +80,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+               cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var options = new EventHubConsumerClientOptions();
                 options.RetryOptions.MaximumRetries = 7;
@@ -107,7 +107,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var singleEvent = EventGenerator.CreateEventFromBody(Array.Empty<byte>());
@@ -141,7 +141,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var singleEvent = EventGenerator.CreateEvents(1).Single();
@@ -175,7 +175,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var buffer = new byte[100000];
                 new Random().NextBytes(buffer);
@@ -212,7 +212,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
@@ -254,7 +254,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var sourceEvents = EventGenerator.CreateEvents(200).ToList();
@@ -292,7 +292,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
@@ -339,7 +339,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var credential = new ClientSecretCredential(TestEnvironment.EventHubsTenant, TestEnvironment.EventHubsClient, TestEnvironment.EventHubsSecret);
                 var sourceEvents = EventGenerator.CreateEvents(50).ToList();
@@ -379,7 +379,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var sourceEvents = EventGenerator.CreateEvents(200).ToList();
@@ -417,7 +417,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var sourceEvents = EventGenerator.CreateEvents(200).ToList();
@@ -470,7 +470,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var seedEvents = EventGenerator.CreateEvents(50).ToList();
@@ -529,7 +529,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var seedEvents = EventGenerator.CreateEvents(50).ToList();
@@ -586,7 +586,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var seedEvents = EventGenerator.CreateEvents(50).ToList();
@@ -642,7 +642,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1, new[] { customConsumerGroup }))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var sourceEvents = EventGenerator.CreateEvents(50).ToList();
@@ -689,7 +689,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(2))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var credential = new ClientSecretCredential(TestEnvironment.EventHubsTenant, TestEnvironment.EventHubsClient, TestEnvironment.EventHubsSecret);
                 var sourceEvents = EventGenerator.CreateEvents(50).ToList();
@@ -729,7 +729,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var sourceEvents = EventGenerator.CreateEvents(15).ToList();
@@ -775,7 +775,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+               cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, TestEnvironment.EventHubsConnectionString, scope.EventHubName))
                 {
@@ -801,7 +801,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+               cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var invalidConsumerGroup = "ThisIsFake";
 
@@ -830,7 +830,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var clientOptions = new EventHubConsumerClientOptions();
                 clientOptions.RetryOptions.MaximumRetries = 0;
@@ -865,7 +865,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var exclusiveOptions = DefaultReadOptions.Clone();
                 exclusiveOptions.OwnerLevel = 20;
@@ -903,7 +903,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var higherOptions = DefaultReadOptions.Clone();
                 higherOptions.OwnerLevel = 40;
@@ -944,7 +944,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(2))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var higherOptions = DefaultReadOptions.Clone();
                 higherOptions.OwnerLevel = 40;
@@ -1001,7 +1001,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1, consumerGroups))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var higherOptions = DefaultReadOptions.Clone();
                 higherOptions.OwnerLevel = 40;
@@ -1050,7 +1050,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var exclusiveOptions = DefaultReadOptions.Clone();
                 exclusiveOptions.OwnerLevel = 20;
@@ -1107,7 +1107,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var higherOptions = DefaultReadOptions.Clone();
                 higherOptions.OwnerLevel = 40;
@@ -1167,7 +1167,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(2))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var exclusiveOptions = DefaultReadOptions.Clone();
                 exclusiveOptions.OwnerLevel = 20;
@@ -1232,7 +1232,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1, consumerGroups))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var exclusiveOptions = DefaultReadOptions.Clone();
                 exclusiveOptions.OwnerLevel = 20;
@@ -1289,7 +1289,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var sourceEvents = EventGenerator.CreateEvents(50).ToList();
@@ -1332,7 +1332,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(2))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var higherOptions = DefaultReadOptions.Clone();
                 higherOptions.OwnerLevel = 40;
@@ -1405,7 +1405,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, TestEnvironment.EventHubsConnectionString, scope.EventHubName))
                 {
@@ -1451,7 +1451,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(partitionCount))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, TestEnvironment.EventHubsConnectionString, scope.EventHubName, clientOptions))
                 {
@@ -1481,7 +1481,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(partitionCount))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var clientOptions = new EventHubConsumerClientOptions { ConnectionOptions = new EventHubConnectionOptions { TransportType = transportType } };
@@ -1515,7 +1515,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(4))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, TestEnvironment.EventHubsConnectionString, scope.EventHubName))
                 {
@@ -1542,7 +1542,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, TestEnvironment.EventHubsConnectionString, scope.EventHubName))
                 {
@@ -1578,7 +1578,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, TestEnvironment.EventHubsConnectionString, scope.EventHubName))
                 {
@@ -1599,7 +1599,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
@@ -1638,7 +1638,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(4))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var sourceEvents = EventGenerator.CreateEvents(100).ToList();
@@ -1678,7 +1678,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(4))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var credential = new ClientSecretCredential(TestEnvironment.EventHubsTenant, TestEnvironment.EventHubsClient, TestEnvironment.EventHubsSecret);
                 var sourceEvents = EventGenerator.CreateEvents(100).ToList();
@@ -1719,7 +1719,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(4))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var sourceEvents = EventGenerator.CreateEvents(100).ToList();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverLiveTests.cs
@@ -46,7 +46,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+               cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
@@ -77,7 +77,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+               cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var options = new PartitionReceiverOptions();
                 options.RetryOptions.MaximumRetries = 7;
@@ -106,7 +106,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var singleEvent = EventGenerator.CreateEventFromBody(Array.Empty<byte>());
@@ -138,7 +138,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var singleEvent = EventGenerator.CreateEvents(1).Single();
@@ -170,7 +170,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var buffer = new byte[100000];
                 new Random().NextBytes(buffer);
@@ -205,7 +205,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var sourceEvents = Enumerable
                     .Range(0, 25)
@@ -244,7 +244,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var sourceEvents = EventGenerator.CreateEvents(200).ToList();
@@ -280,7 +280,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var sourceEvents = EventGenerator.CreateEvents(50)
                     .Select(current =>
@@ -324,7 +324,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var credential = new ClientSecretCredential(TestEnvironment.EventHubsTenant, TestEnvironment.EventHubsClient, TestEnvironment.EventHubsSecret);
                 var sourceEvents = EventGenerator.CreateEvents(50).ToList();
@@ -361,7 +361,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var sourceEvents = EventGenerator.CreateEvents(200).ToList();
@@ -397,7 +397,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var partition = (await QueryPartitionsAsync(connectionString, cancellationSource.Token)).First();
@@ -450,7 +450,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var partition = (await QueryPartitionsAsync(connectionString, cancellationSource.Token)).First();
@@ -514,7 +514,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var partition = (await QueryPartitionsAsync(connectionString, cancellationSource.Token)).First();
@@ -576,7 +576,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var partition = (await QueryPartitionsAsync(connectionString, cancellationSource.Token)).First();
@@ -637,7 +637,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1, new[] { customConsumerGroup }))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var sourceEvents = EventGenerator.CreateEvents(50).ToList();
@@ -682,7 +682,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+               cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var invalidConsumerGroup = "ThisIsFake";
                 var partition = (await QueryPartitionsAsync(TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName), cancellationSource.Token)).First();
@@ -711,7 +711,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var clientOptions = new PartitionReceiverOptions();
                 clientOptions.RetryOptions.MaximumRetries = 0;
@@ -745,7 +745,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(2))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var credential = new ClientSecretCredential(TestEnvironment.EventHubsTenant, TestEnvironment.EventHubsClient, TestEnvironment.EventHubsSecret);
@@ -764,7 +764,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     using var readCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationSource.Token);
                     readCancellation.CancelAfter(TimeSpan.FromSeconds(5));
 
-                    var readState = await ReadEventsAsync(receiver, sourceEvents.Count, readCancellation.Token);
+                    var readState = await ReadEventsAsync(receiver, sourceEvents.Count, readCancellation.Token, waitTime: TimeSpan.FromSeconds(1));
                     Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The main cancellation token should not have been signaled.");
 
                     Assert.That(readState.Events.Count, Is.Zero, "No events should have been read from the empty partition.");
@@ -786,7 +786,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var sourceEvents = EventGenerator.CreateEvents(15).ToList();
@@ -830,7 +830,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+               cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 await using (var receiver = new PartitionReceiver(EventHubConsumerClient.DefaultConsumerGroupName, "-1", EventPosition.Earliest, TestEnvironment.EventHubsConnectionString, scope.EventHubName))
                 {
@@ -855,7 +855,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var exclusiveOptions = new PartitionReceiverOptions { OwnerLevel = 20 };
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
@@ -892,7 +892,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var higherOptions = new PartitionReceiverOptions { OwnerLevel = 40 };
                 var lowerOptions = new PartitionReceiverOptions { OwnerLevel = 20 };
@@ -930,7 +930,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(2))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var higherOptions = new PartitionReceiverOptions { OwnerLevel = 40 };
                 var lowerOptions = new PartitionReceiverOptions { OwnerLevel = 20 };
@@ -983,7 +983,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1, ConsumerGroups))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var higherOptions = new PartitionReceiverOptions { OwnerLevel = 40 };
                 var lowerOptions = new PartitionReceiverOptions { OwnerLevel = 20 };
@@ -1028,7 +1028,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var exclusiveOptions = new PartitionReceiverOptions { OwnerLevel = 20 };
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
@@ -1084,7 +1084,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var higherOptions = new PartitionReceiverOptions { OwnerLevel = 40 };
                 var lowerOptions = new PartitionReceiverOptions { OwnerLevel = 20 };
@@ -1141,7 +1141,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(2))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var exclusiveOptions = new PartitionReceiverOptions { OwnerLevel = 20 };
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
@@ -1204,7 +1204,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1, ConsumerGroups))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var exclusiveOptions = new PartitionReceiverOptions { OwnerLevel = 20 };
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
@@ -1213,8 +1213,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 var partition = (await QueryPartitionsAsync(connectionString, cancellationSource.Token)).First();
                 await SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
 
-                await using (var nonExclusiveReceiver = new PartitionReceiver(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Earliest, connectionString))
-                await using (var exclusiveReceiver = new PartitionReceiver(EventHubConsumerClient.DefaultConsumerGroupName, partition, EventPosition.Earliest, connectionString, exclusiveOptions))
+                await using (var nonExclusiveReceiver = new PartitionReceiver(scope.ConsumerGroups[0], partition, EventPosition.Earliest, connectionString))
+                await using (var exclusiveReceiver = new PartitionReceiver(scope.ConsumerGroups[1], partition, EventPosition.Earliest, connectionString, exclusiveOptions))
                 {
                     // Start the non-exclusive read, waiting until at least some events were read before starting the exclusive reader.
 
@@ -1259,7 +1259,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(2))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(4));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var higherOptions = new PartitionReceiverOptions { OwnerLevel = 40 };
                 var lowerOptions = new PartitionReceiverOptions { OwnerLevel = 20 };
@@ -1318,7 +1318,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var partition = (await QueryPartitionsAsync(connectionString, cancellationSource.Token)).First();
@@ -1363,7 +1363,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var receiverOptions = new PartitionReceiverOptions { ConnectionOptions = new EventHubConnectionOptions { TransportType = transportType } };
@@ -1395,7 +1395,7 @@ namespace Azure.Messaging.EventHubs.Tests
            await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(2));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var connection = new EventHubConnection(connectionString);
@@ -1424,7 +1424,7 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (EventHubScope scope = await EventHubScope.CreateAsync(1))
             {
                 using var cancellationSource = new CancellationTokenSource();
-                cancellationSource.CancelAfter(TimeSpan.FromMinutes(3));
+                cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var partition = (await QueryPartitionsAsync(connectionString, cancellationSource.Token)).First();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientLiveTests.cs
@@ -850,7 +850,7 @@ namespace Azure.Messaging.EventHubs.Tests
                         // Read the events.
 
                         using var cancellationSource = new CancellationTokenSource();
-                        cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
+                        cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                         foreach (string partition in partitionIds)
                         {
@@ -917,7 +917,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     // Read the events.
 
                     using var cancellationSource = new CancellationTokenSource();
-                    cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
+                    cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                     foreach (string partition in partitionIds)
                     {
@@ -987,7 +987,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     // Read the events.
 
                     using var cancellationSource = new CancellationTokenSource();
-                    cancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
+                    cancellationSource.CancelAfter(TestEnvironment.TestExecutionTimeLimit);
 
                     foreach (string partition in partitionIds)
                     {

--- a/sdk/eventhub/test-resources.json
+++ b/sdk/eventhub/test-resources.json
@@ -47,6 +47,13 @@
             "metadata": {
                 "description": "The location of the resources. By default, this is the same as the resource group."
             }
+        },
+        "perTestExecutionLimitMinutes": {
+            "type": "string",
+            "defaultValue": "10",
+            "metadata": {
+                "description": "The maximum duration, in minutes, that a single test is permitted to run before it is considered at-risk for being hung."
+            }
         }
     },
     "variables": {
@@ -95,6 +102,10 @@
         "EVENT_HUBS_RESOURCEGROUP": {
             "type": "string",
             "value": "[resourceGroup().name]"
+        },
+        "EVENT_HUBS_PER_TEST_LIMIT_MINUTES": {
+            "type": "string",
+            "value": "[parameters('perTestExecutionLimitMinutes')]"
         }
     }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to unify the timeout value applied as a safety measure to prevent hangs, hooking it into the test environment to allow for configuration to differ between the local and CI environments.  A few minor tweaks were also made to attempt to stabilize tests that have been misbehaving during nightly runs.

# Last Upstream Rebase

Friday, April 174, 6:18pm (EDT)