### PR TITLE
Add guardrails to TestEnvironment

### DIFF
--- a/sdk/core/Azure.Core/tests/RecordedTestBaseTests.cs
+++ b/sdk/core/Azure.Core/tests/RecordedTestBaseTests.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core.Testing;
+using NUnit.Framework;
+
+namespace Azure.Core.Tests
+{
+    public class RecordedTestBaseTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            Environment.SetEnvironmentVariable("_MOCK_RECORDED", "1");
+            Environment.SetEnvironmentVariable("_MOCK_NOTRECORDED", "2");
+        }
+
+        [Theory]
+        [TestCase(RecordedTestMode.Live)]
+        [TestCase(RecordedTestMode.Playback)]
+        [TestCase(RecordedTestMode.Record)]
+        public void ReadingRecordedValueInCtorThrows(RecordedTestMode mode)
+        {
+            Assert.Throws<InvalidOperationException>(() => new RecordedVariableMisuse(true, mode));
+
+        }
+
+        [Theory]
+        [TestCase(RecordedTestMode.Live)]
+        [TestCase(RecordedTestMode.Playback)]
+        [TestCase(RecordedTestMode.Record)]
+        [TestCase(RecordedTestMode.None)]
+        public void ReadingNonRecordedValueInCtorWorks(RecordedTestMode mode)
+        {
+            var test = new RecordedVariableMisuse(false, mode);
+            Assert.AreEqual("2", test.Value);
+        }
+
+        private class RecordedVariableMisuse : RecordedTestBase<MockTestEnvironment>
+        {
+            // To make NUnit happy
+            public RecordedVariableMisuse(bool isAsync) : base(isAsync)
+            {
+            }
+
+            public RecordedVariableMisuse(bool recorded, RecordedTestMode mode) : base(true, mode)
+            {
+                if (recorded)
+                {
+                    Value = TestEnvironment.RecordedValue;
+                }
+                else
+                {
+                    Value = TestEnvironment.NotRecordedValue;
+                }
+            }
+
+            public string Value { get; }
+        }
+
+        private class MockTestEnvironment: TestEnvironment
+        {
+            public MockTestEnvironment(): base("_mock")
+            {
+            }
+
+            public string RecordedValue => GetRecordedVariable("Recorded");
+            public string NotRecordedValue => GetVariable("NotRecorded");
+
+        }
+    }
+}

--- a/sdk/core/Azure.Core/tests/RecordedTestBaseTests.cs
+++ b/sdk/core/Azure.Core/tests/RecordedTestBaseTests.cs
@@ -65,8 +65,8 @@ namespace Azure.Core.Tests
             {
             }
 
-            public string RecordedValue => GetRecordedVariable("Recorded");
-            public string NotRecordedValue => GetVariable("NotRecorded");
+            public string RecordedValue => GetRecordedVariable("RECORDED");
+            public string NotRecordedValue => GetVariable("NOTRECORDED");
 
         }
     }

--- a/sdk/core/Azure.Core/tests/TestFramework/RecordedTestBase{TEnvironment}.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/RecordedTestBase{TEnvironment}.cs
@@ -8,17 +8,19 @@ namespace Azure.Core.Testing
         protected RecordedTestBase(bool isAsync) : base(isAsync)
         {
             TestEnvironment = new TEnvironment();
+            TestEnvironment.SetMode(Mode);
         }
 
         protected RecordedTestBase(bool isAsync, RecordedTestMode mode) : base(isAsync, mode)
         {
             TestEnvironment = new TEnvironment();
+            TestEnvironment.SetMode(Mode);
         }
 
         public override void StartTestRecording()
         {
             base.StartTestRecording();
-            TestEnvironment.SetRecording(Recording, Mode == RecordedTestMode.Playback);
+            TestEnvironment.SetRecording(Recording);
         }
 
         public TEnvironment TestEnvironment { get; }

--- a/sdk/core/Azure.Core/tests/TestFramework/TestEnvironment.Recorded.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/TestEnvironment.Recorded.cs
@@ -11,20 +11,24 @@ namespace Azure.Core.Testing
     public partial class TestEnvironment
     {
         private TestRecording _recording;
-        private bool _playback;
+        private RecordedTestMode _mode;
 
-        public void SetRecording(TestRecording recording, bool playback)
+        public void SetMode(RecordedTestMode mode)
+        {
+            _mode = mode;
+        }
+
+        public void SetRecording(TestRecording recording)
         {
             _credential = null;
             _recording = recording;
-            _playback = playback;
         }
 
         partial void GetRecordedValue(string name, ref string value)
         {
             if (_recording == null)
             {
-                return;
+                throw new InvalidOperationException("Recorded value should not be retrieved outside the test method invocation");
             }
 
             value =  _recording.GetVariable(name, null);
@@ -32,11 +36,16 @@ namespace Azure.Core.Testing
 
         partial void GetIsPlayback(ref bool playback)
         {
-            playback = _playback;
+            playback = _mode == RecordedTestMode.Playback;
         }
 
         partial void SetRecordedValue(string name, string value)
         {
+            if (_recording == null)
+            {
+                throw new InvalidOperationException("Recorded value should not be retrieved outside the test method invocation");
+            }
+
             _recording?.SetVariable(name, value);
         }
     }


### PR DESCRIPTION
To prevent reading of recorded variables in test class ctors.