### PR TITLE
Normalize special headers in playback record matcher

### DIFF
--- a/sdk/core/Azure.Core/tests/RecordSessionTests.cs
+++ b/sdk/core/Azure.Core/tests/RecordSessionTests.cs
@@ -212,11 +212,13 @@ namespace Azure.Core.Tests
             originalRequest.Method = RequestMethod.Get;
             originalRequest.Uri.Reset(new Uri("http://localhost"));
             originalRequest.Headers.Add(name, "application/json;odata=nometadata");
+            originalRequest.Headers.Add("Date", "This should be ignored");
 
             var playbackRequest = new MockTransport().CreateRequest();
             playbackRequest.Method = RequestMethod.Get;
             playbackRequest.Uri.Reset(new Uri("http://localhost"));
             playbackRequest.Headers.Add(name, "application/json;odata=nometadata");
+            originalRequest.Headers.Add("Date", "It doesn't match");
 
             var matcher = new RecordMatcher(new RecordedTestSanitizer());
             var entry = RecordTransport.CreateEntry(originalRequest, new MockResponse(200));

--- a/sdk/core/Azure.Core/tests/RecordSessionTests.cs
+++ b/sdk/core/Azure.Core/tests/RecordSessionTests.cs
@@ -224,7 +224,6 @@ namespace Azure.Core.Tests
             Assert.NotNull(matcher.FindMatch(playbackRequest, new[] { entry }));
         }
 
-
         private class TestSanitizer : RecordedTestSanitizer
         {
             public override string SanitizeVariable(string variableName, string environmentVariableValue)

--- a/sdk/core/Azure.Core/tests/RecordSessionTests.cs
+++ b/sdk/core/Azure.Core/tests/RecordSessionTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using Azure.Core.Pipeline;
 using Azure.Core.Testing;
 using Moq;
 using NUnit.Framework;
@@ -199,6 +200,30 @@ namespace Azure.Core.Tests
 
             StringAssert.DoesNotContain("secret", text);
         }
+
+        [Theory]
+        [TestCase("Content-Type")]
+        [TestCase("Accept")]
+        [TestCase("Random-Header")]
+        public void SpecialHeadersNormalizedForMatching(string name)
+        {
+            // Use HttpClientTransport as it does header normalization
+            var originalRequest = new HttpClientTransport().CreateRequest();
+            originalRequest.Method = RequestMethod.Get;
+            originalRequest.Uri.Reset(new Uri("http://localhost"));
+            originalRequest.Headers.Add(name, "application/json;odata=nometadata");
+
+            var playbackRequest = new MockTransport().CreateRequest();
+            playbackRequest.Method = RequestMethod.Get;
+            playbackRequest.Uri.Reset(new Uri("http://localhost"));
+            playbackRequest.Headers.Add(name, "application/json;odata=nometadata");
+
+            var matcher = new RecordMatcher(new RecordedTestSanitizer());
+            var entry = RecordTransport.CreateEntry(originalRequest, new MockResponse(200));
+
+            Assert.NotNull(matcher.FindMatch(playbackRequest, new[] { entry }));
+        }
+
 
         private class TestSanitizer : RecordedTestSanitizer
         {

--- a/sdk/core/Azure.Core/tests/TestFramework/RecordMatcher.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/RecordMatcher.cs
@@ -198,6 +198,11 @@ namespace Azure.Core.Testing
                 var requestHeaderValues = header.Value;
                 var headerName = header.Key;
 
+                if (ignoredHeaders.Contains(headerName))
+                {
+                    continue;
+                }
+
                 if (remaining.TryGetValue(headerName, out string[] entryHeaderValues))
                 {
                     // Content-Type, Accept headers are normalized by HttpClient, re-normalize them before comparing
@@ -208,14 +213,13 @@ namespace Azure.Core.Testing
                     }
 
                     remaining.Remove(headerName);
-                    if (!ignoredHeaders.Contains(headerName) &&
-                        !entryHeaderValues.SequenceEqual(requestHeaderValues))
+                    if (!entryHeaderValues.SequenceEqual(requestHeaderValues))
                     {
                         difference++;
                         descriptionBuilder?.AppendLine($"    <{headerName}> values differ, request <{JoinHeaderValues(requestHeaderValues)}>, record <{JoinHeaderValues(entryHeaderValues)}>");
                     }
                 }
