### PR TITLE
Processor updates

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessMessageEventArgs.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessMessageEventArgs.cs
@@ -26,10 +26,10 @@ namespace Azure.Messaging.ServiceBus
         public CancellationToken CancellationToken { get; }
 
         /// <summary>
-        /// Indicates whether the user has attempted to settle the message as part of their callback.
+        /// Indicates whether the user has settled the message as part of their callback.
         /// If they have done so, we will not autocomplete.
         /// </summary>
-        internal bool UserSettled { get; set; }
+        internal bool IsMessageSettled { get; set; }
 
         private readonly ServiceBusReceiver _receiver;
 
@@ -61,7 +61,7 @@ namespace Azure.Messaging.ServiceBus
         {
             await _receiver.AbandonAsync(message, propertiesToModify, cancellationToken)
             .ConfigureAwait(false);
-            UserSettled = true;
+            IsMessageSettled = true;
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace Azure.Messaging.ServiceBus
                 message,
                 cancellationToken)
             .ConfigureAwait(false);
-            UserSettled = true;
+            IsMessageSettled = true;
         }
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace Azure.Messaging.ServiceBus
                 deadLetterErrorDescription,
                 cancellationToken)
             .ConfigureAwait(false);
-            UserSettled = true;
+            IsMessageSettled = true;
         }
 
         /// <summary>
@@ -121,7 +121,7 @@ namespace Azure.Messaging.ServiceBus
                 propertiesToModify,
                 cancellationToken)
             .ConfigureAwait(false);
-            UserSettled = true;
+            IsMessageSettled = true;
         }
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace Azure.Messaging.ServiceBus
                 propertiesToModify,
                 cancellationToken)
             .ConfigureAwait(false);
-            UserSettled = true;
+            IsMessageSettled = true;
         }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessSessionEventArgs.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessSessionEventArgs.cs
@@ -19,7 +19,8 @@ namespace Azure.Messaging.ServiceBus
         public CancellationToken CancellationToken { get; }
 
         /// <summary>
-        /// The <see cref="ServiceBusSessionReceiver"/> that will be used for all settlement methods for the args.
+        /// The <see cref="ServiceBusSessionReceiver"/> that will be used for setting and getting session
+        /// state.
         /// </summary>
         private readonly ServiceBusSessionReceiver _sessionReceiver;
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessSessionEventArgs.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessSessionEventArgs.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Messaging.ServiceBus
+{
+    /// <summary>
+    /// The <see cref="ProcessSessionEventArgs"/> contain event args related to the session being processed.
+    /// </summary>
+    public class ProcessSessionEventArgs : EventArgs
+    {
+        /// <summary>
+        /// The processor's <see cref="System.Threading.CancellationToken"/> instance which will be
+        /// cancelled in the event that <see cref="ServiceBusProcessor.StopProcessingAsync"/> is called.
+        /// </summary>
+        public CancellationToken CancellationToken { get; }
+
+        /// <summary>
+        /// The <see cref="ServiceBusSessionReceiver"/> that will be used for all settlement methods for the args.
+        /// </summary>
+        private readonly ServiceBusSessionReceiver _sessionReceiver;
+
+        /// <summary>
+        /// The Session Id associated with the session being processed.
+        /// </summary>
+        public string SessionId => _sessionReceiver.SessionId;
+
+        /// <summary>
+        /// Gets the <see cref="DateTimeOffset"/> that the current session is locked until.
+        /// </summary>
+        public DateTimeOffset SessionLockedUntil => _sessionReceiver.SessionLockedUntil;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProcessSessionEventArgs"/> class.
+        /// </summary>
+        ///
+        /// <param name="receiver">The <see cref="ServiceBusSessionReceiver"/> that will be used for all settlement methods
+        /// for the args.</param>
+        /// <param name="cancellationToken">The processor's <see cref="System.Threading.CancellationToken"/> instance which will be cancelled in the event that <see cref="ServiceBusProcessor.StopProcessingAsync"/> is called.</param>
+        internal ProcessSessionEventArgs(
+            ServiceBusSessionReceiver receiver,
+            CancellationToken cancellationToken)
+        {
+            _sessionReceiver = receiver;
+            CancellationToken = cancellationToken;
+        }
+
+        /// <summary>
+        /// Gets the session state.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        /// <returns>The session state as byte array.</returns>
+        public virtual async Task<byte[]> GetSessionStateAsync(
+            CancellationToken cancellationToken = default) =>
+            await _sessionReceiver.GetSessionStateAsync(cancellationToken).ConfigureAwait(false);
+
+        /// <summary>
+        /// Set a custom state on the session which can be later retrieved using <see cref="GetSessionStateAsync"/>
+        /// </summary>
+        ///
+        /// <param name="sessionState">A byte array of session state</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        /// <remarks>This state is stored on Service Bus forever unless you set an empty state on it.</remarks>
+        ///
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        public virtual async Task SetSessionStateAsync(
+            byte[] sessionState,
+            CancellationToken cancellationToken = default) =>
+            await _sessionReceiver.SetSessionStateAsync(sessionState, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessSessionMessageEventArgs.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessSessionMessageEventArgs.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -49,7 +48,7 @@ namespace Azure.Messaging.ServiceBus
         internal bool UserSettled { get; set; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ProcessMessageEventArgs"/> class.
+        /// Initializes a new instance of the <see cref="ProcessSessionMessageEventArgs"/> class.
         /// </summary>
         ///
         /// <param name="message">The current <see cref="ServiceBusReceivedMessage"/>.</param>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessSessionMessageEventArgs.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ProcessSessionMessageEventArgs.cs
@@ -42,10 +42,10 @@ namespace Azure.Messaging.ServiceBus
         public DateTimeOffset SessionLockedUntil => _sessionReceiver.SessionLockedUntil;
 
         /// <summary>
-        /// Indicates whether the user has attempted to settle the message as part of their callback.
+        /// Indicates whether the user has settled the message as part of their callback.
         /// If they have done so, we will not autocomplete.
         /// </summary>
-        internal bool UserSettled { get; set; }
+        internal bool IsMessageSettled { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ProcessSessionMessageEventArgs"/> class.
@@ -113,7 +113,7 @@ namespace Azure.Messaging.ServiceBus
         {
             await _sessionReceiver.AbandonAsync(message, propertiesToModify, cancellationToken)
                 .ConfigureAwait(false);
-            UserSettled = true;
+            IsMessageSettled = true;
         }
 
         /// <summary>
@@ -136,7 +136,7 @@ namespace Azure.Messaging.ServiceBus
                 message,
                 cancellationToken)
             .ConfigureAwait(false);
-            UserSettled = true;
+            IsMessageSettled = true;
         }
 
         /// <summary>
@@ -167,7 +167,7 @@ namespace Azure.Messaging.ServiceBus
                 deadLetterErrorDescription,
                 cancellationToken)
             .ConfigureAwait(false);
-            UserSettled = true;
+            IsMessageSettled = true;
         }
 
         /// <summary>
@@ -195,7 +195,7 @@ namespace Azure.Messaging.ServiceBus
                 propertiesToModify,
                 cancellationToken)
             .ConfigureAwait(false);
