### PR TITLE
[Event Hubs Client] Test Environment Housekeeping

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubScope.cs
@@ -198,7 +198,7 @@ namespace Azure.Messaging.EventHubs.Tests
                                                       IEnumerable<string> consumerGroups,
                                                       [CallerMemberName] string caller = "")
         {
-            if (!string.IsNullOrEmpty(EventHubsTestEnvironment.Instance.EventHubName))
+            if (!string.IsNullOrEmpty(EventHubsTestEnvironment.Instance.EventHubNameOverride))
             {
                 return BuildScopeFromExistingEventHub();
             }
@@ -223,10 +223,10 @@ namespace Azure.Messaging.EventHubs.Tests
                 (
                     EventHubsTestEnvironment.Instance.ResourceGroup,
                     EventHubsTestEnvironment.Instance.EventHubsNamespace,
-                    EventHubsTestEnvironment.Instance.EventHubName
+                    EventHubsTestEnvironment.Instance.EventHubNameOverride
                  );
 
-                return new EventHubScope(EventHubsTestEnvironment.Instance.EventHubName, consumerGroups.Select(c => c.Name).ToList(), shouldRemoveEventHubAtScopeCompletion: false);
+                return new EventHubScope(EventHubsTestEnvironment.Instance.EventHubNameOverride, consumerGroups.Select(c => c.Name).ToList(), shouldRemoveEventHubAtScopeCompletion: false);
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubsTestEnvironment.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubsTestEnvironment.cs
@@ -20,47 +20,35 @@ namespace Azure.Messaging.EventHubs.Tests
         /// <summary>The name of the shared access key to be used for accessing an Event Hubs namespace.</summary>
         public const string EventHubsDefaultSharedAccessKey = "RootManageSharedAccessKey";
 
+        /// <summary>The name of the environment variable used to specify The maximum duration, in minutes, that a test is permitted to run normally.</summary>
+        private const string EventHubsPerTestExecutionLimitEnvironmentVariable = "EVENTHUB_PER_TEST_LIMIT_MINUTES";
+
+        /// <summary>The name of the environment variable used to specify the Event Hubs namespace to use for the test run.</summary>
+        private const string EventHubsNamespaceConnectionStringEnvironmentVariable = "EVENTHUB_NAMESPACE_CONNECTION_STRING";
+
+        /// <summary>The name of the environment variable used to specify an override for the Event Hub instance to use for all tests.</summary>
+        private const string EventHubNameOverrideEnvironmentVariable = "EVENTHUB_OVERRIDE_EVENT_HUB_NAME";
+
         /// <summary>The default value for the maximum duration, in minutes, that a single test is permitted to run before it is considered at-risk for being hung.</summary>
         private const int DefaultPerTestExecutionLimitMinutes = 5;
 
-        /// <summary>The environment variable value for the namespace connection string.</summary>
-        private string EventHubsNamespaceConnectionString => GetOptionalVariable("EVENT_HUBS_NAMESPACE_CONNECTION_STRING");
+        /// <summary>The singleton instance of the <see cref="EventHubsTestEnvironment" />, lazily created.</summary>
+        private static readonly Lazy<EventHubsTestEnvironment> Singleton = new Lazy<EventHubsTestEnvironment>(() => new EventHubsTestEnvironment(), LazyThreadSafetyMode.ExecutionAndPublication);
 
         /// <summary>The active Event Hubs namespace for this test run, lazily created.</summary>
         private readonly Lazy<NamespaceProperties> ActiveEventHubsNamespace;
+
+        /// <summary> The environment variable value, or default, for the maximum duration, in minutes, that a single test is permitted to run before it is considered at-risk for being hung, lazily evaluated.</summary>
+        private readonly Lazy<TimeSpan> ActivePerTestExecutionLimit;
 
         /// <summary>The connection string for the active Event Hubs namespace for this test run, lazily created.</summary>
         private readonly Lazy<ConnectionStringProperties> ParsedConnectionString;
 
         /// <summary>
-        /// The environment variable value, or default, for the maximum duration, in minutes,
-        /// that a single test is permitted to run before it is considered at-risk for being hung, lazily evaluated.
+        ///   The shared instance of the <see cref="EventHubsTestEnvironment"/> to be used during test runs.
         /// </summary>
-        private readonly Lazy<TimeSpan> EventHubsPerTestExecutionLimit;
-
-        /// <summary>
-        /// Initializes a new instance of <see cref="EventHubsTestEnvironment"/>.
-        /// </summary>
-        private EventHubsTestEnvironment() : base("eventhub")
-        {
-            ParsedConnectionString = new Lazy<ConnectionStringProperties>(() => ConnectionStringParser.Parse(EventHubsConnectionString), LazyThreadSafetyMode.ExecutionAndPublication);
-            ActiveEventHubsNamespace = new Lazy<NamespaceProperties>(EnsureEventHubsNamespace, LazyThreadSafetyMode.ExecutionAndPublication);
-            EventHubsPerTestExecutionLimit = new Lazy<TimeSpan>(() =>
-            {
-                var interval = DefaultPerTestExecutionLimitMinutes;
-
-                if (int.TryParse(GetOptionalVariable("EVENT_HUBS_PER_TEST_LIMIT_MINUTES"), out var environmentVariable))
-                {
-                    interval = environmentVariable;
-                }
-
-                return TimeSpan.FromMinutes(interval);
-
-            }, LazyThreadSafetyMode.PublicationOnly);
-        }
-
-        /// <summary> The shared instance of the <see cref="EventHubsTestEnvironment"/>. </summary>
-        public static EventHubsTestEnvironment Instance { get; } = new EventHubsTestEnvironment();
+        ///
+        public static EventHubsTestEnvironment Instance => Singleton.Value;
 
         /// <summary>
         ///   Indicates whether or not an ephemeral namespace was created for the current test execution.
@@ -69,6 +57,13 @@ namespace Azure.Messaging.EventHubs.Tests
         /// <value><c>true</c> if an Event Hubs namespace should be removed after the current test run; otherwise, <c>false</c>.</value>
         ///
         public bool ShouldRemoveNamespaceAfterTestRunCompletion => (ActiveEventHubsNamespace.IsValueCreated && ActiveEventHubsNamespace.Value.ShouldRemoveAtCompletion);
+
+        /// <summary>
+        ///   The environment variable value, or default, for the maximum duration, in minutes,
+        ///   that a single test is permitted to run before it is considered at-risk for being hung.
+        /// </summary>
+        ///
+        public TimeSpan TestExecutionTimeLimit => ActivePerTestExecutionLimit.Value;
 
         /// <summary>
         ///   The connection string for the Event Hubs namespace instance to be used for
@@ -99,9 +94,9 @@ namespace Azure.Messaging.EventHubs.Tests
         ///   The name of the Event Hub to use during Live tests.
         /// </summary>
         ///
-        /// <value>The name of the event hub is read from the "EVENT_HUBS_EVENT_HUB_NAME" environment variable.</value>
+        /// <value>The name of the event hub is read from the "EVENTHUB_OVERRIDE_EVENT_HUB_NAME" environment variable.</value>
         ///
-        public string EventHubName => GetOptionalVariable("EVENT_HUBS_OVERRIDE_EVENT_HUB_NAME");
+        public string EventHubNameOverride => GetOptionalVariable(EventHubNameOverrideEnvironmentVariable);
 
         /// <summary>
         ///   The shared access key name for the Event Hubs namespace represented by this scope.
@@ -120,10 +115,27 @@ namespace Azure.Messaging.EventHubs.Tests
         public string SharedAccessKey => ParsedConnectionString.Value.SharedAccessKey;
 
         /// <summary>
-        /// The environment variable value, or default, for the maximum duration, in minutes,
-        /// that a single test is permitted to run before it is considered at-risk for being hung.
+        ///   Initializes a new instance of <see cref="EventHubsTestEnvironment"/>.
         /// </summary>
-        public TimeSpan TestExecutionTimeLimit => EventHubsPerTestExecutionLimit.Value;
+        ///
+        private EventHubsTestEnvironment() : base("eventhub")
+        {
+            ParsedConnectionString = new Lazy<ConnectionStringProperties>(() => ConnectionStringParser.Parse(EventHubsConnectionString), LazyThreadSafetyMode.ExecutionAndPublication);
+            ActiveEventHubsNamespace = new Lazy<NamespaceProperties>(EnsureEventHubsNamespace, LazyThreadSafetyMode.ExecutionAndPublication);
+
+            ActivePerTestExecutionLimit = new Lazy<TimeSpan>(() =>
+            {
+                var interval = DefaultPerTestExecutionLimitMinutes;
+
+                if (int.TryParse(GetOptionalVariable(EventHubsPerTestExecutionLimitEnvironmentVariable), out var environmentVariable))
+                {
+                    interval = environmentVariable;
+                }
+
+                return TimeSpan.FromMinutes(interval);
+
+            }, LazyThreadSafetyMode.PublicationOnly);
+        }
 
         /// <summary>
         ///   Builds a connection string for a specific Event Hub instance under the Event Hubs namespace used for
@@ -135,22 +147,25 @@ namespace Azure.Messaging.EventHubs.Tests
         public string BuildConnectionStringForEventHub(string eventHubName) => $"{ EventHubsConnectionString };EntityPath={ eventHubName }";
 
         /// <summary>
-        ///   It tries to read the <see cref="EventHubsNamespaceConnectionString"/> environment variable.
-        ///   If not found, it creates a new namespace on Azure.
+        ///   Ensures that an Event Hubs namespace is available for the test run, using one if provided by the
+        ///   <see cref="EventHubsNamespaceConnectionStringEnvironmentVariable" /> or creating a new Azure resource specific
+        ///   to the current run.
         /// </summary>
         ///
         /// <returns>The active Event Hubs namespace for this test run.</returns>
         ///
         private NamespaceProperties EnsureEventHubsNamespace()
         {
-            if (!string.IsNullOrEmpty(EventHubsNamespaceConnectionString))
+            var environmentConnectionString = GetOptionalVariable(EventHubsNamespaceConnectionStringEnvironmentVariable);
+
+            if (!string.IsNullOrEmpty(environmentConnectionString))
             {
-                var parsed = ConnectionStringParser.Parse(EventHubsNamespaceConnectionString);
+                var parsed = ConnectionStringParser.Parse(environmentConnectionString);
 
                 return new NamespaceProperties
                 (
                     parsed.Endpoint.Host.Substring(0, parsed.Endpoint.Host.IndexOf('.')),
-                    EventHubsNamespaceConnectionString.Replace($";EntityPath={ parsed.EventHubName }", string.Empty),
+                    environmentConnectionString.Replace($";EntityPath={ parsed.EventHubName }", string.Empty),
                     shouldRemoveAtCompletion: false
                 );
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/CONTRIBUTING.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CONTRIBUTING.md
@@ -46,8 +46,8 @@ The Live tests read information from the following environment variables:
 `EVENTHUB_CLIENT_SECRET`  
  The client secret (password) of the Azure Active Directory application that is associated with the service principal
  
-`EVENT_HUBS_PER_TEST_LIMIT_MINUTES`
-The maximum duration, in minutes, that a single test is permitted to run before it is considered at-risk for being hung.  If not provided, a default suitable for local runs is assumed.
+`EVENTHUB_PER_TEST_LIMIT_MINUTES`
+The maximum duration, in minutes, that a single test is permitted to run before it is considered at-risk for being hung.  If not provided, a default suitable for most local development environment runs is assumed.
 
 To make setting up your environment easier, a [PowerShell script](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/assets/live-tests-azure-setup.ps1) is included in the repository and will create and/or configure the needed Azure resources.  To use this script, open a PowerShell instance and login to your Azure account using `Login-AzAccount`, then execute the script.  You will need to provide some information, after which the script will configure the Azure resources and then output the set of environment variables with the correct values for running tests.
 

--- a/sdk/eventhub/test-resources.json
+++ b/sdk/eventhub/test-resources.json
@@ -83,7 +83,7 @@
       }
     ],
     "outputs": {
-        "EVENT_HUBS_PER_TEST_LIMIT_MINUTES": {
+        "EVENTHUB_PER_TEST_LIMIT_MINUTES": {
             "type": "string",
             "value": "[parameters('perTestExecutionLimitMinutes')]"
         }


### PR DESCRIPTION
# Summary

The focus of these changes is to clean up some inconsistencies caused by dueling changes involving the test environment, and reformat/refactor some
of the recent work into something that closer matches the internal styles used within the Event Hubs source.

# Last Upstream Rebase

Tuesday, April 21, 5:12pm (EDT)