### PR TITLE
Add ReceiptTypeConfidence property to USReceipt

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Constants.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Constants.cs
@@ -6,5 +6,7 @@ namespace Azure.AI.FormRecognizer
     internal static class Constants
     {
         public const string AuthorizationHeader = "Ocp-Apim-Subscription-Key";
+
+        public const float DefaultConfidenceValue = 1.0f;
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormField.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormField.cs
@@ -38,7 +38,7 @@ namespace Azure.AI.FormRecognizer.Models
 
         internal FormField(string name, FieldValue_internal fieldValue, IReadOnlyList<ReadResult_internal> readResults)
         {
-            Confidence = fieldValue.Confidence ?? 1.0f;
+            Confidence = fieldValue.Confidence ?? Constants.DefaultConfidenceValue;
             Name = name;
             LabelText = null;
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/USReceipt.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/USReceipt.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 
 namespace Azure.AI.FormRecognizer.Models
 {
@@ -15,7 +14,9 @@ namespace Azure.AI.FormRecognizer.Models
         internal USReceipt(RecognizedReceipt receipt)
             : base(receipt)
         {
-            ReceiptType = ConvertUSReceiptType();
+            float receiptTypeConfidence;
+            ReceiptType = ConvertUSReceiptType(out receiptTypeConfidence);
+            ReceiptTypeConfidence = receiptTypeConfidence;
 
             MerchantAddress = ConvertStringField("MerchantAddress", RecognizedForm.Fields);
             MerchantName = ConvertStringField("MerchantName", RecognizedForm.Fields);
@@ -33,6 +34,10 @@ namespace Azure.AI.FormRecognizer.Models
         /// <summary>
         /// </summary>
         public USReceiptType ReceiptType { get; internal set; }
+
+        /// <summary>
+        /// </summary>
+        public float ReceiptTypeConfidence { get; internal set; }
 
         /// <summary>
         /// </summary>
@@ -77,13 +82,16 @@ namespace Azure.AI.FormRecognizer.Models
         /// </summary>
         public FormField<TimeSpan> TransactionTime { get; internal set; }
 
-        private USReceiptType ConvertUSReceiptType()
+        private USReceiptType ConvertUSReceiptType(out float receiptTypeConfidence)
         {
             USReceiptType receiptType = USReceiptType.Unrecognized;
+            receiptTypeConfidence = Constants.DefaultConfidenceValue;
 
             FormField value;
             if (RecognizedForm.Fields.TryGetValue("ReceiptType", out value))
             {
+                receiptTypeConfidence = value.Confidence;
+
                 receiptType = value.Value.AsString() switch
                 {
                     "Itemized" => USReceiptType.Itemized,

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
@@ -174,6 +174,9 @@ namespace Azure.AI.FormRecognizer.Tests
             // The expected values are based on the values returned by the service, and not the actual
             // values present in the receipt. We are not testing the service here, but the SDK.
 
+            Assert.AreEqual(USReceiptType.Itemized, receipt.ReceiptType);
+            Assert.That(receipt.ReceiptTypeConfidence, Is.EqualTo(0.66).Within(0.01));
+
             Assert.AreEqual(1, receipt.RecognizedForm.PageRange.FirstPageNumber);
             Assert.AreEqual(1, receipt.RecognizedForm.PageRange.LastPageNumber);
 


### PR DESCRIPTION
Fixes https://github.com/azure/azure-sdk-for-net/issues/11121

This solution exposes the confidence value for the receipt type without adding a new type to the Preview 1 design. 