-            UserSettled = true;
+            IsMessageSettled = true;
         }
 
         /// <summary> Defers the processing for a message.</summary>
@@ -224,7 +224,7 @@ namespace Azure.Messaging.ServiceBus
                 propertiesToModify,
                 cancellationToken)
             .ConfigureAwait(false);
-            UserSettled = true;
+            IsMessageSettled = true;
         }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -30,6 +30,10 @@ namespace Azure.Messaging.ServiceBus
 
         private Func<ProcessErrorEventArgs, Task> _processErrorAsync = default;
 
+        private Func<ProcessSessionEventArgs, Task> _sessionInitializingAsync;
+
+        private Func<ProcessSessionEventArgs, Task> _sessionClosingAsync;
+
         private SemaphoreSlim MessageHandlerSemaphore;
 
         /// <summary>
@@ -67,6 +71,44 @@ namespace Azure.Messaging.ServiceBus
         ///
         /// <param name="eventArgs">The set of arguments to identify the context of the error to be processed.</param>
         private Task OnProcessErrorAsync(ProcessErrorEventArgs eventArgs) => _processErrorAsync(eventArgs);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="receiver"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        private async Task OnSessionInitializingAsync(
+            ServiceBusSessionReceiver receiver,
+            CancellationToken cancellationToken)
+        {
+            // Handlers cannot be changed while the processor is running; it is safe to check and call
+            // without capturing a local reference.
+            if (_sessionInitializingAsync != null)
+            {
+                var args = new ProcessSessionEventArgs(receiver, cancellationToken);
+                await _sessionInitializingAsync(args).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="receiver"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        private async Task OnSessionClosingAsync(
+            ServiceBusSessionReceiver receiver,
+            CancellationToken cancellationToken)
+        {
+            // Handlers cannot be changed while the processor is running; it is safe to check and call
+            // without capturing a local reference.
+            if (_sessionClosingAsync != null)
+            {
+                var args = new ProcessSessionEventArgs(receiver, cancellationToken);
+                await _sessionClosingAsync(args).ConfigureAwait(false);
+            }
+        }
 
         /// <summary>
         /// The fully qualified Service Bus namespace that the receiver is associated with.  This is likely
@@ -141,6 +183,7 @@ namespace Azure.Messaging.ServiceBus
 
         private int _maxConcurrentCalls;
         private int _maxConcurrentAcceptSessions;
+
         private const int DefaultMaxConcurrentCalls = 1;
         private const int DefaultMaxConcurrentSessions = 8;
 
@@ -339,6 +382,68 @@ namespace Azure.Messaging.ServiceBus
                 }
 
                 EnsureNotRunningAndInvoke(() => _processErrorAsync = default);
+            }
+        }
+
+        /// <summary>
+        /// Optional event that can be set to be notified when a new session is about to be processed.
+        /// </summary>
+        [SuppressMessage("Usage", "AZC0002:Ensure all service methods take an optional CancellationToken parameter.", Justification = "Guidance does not apply; this is an event.")]
+        [SuppressMessage("Usage", "AZC0003:DO make service methods virtual.", Justification = "This member follows the standard .NET event pattern; override via the associated On<<EVENT>> method.")]
+        internal event Func<ProcessSessionEventArgs, Task> SessionInitializingAsync
+        {
+            add
+            {
+                Argument.AssertNotNull(value, nameof(SessionInitializingAsync));
+
+                if (_sessionInitializingAsync != default)
+                {
+                    throw new NotSupportedException(Resources.HandlerHasAlreadyBeenAssigned);
+                }
+                EnsureNotRunningAndInvoke(() => _sessionInitializingAsync = value);
+
+            }
+
+            remove
+            {
+                Argument.AssertNotNull(value, nameof(SessionInitializingAsync));
+                if (_sessionInitializingAsync != value)
+                {
+                    throw new ArgumentException(Resources.HandlerHasNotBeenAssigned);
+                }
+                EnsureNotRunningAndInvoke(() => _sessionInitializingAsync = default);
+            }
+        }
+
+        /// <summary>
+        /// Optional event that can be set to be notified when a session is about to be closed for processing.
+        /// This means that the most recent ReceiveAsync call timed out so there are currently no messages
+        /// available to be received for the session.
+        /// </summary>
+        [SuppressMessage("Usage", "AZC0002:Ensure all service methods take an optional CancellationToken parameter.", Justification = "Guidance does not apply; this is an event.")]
+        [SuppressMessage("Usage", "AZC0003:DO make service methods virtual.", Justification = "This member follows the standard .NET event pattern; override via the associated On<<EVENT>> method.")]
+        internal event Func<ProcessSessionEventArgs, Task> SessionClosingAsync
+        {
+            add
+            {
+                Argument.AssertNotNull(value, nameof(SessionClosingAsync));
+
+                if (_sessionClosingAsync != default)
+                {
+                    throw new NotSupportedException(Resources.HandlerHasAlreadyBeenAssigned);
+                }
+                EnsureNotRunningAndInvoke(() => _sessionClosingAsync = value);
+
+            }
+
+            remove
+            {
+                Argument.AssertNotNull(value, nameof(SessionClosingAsync));
+                if (_sessionClosingAsync != value)
+                {
+                    throw new ArgumentException(Resources.HandlerHasNotBeenAssigned);
+                }
+                EnsureNotRunningAndInvoke(() => _sessionClosingAsync = default);
             }
         }
 
