### PR TITLE
Make Remove-TestResource invoke custom script prior to deletion of the resource group

### DIFF
--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -39,6 +39,9 @@ param (
     [Parameter(ParameterSetName = 'ResourceGroup+Provisioner', Mandatory = $true)]
     [string] $ProvisionerApplicationSecret,
 
+    [Parameter(Mandatory = $false)]
+    [string] $ServiceDirectory,
+
     [Parameter()]
     [ValidateSet('AzureCloud', 'AzureUSGovernment', 'AzureChinaCloud')]
     [string] $Environment = 'AzureCloud',
@@ -116,6 +119,13 @@ if (!$ResourceGroupName) {
     $ResourceGroupName = "rg-$BaseName"
 }
 
+$root = [System.IO.Path]::Combine("$PSScriptRoot/../../../sdk", $ServiceDirectory) | Resolve-Path
+$preRemovalScript = Join-Path -Path $root -ChildPath 'remove-test-resources-pre.ps1'
+if (Test-Path $preRemovalScript) {
+    Log "Invoking pre resource removal script '$preRemovalScript'"
+    &$preRemovalScript -ResourceGroupName $ResourceGroupName @PSBoundParameters
+}
+
 Log "Deleting resource group '$ResourceGroupName'"
 if (Retry { Remove-AzResourceGroup -Name "$ResourceGroupName" -Force:$Force }) {
     Write-Verbose "Successfully deleted resource group '$ResourceGroupName'"
@@ -156,6 +166,10 @@ A service principal ID to provision test resources when a provisioner is specifi
 
 .PARAMETER ProvisionerApplicationSecret
 A service principal secret (password) to provision test resources when a provisioner is specified.
+
+.PARAMETER ServiceDirectory
+A directory under 'sdk' in the repository root - optionally with subdirectories
+specified - in which to discover pre removal script named 'remove-test-resources-pre.json'.
 
 .PARAMETER Environment
 Name of the cloud environment. The default is the Azure Public Cloud

--- a/eng/common/TestResources/Remove-TestResources.ps1.md
+++ b/eng/common/TestResources/Remove-TestResources.ps1.md
@@ -168,6 +168,21 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+### -ServiceDirectory
+A directory under 'sdk' in the repository root - optionally with subdirectories
+specified - specified - in which to discover pre removal script named 'remove-test-resources-pre.json'.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Environment
 Name of the cloud environment.


### PR DESCRIPTION
Since there are certain actions that might need to be taken prior to deletion of test resources, we will invoke custom scripts in the service directory named : remove-test-resources-pre.ps1