### PR TITLE
[FormRecognizer] Preview 1: fix modelId not being set in operation (bug fix)

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClient.cs
@@ -242,7 +242,7 @@ namespace Azure.AI.FormRecognizer
             ContentType contentType = recognizeOptions.ContentType ?? DetectContentType(formFileStream, nameof(formFileStream));
 
             ResponseWithHeaders<ServiceAnalyzeWithCustomModelHeaders> response = ServiceClient.RestClient.AnalyzeWithCustomModel(guid, contentType, formFileStream, includeTextDetails: recognizeOptions.IncludeTextContent, cancellationToken);
-            return new RecognizeCustomFormsOperation(ServiceClient, Diagnostics, modelId, response.Headers.OperationLocation);
+            return new RecognizeCustomFormsOperation(ServiceClient, Diagnostics, response.Headers.OperationLocation);
         }
 
         /// <summary>
@@ -266,7 +266,7 @@ namespace Azure.AI.FormRecognizer
 
             SourcePath_internal sourcePath = new SourcePath_internal(formFileUri.ToString());
             ResponseWithHeaders<ServiceAnalyzeWithCustomModelHeaders> response = ServiceClient.RestClient.AnalyzeWithCustomModel(guid, includeTextDetails: recognizeOptions.IncludeTextContent, sourcePath, cancellationToken);
-            return new RecognizeCustomFormsOperation(ServiceClient, Diagnostics, modelId, response.Headers.OperationLocation);
+            return new RecognizeCustomFormsOperation(ServiceClient, Diagnostics, response.Headers.OperationLocation);
         }
 
         /// <summary>
@@ -290,7 +290,7 @@ namespace Azure.AI.FormRecognizer
             ContentType contentType = recognizeOptions.ContentType ?? DetectContentType(formFileStream, nameof(formFileStream));
 
             ResponseWithHeaders<ServiceAnalyzeWithCustomModelHeaders> response = await ServiceClient.RestClient.AnalyzeWithCustomModelAsync(guid, contentType, formFileStream, includeTextDetails: recognizeOptions.IncludeTextContent, cancellationToken).ConfigureAwait(false);
-            return new RecognizeCustomFormsOperation(ServiceClient, Diagnostics, modelId, response.Headers.OperationLocation);
+            return new RecognizeCustomFormsOperation(ServiceClient, Diagnostics, response.Headers.OperationLocation);
         }
 
         /// <summary>
@@ -314,7 +314,7 @@ namespace Azure.AI.FormRecognizer
 
             SourcePath_internal sourcePath = new SourcePath_internal(formFileUri.ToString());
             ResponseWithHeaders<ServiceAnalyzeWithCustomModelHeaders> response = await ServiceClient.RestClient.AnalyzeWithCustomModelAsync(guid, includeTextDetails: recognizeOptions.IncludeTextContent, sourcePath, cancellationToken).ConfigureAwait(false);
-            return new RecognizeCustomFormsOperation(ServiceClient, Diagnostics, modelId, response.Headers.OperationLocation);
+            return new RecognizeCustomFormsOperation(ServiceClient, Diagnostics, response.Headers.OperationLocation);
         }
 
         #endregion

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeCustomFormsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeCustomFormsOperation.cs
@@ -33,6 +33,9 @@ namespace Azure.AI.FormRecognizer.Models
         /// <summary>The id of the model to use for recognizing form values.</summary>
         private readonly string _modelId;
 
+        /// <summary>An ID representing the operation that can be used along with <see cref="_modelId"/> to poll for the status of the long-running operation.</summary>
+        private readonly string _resultId;
+
         /// <inheritdoc/>
         public override string Id { get; }
 
@@ -60,17 +63,21 @@ namespace Azure.AI.FormRecognizer.Models
         /// </summary>
         /// <param name="operations"></param>
         /// <param name="diagnostics"></param>
-        /// <param name="modelId"></param>
         /// <param name="operationLocation"></param>
