### PR TITLE
[Service Bus] Improve errors and update API docs as per the feedback from UX study

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
@@ -208,7 +208,8 @@ namespace Azure.Messaging.ServiceBus
 
         /// <summary>
         /// Creates a <see cref="ServiceBusReceiver"/> instance that can be used for receiving and settling messages
-        /// from a specific queue.
+        /// from a specific queue. It uses <see cref="ReceiveMode"/> to specify how messages are received. Defaults to PeekLock mode.
+        /// If you want to change the <see cref="ReceiveMode"/>, use <see cref="CreateReceiver(string, ServiceBusReceiverOptions)"/> method.
         /// </summary>
         ///
         /// <param name="queueName">The queue to create a <see cref="ServiceBusReceiver"/> for.</param>
@@ -226,7 +227,7 @@ namespace Azure.Messaging.ServiceBus
 
         /// <summary>
         /// Creates a <see cref="ServiceBusReceiver"/> instance that can be used for receiving and settling messages
-        /// from a specific queue.
+        /// from a specific queue. It uses <see cref="ReceiveMode"/> to specify how messages are received. Defaults to PeekLock mode.
         /// </summary>
         ///
         /// <param name="queueName">The queue to create a <see cref="ServiceBusReceiver"/> for.</param>
@@ -249,7 +250,9 @@ namespace Azure.Messaging.ServiceBus
 
         /// <summary>
         /// Creates a <see cref="ServiceBusReceiver"/> instance that can be used for receiving and
-        /// settling messages from a specific subscription.
+        /// settling messages from a specific subscription. It uses <see cref="ReceiveMode"/> to specify
+        /// how messages are received. Defaults to PeekLock mode. If you want to change the <see cref="ReceiveMode"/>,
+        /// use <see cref="CreateReceiver(string, string, ServiceBusReceiverOptions)"/> method.
         /// </summary>
         ///
         /// <param name="topicName">The topic to create a <see cref="ServiceBusReceiver"/> for.</param>
@@ -272,7 +275,8 @@ namespace Azure.Messaging.ServiceBus
 
         /// <summary>
         /// Creates a <see cref="ServiceBusReceiver"/> instance that can be used for
-        /// receiving and settling messages from a specific subscription.
+        /// receiving and settling messages from a specific subscription. It uses <see cref="ReceiveMode"/> to specify
+        /// how messages are received. Defaults to PeekLock mode.
         /// </summary>
         ///
         /// <param name="topicName">The topic to create a <see cref="ServiceBusReceiver"/> for.</param>
@@ -298,7 +302,8 @@ namespace Azure.Messaging.ServiceBus
 
         /// <summary>
         /// Creates a <see cref="ServiceBusSessionReceiver"/> instance that can be used for receiving
-        /// and settling messages from a specific session-enabled queue.
+        /// and settling messages from a specific session-enabled queue. It uses <see cref="ReceiveMode"/> to specify
+        /// how messages are received. Defaults to PeekLock mode.
         /// </summary>
         ///
         /// <param name="queueName">The session-enabled queue to create a <see cref="ServiceBusSessionReceiver"/> for.</param>
@@ -332,7 +337,8 @@ namespace Azure.Messaging.ServiceBus
 
         /// <summary>
         /// Creates a <see cref="ServiceBusSessionReceiver"/> instance that can be used for receiving
-        /// and settling messages from a specific session-enabled subscription.
+        /// and settling messages from a specific session-enabled subscription. It uses <see cref="ReceiveMode"/> to specify
+        /// how messages are received. Defaults to PeekLock mode.
         /// </summary>
         ///
         /// <param name="topicName">The topic to create a <see cref="ServiceBusSessionReceiver"/> for.</param>
@@ -368,7 +374,8 @@ namespace Azure.Messaging.ServiceBus
 
         /// <summary>
         /// Creates a <see cref="ServiceBusReceiver"/> instance that can be used for receiving from the
-        /// dead letter queue for the specified queue.
+        /// dead letter queue for the specified queue. It uses <see cref="ReceiveMode"/> to specify
+        /// how messages are received. Defaults to PeekLock mode.
         /// </summary>
         ///
         /// <param name="queueName">The queue to create a <see cref="ServiceBusReceiver"/> for.</param>
@@ -392,7 +399,8 @@ namespace Azure.Messaging.ServiceBus
 
         /// <summary>
         /// Creates a <see cref="ServiceBusReceiver"/> instance that can be used for receiving from the
-        /// dead letter queue for the specified subscription.
+        /// dead letter queue for the specified subscription. It uses <see cref="ReceiveMode"/> to specify
+        /// how messages are received. Defaults to PeekLock mode.
         /// </summary>
         ///
         /// <param name="topicName">The topic to create a <see cref="ServiceBusReceiver"/> for.</param>