@@ -581,6 +686,11 @@ namespace Azure.Messaging.ServiceBus
                                 connection: _connection,
                                 options: receiverOptions,
                                 cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                            await OnSessionInitializingAsync(
+                                (ServiceBusSessionReceiver)receiver,
+                                cancellationToken).
+                                ConfigureAwait(false);
                         }
                         catch (ServiceBusException ex)
                         when (ex.Reason == ServiceBusException.FailureReason.ServiceTimeout)
@@ -621,6 +731,10 @@ namespace Azure.Messaging.ServiceBus
                         // 2. break out of the loop to allow requesting another session from the service
                         if (IsSessionProcessor && _sessionId == null)
                         {
+                            await OnSessionClosingAsync(
+                                (ServiceBusSessionReceiver)receiver,
+                                cancellationToken)
+                                .ConfigureAwait(false);
                             await CancelTask(
                                 renewSessionLockCancellationSource,
                                 renewSessionLock).ConfigureAwait(false);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -842,7 +842,7 @@ namespace Azure.Messaging.ServiceBus
                     }
                     finally
                     {
-                        userSettled = args.UserSettled;
+                        userSettled = args.IsMessageSettled;
                     }
                 }
                 else
@@ -857,7 +857,7 @@ namespace Azure.Messaging.ServiceBus
                     }
                     finally
                     {
-                        userSettled = args.UserSettled;
+                        userSettled = args.IsMessageSettled;
                     }
                 }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs
@@ -153,6 +153,45 @@ namespace Azure.Messaging.ServiceBus
         }
 
         /// <summary>