-        internal RecognizeCustomFormsOperation(ServiceClient operations, ClientDiagnostics diagnostics, string modelId, string operationLocation)
+        internal RecognizeCustomFormsOperation(ServiceClient operations, ClientDiagnostics diagnostics, string operationLocation)
         {
             _serviceClient = operations;
             _diagnostics = diagnostics;
-            _modelId = modelId;
 
             // TODO: Add validation here
             // https://github.com/Azure/azure-sdk-for-net/issues/10385
-            Id = operationLocation.Split('/').Last();
+
+            string[] substrs = operationLocation.Split('/');
+
+            _resultId = substrs[substrs.Length - 1];
+            _modelId = substrs[substrs.Length - 3];
+
+            Id = string.Join("/", substrs, substrs.Length - 3, 3);
         }
 
         /// <summary>
@@ -80,9 +87,15 @@ namespace Azure.AI.FormRecognizer.Models
         /// <param name="client">The client used to check for completion.</param>
         public RecognizeCustomFormsOperation(string operationId, FormRecognizerClient client)
         {
-            Id = operationId;
             _serviceClient = client.ServiceClient;
             _diagnostics = client.Diagnostics;
+
+            string[] substrs = operationId.Split('/');
+
+            _resultId = substrs.Last();
+            _modelId = substrs.First();
+
+            Id = operationId;
         }
 
         /// <summary>
@@ -105,8 +118,8 @@ namespace Azure.AI.FormRecognizer.Models
             if (!_hasCompleted)
             {
                 Response<AnalyzeOperationResult_internal> update = async
-                    ? await _serviceClient.GetAnalyzeFormResultAsync(new Guid(_modelId), new Guid(Id), cancellationToken).ConfigureAwait(false)
-                    : _serviceClient.GetAnalyzeFormResult(new Guid(_modelId), new Guid(Id), cancellationToken);
+                    ? await _serviceClient.GetAnalyzeFormResultAsync(new Guid(_modelId), new Guid(_resultId), cancellationToken).ConfigureAwait(false)
+                    : _serviceClient.GetAnalyzeFormResult(new Guid(_modelId), new Guid(_resultId), cancellationToken);
 
                 // TODO: Add reasonable null checks.
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeCustomFormsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeCustomFormsOperation.cs
@@ -69,7 +69,10 @@ namespace Azure.AI.FormRecognizer.Models
             _serviceClient = operations;
             _diagnostics = diagnostics;
 
-            // TODO: Add validation here
+            // TODO: Use regex to parse ids.
+            // https://github.com/Azure/azure-sdk-for-net/issues/11505
+
+            // TODO: Add validation here (should we store _resuldId and _modelId as GUIDs?)
             // https://github.com/Azure/azure-sdk-for-net/issues/10385
 
             string[] substrs = operationLocation.Split('/');
@@ -90,7 +93,18 @@ namespace Azure.AI.FormRecognizer.Models
             _serviceClient = client.ServiceClient;
             _diagnostics = client.Diagnostics;
 
+            // TODO: Use regex to parse ids.
+            // https://github.com/Azure/azure-sdk-for-net/issues/11505
+
+            // TODO: Add validation here (should we store _resuldId and _modelId as GUIDs?)
+            // https://github.com/Azure/azure-sdk-for-net/issues/10385
+
             string[] substrs = operationId.Split('/');
+
+            if (substrs.Length < 3)
+            {
+                throw new ArgumentException($"Invalid {operationId}. It should be formatted as: '{{modelId}}/analyzeresults/{{resultId}}'.", operationId);
+            }
 
             _resultId = substrs.Last();
             _modelId = substrs.First();


### PR DESCRIPTION
These changes fix a minor bug found in `RecognizeCustomForms` operation. The `public` constructor was not setting `_modelId`, which would cause issues when polling results from the service.

Solution: create a `_resultId` `private` field to store the actual operation id. The actual `Id` property returns `{modelId}/analyzeresults/{resultId}` and can be used as a single id itself.