@@ -421,7 +429,9 @@ namespace Azure.Messaging.ServiceBus
 
         /// <summary>
         /// Creates a <see cref="ServiceBusProcessor"/> instance that can be used to process messages using
-        /// event handlers that are set on the processor.
+        /// event handlers that are set on the processor. It uses <see cref="ReceiveMode"/> to specify
+        /// how messages are received. Defaults to PeekLock mode. If you want to change the <see cref="ReceiveMode"/>,
+        /// use <see cref="CreateProcessor(string, ServiceBusProcessorOptions)"/> method.
         /// </summary>
         ///
         /// <param name="queueName">The queue to create a <see cref="ServiceBusProcessor"/> for.</param>
@@ -440,7 +450,8 @@ namespace Azure.Messaging.ServiceBus
 
         /// <summary>
         /// Creates a <see cref="ServiceBusProcessor"/> instance that can be used to process messages using
-        /// event handlers that are set on the processor.
+        /// event handlers that are set on the processor. It uses <see cref="ReceiveMode"/> to specify
+        /// how messages are received. Defaults to PeekLock mode.
         /// </summary>
         ///
         /// <param name="queueName">The queue to create a <see cref="ServiceBusProcessor"/> for.</param>
@@ -463,7 +474,9 @@ namespace Azure.Messaging.ServiceBus
 
         /// <summary>
         /// Creates a <see cref="ServiceBusProcessor"/> instance that can be used to process messages using
-        /// event handlers that are set on the processor.
+        /// event handlers that are set on the processor. It uses <see cref="ReceiveMode"/> to specify
+        /// how messages are received. Defaults to PeekLock mode. If you want to change the <see cref="ReceiveMode"/>,
+        /// use <see cref="CreateProcessor(string, string, ServiceBusProcessorOptions)"/> method.
         /// </summary>
         ///
         /// <param name="topicName">The topic to create a <see cref="ServiceBusProcessor"/> for.</param>
@@ -485,7 +498,8 @@ namespace Azure.Messaging.ServiceBus
 
         /// <summary>
         /// Creates a <see cref="ServiceBusProcessor"/> instance that can be used to process messages using
-        /// event handlers that are set on the processor.
+        /// event handlers that are set on the processor. It uses <see cref="ReceiveMode"/> to specify
+        /// how messages are received. Defaults to PeekLock mode.
         /// </summary>
         ///
         /// <param name="topicName">The topic to create a <see cref="ServiceBusProcessor"/> for.</param>
@@ -510,7 +524,8 @@ namespace Azure.Messaging.ServiceBus
 
         /// <summary>
         /// Creates a <see cref="ServiceBusSessionProcessor"/> instance that can be used to process session messages using
-        /// event handlers that are set on the processor.
+        /// event handlers that are set on the processor. It uses <see cref="ReceiveMode"/> to specify
+        /// how messages are received. Defaults to PeekLock mode.
         /// </summary>
         ///
         /// <param name="queueName">The queue to create a <see cref="ServiceBusSessionProcessor"/> for.</param>
@@ -535,7 +550,8 @@ namespace Azure.Messaging.ServiceBus
 
         /// <summary>
         /// Creates a <see cref="ServiceBusSessionProcessor"/> instance that can be used to process
-        /// messages using event handlers that are set on the processor.
+        /// messages using event handlers that are set on the processor. It uses <see cref="ReceiveMode"/> to specify
+        /// how messages are received. Defaults to PeekLock mode.
         /// </summary>
         ///
         /// <param name="topicName">The topic to create a <see cref="ServiceBusSessionProcessor"/> for.</param>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
@@ -210,6 +210,7 @@ namespace Azure.Messaging.ServiceBus
         /// Creates a <see cref="ServiceBusReceiver"/> instance that can be used for receiving and settling messages
         /// from a specific queue. It uses <see cref="ReceiveMode"/> to specify how messages are received. Defaults to PeekLock mode.
         /// If you want to change the <see cref="ReceiveMode"/>, use <see cref="CreateReceiver(string, ServiceBusReceiverOptions)"/> method.
+        /// The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/> type.
         /// </summary>
         ///
         /// <param name="queueName">The queue to create a <see cref="ServiceBusReceiver"/> for.</param>
@@ -228,6 +229,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Creates a <see cref="ServiceBusReceiver"/> instance that can be used for receiving and settling messages
         /// from a specific queue. It uses <see cref="ReceiveMode"/> to specify how messages are received. Defaults to PeekLock mode.
