### PR TITLE
Update core ci so mgmt plane PRs do not trigger it

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -21,6 +21,8 @@ trigger:
     include:
     - sdk/core/
     - eng/
+    exclude:
+    - eng/mgmt/
 
 pr:
   branches:


### PR DESCRIPTION
Most management plane PRs modify `eng/mgmt/`, but `net - core - ci` is triggered by any change in `eng/`, which is not necessary, so I excluded it.