### PR TITLE
Update ci.yml for Azure Pipelines

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -36,6 +36,8 @@ pr:
     - sdk/core/
     - eng/
     - samples/
+    exclude:
+    - eng/mgmt/
 
 stages:
 - template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml


### PR DESCRIPTION
Exclude `eng/mgmt/` in pr validation of the "net - core - ci" pipeline

Forgot to update pr validation section in my last PR #11495 