+        /// The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/> type.
         /// </summary>
         ///
         /// <param name="queueName">The queue to create a <see cref="ServiceBusReceiver"/> for.</param>
@@ -253,6 +255,7 @@ namespace Azure.Messaging.ServiceBus
         /// settling messages from a specific subscription. It uses <see cref="ReceiveMode"/> to specify
         /// how messages are received. Defaults to PeekLock mode. If you want to change the <see cref="ReceiveMode"/>,
         /// use <see cref="CreateReceiver(string, string, ServiceBusReceiverOptions)"/> method.
+        /// The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/> type.
         /// </summary>
         ///
         /// <param name="topicName">The topic to create a <see cref="ServiceBusReceiver"/> for.</param>
@@ -276,7 +279,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Creates a <see cref="ServiceBusReceiver"/> instance that can be used for
         /// receiving and settling messages from a specific subscription. It uses <see cref="ReceiveMode"/> to specify
-        /// how messages are received. Defaults to PeekLock mode.
+        /// how messages are received. Defaults to PeekLock mode. The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/> type.
         /// </summary>
         ///
         /// <param name="topicName">The topic to create a <see cref="ServiceBusReceiver"/> for.</param>
@@ -303,7 +306,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Creates a <see cref="ServiceBusSessionReceiver"/> instance that can be used for receiving
         /// and settling messages from a specific session-enabled queue. It uses <see cref="ReceiveMode"/> to specify
-        /// how messages are received. Defaults to PeekLock mode.
+        /// how messages are received. Defaults to PeekLock mode. The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/> type.
         /// </summary>
         ///
         /// <param name="queueName">The session-enabled queue to create a <see cref="ServiceBusSessionReceiver"/> for.</param>
@@ -338,7 +341,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Creates a <see cref="ServiceBusSessionReceiver"/> instance that can be used for receiving
         /// and settling messages from a specific session-enabled subscription. It uses <see cref="ReceiveMode"/> to specify
-        /// how messages are received. Defaults to PeekLock mode.
+        /// how messages are received. Defaults to PeekLock mode. The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/> type.
         /// </summary>
         ///
         /// <param name="topicName">The topic to create a <see cref="ServiceBusSessionReceiver"/> for.</param>
@@ -375,7 +378,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Creates a <see cref="ServiceBusReceiver"/> instance that can be used for receiving from the
         /// dead letter queue for the specified queue. It uses <see cref="ReceiveMode"/> to specify
-        /// how messages are received. Defaults to PeekLock mode.
+        /// how messages are received. Defaults to PeekLock mode. The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/> type.
         /// </summary>
         ///
         /// <param name="queueName">The queue to create a <see cref="ServiceBusReceiver"/> for.</param>
@@ -400,7 +403,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Creates a <see cref="ServiceBusReceiver"/> instance that can be used for receiving from the
         /// dead letter queue for the specified subscription. It uses <see cref="ReceiveMode"/> to specify
-        /// how messages are received. Defaults to PeekLock mode.
+        /// how messages are received. Defaults to PeekLock mode. The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/> type.
         /// </summary>
         ///
         /// <param name="topicName">The topic to create a <see cref="ServiceBusReceiver"/> for.</param>
@@ -432,6 +435,7 @@ namespace Azure.Messaging.ServiceBus
         /// event handlers that are set on the processor. It uses <see cref="ReceiveMode"/> to specify
         /// how messages are received. Defaults to PeekLock mode. If you want to change the <see cref="ReceiveMode"/>,
         /// use <see cref="CreateProcessor(string, ServiceBusProcessorOptions)"/> method.
+        /// The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusProcessorOptions"/> type.
         /// </summary>
         ///
         /// <param name="queueName">The queue to create a <see cref="ServiceBusProcessor"/> for.</param>
@@ -451,7 +455,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Creates a <see cref="ServiceBusProcessor"/> instance that can be used to process messages using
         /// event handlers that are set on the processor. It uses <see cref="ReceiveMode"/> to specify
-        /// how messages are received. Defaults to PeekLock mode.
+        /// how messages are received. Defaults to PeekLock mode. The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusProcessorOptions"/> type.
         /// </summary>
         ///
         /// <param name="queueName">The queue to create a <see cref="ServiceBusProcessor"/> for.</param>
@@ -477,6 +481,7 @@ namespace Azure.Messaging.ServiceBus
         /// event handlers that are set on the processor. It uses <see cref="ReceiveMode"/> to specify
         /// how messages are received. Defaults to PeekLock mode. If you want to change the <see cref="ReceiveMode"/>,
         /// use <see cref="CreateProcessor(string, string, ServiceBusProcessorOptions)"/> method.