+        /// Optional event that can be set to be notified when a new session is about to be processed.
+        /// </summary>
+        [SuppressMessage("Usage", "AZC0002:Ensure all service methods take an optional CancellationToken parameter.", Justification = "Guidance does not apply; this is an event.")]
+        [SuppressMessage("Usage", "AZC0003:DO make service methods virtual.", Justification = "This member follows the standard .NET event pattern; override via the associated On<<EVENT>> method.")]
+        public event Func<ProcessSessionEventArgs, Task> SessionInitializingAsync
+        {
+            add
+            {
+                _innerProcessor.SessionInitializingAsync += value;
+
+            }
+
+            remove
+            {
+                _innerProcessor.SessionInitializingAsync -= value;
+            }
+        }
+
+        /// <summary>
+        /// Optional event that can be set to be notified when a session is about to be closed for processing.
+        /// This means that the most recent ReceiveAsync call timed out so there are currently no messages
+        /// available to be received for the session.
+        /// </summary>
+        [SuppressMessage("Usage", "AZC0002:Ensure all service methods take an optional CancellationToken parameter.", Justification = "Guidance does not apply; this is an event.")]
+        [SuppressMessage("Usage", "AZC0003:DO make service methods virtual.", Justification = "This member follows the standard .NET event pattern; override via the associated On<<EVENT>> method.")]
+        public event Func<ProcessSessionEventArgs, Task> SessionClosingAsync
+        {
+            add
+            {
+                _innerProcessor.SessionClosingAsync += value;
+            }
+
+            remove
+            {
+                _innerProcessor.SessionClosingAsync -= value;
+            }
+        }
+
+        /// <summary>
         /// Signals the <see cref="ServiceBusSessionProcessor" /> to begin processing messages. Should this method be called while the processor
         /// is running, no action is taken.
         /// </summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
@@ -75,6 +75,12 @@ namespace Azure.Messaging.ServiceBus
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceBusReceiver"/> class for mocking.
+        /// </summary>
+        ///
+        protected ServiceBusSessionReceiver() : base() { }
+
+        /// <summary>
         /// Gets the session state.
         /// </summary>
         ///

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/TestException.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Infrastructure/TestException.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Messaging.ServiceBus.Tests.Infrastructure
+{
+    public class TestException : Exception
+    {
+
+    }
+}

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
@@ -105,7 +105,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var messageSendCt = numThreads * 2;
                 ServiceBusMessageBatch messageBatch = AddMessages(batch, messageSendCt);
 
