### PR TITLE
[FormRecognizer] Preview 1: argument validation

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ClientCommon.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ClientCommon.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.AI.FormRecognizer
+{
+    internal static class ClientCommon
+    {
+        /// <summary>
+        /// Used as part of argument validation. Attempts to create a <see cref="Guid"/> from a <c>string</c> and
+        /// throws an <see cref="ArgumentException"/> in case of failure.
+        /// </summary>
+        /// <param name="modelId">The model identifier to be parsed into a <see cref="Guid"/>.</param>
+        /// <param name="paramName">The original parameter name of the <paramref name="modelId"/>. Used to create exceptions in case of failure.</param>
+        /// <returns>The <see cref="Guid"/> instance created from the <paramref name="modelId"/>.</returns>
+        /// <exception cref="ArgumentException">Happens when parsing fails.</exception>
+        public static Guid ValidateModelId(string modelId, string paramName)
+        {
+            Guid guid;
+
+            try
+            {
+                guid = new Guid(modelId);
+            }
+            catch (Exception ex) when (ex is FormatException || ex is OverflowException)
+            {
+                throw new ArgumentException($"The {paramName} must be a valid GUID.", paramName, ex);
+            }
+
+            return guid;
+        }
+    }
+}

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
@@ -231,10 +231,12 @@ namespace Azure.AI.FormRecognizer
             Argument.AssertNotNullOrEmpty(modelId, nameof(modelId));
             Argument.AssertNotNull(formFileStream, nameof(formFileStream));
 
+            Guid guid = ValidateModelId(modelId, nameof(modelId));
+
             recognizeOptions ??= new RecognizeOptions();
             ContentType contentType = recognizeOptions.ContentType ?? DetectContentType(formFileStream, nameof(formFileStream));
 
-            ResponseWithHeaders<ServiceAnalyzeWithCustomModelHeaders> response = ServiceClient.RestClient.AnalyzeWithCustomModel(new Guid(modelId), contentType, formFileStream, includeTextDetails: recognizeOptions.IncludeTextContent, cancellationToken);
+            ResponseWithHeaders<ServiceAnalyzeWithCustomModelHeaders> response = ServiceClient.RestClient.AnalyzeWithCustomModel(guid, contentType, formFileStream, includeTextDetails: recognizeOptions.IncludeTextContent, cancellationToken);
             return new RecognizeCustomFormsOperation(ServiceClient, modelId, response.Headers.OperationLocation);
         }
 
@@ -253,10 +255,12 @@ namespace Azure.AI.FormRecognizer
             Argument.AssertNotNullOrEmpty(modelId, nameof(modelId));
             Argument.AssertNotNull(formFileUri, nameof(formFileUri));
 
+            Guid guid = ValidateModelId(modelId, nameof(modelId));
+
             recognizeOptions ??= new RecognizeOptions();
 
             SourcePath_internal sourcePath = new SourcePath_internal(formFileUri.ToString());
-            ResponseWithHeaders<ServiceAnalyzeWithCustomModelHeaders> response = ServiceClient.RestClient.AnalyzeWithCustomModel(new Guid(modelId), includeTextDetails: recognizeOptions.IncludeTextContent, sourcePath, cancellationToken);
+            ResponseWithHeaders<ServiceAnalyzeWithCustomModelHeaders> response = ServiceClient.RestClient.AnalyzeWithCustomModel(guid, includeTextDetails: recognizeOptions.IncludeTextContent, sourcePath, cancellationToken);
             return new RecognizeCustomFormsOperation(ServiceClient, modelId, response.Headers.OperationLocation);
         }
 
@@ -275,10 +279,12 @@ namespace Azure.AI.FormRecognizer
             Argument.AssertNotNullOrEmpty(modelId, nameof(modelId));
             Argument.AssertNotNull(formFileStream, nameof(formFileStream));
 
+            Guid guid = ValidateModelId(modelId, nameof(modelId));
+
             recognizeOptions ??= new RecognizeOptions();
             ContentType contentType = recognizeOptions.ContentType ?? DetectContentType(formFileStream, nameof(formFileStream));
 
-            ResponseWithHeaders<ServiceAnalyzeWithCustomModelHeaders> response = await ServiceClient.RestClient.AnalyzeWithCustomModelAsync(new Guid(modelId), contentType, formFileStream, includeTextDetails: recognizeOptions.IncludeTextContent, cancellationToken).ConfigureAwait(false);
+            ResponseWithHeaders<ServiceAnalyzeWithCustomModelHeaders> response = await ServiceClient.RestClient.AnalyzeWithCustomModelAsync(guid, contentType, formFileStream, includeTextDetails: recognizeOptions.IncludeTextContent, cancellationToken).ConfigureAwait(false);
             return new RecognizeCustomFormsOperation(ServiceClient, modelId, response.Headers.OperationLocation);
         }
 
@@ -297,10 +303,12 @@ namespace Azure.AI.FormRecognizer
             Argument.AssertNotNullOrEmpty(modelId, nameof(modelId));
             Argument.AssertNotNull(formFileUri, nameof(formFileUri));
 
