### PR TITLE
[Service Bus] Change from static factory method to constructor for copying received message

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/ServiceBusMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/ServiceBusMessage.cs
@@ -27,7 +27,7 @@ namespace Azure.Messaging.ServiceBus
         /// Creates a new Message
         /// </summary>
         public ServiceBusMessage()
-            : this(default)
+            : this(default(ReadOnlyMemory<byte>))
         {
         }
 
@@ -39,6 +39,28 @@ namespace Azure.Messaging.ServiceBus
         {
             Body = body;
             Properties = new Dictionary<string, object>();
+        }
+
+        /// <summary>
+        /// Creates a new message from the specified received message by copying the properties.
+        /// </summary>
+        /// <param name="receivedMessage">The received message to copy the data from.</param>
+        public ServiceBusMessage(ServiceBusReceivedMessage receivedMessage)
+        {
+            Body = receivedMessage.Body;
+            ContentType = receivedMessage.ContentType;
+            CorrelationId = receivedMessage.CorrelationId;
+            Label = receivedMessage.Label;
+            MessageId = receivedMessage.MessageId;
+            PartitionKey = receivedMessage.PartitionKey;
+            Properties = new Dictionary<string, object>(receivedMessage.Properties);
+            ReplyTo = receivedMessage.ReplyTo;
+            ReplyToSessionId = receivedMessage.ReplyToSessionId;
+            SessionId = receivedMessage.SessionId;
+            ScheduledEnqueueTime = receivedMessage.ScheduledEnqueueTime;
+            TimeToLive = receivedMessage.TimeToLive;
+            To = receivedMessage.To;
+            ViaPartitionKey = receivedMessage.ViaPartitionKey;
         }
 
         /// <summary>
@@ -258,33 +280,6 @@ namespace Azure.Messaging.ServiceBus
         public override string ToString()
         {
             return string.Format(CultureInfo.CurrentCulture, "{{MessageId:{0}}}", MessageId);
-        }
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="message"></param>
-        /// <returns></returns>
-        public static ServiceBusMessage CreateFrom(ServiceBusReceivedMessage message)
-        {
-            var copiedMessage = new ServiceBusMessage
-            {
-                Body = message.Body,
-                ContentType = message.ContentType,
-                CorrelationId = message.CorrelationId,
-                Label = message.Label,
-                MessageId = message.MessageId,
-                PartitionKey = message.PartitionKey,
-                Properties = new Dictionary<string, object>(message.Properties),
-                ReplyTo = message.ReplyTo,
-                ReplyToSessionId = message.ReplyToSessionId,
-                SessionId = message.SessionId,
-                ScheduledEnqueueTime = message.ScheduledEnqueueTime,
-                TimeToLive = message.TimeToLive,
-                To = message.To,
-                ViaPartitionKey = message.ViaPartitionKey
-            };
-            return copiedMessage;
         }
 
         private static void ValidateMessageId(string messageId)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/ServiceBusMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/ServiceBusMessage.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using Azure.Core;
 using Azure.Messaging.ServiceBus.Primitives;
 
 namespace Azure.Messaging.ServiceBus
@@ -47,6 +48,8 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="receivedMessage">The received message to copy the data from.</param>
         public ServiceBusMessage(ServiceBusReceivedMessage receivedMessage)
         {
+            Argument.AssertNotNull(receivedMessage, nameof(receivedMessage));
+
             Body = receivedMessage.Body;
             ContentType = receivedMessage.ContentType;
             CorrelationId = receivedMessage.CorrelationId;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
@@ -121,7 +121,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
                     });
                 var received = await receiver.ReceiveAsync();
                 AssertMessagesEqual(msg, received);
-                var toSend = ServiceBusMessage.CreateFrom(received);
+                var toSend = new ServiceBusMessage(received);
                 AssertMessagesEqual(toSend, received);
 
                 void AssertMessagesEqual(ServiceBusMessage sentMessage, ServiceBusReceivedMessage received)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
@@ -281,7 +281,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 }
                 foreach (ServiceBusReceivedMessage msg in receivedMessages)
                 {
-                    await sender.SendAsync(ServiceBusMessage.CreateFrom(msg));
+                    await sender.SendAsync(new ServiceBusMessage(msg));
                 }
 
                 var messageEnum = receivedMessages.GetEnumerator();


### PR DESCRIPTION
Closes #11633

I was assuming no obsolete is necessary due to the client being in preview