### PR TITLE
Enable to playback track 1 session record for track 2 mgmt sdk test cases

### DIFF
--- a/sdk/core/Azure.Core/tests/TestFramework/DiagnosticScopeValidatingInterceptor.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/DiagnosticScopeValidatingInterceptor.cs
@@ -19,7 +19,14 @@ namespace Azure.Core.Testing
             {
                 Type declaringType = invocation.Method.DeclaringType;
                 var ns = declaringType.Namespace;
-                var expectedName = declaringType.Name + "." + methodName.Substring(0, methodName.Length - 5);
+                var methodNameNoAysnc = methodName.Substring(0, methodName.Length - 5);
+                var expectedName = declaringType.Name + "." + methodNameNoAysnc;
+                string expectedNameNoStart = null;
+                //Fix scenario: StartCreateOrUpdateAsync -> CreateOrUpdate
+                if (methodNameNoAysnc.StartsWith("Start"))
+                {
+                    expectedNameNoStart = $"{declaringType.Name}.{methodNameNoAysnc.Substring(5)}";
+                }
                 using ClientDiagnosticListener diagnosticListener = new ClientDiagnosticListener(s => s.StartsWith("Azure."));
                 invocation.Proceed();
 
@@ -71,6 +78,10 @@ namespace Azure.Core.Testing
                         if (strict)
                         {
                             ClientDiagnosticListener.ProducedDiagnosticScope e = diagnosticListener.Scopes.FirstOrDefault(e => e.Name == expectedName);
+                            if (e == default && !string.IsNullOrEmpty(expectedNameNoStart))
+                            {
+                                e = diagnosticListener.Scopes.FirstOrDefault(e => e.Name == expectedNameNoStart);
+                            }
 
                             if (e == default)
                             {

--- a/sdk/core/Azure.Core/tests/TestFramework/DiagnosticScopeValidatingInterceptor.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/DiagnosticScopeValidatingInterceptor.cs
@@ -19,14 +19,7 @@ namespace Azure.Core.Testing
             {
                 Type declaringType = invocation.Method.DeclaringType;
                 var ns = declaringType.Namespace;
-                var methodNameNoAysnc = methodName.Substring(0, methodName.Length - 5);
-                var expectedName = declaringType.Name + "." + methodNameNoAysnc;
-                string expectedNameNoStart = null;
-                //Fix scenario: StartCreateOrUpdateAsync -> CreateOrUpdate
-                if (methodNameNoAysnc.StartsWith("Start"))
-                {
-                    expectedNameNoStart = $"{declaringType.Name}.{methodNameNoAysnc.Substring(5)}";
-                }
+                var expectedName = declaringType.Name + "." + methodName.Substring(0, methodName.Length - 5);
                 using ClientDiagnosticListener diagnosticListener = new ClientDiagnosticListener(s => s.StartsWith("Azure."));
                 invocation.Proceed();
 
@@ -78,10 +71,6 @@ namespace Azure.Core.Testing
                         if (strict)
                         {
                             ClientDiagnosticListener.ProducedDiagnosticScope e = diagnosticListener.Scopes.FirstOrDefault(e => e.Name == expectedName);
-                            if (e == default && !string.IsNullOrEmpty(expectedNameNoStart))
-                            {
-                                e = diagnosticListener.Scopes.FirstOrDefault(e => e.Name == expectedNameNoStart);
-                            }
 
                             if (e == default)
                             {

--- a/sdk/core/Azure.Core/tests/TestFramework/RecordEntry.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/RecordEntry.cs
@@ -17,6 +17,9 @@ namespace Azure.Core.Testing
 
         public string RequestUri { get; set; }
 
+        //Used only for deserializing track 1 session record files
+        public string EncodedRequestUri { get; set; }
+
         public RequestMethod RequestMethod { get; set; }
 
         public int StatusCode { get; set; }
@@ -33,6 +36,11 @@ namespace Azure.Core.Testing
             if (element.TryGetProperty(nameof(RequestUri), out property))
             {
                 record.RequestUri = property.GetString();
+            }
+
+            if (element.TryGetProperty(nameof(EncodedRequestUri), out property))
+            {
+                record.EncodedRequestUri = property.GetString();
             }
 
             if (element.TryGetProperty("RequestHeaders", out property))

--- a/sdk/core/Azure.Core/tests/TestFramework/RecordEntry.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/RecordEntry.cs
@@ -17,8 +17,7 @@ namespace Azure.Core.Testing
 
         public string RequestUri { get; set; }
 
-        //Used only for deserializing track 1 session record files
-        public string EncodedRequestUri { get; set; }
+        public bool IsTrack1Recording { get; set; }
 
         public RequestMethod RequestMethod { get; set; }
 
@@ -38,9 +37,9 @@ namespace Azure.Core.Testing
                 record.RequestUri = property.GetString();
             }
 
-            if (element.TryGetProperty(nameof(EncodedRequestUri), out property))
+            if (element.TryGetProperty("EncodedRequestUri", out property))
             {
-                record.EncodedRequestUri = property.GetString();
+                record.IsTrack1Recording = true;
             }
 
             if (element.TryGetProperty("RequestHeaders", out property))

--- a/sdk/core/Azure.Core/tests/TestFramework/RecordMatcher.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/RecordMatcher.cs
@@ -70,14 +70,12 @@ namespace Azure.Core.Testing
             int bestScore = int.MaxValue;
             RecordEntry bestScoreEntry = null;
 
-            bool isTrack1Record = entries.Any(item => !string.IsNullOrEmpty(item.EncodedRequestUri));
-
             foreach (RecordEntry entry in entries)
             {
                 int score = 0;
 
                 var recordRequestUri = entry.RequestUri;
-                if (isTrack1Record)
+                if (entry.IsTrack1Recording)
                 {
                     //there's no domain name for request uri in track 1 record, so add it from reqeust uri
                     int len = 8; //length of "https://"
@@ -99,9 +97,9 @@ namespace Azure.Core.Testing
                 }
 
                 //we only check Uri + RequestMethod for track1 record
-                if (!isTrack1Record)
+                if (entry.IsTrack1Recording)
                 {
-                score += CompareHeaderDictionaries(headers, entry.Request.Headers, ExcludeHeaders);
+                    score += CompareHeaderDictionaries(headers, entry.Request.Headers, ExcludeHeaders);
                 }
 
                 if (score == 0)

--- a/sdk/core/Azure.Core/tests/TestFramework/RecordMatcher.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/RecordMatcher.cs
@@ -70,11 +70,25 @@ namespace Azure.Core.Testing
             int bestScore = int.MaxValue;
             RecordEntry bestScoreEntry = null;
 
+            bool isTrack1Record = entries.Any(item => !string.IsNullOrEmpty(item.EncodedRequestUri));
+
             foreach (RecordEntry entry in entries)
             {
                 int score = 0;
 
-                if (!AreUrisSame(entry.RequestUri, uri))
+                var recordRequestUri = entry.RequestUri;
+                if (isTrack1Record)
+                {
+                    //there's no domain name for request uri in track 1 record, so add it from reqeust uri
+                    int len = 8; //length of "https://"
+                    int domainEndingIndex = uri.IndexOf('/', len);
+                    if (domainEndingIndex > 0)
+                    {
+                        recordRequestUri = uri.Substring(0, domainEndingIndex) + recordRequestUri;
+                    }
+                }
+
+                if (!AreUrisSame(recordRequestUri, uri))
                 {
                     score++;
                 }
@@ -84,7 +98,11 @@ namespace Azure.Core.Testing
                     score++;
                 }
 
+                //we only check Uri + RequestMethod for track1 record
+                if (!isTrack1Record)
+                {
                 score += CompareHeaderDictionaries(headers, entry.Request.Headers, ExcludeHeaders);
+                }
 
                 if (score == 0)
                 {

--- a/sdk/core/Azure.Core/tests/TestFramework/RecordSession.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/RecordSession.cs
@@ -14,6 +14,9 @@ namespace Azure.Core.Testing
 
         public SortedDictionary<string, string> Variables { get; } = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
+        //Used only for deserializing track 1 session record files
+        public Dictionary<string, Queue<string>> Names { get; set; } = new Dictionary<string, Queue<string>>();
+
         public void Serialize(Utf8JsonWriter jsonWriter)
         {
             jsonWriter.WriteStartObject();
@@ -50,6 +53,19 @@ namespace Azure.Core.Testing
                 foreach (JsonProperty item in property.EnumerateObject())
                 {
                     session.Variables[item.Name] = item.Value.GetString();
+                }
+            }
+
+            if (element.TryGetProperty(nameof(Names), out property))
+            {
+                foreach (JsonProperty item in property.EnumerateObject())
+                {
+                    var queue = new Queue<string>();
+                    foreach (JsonElement subItem in item.Value.EnumerateArray())
+                    {
+                        queue.Enqueue(subItem.GetString());
+                    }
+                    session.Names[item.Name] = queue;
                 }
             }
             return session;

--- a/sdk/core/Azure.Core/tests/TestFramework/TestRecording.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/TestRecording.cs
@@ -225,7 +225,7 @@ namespace Azure.Core.Testing
 
         public bool IsTrack1SessionRecord()
         {
-            return _session.Entries.Any(item => !string.IsNullOrEmpty(item.EncodedRequestUri));
+            return _session.Entries.FirstOrDefault()?.IsTrack1Recording ?? false;
         }
 
         public string GetVariable(string variableName, string defaultValue)


### PR DESCRIPTION
The update will support to read track 1 session record for track 2 mgmt sdk test cases in playback mode. In record mode, it will save session record in v2 format.