+        /// The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusProcessorOptions"/> type.
         /// </summary>
         ///
         /// <param name="topicName">The topic to create a <see cref="ServiceBusProcessor"/> for.</param>
@@ -499,7 +504,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Creates a <see cref="ServiceBusProcessor"/> instance that can be used to process messages using
         /// event handlers that are set on the processor. It uses <see cref="ReceiveMode"/> to specify
-        /// how messages are received. Defaults to PeekLock mode.
+        /// how messages are received. Defaults to PeekLock mode. The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusProcessorOptions"/> type.
         /// </summary>
         ///
         /// <param name="topicName">The topic to create a <see cref="ServiceBusProcessor"/> for.</param>
@@ -525,7 +530,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Creates a <see cref="ServiceBusSessionProcessor"/> instance that can be used to process session messages using
         /// event handlers that are set on the processor. It uses <see cref="ReceiveMode"/> to specify
-        /// how messages are received. Defaults to PeekLock mode.
+        /// how messages are received. Defaults to PeekLock mode. The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusProcessorOptions"/> type.
         /// </summary>
         ///
         /// <param name="queueName">The queue to create a <see cref="ServiceBusSessionProcessor"/> for.</param>
@@ -551,7 +556,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Creates a <see cref="ServiceBusSessionProcessor"/> instance that can be used to process
         /// messages using event handlers that are set on the processor. It uses <see cref="ReceiveMode"/> to specify
-        /// how messages are received. Defaults to PeekLock mode.
+        /// how messages are received. Defaults to PeekLock mode. The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusProcessorOptions"/> type.
         /// </summary>
         ///
         /// <param name="topicName">The topic to create a <see cref="ServiceBusSessionProcessor"/> for.</param>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Client/ServiceBusClient.cs
@@ -210,7 +210,7 @@ namespace Azure.Messaging.ServiceBus
         /// Creates a <see cref="ServiceBusReceiver"/> instance that can be used for receiving and settling messages
         /// from a specific queue. It uses <see cref="ReceiveMode"/> to specify how messages are received. Defaults to PeekLock mode.
         /// If you want to change the <see cref="ReceiveMode"/>, use <see cref="CreateReceiver(string, ServiceBusReceiverOptions)"/> method.
-        /// The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/> type.
+        /// The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/>.
         /// </summary>
         ///
         /// <param name="queueName">The queue to create a <see cref="ServiceBusReceiver"/> for.</param>
@@ -229,7 +229,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Creates a <see cref="ServiceBusReceiver"/> instance that can be used for receiving and settling messages
         /// from a specific queue. It uses <see cref="ReceiveMode"/> to specify how messages are received. Defaults to PeekLock mode.
-        /// The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/> type.
+        /// The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/>.
         /// </summary>
         ///
         /// <param name="queueName">The queue to create a <see cref="ServiceBusReceiver"/> for.</param>
@@ -255,7 +255,7 @@ namespace Azure.Messaging.ServiceBus
         /// settling messages from a specific subscription. It uses <see cref="ReceiveMode"/> to specify
         /// how messages are received. Defaults to PeekLock mode. If you want to change the <see cref="ReceiveMode"/>,
         /// use <see cref="CreateReceiver(string, string, ServiceBusReceiverOptions)"/> method.
-        /// The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/> type.
+        /// The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/>.
         /// </summary>
         ///
         /// <param name="topicName">The topic to create a <see cref="ServiceBusReceiver"/> for.</param>
@@ -279,7 +279,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Creates a <see cref="ServiceBusReceiver"/> instance that can be used for
         /// receiving and settling messages from a specific subscription. It uses <see cref="ReceiveMode"/> to specify
-        /// how messages are received. Defaults to PeekLock mode. The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/> type.
+        /// how messages are received. Defaults to PeekLock mode. The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/>.
         /// </summary>
         ///
         /// <param name="topicName">The topic to create a <see cref="ServiceBusReceiver"/> for.</param>
@@ -306,7 +306,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Creates a <see cref="ServiceBusSessionReceiver"/> instance that can be used for receiving
         /// and settling messages from a specific session-enabled queue. It uses <see cref="ReceiveMode"/> to specify
-        /// how messages are received. Defaults to PeekLock mode. The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/> type.
+        /// how messages are received. Defaults to PeekLock mode. The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/>.
         /// </summary>
         ///
         /// <param name="queueName">The session-enabled queue to create a <see cref="ServiceBusSessionReceiver"/> for.</param>
@@ -341,7 +341,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Creates a <see cref="ServiceBusSessionReceiver"/> instance that can be used for receiving
         /// and settling messages from a specific session-enabled subscription. It uses <see cref="ReceiveMode"/> to specify