-                else if (!ignoredHeaders.Contains(headerName))
+                else
                 {
                     difference++;
                     descriptionBuilder?.AppendLine($"    <{headerName}> is absent in record, value <{JoinHeaderValues(requestHeaderValues)}>");

--- a/sdk/core/Azure.Core/tests/TestFramework/RecordMatcher.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/RecordMatcher.cs
@@ -13,6 +13,13 @@ namespace Azure.Core.Testing
     {
         private readonly RecordedTestSanitizer _sanitizer;
 
+        // Headers that are normalized by HttpClient
+        private HashSet<string> _normalizedHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Accept",
+            "Content-Type"
+        };
+
         public RecordMatcher(RecordedTestSanitizer sanitizer)
         {
             _sanitizer = sanitizer;
@@ -171,26 +178,47 @@ namespace Azure.Core.Testing
             return string.Join(",", values);
         }
 
+        private string[] RenormalizeSemicolons(string[] values)
+        {
+            string[] outputs = new string[values.Length];
+            for (int i = 0; i < values.Length; i++)
+            {
+                outputs[i] = string.Join("; ", values[i].Split(';').Select(part => part.Trim()));
+            }
+
+            return outputs;
+        }
+
         private int CompareHeaderDictionaries(SortedDictionary<string, string[]> headers, SortedDictionary<string, string[]> entryHeaders, HashSet<string> ignoredHeaders, StringBuilder descriptionBuilder = null)
         {
             int difference = 0;
             var remaining = new SortedDictionary<string, string[]>(entryHeaders, entryHeaders.Comparer);
             foreach (KeyValuePair<string, string[]> header in headers)
             {
-                if (remaining.TryGetValue(header.Key, out string[] values))
+                var requestHeaderValues = header.Value;
+                var headerName = header.Key;
+
+                if (remaining.TryGetValue(headerName, out string[] entryHeaderValues))
                 {
-                    remaining.Remove(header.Key);
-                    if (!ignoredHeaders.Contains(header.Key) &&
-                        !values.SequenceEqual(header.Value))
+                    // Content-Type, Accept headers are normalized by HttpClient, re-normalize them before comparing
+                    if (_normalizedHeaders.Contains(headerName))
+                    {
+                        requestHeaderValues = RenormalizeSemicolons(requestHeaderValues);
+                        entryHeaderValues = RenormalizeSemicolons(entryHeaderValues);
+                    }
+
+                    remaining.Remove(headerName);
+                    if (!ignoredHeaders.Contains(headerName) &&
+                        !entryHeaderValues.SequenceEqual(requestHeaderValues))
                     {
                         difference++;
-                        descriptionBuilder?.AppendLine($"    <{header.Key}> values differ, request <{JoinHeaderValues(header.Value)}>, record <{JoinHeaderValues(values)}>");
+                        descriptionBuilder?.AppendLine($"    <{headerName}> values differ, request <{JoinHeaderValues(requestHeaderValues)}>, record <{JoinHeaderValues(entryHeaderValues)}>");
                     }
                 }
-                else if (!ignoredHeaders.Contains(header.Key))
+                else if (!ignoredHeaders.Contains(headerName))
                 {
                     difference++;
-                    descriptionBuilder?.AppendLine($"    <{header.Key}> is absent in record, value <{JoinHeaderValues(header.Value)}>");
+                    descriptionBuilder?.AppendLine($"    <{headerName}> is absent in record, value <{JoinHeaderValues(requestHeaderValues)}>");
                 }
             }
 

--- a/sdk/core/Azure.Core/tests/TestFramework/RecordTransport.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/RecordTransport.cs
@@ -65,7 +65,7 @@ namespace Azure.Core.Testing
             return request;
         }
 
-        public RecordEntry CreateEntry(Request request, Response response)
+        internal static RecordEntry CreateEntry(Request request, Response response)
         {
             var entry = new RecordEntry
             {
@@ -105,7 +105,7 @@ namespace Azure.Core.Testing
             return entry;
         }
 
-        private byte[] ReadToEnd(Response response)
+        private static byte[] ReadToEnd(Response response)
         {
             Stream responseContentStream = response.ContentStream;
             if (responseContentStream == null)
@@ -122,7 +122,7 @@ namespace Azure.Core.Testing
             return memoryStream.ToArray();
         }
 
-        private byte[] ReadToEnd(RequestContent requestContent)
+        private static byte[] ReadToEnd(RequestContent requestContent)
         {
             if (requestContent == null)
             {


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/11569