-                await sender.SendBatchAsync(messageBatch);
+                await sender.SendAsync(messageBatch);
 
                 var options = new ServiceBusProcessorOptions
                 {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus.Tests.Infrastructure;
 using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Receiver
@@ -60,10 +61,90 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                         var message = args.Message;
                         if (!autoComplete)
                         {
-                            var lockedUntil = message.LockedUntil;
-                            await args.RenewMessageLockAsync(message);
-                            Assert.That(message.LockedUntil > lockedUntil);
                             await args.CompleteAsync(message, args.CancellationToken);
+                        }
+                        Interlocked.Increment(ref messageCt);
+                    }
+                    finally
+                    {
+
+                        var setIndex = Interlocked.Increment(ref completionSourceIndex);
+                        if (setIndex < numThreads)
+                        {
+                            completionSources[setIndex].SetResult(true);
+                        }
+                    }
+                }
+                await Task.WhenAll(completionSources.Select(source => source.Task));
+                await processor.StopProcessingAsync();
+
+                // we complete each task after one message being processed, so the total number of messages
+                // processed should equal the number of threads, but it's possible that we may process a few more per thread.
+                Assert.IsTrue(messageCt >= numThreads);
+                Assert.IsTrue(messageCt < messageSendCt);
+            }
+        }
+
+        [Test]
+        [TestCase(1)]
+        [TestCase(5)]
+        [TestCase(10)]
+        [TestCase(20)]
+        public async Task UserSettlingWithAutoCompleteDoesNotThrow(int numThreads)
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(
+                enablePartitioning: false,
+                enableSession: false))
+            {
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+                ServiceBusSender sender = client.CreateSender(scope.QueueName);
+
+                // use double the number of threads so we can make sure we test that we don't
+                // retrieve more messages than expected when there are more messages available
+                using ServiceBusMessageBatch batch = await sender.CreateBatchAsync();
+                var messageSendCt = numThreads * 2;
+                ServiceBusMessageBatch messageBatch = AddMessages(batch, messageSendCt);
+
+                await sender.SendBatchAsync(messageBatch);
+
+                var options = new ServiceBusProcessorOptions
+                {
+                    MaxConcurrentCalls = numThreads,
+                    AutoComplete = true,
+                    MaxReceiveWaitTime = TimeSpan.FromSeconds(30)
+                };
+                var processor = client.CreateProcessor(scope.QueueName, options);
+                int messageCt = 0;
+
+                TaskCompletionSource<bool>[] completionSources = Enumerable
+                .Range(0, numThreads)
+                .Select(index => new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously))
+                .ToArray();
+                var completionSourceIndex = -1;
+
+                processor.ProcessMessageAsync += ProcessMessage;
+                processor.ProcessErrorAsync += ExceptionHandler;
+                await processor.StartProcessingAsync();
+
+                async Task ProcessMessage(ProcessMessageEventArgs args)
+                {
+                    try
+                    {
+                        var message = args.Message;
+                        switch (numThreads)
+                        {
+                            case 1:
+                                await args.CompleteAsync(message, args.CancellationToken);
+                                break;
+                            case 5:
+                                await args.AbandonAsync(message);
+                                break;
+                            case 10:
+                                await args.DeadLetterAsync(message);
+                                break;
+                            case 20:
+                                await args.DeferAsync(message);
+                                break;
                         }
                         Interlocked.Increment(ref messageCt);
                     }
@@ -383,11 +464,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
         [Test]
         public async Task StopProcessingDoesNotCancelAutoCompletion()
         {
-            var lockDuration = TimeSpan.FromSeconds(5);
             await using (var scope = await ServiceBusScope.CreateWithQueue(
                 enablePartitioning: false,
-                enableSession: false,
-                lockDuration: lockDuration))
+                enableSession: false))
             {
                 await using var client = GetClient();
                 var sender = client.CreateSender(scope.QueueName);
@@ -412,6 +491,79 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 var receiver = client.CreateReceiver(scope.QueueName);
                 var msg = await receiver.ReceiveAsync();
                 Assert.IsNull(msg);
+            }
+        }
+
+        [Test]
+        [TestCase("")]
+        [TestCase("Abandon")]
+        [TestCase("Complete")]
+        [TestCase("Defer")]
+        [TestCase("Deadletter")]
+        [TestCase("DeadletterOverload")]
+        public async Task UserCallbackThrowingCausesMessageToBeAbandonedIfNotSettled(string settleMethod)
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(
+                enablePartitioning: false,
+                enableSession: false))
+            {
+                await using var client = GetClient();
+                var sender = client.CreateSender(scope.QueueName);
+                await sender.SendAsync(GetMessage());
+                var processor = client.CreateProcessor(scope.QueueName, new ServiceBusProcessorOptions
+                {
+                    AutoComplete = true
+                });
+                var tcs = new TaskCompletionSource<bool>();
+
+                async Task ProcessMessage(ProcessMessageEventArgs args)
+                {
+                    switch (settleMethod)
+                    {
+                        case "Abandon":
+                            await args.AbandonAsync(args.Message);
+                            break;
+                        case "Complete":
+                            await args.CompleteAsync(args.Message);
+                            break;
+                        case "Defer":
+                            await args.DeferAsync(args.Message);
+                            break;
+                        case "Deadletter":
+                            await args.DeadLetterAsync(args.Message);
+                            break;
+                        case "DeadletterOverload":
+                            await args.DeadLetterAsync(args.Message, "reason");
+                            break;
+                    }
+                    throw new TestException();
+                }
+
+                Task ExceptionHandler(ProcessErrorEventArgs args)
+                {
+                    tcs.SetResult(true);
+                    if (!(args.Exception is TestException))
+                    {
+                        Assert.Fail(args.Exception.ToString());
+                    }
+                    return Task.CompletedTask;
+                }
+                processor.ProcessMessageAsync += ProcessMessage;
+                processor.ProcessErrorAsync += ExceptionHandler;
+
+                await processor.StartProcessingAsync();
+                await tcs.Task;
+                await processor.StopProcessingAsync();
+                var receiver = client.CreateReceiver(scope.QueueName);
+                var msg = await receiver.ReceiveAsync(TimeSpan.FromSeconds(5));
+                if (settleMethod == "" || settleMethod == "Abandon")
+                {
+                    Assert.IsNotNull(msg);
+                }
+                else
+                {
+                    Assert.IsNull(msg);
+                }
             }
         }
     }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -112,6 +113,110 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
             Assert.AreEqual(options.MaxAutoLockRenewalDuration, processor.MaxAutoLockRenewalDuration);
             Assert.AreEqual(fullyQualifiedNamespace, processor.FullyQualifiedNamespace);
             Assert.AreEqual(options.MaxReceiveWaitTime, processor.MaxReceiveWaitTime);
