### PR TITLE
Undo excluding some mgmt plane tests projects

### DIFF
--- a/sdk/azurestack/Microsoft.AzureStack.Management.Fabric.Admin/tests/Microsoft.AzureStack.Management.Fabric.Tests.csproj
+++ b/sdk/azurestack/Microsoft.AzureStack.Management.Fabric.Admin/tests/Microsoft.AzureStack.Management.Fabric.Tests.csproj
@@ -9,8 +9,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup>
-    <ExcludeFromBuild>true</ExcludeFromBuild>
-    <ExcludeFromTest>true</ExcludeFromTest>
+    <ExcludeFromBuild>false</ExcludeFromBuild>
+    <ExcludeFromTest>false</ExcludeFromTest>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\Microsoft.AzureStack.Management.Fabric.Admin.csproj" />

--- a/sdk/subscription/Microsoft.Azure.Management.Subscription/tests/FullDesktop/Microsoft.Azure.Management.Subscription.FullDesktop.Tests.csproj
+++ b/sdk/subscription/Microsoft.Azure.Management.Subscription/tests/FullDesktop/Microsoft.Azure.Management.Subscription.FullDesktop.Tests.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(RepoEngPath)/mgmt/AzSdk.test.reference.props" />
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>    
+    <TargetFrameworks>net452</TargetFrameworks>
     <PackageId>Subscription.FullDesktop.Tests</PackageId>
     <Description>Subscription.FullDesktop.Tests Class Library</Description>
     <AssemblyName>FullDesktop.Tests</AssemblyName>
     <VersionPrefix>1.0.0-preview</VersionPrefix>
   </PropertyGroup>
   <PropertyGroup>
-    <ExcludeFromBuild>true</ExcludeFromBuild>
-    <ExcludeFromTest>true</ExcludeFromTest>
+    <ExcludeFromBuild>false</ExcludeFromBuild>
+    <ExcludeFromTest>false</ExcludeFromTest>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Azure.Management.Subscription.csproj" />

--- a/sdk/subscription/Microsoft.Azure.Management.Subscription/tests/NetCore/Microsoft.Azure.Management.Subscription.Netcore.Tests.csproj
+++ b/sdk/subscription/Microsoft.Azure.Management.Subscription/tests/NetCore/Microsoft.Azure.Management.Subscription.Netcore.Tests.csproj
@@ -8,8 +8,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup>
-    <ExcludeFromBuild>true</ExcludeFromBuild>
-    <ExcludeFromTest>true</ExcludeFromTest>
+    <ExcludeFromBuild>false</ExcludeFromBuild>
+    <ExcludeFromTest>false</ExcludeFromTest>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

Some test projects of management plane SDKs were excluded for they failed to build/run after the repo restructure.
I've tested a few of them and can confirm these are fine now.

Fixes #6572, Fixes #6571, Fixes #6570



---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [x] Title of the pull request is clear and informative.

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