+            Guid guid = ValidateModelId(modelId, nameof(modelId));
+
             recognizeOptions ??= new RecognizeOptions();
 
             SourcePath_internal sourcePath = new SourcePath_internal(formFileUri.ToString());
-            ResponseWithHeaders<ServiceAnalyzeWithCustomModelHeaders> response = await ServiceClient.RestClient.AnalyzeWithCustomModelAsync(new Guid(modelId), includeTextDetails: recognizeOptions.IncludeTextContent, sourcePath, cancellationToken).ConfigureAwait(false);
+            ResponseWithHeaders<ServiceAnalyzeWithCustomModelHeaders> response = await ServiceClient.RestClient.AnalyzeWithCustomModelAsync(guid, includeTextDetails: recognizeOptions.IncludeTextContent, sourcePath, cancellationToken).ConfigureAwait(false);
             return new RecognizeCustomFormsOperation(ServiceClient, modelId, response.Headers.OperationLocation);
         }
 
@@ -317,6 +325,30 @@ namespace Azure.AI.FormRecognizer
         }
 
         #endregion Training client
+
+        /// <summary>
+        /// Used as part of argument validation. Attempts to create a <see cref="Guid"/> from a <c>string</c> and
+        /// throws an <see cref="ArgumentException"/> in case of failure.
+        /// </summary>
+        /// <param name="modelId">The model identifier to be parsed into a <see cref="Guid"/>.</param>
+        /// <param name="paramName">The original parameter name of the <paramref name="modelId"/>. Used to create exceptions in case of failure.</param>
+        /// <returns>The <see cref="Guid"/> instance created from the <paramref name="modelId"/>.</returns>
+        /// <exception cref="ArgumentException">Happens when parsing fails.</exception>
+        private static Guid ValidateModelId(string modelId, string paramName)
+        {
+            Guid guid;
+
+            try
+            {
+                guid = new Guid(modelId);
+            }
+            catch (Exception ex) when (ex is FormatException || ex is OverflowException)
+            {
+                throw new ArgumentException($"The {paramName} must be a valid GUID.", paramName, ex);
+            }
+
+            return guid;
+        }
 
         /// <summary>
         /// Used as part of argument validation. Detects the <see cref="ContentType"/> of a stream and

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
@@ -33,6 +33,10 @@ namespace Azure.AI.FormRecognizer
         /// </summary>
         public FormRecognizerClient(Uri endpoint, AzureKeyCredential credential, FormRecognizerClientOptions options)
         {
+            Argument.AssertNotNull(endpoint, nameof(endpoint));
+            Argument.AssertNotNull(credential, nameof(credential));
+            Argument.AssertNotNull(options, nameof(options));
+
             _endpoint = endpoint;
             _credential = credential;
             var diagnostics = new ClientDiagnostics(options);
@@ -59,6 +63,8 @@ namespace Azure.AI.FormRecognizer
         [ForwardsClientCalls]
         public virtual RecognizeContentOperation StartRecognizeContent(Stream formFileStream, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
         {
+            Argument.AssertNotNull(formFileStream, nameof(formFileStream));
+
             recognizeOptions ??= new RecognizeOptions();
             ContentType contentType = recognizeOptions.ContentType ?? DetectContentType(formFileStream, nameof(formFileStream));
 
@@ -77,6 +83,8 @@ namespace Azure.AI.FormRecognizer
         [ForwardsClientCalls]
         public virtual async Task<RecognizeContentOperation> StartRecognizeContentAsync(Stream formFileStream, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
         {
+            Argument.AssertNotNull(formFileStream, nameof(formFileStream));
+
             recognizeOptions ??= new RecognizeOptions();
             ContentType contentType = recognizeOptions.ContentType ?? DetectContentType(formFileStream, nameof(formFileStream));
 
@@ -95,6 +103,8 @@ namespace Azure.AI.FormRecognizer
         [ForwardsClientCalls]
         public virtual RecognizeContentOperation StartRecognizeContentFromUri(Uri formFileUri, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
         {
+            Argument.AssertNotNull(formFileUri, nameof(formFileUri));
+
             SourcePath_internal sourcePath = new SourcePath_internal(formFileUri.ToString());
             ResponseWithHeaders<ServiceAnalyzeLayoutAsyncHeaders> response = ServiceClient.RestClient.AnalyzeLayoutAsync(sourcePath, cancellationToken);
             return new RecognizeContentOperation(ServiceClient, response.Headers.OperationLocation);
@@ -111,6 +121,8 @@ namespace Azure.AI.FormRecognizer
         [ForwardsClientCalls]
         public virtual async Task<RecognizeContentOperation> StartRecognizeContentFromUriAsync(Uri formFileUri, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
         {
+            Argument.AssertNotNull(formFileUri, nameof(formFileUri));
+
             SourcePath_internal sourcePath = new SourcePath_internal(formFileUri.ToString());
             ResponseWithHeaders<ServiceAnalyzeLayoutAsyncHeaders> response = await ServiceClient.RestClient.AnalyzeLayoutAsyncAsync(sourcePath, cancellationToken).ConfigureAwait(false);
             return new RecognizeContentOperation(ServiceClient, response.Headers.OperationLocation);
@@ -131,6 +143,8 @@ namespace Azure.AI.FormRecognizer
         [ForwardsClientCalls]
         public virtual async Task<RecognizeReceiptsOperation> StartRecognizeReceiptsAsync(Stream receiptFileStream, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
         {
+            Argument.AssertNotNull(receiptFileStream, nameof(receiptFileStream));
+
             recognizeOptions ??= new RecognizeOptions();
             ContentType contentType = recognizeOptions.ContentType ?? DetectContentType(receiptFileStream, nameof(receiptFileStream));
 
@@ -149,6 +163,8 @@ namespace Azure.AI.FormRecognizer
         [ForwardsClientCalls]
         public virtual RecognizeReceiptsOperation StartRecognizeReceipts(Stream receiptFileStream, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
         {
+            Argument.AssertNotNull(receiptFileStream, nameof(receiptFileStream));
+
             recognizeOptions ??= new RecognizeOptions();
             ContentType contentType = recognizeOptions.ContentType ?? DetectContentType(receiptFileStream, nameof(receiptFileStream));
 
@@ -167,6 +183,8 @@ namespace Azure.AI.FormRecognizer
         [ForwardsClientCalls]
         public virtual async Task<RecognizeReceiptsOperation> StartRecognizeReceiptsFromUriAsync(Uri receiptFileUri, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
         {
+            Argument.AssertNotNull(receiptFileUri, nameof(receiptFileUri));
+
             recognizeOptions ??= new RecognizeOptions();
 
             SourcePath_internal sourcePath = new SourcePath_internal(receiptFileUri.ToString());
@@ -185,6 +203,8 @@ namespace Azure.AI.FormRecognizer
         [ForwardsClientCalls]
         public virtual RecognizeReceiptsOperation StartRecognizeReceiptsFromUri(Uri receiptFileUri, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
         {
+            Argument.AssertNotNull(receiptFileUri, nameof(receiptFileUri));
+
             recognizeOptions ??= new RecognizeOptions();
 
             SourcePath_internal sourcePath = new SourcePath_internal(receiptFileUri.ToString());

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
@@ -233,7 +233,7 @@ namespace Azure.AI.FormRecognizer
             Argument.AssertNotNullOrEmpty(modelId, nameof(modelId));
             Argument.AssertNotNull(formFileStream, nameof(formFileStream));
 
-            Guid guid = ValidateModelId(modelId, nameof(modelId));
+            Guid guid = ClientCommon.ValidateModelId(modelId, nameof(modelId));
 
             recognizeOptions ??= new RecognizeOptions();
             ContentType contentType = recognizeOptions.ContentType ?? DetectContentType(formFileStream, nameof(formFileStream));
@@ -257,7 +257,7 @@ namespace Azure.AI.FormRecognizer
             Argument.AssertNotNullOrEmpty(modelId, nameof(modelId));
             Argument.AssertNotNull(formFileUri, nameof(formFileUri));
 
-            Guid guid = ValidateModelId(modelId, nameof(modelId));
+            Guid guid = ClientCommon.ValidateModelId(modelId, nameof(modelId));
 
             recognizeOptions ??= new RecognizeOptions();
 
@@ -281,7 +281,7 @@ namespace Azure.AI.FormRecognizer
             Argument.AssertNotNullOrEmpty(modelId, nameof(modelId));
             Argument.AssertNotNull(formFileStream, nameof(formFileStream));
 
-            Guid guid = ValidateModelId(modelId, nameof(modelId));
+            Guid guid = ClientCommon.ValidateModelId(modelId, nameof(modelId));
 
             recognizeOptions ??= new RecognizeOptions();
             ContentType contentType = recognizeOptions.ContentType ?? DetectContentType(formFileStream, nameof(formFileStream));
@@ -305,7 +305,7 @@ namespace Azure.AI.FormRecognizer
             Argument.AssertNotNullOrEmpty(modelId, nameof(modelId));
             Argument.AssertNotNull(formFileUri, nameof(formFileUri));
 
-            Guid guid = ValidateModelId(modelId, nameof(modelId));
+            Guid guid = ClientCommon.ValidateModelId(modelId, nameof(modelId));
 
             recognizeOptions ??= new RecognizeOptions();
 
@@ -327,30 +327,6 @@ namespace Azure.AI.FormRecognizer
         }
 
         #endregion Training client
-
-        /// <summary>
-        /// Used as part of argument validation. Attempts to create a <see cref="Guid"/> from a <c>string</c> and
-        /// throws an <see cref="ArgumentException"/> in case of failure.
-        /// </summary>
-        /// <param name="modelId">The model identifier to be parsed into a <see cref="Guid"/>.</param>
-        /// <param name="paramName">The original parameter name of the <paramref name="modelId"/>. Used to create exceptions in case of failure.</param>
-        /// <returns>The <see cref="Guid"/> instance created from the <paramref name="modelId"/>.</returns>
-        /// <exception cref="ArgumentException">Happens when parsing fails.</exception>
-        private static Guid ValidateModelId(string modelId, string paramName)
-        {
-            Guid guid;
-
-            try
-            {
-                guid = new Guid(modelId);
-            }
-            catch (Exception ex) when (ex is FormatException || ex is OverflowException)
-            {
-                throw new ArgumentException($"The {paramName} must be a valid GUID.", paramName, ex);
-            }
-
-            return guid;
-        }
 
         /// <summary>
         /// Used as part of argument validation. Detects the <see cref="ContentType"/> of a stream and

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
@@ -228,6 +228,9 @@ namespace Azure.AI.FormRecognizer
         [ForwardsClientCalls]
         public virtual RecognizeCustomFormsOperation StartRecognizeCustomForms(string modelId, Stream formFileStream, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
         {
+            Argument.AssertNotNullOrEmpty(modelId, nameof(modelId));
+            Argument.AssertNotNull(formFileStream, nameof(formFileStream));
+
             recognizeOptions ??= new RecognizeOptions();
             ContentType contentType = recognizeOptions.ContentType ?? DetectContentType(formFileStream, nameof(formFileStream));
 
@@ -247,6 +250,9 @@ namespace Azure.AI.FormRecognizer
         [ForwardsClientCalls]
         public virtual RecognizeCustomFormsOperation StartRecognizeCustomFormsFromUri(string modelId, Uri formFileUri, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
         {
+            Argument.AssertNotNullOrEmpty(modelId, nameof(modelId));
+            Argument.AssertNotNull(formFileUri, nameof(formFileUri));
+
             recognizeOptions ??= new RecognizeOptions();
 
             SourcePath_internal sourcePath = new SourcePath_internal(formFileUri.ToString());
@@ -266,6 +272,9 @@ namespace Azure.AI.FormRecognizer
         [ForwardsClientCalls]
         public virtual async Task<RecognizeCustomFormsOperation> StartRecognizeCustomFormsAsync(string modelId, Stream formFileStream, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
         {
+            Argument.AssertNotNullOrEmpty(modelId, nameof(modelId));
+            Argument.AssertNotNull(formFileStream, nameof(formFileStream));
+
             recognizeOptions ??= new RecognizeOptions();
             ContentType contentType = recognizeOptions.ContentType ?? DetectContentType(formFileStream, nameof(formFileStream));
 
@@ -285,6 +294,9 @@ namespace Azure.AI.FormRecognizer
         [ForwardsClientCalls]
         public virtual async Task<RecognizeCustomFormsOperation> StartRecognizeCustomFormsFromUriAsync(string modelId, Uri formFileUri, RecognizeOptions recognizeOptions = default, CancellationToken cancellationToken = default)
         {
+            Argument.AssertNotNullOrEmpty(modelId, nameof(modelId));
+            Argument.AssertNotNull(formFileUri, nameof(formFileUri));
+
             recognizeOptions ??= new RecognizeOptions();
 
             SourcePath_internal sourcePath = new SourcePath_internal(formFileUri.ToString());

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTrainingClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTrainingClient.cs
@@ -103,7 +103,9 @@ namespace Azure.AI.FormRecognizer.Training
         {
             Argument.AssertNotNullOrEmpty(modelId, nameof(modelId));
 
-            Response<Model_internal> response = ServiceClient.GetCustomModel(new Guid(modelId), includeKeys: true, cancellationToken);
+            Guid guid = ValidateModelId(modelId, nameof(modelId));
+
+            Response<Model_internal> response = ServiceClient.GetCustomModel(guid, includeKeys: true, cancellationToken);
             return Response.FromValue(new CustomFormModel(response.Value), response.GetRawResponse());
         }
 
@@ -118,7 +120,9 @@ namespace Azure.AI.FormRecognizer.Training
         {
             Argument.AssertNotNullOrEmpty(modelId, nameof(modelId));
 
-            Response<Model_internal> response = await ServiceClient.GetCustomModelAsync(new Guid(modelId), includeKeys: true, cancellationToken).ConfigureAwait(false);
+            Guid guid = ValidateModelId(modelId, nameof(modelId));
+
+            Response<Model_internal> response = await ServiceClient.GetCustomModelAsync(guid, includeKeys: true, cancellationToken).ConfigureAwait(false);
             return Response.FromValue(new CustomFormModel(response.Value), response.GetRawResponse());
         }
 
@@ -133,7 +137,9 @@ namespace Azure.AI.FormRecognizer.Training
         {
             Argument.AssertNotNullOrEmpty(modelId, nameof(modelId));
 
-            return ServiceClient.DeleteCustomModel(new Guid(modelId), cancellationToken);
+            Guid guid = ValidateModelId(modelId, nameof(modelId));
+
+            return ServiceClient.DeleteCustomModel(guid, cancellationToken);
         }
 
         /// <summary>
@@ -147,7 +153,9 @@ namespace Azure.AI.FormRecognizer.Training
         {
             Argument.AssertNotNullOrEmpty(modelId, nameof(modelId));
 
-            return await ServiceClient.DeleteCustomModelAsync(new Guid(modelId), cancellationToken).ConfigureAwait(false);
+            Guid guid = ValidateModelId(modelId, nameof(modelId));
+
+            return await ServiceClient.DeleteCustomModelAsync(guid, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -199,5 +207,29 @@ namespace Azure.AI.FormRecognizer.Training
         }
 
         #endregion
+
+        /// <summary>
+        /// Used as part of argument validation. Attempts to create a <see cref="Guid"/> from a <c>string</c> and
+        /// throws an <see cref="ArgumentException"/> in case of failure.
+        /// </summary>
+        /// <param name="modelId">The model identifier to be parsed into a <see cref="Guid"/>.</param>
+        /// <param name="paramName">The original parameter name of the <paramref name="modelId"/>. Used to create exceptions in case of failure.</param>
+        /// <returns>The <see cref="Guid"/> instance created from the <paramref name="modelId"/>.</returns>
+        /// <exception cref="ArgumentException">Happens when parsing fails.</exception>
+        private static Guid ValidateModelId(string modelId, string paramName)
+        {
+            Guid guid;
+
+            try
+            {
+                guid = new Guid(modelId);
+            }
+            catch (Exception ex) when (ex is FormatException || ex is OverflowException)
+            {
+                throw new ArgumentException($"The {paramName} must be a valid GUID.", paramName, ex);
+            }
+
+            return guid;
+        }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTrainingClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTrainingClient.cs
@@ -103,7 +103,7 @@ namespace Azure.AI.FormRecognizer.Training
         {
             Argument.AssertNotNullOrEmpty(modelId, nameof(modelId));
 
-            Guid guid = ValidateModelId(modelId, nameof(modelId));
+            Guid guid = ClientCommon.ValidateModelId(modelId, nameof(modelId));
 
             Response<Model_internal> response = ServiceClient.GetCustomModel(guid, includeKeys: true, cancellationToken);
             return Response.FromValue(new CustomFormModel(response.Value), response.GetRawResponse());
@@ -120,7 +120,7 @@ namespace Azure.AI.FormRecognizer.Training
         {
             Argument.AssertNotNullOrEmpty(modelId, nameof(modelId));
 
-            Guid guid = ValidateModelId(modelId, nameof(modelId));
+            Guid guid = ClientCommon.ValidateModelId(modelId, nameof(modelId));
 
             Response<Model_internal> response = await ServiceClient.GetCustomModelAsync(guid, includeKeys: true, cancellationToken).ConfigureAwait(false);
             return Response.FromValue(new CustomFormModel(response.Value), response.GetRawResponse());
@@ -137,7 +137,7 @@ namespace Azure.AI.FormRecognizer.Training
         {
             Argument.AssertNotNullOrEmpty(modelId, nameof(modelId));
 
-            Guid guid = ValidateModelId(modelId, nameof(modelId));
+            Guid guid = ClientCommon.ValidateModelId(modelId, nameof(modelId));
 
             return ServiceClient.DeleteCustomModel(guid, cancellationToken);
         }
@@ -153,7 +153,7 @@ namespace Azure.AI.FormRecognizer.Training
         {
             Argument.AssertNotNullOrEmpty(modelId, nameof(modelId));
 
-            Guid guid = ValidateModelId(modelId, nameof(modelId));
+            Guid guid = ClientCommon.ValidateModelId(modelId, nameof(modelId));
 
             return await ServiceClient.DeleteCustomModelAsync(guid, cancellationToken).ConfigureAwait(false);
         }
@@ -207,29 +207,5 @@ namespace Azure.AI.FormRecognizer.Training
         }
 
         #endregion
-
-        /// <summary>
-        /// Used as part of argument validation. Attempts to create a <see cref="Guid"/> from a <c>string</c> and
-        /// throws an <see cref="ArgumentException"/> in case of failure.
-        /// </summary>
-        /// <param name="modelId">The model identifier to be parsed into a <see cref="Guid"/>.</param>
-        /// <param name="paramName">The original parameter name of the <paramref name="modelId"/>. Used to create exceptions in case of failure.</param>
-        /// <returns>The <see cref="Guid"/> instance created from the <paramref name="modelId"/>.</returns>
-        /// <exception cref="ArgumentException">Happens when parsing fails.</exception>
-        private static Guid ValidateModelId(string modelId, string paramName)
-        {
-            Guid guid;
-
-            try
-            {
-                guid = new Guid(modelId);
-            }
-            catch (Exception ex) when (ex is FormatException || ex is OverflowException)
-            {
-                throw new ArgumentException($"The {paramName} must be a valid GUID.", paramName, ex);
-            }
-
-            return guid;
-        }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
@@ -229,6 +229,5 @@ namespace Azure.AI.FormRecognizer.Tests
             FormTrainingClient trainingClient = client.GetFormTrainingClient();
             Assert.IsNotNull(trainingClient);
         }
-
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientTests.cs
@@ -25,18 +25,23 @@ namespace Azure.AI.FormRecognizer.Tests
         }
 
         /// <summary>
+        /// Creates a fake <see cref="FormRecognizerClient" />.
+        /// </summary>
+        /// <returns>The fake <see cref="FormRecognizerClient" />.</returns>
+        private FormRecognizerClient CreateClient()
+        {
+            var fakeEndpoint = new Uri("http://localhost");
+            var fakeCredential = new AzureKeyCredential("fakeKey");
+
+            return new FormRecognizerClient(fakeEndpoint, fakeCredential);
+        }
+
+        /// <summary>
         /// Creates a fake <see cref="FormRecognizerClient" /> and instruments it to make use of the Azure Core
         /// Test Framework functionalities.
         /// </summary>
         /// <returns>The instrumented <see cref="FormRecognizerClient" />.</returns>
-        private FormRecognizerClient CreateInstrumentedClient()
-        {
-            var fakeEndpoint = new Uri("http://localhost");
-            var fakeCredential = new AzureKeyCredential("fakeKey");
-            var client = new FormRecognizerClient(fakeEndpoint, fakeCredential);
-
-            return InstrumentClient(client);
-        }
+        private FormRecognizerClient CreateInstrumentedClient() => InstrumentClient(CreateClient());
 
         /// <summary>
         /// Verifies functionality of the <see cref="FormRecognizerClient"/> constructors.
@@ -219,14 +224,13 @@ namespace Azure.AI.FormRecognizer.Tests
         /// method.
         /// </summary>
         [Test]
-        [Ignore("Failing due to an issue with the Core test framework.")]
         public void StartRecognizeCustomFormsValidatesTheModelIdFormat()
         {
-            var client = CreateInstrumentedClient();
+            var client = CreateClient();
             using var stream = new MemoryStream(Array.Empty<byte>());
             var options = new RecognizeOptions { ContentType = ContentType.Jpeg };
 
-            Assert.ThrowsAsync<FormatException>(async () => await client.StartRecognizeCustomFormsAsync("1975-04-04", stream, options));
+            Assert.ThrowsAsync<ArgumentException>(async () => await client.StartRecognizeCustomFormsAsync("1975-04-04", stream, options));
         }
 
         /// <summary>
@@ -281,14 +285,13 @@ namespace Azure.AI.FormRecognizer.Tests
         /// method.
         /// </summary>
         [Test]
-        [Ignore("Failing due to an issue with the Core test framework.")]
         public void StartRecognizeCustomFormsFromUriValidatesTheModelIdFormat()
         {
-            var client = CreateInstrumentedClient();
+            var client = CreateClient();
             var uri = new Uri("https://thatistheques.ti.on");
             var options = new RecognizeOptions { ContentType = ContentType.Jpeg };
 
-            Assert.ThrowsAsync<FormatException>(async () => await client.StartRecognizeCustomFormsFromUriAsync("1975-04-04", uri, options));
+            Assert.ThrowsAsync<ArgumentException>(async () => await client.StartRecognizeCustomFormsFromUriAsync("1975-04-04", uri, options));
         }
 
         /// <summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientTests.cs
@@ -42,7 +42,6 @@ namespace Azure.AI.FormRecognizer.Tests
         /// Verifies functionality of the <see cref="FormRecognizerClient"/> constructors.
         /// </summary>
         [Test]
-        [Ignore("Argument validation not implemented yet.")]
         public void ConstructorRequiresTheEndpoint()
         {
             var credential = new AzureKeyCredential("key");
@@ -55,7 +54,6 @@ namespace Azure.AI.FormRecognizer.Tests
         /// Verifies functionality of the <see cref="FormRecognizerClient"/> constructors.
         /// </summary>
         [Test]
-        [Ignore("Argument validation not implemented yet.")]
         public void ConstructorRequiresTheCredential()
         {
             var endpoint = new Uri("http://localhost");
@@ -68,7 +66,6 @@ namespace Azure.AI.FormRecognizer.Tests
         /// Verifies functionality of the <see cref="FormRecognizerClient"/> constructors.
         /// </summary>
         [Test]
-        [Ignore("Argument validation not implemented yet.")]
         public void ConstructorRequiresTheOptions()
         {
             var endpoint = new Uri("http://localhost");
@@ -82,7 +79,6 @@ namespace Azure.AI.FormRecognizer.Tests
         /// method.
         /// </summary>
         [Test]
-        [Ignore("Argument validation not implemented yet.")]
         public void StartRecognizeContentRequiresTheFormFileStream()
         {
             var client = CreateInstrumentedClient();
@@ -111,7 +107,6 @@ namespace Azure.AI.FormRecognizer.Tests
         /// method.
         /// </summary>
         [Test]
-        [Ignore("Argument validation not implemented yet.")]
         public void StartRecognizeContentFromUriRequiresTheFormFileUri()
         {
             var client = CreateInstrumentedClient();
@@ -139,7 +134,6 @@ namespace Azure.AI.FormRecognizer.Tests
         /// method.
         /// </summary>
         [Test]
-        [Ignore("Argument validation not implemented yet.")]
         public void StartRecognizeReceiptsRequiresTheReceiptFileStream()
         {
             var client = CreateInstrumentedClient();
@@ -168,7 +162,6 @@ namespace Azure.AI.FormRecognizer.Tests
         /// method.
         /// </summary>
         [Test]
-        [Ignore("Argument validation not implemented yet.")]
         public void StartRecognizeReceiptsFromUriRequiresTheReceiptFileUri()
         {
             var client = CreateInstrumentedClient();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientTests.cs
@@ -219,6 +219,21 @@ namespace Azure.AI.FormRecognizer.Tests
         /// method.
         /// </summary>
         [Test]
+        [Ignore("Failing due to an issue with the Core test framework.")]
+        public void StartRecognizeCustomFormsValidatesTheModelIdFormat()
+        {
+            var client = CreateInstrumentedClient();
+            using var stream = new MemoryStream(Array.Empty<byte>());
+            var options = new RecognizeOptions { ContentType = ContentType.Jpeg };
+
+            Assert.ThrowsAsync<FormatException>(async () => await client.StartRecognizeCustomFormsAsync("1975-04-04", stream, options));
+        }
+
+        /// <summary>
+        /// Verifies functionality of the <see cref="FormRecognizerClient.StartRecognizeCustomFormsAsync"/>
+        /// method.
+        /// </summary>
+        [Test]
         public void StartRecognizeCustomFormsRespectsTheCancellationToken()
         {
             var client = CreateInstrumentedClient();
@@ -259,6 +274,21 @@ namespace Azure.AI.FormRecognizer.Tests
         {
             var client = CreateInstrumentedClient();
             Assert.ThrowsAsync<ArgumentNullException>(async () => await client.StartRecognizeCustomFormsFromUriAsync("00000000-0000-0000-0000-000000000000", null));
+        }
+
+        /// <summary>
+        /// Verifies functionality of the <see cref="FormRecognizerClient.StartRecognizeCustomFormsFromUriAsync"/>
+        /// method.
+        /// </summary>
+        [Test]
+        [Ignore("Failing due to an issue with the Core test framework.")]
+        public void StartRecognizeCustomFormsFromUriValidatesTheModelIdFormat()
+        {
+            var client = CreateInstrumentedClient();
+            var uri = new Uri("https://thatistheques.ti.on");
+            var options = new RecognizeOptions { ContentType = ContentType.Jpeg };
+
+            Assert.ThrowsAsync<FormatException>(async () => await client.StartRecognizeCustomFormsFromUriAsync("1975-04-04", uri, options));
         }
 
         /// <summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientTests.cs
@@ -274,7 +274,7 @@ namespace Azure.AI.FormRecognizer.Tests
         /// method.
         /// </summary>
         [Test]
-        public void StartRecognizeCustomFormsFromUriRequiresTheFormFileStream()
+        public void StartRecognizeCustomFormsFromUriRequiresTheFormFileUri()
         {
             var client = CreateInstrumentedClient();
             Assert.ThrowsAsync<ArgumentNullException>(async () => await client.StartRecognizeCustomFormsFromUriAsync("00000000-0000-0000-0000-000000000000", null));

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientTests.cs
@@ -184,5 +184,97 @@ namespace Azure.AI.FormRecognizer.Tests
             Assert.ThrowsAsync<TaskCanceledException>(async () => await client.StartRecognizeReceiptsFromUriAsync(fakeUri, cancellationToken: cancellationSource.Token));
         }
 
+        /// <summary>
+        /// Verifies functionality of the <see cref="FormRecognizerClient.StartRecognizeCustomFormsAsync"/>
+        /// method.
+        /// </summary>
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void StartRecognizeCustomFormsRequiresTheModelId(string modelId)
+        {
+            var client = CreateInstrumentedClient();
+            var expectedType = modelId == null
+                ? typeof(ArgumentNullException)
+                : typeof(ArgumentException);
+
+            using var stream = new MemoryStream(Array.Empty<byte>());
+
+            Assert.ThrowsAsync(expectedType, async () => await client.StartRecognizeCustomFormsAsync(modelId, stream));
+        }
+
+        /// <summary>
+        /// Verifies functionality of the <see cref="FormRecognizerClient.StartRecognizeCustomFormsAsync"/>
+        /// method.
+        /// </summary>
+        [Test]
+        public void StartRecognizeCustomFormsRequiresTheFormFileStream()
+        {
+            var client = CreateInstrumentedClient();
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await client.StartRecognizeCustomFormsAsync("00000000-0000-0000-0000-000000000000", null));
+        }
+
+        /// <summary>
+        /// Verifies functionality of the <see cref="FormRecognizerClient.StartRecognizeCustomFormsAsync"/>
+        /// method.
+        /// </summary>
+        [Test]
+        public void StartRecognizeCustomFormsRespectsTheCancellationToken()
+        {
+            var client = CreateInstrumentedClient();
+            var options = new RecognizeOptions { ContentType = ContentType.Pdf };
+
+            using var stream = new MemoryStream(Array.Empty<byte>());
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.Cancel();
+
+            Assert.ThrowsAsync<TaskCanceledException>(async () => await client.StartRecognizeCustomFormsAsync("00000000-0000-0000-0000-000000000000", stream, recognizeOptions: options, cancellationToken: cancellationSource.Token));
+        }
+
+        /// <summary>
+        /// Verifies functionality of the <see cref="FormRecognizerClient.StartRecognizeCustomFormsFromUriAsync"/>
+        /// method.
+        /// </summary>
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void StartRecognizeCustomFormsFromUriRequiresTheModelId(string modelId)
+        {
+            var client = CreateInstrumentedClient();
+            var expectedType = modelId == null
+                ? typeof(ArgumentNullException)
+                : typeof(ArgumentException);
+
+            var uri = new Uri("https://tobeornot.to.be");
+
+            Assert.ThrowsAsync(expectedType, async () => await client.StartRecognizeCustomFormsFromUriAsync(modelId, uri));
+        }
+
+        /// <summary>
+        /// Verifies functionality of the <see cref="FormRecognizerClient.StartRecognizeCustomFormsFromUriAsync"/>
+        /// method.
+        /// </summary>
+        [Test]
+        public void StartRecognizeCustomFormsFromUriRequiresTheFormFileStream()
+        {
+            var client = CreateInstrumentedClient();
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await client.StartRecognizeCustomFormsFromUriAsync("00000000-0000-0000-0000-000000000000", null));
+        }
+
+        /// <summary>
+        /// Verifies functionality of the <see cref="FormRecognizerClient.StartRecognizeCustomFormsFromUriAsync"/>
+        /// method.
+        /// </summary>
+        [Test]
+        public void StartRecognizeCustomFormsFromUriRespectsTheCancellationToken()
+        {
+            var client = CreateInstrumentedClient();
+            var fakeUri = new Uri("http://localhost");
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.Cancel();
+
+            Assert.ThrowsAsync<TaskCanceledException>(async () => await client.StartRecognizeCustomFormsFromUriAsync("00000000-0000-0000-0000-000000000000", fakeUri, cancellationToken: cancellationSource.Token));
+        }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientTests.cs
@@ -204,8 +204,9 @@ namespace Azure.AI.FormRecognizer.Tests
                 : typeof(ArgumentException);
 
             using var stream = new MemoryStream(Array.Empty<byte>());
+            var options = new RecognizeOptions { ContentType = ContentType.Jpeg };
 
-            Assert.ThrowsAsync(expectedType, async () => await client.StartRecognizeCustomFormsAsync(modelId, stream));
+            Assert.ThrowsAsync(expectedType, async () => await client.StartRecognizeCustomFormsAsync(modelId, stream, options));
         }
 
         /// <summary>
@@ -289,9 +290,8 @@ namespace Azure.AI.FormRecognizer.Tests
         {
             var client = CreateClient();
             var uri = new Uri("https://thatistheques.ti.on");
-            var options = new RecognizeOptions { ContentType = ContentType.Jpeg };
 
-            Assert.ThrowsAsync<ArgumentException>(async () => await client.StartRecognizeCustomFormsFromUriAsync("1975-04-04", uri, options));
+            Assert.ThrowsAsync<ArgumentException>(async () => await client.StartRecognizeCustomFormsFromUriAsync("1975-04-04", uri));
         }
 
         /// <summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientTests.cs
@@ -61,6 +61,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
             Assert.ThrowsAsync<ArgumentNullException>(() => client.GetCustomModelAsync(null));
             Assert.ThrowsAsync<ArgumentException>(() => client.GetCustomModelAsync(string.Empty));
+            Assert.ThrowsAsync<ArgumentException>(() => client.GetCustomModelAsync("1975-04-04"));
         }
 
         [Test]
@@ -70,6 +71,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
             Assert.ThrowsAsync<ArgumentNullException>(() => client.DeleteModelAsync(null));
             Assert.ThrowsAsync<ArgumentException>(() => client.DeleteModelAsync(string.Empty));
+            Assert.ThrowsAsync<ArgumentException>(() => client.DeleteModelAsync("1975-04-04"));
         }
     }
 }


### PR DESCRIPTION
These changes include the remaining bits of argument validation for the first preview. These include:

- Argument validation for all public methods of the `FormRecognizerClient`.
- `GUID` format validation for the `FormTrainingClient` as well. It's been decided that an `ArgumentException` will be thrown when an invalid format is specified.
- Existing tests that were being ignored are passing now. We don't have skipped tests anymore.
- New tests for the remaining methods.

Fixes #11383.