### PR TITLE
Adding minor context to the Public API additions section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,13 +137,9 @@ In some cases, you might want to test against the latest versions of the client 
 
 ## Public API additions
 
-If you make a public API addition, the `eng\scripts\Export-API.ps1` script has to be run to update public API listings. If this step is required, you may see your CI build fail with an error similar to:
+If you make a public API addition, the `eng\scripts\Export-API.ps1` script has to be run to update public API listings.
 
-```
-Unhandled Exception: System.IO.DirectoryNotFoundException: Could not find a part of the path 'D:\a\1\s\sdk\tables\Azure.Data.Tables\api\Azure.Data.Tables.netstandard2.0.cs'.
-```
-
-Running the script in this example would look like this: 
+Running the script for a project in `sdk\tables` would look like this: 
 ```
 eng\scripts\Export-API.ps1 tables
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,16 @@ In some cases, you might want to test against the latest versions of the client 
 
 ## Public API additions
 
-If you make a public API addition, the `eng\scripts\Export-API.ps1` script has to be run to update public API listings.
+If you make a public API addition, the `eng\scripts\Export-API.ps1` script has to be run to update public API listings. If this step is required, you may see your CI build fail with an error similar to:
+
+```
+Unhandled Exception: System.IO.DirectoryNotFoundException: Could not find a part of the path 'D:\a\1\s\sdk\tables\Azure.Data.Tables\api\Azure.Data.Tables.netstandard2.0.cs'.
+```
+
+Running the script in this example would look like this: 
+```
+eng\scripts\Export-API.ps1 tables
+```
 
 ## API Compatibility Verification
 

--- a/eng/ApiListing.targets
+++ b/eng/ApiListing.targets
@@ -21,6 +21,7 @@
       <GenAPITargetPath>$(_RefSourceOutputPath)$(AssemblyName).$(TargetFramework).cs</GenAPITargetPath>
     </PropertyGroup>
     <Delete Files="$(GenAPITargetPath)" />
+    <MakeDir Directories="$(_RefSourceOutputPath)"/>
   </Target>
 
   <Target Name="_CheckGenerateAPIListingValue" AfterTargets="Build">


### PR DESCRIPTION
Just adding some context to how a missing API export manifests and how to run the script.