### PR TITLE
Verify Confidence and more

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTableCell.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTableCell.cs
@@ -14,7 +14,7 @@ namespace Azure.AI.FormRecognizer.Models
         {
             ColumnIndex = dataTableCell.ColumnIndex;
             ColumnSpan = dataTableCell.ColumnSpan ?? 1;
-            Confidence = dataTableCell.Confidence;
+            Confidence = dataTableCell.Confidence == 0 ? Constants.DefaultConfidenceValue : dataTableCell.Confidence;
             IsFooter = dataTableCell.IsFooter ?? false;
             IsHeader = dataTableCell.IsHeader ?? false;
             RowIndex = dataTableCell.RowIndex;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormWord.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormWord.cs
@@ -10,7 +10,7 @@ namespace Azure.AI.FormRecognizer.Models
         internal FormWord(TextWord_internal textWord, int pageNumber)
             : base(new BoundingBox(textWord.BoundingBox), pageNumber, textWord.Text)
         {
-            Confidence = textWord.Confidence;
+            Confidence = textWord.Confidence != null ? textWord.Confidence : Constants.DefaultConfidenceValue;
         }
 
         /// <summary>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
@@ -100,8 +100,12 @@ namespace Azure.AI.FormRecognizer.Tests
                 var line = lines[lineIndex];
 
                 Assert.NotNull(line.Text, $"Text should not be null in line {lineIndex}. ");
-                Assert.Greater(line.Words.Count, 0, $"There should be at least one word in line {lineIndex}.");
                 Assert.AreEqual(4, line.BoundingBox.Points.Count(), $"There should be exactly 4 points in the bounding box in line {lineIndex}.");
+                Assert.Greater(line.Words.Count, 0, $"There should be at least one word in line {lineIndex}.");
+                foreach (var item in line.Words)
+                {
+                    Assert.Greater(item.Confidence, 0);
+                }
             }
 
             var table = formPage.Tables.Single();
@@ -138,8 +142,8 @@ namespace Azure.AI.FormRecognizer.Tests
                 Assert.IsFalse(cell.IsFooter, $"Cell with text {cell.Text} should not have been classified as footer.");
                 Assert.IsFalse(cell.IsHeader, $"Cell with text {cell.Text} should not have been classified as header.");
 
-                Assert.GreaterOrEqual(cell.Confidence, 0, $"Cell with text {cell.Text} should have confidence greater than or equal to zero.");
-                Assert.LessOrEqual(cell.RowIndex, 1, $"Cell with text {cell.Text} should have confidence less than or equal to one.");
+                Assert.Greater(cell.Confidence, 0, $"Cell with text {cell.Text} should have confidence greater than zero.");
+                Assert.LessOrEqual(cell.RowIndex, 1, $"Cell with text {cell.Text} should have a row index less than or equal to one.");
 
                 Assert.Greater(cell.TextContent.Count, 0, $"Cell with text {cell.Text} should have text content.");
             }
@@ -235,8 +239,8 @@ namespace Azure.AI.FormRecognizer.Tests
         /// </summary>
         [Test]
         [TestCase(true)]
-        [TestCase(false, Ignore = "The form has not been uploaded to GitHub yet.")]
-        public async Task StartRecognizeCustomFormsLabeled(bool useStream)
+        [TestCase(false)]
+        public async Task StartRecognizeCustomFormsWithLabels(bool useStream)
         {
             var client = CreateInstrumentedClient();
             RecognizeCustomFormsOperation operation;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/TestEnvironment.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/TestEnvironment.cs
@@ -35,7 +35,7 @@ namespace Azure.AI.FormRecognizer.Tests
         private const string InvoiceFilenameFormat = "Invoice_{0}.{1}";
 
         /// <summary>The name of the JPG file which contains the form to be used for tests.</summary>
-        private const string FormFilename = "form_1.jpg";
+        private const string FormFilename = "Form_1.jpg";
 
         /// <summary>The format to generate the GitHub URIs of the files to be used for tests.</summary>
         private const string FileUriFormat = "https://raw.githubusercontent.com/Azure/azure-sdk-for-net/master/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/{0}/{1}";


### PR DESCRIPTION
- Fixes: https://github.com/Azure/azure-sdk-for-net/issues/10490 by setting confidence to its default value of 1.0f
- Enables `StartRecognizeCustomFormsFromUriAsync` test 