+        }
+
+        [Test]
+        public async Task UserSettledPropertySetCorrectly()
+        {
+            var msg = new ServiceBusReceivedMessage();
+            var args = new ProcessMessageEventArgs(
+                msg,
+                new Mock<ServiceBusReceiver>().Object,
+                CancellationToken.None);
+
+            Assert.IsFalse(args.UserSettled);
+
+            args.UserSettled = false;
+            await args.AbandonAsync(msg);
+            Assert.IsTrue(args.UserSettled);
+
+            await args.CompleteAsync(msg);
+            Assert.IsTrue(args.UserSettled);
+
+            args.UserSettled = false;
+            await args.DeadLetterAsync(msg);
+            Assert.IsTrue(args.UserSettled);
+
+            args.UserSettled = false;
+            await args.DeadLetterAsync(msg, "reason");
+            Assert.IsTrue(args.UserSettled);
+
+            args.UserSettled = false;
+            await args.DeferAsync(msg);
+            Assert.IsTrue(args.UserSettled);
+        }
+
+        [Test]
+        public void UserSettledPropertySetCorrectlyOnException()
+        {
+            var msg = new ServiceBusReceivedMessage();
+            var mockReceiver = new Mock<ServiceBusReceiver>();
+
+            mockReceiver
+                .Setup(receiver => receiver.AbandonAsync(
+                    It.IsAny<ServiceBusReceivedMessage>(),
+                    It.IsAny<IDictionary<string, object>>(),
+                    It.IsAny<CancellationToken>()))
+                .Throws(new Exception());
+
+            mockReceiver
+                .Setup(receiver => receiver.DeferAsync(
+                    It.IsAny<ServiceBusReceivedMessage>(),
+                    It.IsAny<IDictionary<string, object>>(),
+                    It.IsAny<CancellationToken>()))
+                .Throws(new Exception());
+
+            mockReceiver
+                .Setup(receiver => receiver.CompleteAsync(
+                    It.IsAny<ServiceBusReceivedMessage>(),
+                    It.IsAny<CancellationToken>()))
+                .Throws(new Exception());
+
+            mockReceiver
+                .Setup(receiver => receiver.DeadLetterAsync(
+                    It.IsAny<ServiceBusReceivedMessage>(),
+                    It.IsAny<IDictionary<string, object>>(),
+                    It.IsAny<CancellationToken>()))
+                .Throws(new Exception());
+
+            mockReceiver
+                .Setup(receiver => receiver.DeadLetterAsync(
+                    It.IsAny<ServiceBusReceivedMessage>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .Throws(new Exception());
+
+            var args = new ProcessMessageEventArgs(
+                msg,
+                mockReceiver.Object,
+                CancellationToken.None);
+
+            Assert.IsFalse(args.UserSettled);
+
+            args.UserSettled = false;
+            Assert.That(async () => await args.AbandonAsync(msg),
+                Throws.InstanceOf<Exception>());
+            Assert.IsFalse(args.UserSettled);
+
+            Assert.That(async () => await args.CompleteAsync(msg),
+                Throws.InstanceOf<Exception>());
+            Assert.IsFalse(args.UserSettled);
+
+            args.UserSettled = false;
+            Assert.That(async () => await args.DeadLetterAsync(msg),
+                Throws.InstanceOf<Exception>());
+            Assert.IsFalse(args.UserSettled);
+
+            args.UserSettled = false;
+            Assert.That(async () => await args.DeadLetterAsync(msg, "reason"),
+                Throws.InstanceOf<Exception>());
+            Assert.IsFalse(args.UserSettled);
+
+            args.UserSettled = false;
+            Assert.That(async () => await args.DeferAsync(msg),
+                Throws.InstanceOf<Exception>());
+            Assert.IsFalse(args.UserSettled);
         }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorTests.cs
@@ -124,26 +124,26 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 new Mock<ServiceBusReceiver>().Object,
                 CancellationToken.None);
 
-            Assert.IsFalse(args.UserSettled);
+            Assert.IsFalse(args.IsMessageSettled);
 
-            args.UserSettled = false;
+            args.IsMessageSettled = false;
             await args.AbandonAsync(msg);
-            Assert.IsTrue(args.UserSettled);
+            Assert.IsTrue(args.IsMessageSettled);
 
             await args.CompleteAsync(msg);
-            Assert.IsTrue(args.UserSettled);
+            Assert.IsTrue(args.IsMessageSettled);
 
-            args.UserSettled = false;
+            args.IsMessageSettled = false;
             await args.DeadLetterAsync(msg);
-            Assert.IsTrue(args.UserSettled);
+            Assert.IsTrue(args.IsMessageSettled);
 
-            args.UserSettled = false;
+            args.IsMessageSettled = false;
             await args.DeadLetterAsync(msg, "reason");
-            Assert.IsTrue(args.UserSettled);
+            Assert.IsTrue(args.IsMessageSettled);
 
-            args.UserSettled = false;
+            args.IsMessageSettled = false;
             await args.DeferAsync(msg);
-            Assert.IsTrue(args.UserSettled);
+            Assert.IsTrue(args.IsMessageSettled);
         }
 
         [Test]
@@ -192,31 +192,31 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 mockReceiver.Object,
                 CancellationToken.None);
 
-            Assert.IsFalse(args.UserSettled);
+            Assert.IsFalse(args.IsMessageSettled);
 
-            args.UserSettled = false;
+            args.IsMessageSettled = false;
             Assert.That(async () => await args.AbandonAsync(msg),
                 Throws.InstanceOf<Exception>());
-            Assert.IsFalse(args.UserSettled);
+            Assert.IsFalse(args.IsMessageSettled);
 
             Assert.That(async () => await args.CompleteAsync(msg),
                 Throws.InstanceOf<Exception>());
-            Assert.IsFalse(args.UserSettled);
+            Assert.IsFalse(args.IsMessageSettled);
 
-            args.UserSettled = false;
+            args.IsMessageSettled = false;
             Assert.That(async () => await args.DeadLetterAsync(msg),
                 Throws.InstanceOf<Exception>());