-        /// how messages are received. Defaults to PeekLock mode. The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/> type.
+        /// how messages are received. Defaults to PeekLock mode. The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/>.
         /// </summary>
         ///
         /// <param name="topicName">The topic to create a <see cref="ServiceBusSessionReceiver"/> for.</param>
@@ -378,7 +378,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Creates a <see cref="ServiceBusReceiver"/> instance that can be used for receiving from the
         /// dead letter queue for the specified queue. It uses <see cref="ReceiveMode"/> to specify
-        /// how messages are received. Defaults to PeekLock mode. The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/> type.
+        /// how messages are received. Defaults to PeekLock mode. The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/>.
         /// </summary>
         ///
         /// <param name="queueName">The queue to create a <see cref="ServiceBusReceiver"/> for.</param>
@@ -403,7 +403,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Creates a <see cref="ServiceBusReceiver"/> instance that can be used for receiving from the
         /// dead letter queue for the specified subscription. It uses <see cref="ReceiveMode"/> to specify
-        /// how messages are received. Defaults to PeekLock mode. The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/> type.
+        /// how messages are received. Defaults to PeekLock mode. The <see cref="ReceiveMode"/> is set in <see cref="ServiceBusReceiverOptions"/>.
         /// </summary>
         ///
         /// <param name="topicName">The topic to create a <see cref="ServiceBusReceiver"/> for.</param>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Compatibility/ServiceBusClientBuilderExtensions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Compatibility/ServiceBusClientBuilderExtensions.cs
@@ -1,75 +1,44 @@
-#pragma warning disable SA1636 // File header copyright text should match
 // Copyright (c) Microsoft Corporation. All rights reserved.
-#pragma warning restore SA1636 // File header copyright text should match
 // Licensed under the MIT License.
-//        /// <summary>
-//        ///   Registers a <see cref="ServiceBusSenderClient"/> instance with the provided <paramref name="connectionString"/> and <paramref name="eventHubName"/>
-//        /// </summary>
-//        ///
-//        public static IAzureClientBuilder<ServiceBusSenderClient, ServiceBusSenderClientOptions> AddEventHubProducerClient<TBuilder>(this TBuilder builder, string connectionString, string eventHubName)
-//            where TBuilder : IAzureClientFactoryBuilder
-//        {
-//            return builder.RegisterClientFactory<ServiceBusSenderClient, ServiceBusSenderClientOptions>(options => new ServiceBusSenderClient(connectionString, eventHubName, options));
-//        }
 
-//        /// <summary>
-//        ///   Registers a <see cref="ServiceBusSenderClient"/> instance with the provided <paramref name="fullyQualifiedNamespace"/> and <paramref name="eventHubName"/>
-//        /// </summary>
-//        ///
-//        public static IAzureClientBuilder<ServiceBusSenderClient, ServiceBusSenderClientOptions> AddEventHubProducerClientWithNamespace<TBuilder>(this TBuilder builder, string fullyQualifiedNamespace, string eventHubName)
-//            where TBuilder : IAzureClientFactoryBuilderWithCredential
-//        {
-//            return builder.RegisterClientFactory<ServiceBusSenderClient, ServiceBusSenderClientOptions>((options, token) => new ServiceBusSenderClient(fullyQualifiedNamespace, eventHubName, token, options));
-//        }
+using Azure.Core.Extensions;
+using Azure.Messaging.ServiceBus;
 
