### PR TITLE
Two small bugfixes for Azure.Identity

### DIFF
--- a/sdk/identity/Azure.Identity/src/AzureCliCredential.cs
+++ b/sdk/identity/Azure.Identity/src/AzureCliCredential.cs
@@ -55,7 +55,7 @@ namespace Azure.Identity
         {
             _pipeline = pipeline;
             _path = !string.IsNullOrEmpty(EnvironmentVariables.Path) ? EnvironmentVariables.Path : DefaultPath;
-            _processService = processService;
+            _processService = processService ?? ProcessService.Default;
         }
 
         /// <summary>

--- a/sdk/identity/Azure.Identity/src/VisualStudioCodeCredential.cs
+++ b/sdk/identity/Azure.Identity/src/VisualStudioCodeCredential.cs
@@ -68,7 +68,7 @@ namespace Azure.Identity
                 var cloudInstance = GetAzureCloudInstance(environmentName);
                 var storedCredentials = _vscAdapter.GetCredentials(CredentialsSection, environmentName);
 
-                if (!IsBase64UrlString(storedCredentials))
+                if (!IsRefreshTokenString(storedCredentials))
                 {
                     throw new CredentialUnavailableException("Need to re-authenticate user in VSCode Azure Account.");
                 }
@@ -87,7 +87,7 @@ namespace Azure.Identity
             }
         }
 
-        private static bool IsBase64UrlString(string str)
+        private static bool IsRefreshTokenString(string str)
         {
             for (var index = 0; index < str.Length; index++)
             {

--- a/sdk/identity/Azure.Identity/src/VisualStudioCodeCredential.cs
+++ b/sdk/identity/Azure.Identity/src/VisualStudioCodeCredential.cs
@@ -92,7 +92,7 @@ namespace Azure.Identity
             for (var index = 0; index < str.Length; index++)
             {
                 var ch = (uint)str[index];
-                if ((ch < '0' || ch > '9') && (ch < 'A' || ch > 'Z') && (ch < 'a' || ch > 'z') && ch != '_' && ch != '-')
+                if ((ch < '0' || ch > '9') && (ch < 'A' || ch > 'Z') && (ch < 'a' || ch > 'z') && ch != '_' && ch != '-' && ch != '.')
                 {
                     return false;
                 }


### PR DESCRIPTION
- Add `.` to refresh token supported characters in `VisualStudioCodeCredential`
- Use default `ProcessService` in Azure CLI credential