-            Assert.IsFalse(args.UserSettled);
+            Assert.IsFalse(args.IsMessageSettled);
 
-            args.UserSettled = false;
+            args.IsMessageSettled = false;
             Assert.That(async () => await args.DeadLetterAsync(msg, "reason"),
                 Throws.InstanceOf<Exception>());
-            Assert.IsFalse(args.UserSettled);
+            Assert.IsFalse(args.IsMessageSettled);
 
-            args.UserSettled = false;
+            args.IsMessageSettled = false;
             Assert.That(async () => await args.DeferAsync(msg),
                 Throws.InstanceOf<Exception>());
-            Assert.IsFalse(args.UserSettled);
+            Assert.IsFalse(args.IsMessageSettled);
         }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
@@ -264,7 +264,16 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 // there is only one message for each session, and one
                 // thread for each session, so the total messages processed
                 // should equal the number of threads
-                Assert.AreEqual(numThreads, messageCt);
+                if (numThreads == 5)
+                {
+                    // when abandoning, it is possible we could process the same message more than once
+                    // since the service will make the message available immediately
+                    Assert.LessOrEqual(numThreads, messageCt);
+                }
+                else
+                {
+                    Assert.AreEqual(numThreads, messageCt);
+                }
 
                 // we should have received messages from each of the sessions
                 Assert.AreEqual(0, sessions.Count);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorTests.cs
@@ -2,7 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
 using NUnit.Framework;
 
 namespace Azure.Messaging.ServiceBus.Tests.Processor
@@ -31,6 +35,120 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
             Assert.AreEqual(options.ReceiveMode, processor.ReceiveMode);
             Assert.AreEqual(options.MaxAutoLockRenewalDuration, processor.MaxAutoLockRenewalDuration);
             Assert.AreEqual(fullyQualifiedNamespace, processor.FullyQualifiedNamespace);
+        }
+
+
+        [Test]
+        public async Task UserSettledPropertySetCorrectly()
+        {
+            var msg = new ServiceBusReceivedMessage();
+            var args = new ProcessSessionMessageEventArgs(
+                msg,
+                new Mock<ServiceBusSessionReceiver>().Object,
+                CancellationToken.None);
+
+            Assert.IsFalse(args.UserSettled);
+
+            args.UserSettled = false;
+            await args.AbandonAsync(msg);
+            Assert.IsTrue(args.UserSettled);
+
+            await args.CompleteAsync(msg);
+            Assert.IsTrue(args.UserSettled);
+
+            args.UserSettled = false;
+            await args.DeadLetterAsync(msg);
+            Assert.IsTrue(args.UserSettled);
+
+            args.UserSettled = false;
+            await args.DeadLetterAsync(msg, "reason");
+            Assert.IsTrue(args.UserSettled);
+
+            args.UserSettled = false;
+            await args.DeferAsync(msg);
+            Assert.IsTrue(args.UserSettled);
+
+            // getting or setting session state doesn't count as settling
+            args.UserSettled = false;
+            await args.GetSessionStateAsync();
+            Assert.IsFalse(args.UserSettled);
+
+            args.UserSettled = false;
+            await args.SetSessionStateAsync(new byte[] { });
+            Assert.IsFalse(args.UserSettled);
+        }
+
+        [Test]
+        public void UserSettledPropertySetCorrectlyOnException()
+        {
+            var msg = new ServiceBusReceivedMessage();
+            var mockReceiver = new Mock<ServiceBusSessionReceiver>();
+
+            mockReceiver
+                .Setup(receiver => receiver.AbandonAsync(
+                    It.IsAny<ServiceBusReceivedMessage>(),
+                    It.IsAny<IDictionary<string, object>>(),
+                    It.IsAny<CancellationToken>()))
+                .Throws(new Exception());
+
+            mockReceiver
+                .Setup(receiver => receiver.DeferAsync(
+                    It.IsAny<ServiceBusReceivedMessage>(),
+                    It.IsAny<IDictionary<string, object>>(),
+                    It.IsAny<CancellationToken>()))
+                .Throws(new Exception());
+
+            mockReceiver
+                .Setup(receiver => receiver.CompleteAsync(
+                    It.IsAny<ServiceBusReceivedMessage>(),
+                    It.IsAny<CancellationToken>()))
+                .Throws(new Exception());
+
+            mockReceiver
+                .Setup(receiver => receiver.DeadLetterAsync(
+                    It.IsAny<ServiceBusReceivedMessage>(),
+                    It.IsAny<IDictionary<string, object>>(),
+                    It.IsAny<CancellationToken>()))
+                .Throws(new Exception());
+
+            mockReceiver
+                .Setup(receiver => receiver.DeadLetterAsync(
+                    It.IsAny<ServiceBusReceivedMessage>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .Throws(new Exception());
+
+            var args = new ProcessSessionMessageEventArgs(
+                msg,
+                mockReceiver.Object,
+                CancellationToken.None);
+
+            Assert.IsFalse(args.UserSettled);
+
+            args.UserSettled = false;
+            Assert.That(async () => await args.AbandonAsync(msg),
+                Throws.InstanceOf<Exception>());
+            Assert.IsFalse(args.UserSettled);
+
+            Assert.That(async () => await args.CompleteAsync(msg),
+                Throws.InstanceOf<Exception>());
+            Assert.IsFalse(args.UserSettled);
+
+            args.UserSettled = false;
+            Assert.That(async () => await args.DeadLetterAsync(msg),
+                Throws.InstanceOf<Exception>());
+            Assert.IsFalse(args.UserSettled);
+
+            args.UserSettled = false;
+            Assert.That(async () => await args.DeadLetterAsync(msg, "reason"),
+                Throws.InstanceOf<Exception>());
+            Assert.IsFalse(args.UserSettled);
+
+            args.UserSettled = false;
+            Assert.That(async () => await args.DeferAsync(msg),
+                Throws.InstanceOf<Exception>());
+            Assert.IsFalse(args.UserSettled);
         }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorTests.cs
@@ -139,35 +139,35 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 new Mock<ServiceBusSessionReceiver>().Object,
                 CancellationToken.None);
 
-            Assert.IsFalse(args.UserSettled);
+            Assert.IsFalse(args.IsMessageSettled);
 
-            args.UserSettled = false;
+            args.IsMessageSettled = false;
             await args.AbandonAsync(msg);
-            Assert.IsTrue(args.UserSettled);
+            Assert.IsTrue(args.IsMessageSettled);
 
             await args.CompleteAsync(msg);
-            Assert.IsTrue(args.UserSettled);
+            Assert.IsTrue(args.IsMessageSettled);
 
-            args.UserSettled = false;
+            args.IsMessageSettled = false;
             await args.DeadLetterAsync(msg);
-            Assert.IsTrue(args.UserSettled);
+            Assert.IsTrue(args.IsMessageSettled);
 
-            args.UserSettled = false;
+            args.IsMessageSettled = false;
             await args.DeadLetterAsync(msg, "reason");
-            Assert.IsTrue(args.UserSettled);
+            Assert.IsTrue(args.IsMessageSettled);
 
-            args.UserSettled = false;
+            args.IsMessageSettled = false;
             await args.DeferAsync(msg);
-            Assert.IsTrue(args.UserSettled);
+            Assert.IsTrue(args.IsMessageSettled);
 
             // getting or setting session state doesn't count as settling
-            args.UserSettled = false;
+            args.IsMessageSettled = false;
             await args.GetSessionStateAsync();
-            Assert.IsFalse(args.UserSettled);
+            Assert.IsFalse(args.IsMessageSettled);
 
-            args.UserSettled = false;
+            args.IsMessageSettled = false;
             await args.SetSessionStateAsync(new byte[] { });
-            Assert.IsFalse(args.UserSettled);
+            Assert.IsFalse(args.IsMessageSettled);
         }
 
         [Test]