-//        /// <summary>
-//        ///   Registers a <see cref="ServiceBusSenderClient"/> instance with connection options loaded from the provided <paramref name="configuration"/> instance.
-//        /// </summary>
-//        ///
-//        public static IAzureClientBuilder<ServiceBusSenderClient, ServiceBusSenderClientOptions> AddEventHubProducerClient<TBuilder, TConfiguration>(this TBuilder builder, TConfiguration configuration)
-//            where TBuilder : IAzureClientFactoryBuilderWithConfiguration<TConfiguration>
-//        {
-//            return builder.RegisterClientFactory<ServiceBusSenderClient, ServiceBusSenderClientOptions>(configuration);
-//        }
+namespace Microsoft.Extensions.Azure
+{
+    /// <summary>
+    ///    The set of extensions to add the Service Bus client types to the clients builder
+    /// </summary>
+    public static class ServiceBusClientBuilderExtensions
+    {
+        /// <summary>
+        ///   Registers a <see cref="ServiceBusClient "/> instance with the provided <paramref name="connectionString"/>.
+        /// </summary>
+        ///
+        public static IAzureClientBuilder<ServiceBusClient, ServiceBusClientOptions> AddServiceBusClient<TBuilder>(this TBuilder builder, string connectionString)
+            where TBuilder : IAzureClientFactoryBuilder
+        {
+            return builder.RegisterClientFactory<ServiceBusClient, ServiceBusClientOptions>(options => new ServiceBusClient(connectionString, options));
+        }
 
-//        /// <summary>
-//        ///   Registers a <see cref="ServiceBusReceiverClientOptions"/> instance with the provided <paramref name="connectionString"/>
-//        /// </summary>
-//        ///
-//        public static IAzureClientBuilder<ServiceBusReceiverClient, ServiceBusReceiverClientOptions> AddEventHubConsumerClient<TBuilder>(this TBuilder builder, string consumerGroup, string connectionString)
-//            where TBuilder : IAzureClientFactoryBuilder
-//        {
-//            return builder.RegisterClientFactory<ServiceBusReceiverClient, ServiceBusReceiverClientOptions>(options => new ServiceBusReceiverClient(consumerGroup, connectionString, options));
-//        }
+        /// <summary>
+        ///   Registers a <see cref="ServiceBusClient"/> instance with the provided <paramref name="fullyQualifiedNamespace"/>.
+        /// </summary>
+        ///
+        public static IAzureClientBuilder<ServiceBusClient, ServiceBusClientOptions> AddServiceBusClientWithNamespace<TBuilder>(this TBuilder builder, string fullyQualifiedNamespace)
+            where TBuilder : IAzureClientFactoryBuilderWithCredential
+        {
+            return builder.RegisterClientFactory<ServiceBusClient, ServiceBusClientOptions>((options, token) => new ServiceBusClient(fullyQualifiedNamespace, token, options));
+        }
 
-//        /// <summary>
-//        ///   Registers a <see cref="ServiceBusReceiverClient"/> instance with the provided <paramref name="connectionString"/> and <paramref name="eventHubName"/>
-//        /// </summary>
-//        ///
-//        public static IAzureClientBuilder<ServiceBusReceiverClient, ServiceBusReceiverClientOptions> AddEventHubConsumerClient<TBuilder>(this TBuilder builder, string consumerGroup, string connectionString, string eventHubName)
-//            where TBuilder : IAzureClientFactoryBuilder
-//        {
-//            return builder.RegisterClientFactory<ServiceBusReceiverClient, ServiceBusReceiverClientOptions>(options => new ServiceBusReceiverClient(connectionString, eventHubName, options));
-//        }
-
-//        /// <summary>
-//        ///   Registers a <see cref="ServiceBusReceiverClient"/> instance with the provided <paramref name="fullyQualifiedNamespace"/> and <paramref name="eventHubName"/>
-//        /// </summary>
-//        ///
-//        public static IAzureClientBuilder<ServiceBusReceiverClient, ServiceBusReceiverClientOptions> AddEventHubConsumerClientWithNamespace<TBuilder>(this TBuilder builder, string consumerGroup, string fullyQualifiedNamespace, string eventHubName)
-//            where TBuilder : IAzureClientFactoryBuilderWithCredential
-//        {
-//            return builder.RegisterClientFactory<ServiceBusReceiverClient, ServiceBusReceiverClientOptions>((options, token) => new ServiceBusReceiverClient(fullyQualifiedNamespace, eventHubName, token, options));
-//        }
-
-//        /// <summary>
-//        ///   Registers a <see cref="ServiceBusReceiverClient"/> instance with connection options loaded from the provided <paramref name="configuration"/> instance.
-//        /// </summary>
-//        ///
-//        public static IAzureClientBuilder<ServiceBusReceiverClient, ServiceBusReceiverClientOptions> AddEventHubConsumerClient<TBuilder, TConfiguration>(this TBuilder builder, TConfiguration configuration)
-//            where TBuilder : IAzureClientFactoryBuilderWithConfiguration<TConfiguration>
-//        {
-//            return builder.RegisterClientFactory<ServiceBusReceiverClient, ServiceBusReceiverClientOptions>(configuration);
-//        }
-//    }
-//}
+        /// <summary>
+        ///   Registers a <see cref="ServiceBusClient"/> instance with connection options loaded from the provided <paramref name="configuration"/> instance.
+        /// </summary>
+        ///
+        public static IAzureClientBuilder<ServiceBusClient, ServiceBusClientOptions> AddServiceBusClient<TBuilder, TConfiguration>(this TBuilder builder, TConfiguration configuration)
+            where TBuilder : IAzureClientFactoryBuilderWithConfiguration<TConfiguration>
+        {
+            return builder.RegisterClientFactory<ServiceBusClient, ServiceBusClientOptions>(configuration);
+        }
+    }
+}

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -21,6 +21,9 @@ namespace Azure.Messaging.ServiceBus
     /// The event handler is specified with the <see cref="ProcessMessageAsync"/>
     /// property. The error handler is specified with the <see cref="ProcessErrorAsync"/> property.
     /// To start processing after the handlers have been specified, call <see cref="StartProcessingAsync"/>.
