### PR TITLE
Parse expires_on with an invariant culture and no datetime style when ManagedIdentityClient tries to deserialize authentication response

### DIFF
--- a/sdk/identity/Azure.Identity/src/ManagedIdentityClient.cs
+++ b/sdk/identity/Azure.Identity/src/ManagedIdentityClient.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
@@ -446,7 +446,7 @@ namespace Azure.Identity
             // if s_msiType is AppService expires_on will be a string formatted datetimeoffset
             if (_msiType == MsiType.AppService)
             {
-                if (!DateTimeOffset.TryParse(expiresOnProp.Value.GetString(), out expiresOn))
+                if (!DateTimeOffset.TryParse(expiresOnProp.Value.GetString(), CultureInfo.InvariantCulture, DateTimeStyles.None, out expiresOn))
                 {
                     throw new AuthenticationFailedException(AuthenticationResponseInvalidFormatError);
                 }

--- a/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 using System.IO;
-using System.Net.Http;
-using System.Net.Sockets;
-using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -136,7 +134,7 @@ namespace Azure.Identity.Tests
 
                 var expectedToken = "mock-msi-access-token";
 
-                response.SetContent($"{{ \"access_token\": \"{expectedToken}\", \"expires_on\": \"{DateTimeOffset.UtcNow.ToString()}\" }}");
+                response.SetContent($"{{ \"access_token\": \"{expectedToken}\", \"expires_on\": \"{DateTimeOffset.UtcNow.ToString(CultureInfo.InvariantCulture)}\" }}");
 
                 var mockTransport = new MockTransport(response);
 
@@ -175,7 +173,7 @@ namespace Azure.Identity.Tests
 
                 var expectedToken = "mock-msi-access-token";
 
-                response.SetContent($"{{ \"access_token\": \"{expectedToken}\", \"expires_on\": \"{DateTimeOffset.UtcNow.ToString()}\" }}");
+                response.SetContent($"{{ \"access_token\": \"{expectedToken}\", \"expires_on\": \"{DateTimeOffset.UtcNow.ToString(CultureInfo.InvariantCulture)}\" }}");
 
                 var mockTransport = new MockTransport(response);
 


### PR DESCRIPTION
Parse expires_on with an invariant culture and no datetime style when ManagedIdentityClient tries to deserialize authentication response.