@@ -216,31 +216,31 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 mockReceiver.Object,
                 CancellationToken.None);
 
-            Assert.IsFalse(args.UserSettled);
+            Assert.IsFalse(args.IsMessageSettled);
 
-            args.UserSettled = false;
+            args.IsMessageSettled = false;
             Assert.That(async () => await args.AbandonAsync(msg),
                 Throws.InstanceOf<Exception>());
-            Assert.IsFalse(args.UserSettled);
+            Assert.IsFalse(args.IsMessageSettled);
 
             Assert.That(async () => await args.CompleteAsync(msg),
                 Throws.InstanceOf<Exception>());
-            Assert.IsFalse(args.UserSettled);
+            Assert.IsFalse(args.IsMessageSettled);
 
-            args.UserSettled = false;
+            args.IsMessageSettled = false;
             Assert.That(async () => await args.DeadLetterAsync(msg),
                 Throws.InstanceOf<Exception>());
-            Assert.IsFalse(args.UserSettled);
+            Assert.IsFalse(args.IsMessageSettled);
 
-            args.UserSettled = false;
+            args.IsMessageSettled = false;
             Assert.That(async () => await args.DeadLetterAsync(msg, "reason"),
                 Throws.InstanceOf<Exception>());
-            Assert.IsFalse(args.UserSettled);
+            Assert.IsFalse(args.IsMessageSettled);
 
-            args.UserSettled = false;
+            args.IsMessageSettled = false;
             Assert.That(async () => await args.DeferAsync(msg),
                 Throws.InstanceOf<Exception>());
-            Assert.IsFalse(args.UserSettled);
+            Assert.IsFalse(args.IsMessageSettled);
         }
     }
 }


### PR DESCRIPTION
- Don't autocomplete messages that have already been settled
- Remove lock renewal from processor event args
- Session Init/Close events

Fixes https://github.com/Azure/azure-sdk-for-net/issues/11554, https://github.com/Azure/azure-sdk-for-net/issues/11351, and https://github.com/Azure/azure-sdk-for-net/issues/11349