+    ///
+    /// <see cref="ServiceBusProcessor"/> is used for receiving messages, not for sending messages.
+    /// In order to receive messages it uses <see cref="ServiceBusReceiver"/> under the hood.
     /// </summary>
     public class ServiceBusProcessor
     {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -15,15 +15,12 @@ using Azure.Messaging.ServiceBus.Diagnostics;
 namespace Azure.Messaging.ServiceBus
 {
     /// <summary>
-    /// A <see cref="ServiceBusProcessor"/> is responsible for processing <see cref="ServiceBusReceivedMessage" /> from a specific
-    /// entity using event handlers. It is constructed by calling
-    ///  <see cref="ServiceBusClient.CreateProcessor(string, ServiceBusProcessorOptions)"/>.
+    /// The <see cref="ServiceBusProcessor"/> provides an abstraction around a set of <see cref="ServiceBusReceiver"/> that
+    /// allows using an event based model for processing received <see cref="ServiceBusReceivedMessage" />. It is constructed by calling
+    /// <see cref="ServiceBusClient.CreateProcessor(string, ServiceBusProcessorOptions)"/>.
     /// The event handler is specified with the <see cref="ProcessMessageAsync"/>
     /// property. The error handler is specified with the <see cref="ProcessErrorAsync"/> property.
     /// To start processing after the handlers have been specified, call <see cref="StartProcessingAsync"/>.
-    ///
-    /// <see cref="ServiceBusProcessor"/> is used for receiving messages, not for sending messages.
-    /// In order to receive messages it uses <see cref="ServiceBusReceiver"/> under the hood.
     /// </summary>
     public class ServiceBusProcessor
     {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs
@@ -17,6 +17,9 @@ namespace Azure.Messaging.ServiceBus
     /// The event handler is specified with the <see cref="ProcessMessageAsync"/>
     /// property. The error handler is specified with the <see cref="ProcessErrorAsync"/> property.
     /// To start processing after the handlers have been specified, call <see cref="StartProcessingAsync"/>.
+    ///
+    /// <see cref="ServiceBusSessionProcessor"/> is used for receiving messages, not for sending messages.
+    /// In order to receive messages it uses <see cref="ServiceBusSessionReceiver"/> under the hood.
     /// </summary>
     public class ServiceBusSessionProcessor
     {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs
@@ -10,16 +10,12 @@ using System.Threading.Tasks;
 namespace Azure.Messaging.ServiceBus
 {
     /// <summary>
-    /// A <see cref="ServiceBusSessionProcessor"/> is responsible for processing
-    /// <see cref="ServiceBusReceivedMessage" /> from a specific entity using event handlers.
-    /// It is constructed by calling
-    ///  <see cref="ServiceBusClient.CreateSessionProcessor(string, ServiceBusProcessorOptions, string)"/>.
+    /// The <see cref="ServiceBusSessionProcessor"/> provides an abstraction around a set of <see cref="ServiceBusSessionReceiver"/> that
+    /// allows using an event based model for processing received <see cref="ServiceBusReceivedMessage" />.
+    /// It is constructed by calling <see cref="ServiceBusClient.CreateSessionProcessor(string, ServiceBusProcessorOptions, string)"/>.
     /// The event handler is specified with the <see cref="ProcessMessageAsync"/>
     /// property. The error handler is specified with the <see cref="ProcessErrorAsync"/> property.
     /// To start processing after the handlers have been specified, call <see cref="StartProcessingAsync"/>.
-    ///
-    /// <see cref="ServiceBusSessionProcessor"/> is used for receiving messages, not for sending messages.
-    /// In order to receive messages it uses <see cref="ServiceBusSessionReceiver"/> under the hood.
     /// </summary>
     public class ServiceBusSessionProcessor
     {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.Designer.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.Designer.cs
@@ -493,6 +493,15 @@ namespace Azure.Messaging.ServiceBus {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The operation is not supported for peeked message. Only received message can be settled..
+        /// </summary>
+        internal static string SettlementOperationNotSupported {
+            get {
+                return ResourceManager.GetString("SettlementOperationNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to In order to update the signature, a shared access key must have been provided when the shared access signature was created..
         /// </summary>
         internal static string SharedAccessKeyIsRequired {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.resx
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.resx
@@ -297,4 +297,7 @@
   <data name="MessageBatchIsLocked" xml:space="preserve">
     <value>The message batch is currently being used in communication with the Service Bus service; messages may not be added until the active operation is complete.</value>
   </data>
+  <data name="SettlementOperationNotSupported" xml:space="preserve">
+    <value>The operation is not supported for peeked message. Only received message can be settled.</value>
+  </data>
 </root>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
-using Azure.Core.Pipeline;
 using Azure.Messaging.ServiceBus.Core;
 using Azure.Messaging.ServiceBus.Diagnostics;
 
@@ -17,7 +16,7 @@ namespace Azure.Messaging.ServiceBus
 {
     /// <summary>
     ///   A client responsible for sending <see cref="ServiceBusMessage" /> to a specific Service Bus entity
-    ///   (Queue or Topic). It is constructed by calling <see cref="ServiceBusClient.CreateSender(string)"/>.
+    ///   (Queue or Topic). It can be used for session enabled entities. It is constructed by calling <see cref="ServiceBusClient.CreateSender(string)"/>.
     /// </summary>
     ///
     public class ServiceBusSender : IAsyncDisposable

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -16,7 +16,7 @@ namespace Azure.Messaging.ServiceBus
 {
     /// <summary>
     ///   A client responsible for sending <see cref="ServiceBusMessage" /> to a specific Service Bus entity
-    ///   (Queue or Topic). It can be used for session enabled entities. It is constructed by calling <see cref="ServiceBusClient.CreateSender(string)"/>.
+    ///   (Queue or Topic). It can be used for both session and non-session entities. It is constructed by calling <see cref="ServiceBusClient.CreateSender(string)"/>.
     /// </summary>
     ///
     public class ServiceBusSender : IAsyncDisposable

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -413,5 +413,105 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 Assert.IsTrue(diff.TotalSeconds > 10);
             }
         }
+
+        [Test]
+        public async Task ThrowIfCompletePeekedMessage()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+
+                ServiceBusSender sender = client.CreateSender(scope.QueueName);
+                await sender.SendAsync(GetMessage());
+
+                var receiver = client.CreateReceiver(scope.QueueName);
+
+                var peekedMessage = await receiver.PeekAsync();
+
+                Assert.That(
+                    async () => await receiver.CompleteAsync(peekedMessage),
+                    Throws.InstanceOf<InvalidOperationException>());
+            }
+        }
+
+        [Test]
+        public async Task ThrowIfAbandonPeekedMessage()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+
+                ServiceBusSender sender = client.CreateSender(scope.QueueName);
+                await sender.SendAsync(GetMessage());
+
+                var receiver = client.CreateReceiver(scope.QueueName);
+
+                var peekedMessage = await receiver.PeekAsync();
+
+                Assert.That(
+                    async () => await receiver.AbandonAsync(peekedMessage),
+                    Throws.InstanceOf<InvalidOperationException>());
+            }
+        }
+
+        [Test]
+        public async Task ThrowIfDeferPeekedMessage()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+
+                ServiceBusSender sender = client.CreateSender(scope.QueueName);
+                await sender.SendAsync(GetMessage());
+
+                var receiver = client.CreateReceiver(scope.QueueName);
+
+                var peekedMessage = await receiver.PeekAsync();
+
+                Assert.That(
+                    async () => await receiver.DeferAsync(peekedMessage),
+                    Throws.InstanceOf<InvalidOperationException>());
+            }
+        }
+
+        [Test]
+        public async Task ThrowIfDeadletterPeekedMessage()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+
+                ServiceBusSender sender = client.CreateSender(scope.QueueName);
+                await sender.SendAsync(GetMessage());
+
+                var receiver = client.CreateReceiver(scope.QueueName);
+
+                var peekedMessage = await receiver.PeekAsync();
+
+                Assert.That(
+                    async () => await receiver.DeadLetterAsync(peekedMessage),
+                    Throws.InstanceOf<InvalidOperationException>());
+            }
+        }
+
+        [Test]
+        public async Task ThrowIfRenewlockOfPeekedMessage()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+
+                ServiceBusSender sender = client.CreateSender(scope.QueueName);
+                await sender.SendAsync(GetMessage());
+
+                var receiver = client.CreateReceiver(scope.QueueName);
+
+                var peekedMessage = await receiver.PeekAsync();
+
+                Assert.That(
+                    async () => await receiver.RenewMessageLockAsync(peekedMessage),
+                    Throws.InstanceOf<InvalidOperationException>());
+            }
+        }
     }
 }


### PR DESCRIPTION
* Improve error message when user attempts to settle a peeked message.
* Update ServiceBusSender docs by making it clear that it can be used for session entities.
* Update Processor docs by including that this is used for receiving messages, not sending messages.
* Include default ReceiveMode in more places in documentation.
* Add ClientBuilderExtensions to be used for dependency injection.