### PR TITLE
Add Iot Hub API categories to design doc

### DIFF
--- a/sdk/iot/Azure.Iot.Hub.Service/src/API Design.md
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/API Design.md
@@ -58,8 +58,22 @@ This document outlines the APIs for the Azure Iot Hub Service SDK
 ```
 </details>
 
+<details><summary><b>Cloud to Device Messaging</b></summary>
+No sign of this in the swagger    
+```csharp
+
+```
+</details>
+
 <details><summary><b>Feedback Message</b></summary>
     
+```csharp
+
+```
+</details>
+
+<details><summary><b>File Upload Notifications</b></summary>
+No sign of this in the swagger
 ```csharp
 
 ```

--- a/sdk/iot/Azure.Iot.Hub.Service/src/API Design.md
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/API Design.md
@@ -2,12 +2,14 @@
 This document outlines the APIs for the Azure Iot Hub Service SDK
 
 <details><summary><b>Constructors</b></summary>
+    
 ```csharp
 
 ```
 </details>
 
 <details><summary><b>Configuration APIs</b></summary>
+    
 ```csharp
 
 ```
@@ -21,12 +23,14 @@ This document outlines the APIs for the Azure Iot Hub Service SDK
 </details>
 
 <details><summary><b>Registry APIs</b></summary>
+    
 ```csharp
 
 ```
 </details>
 
 <details><summary><b>Job APIs</b></summary>
+    
 ```csharp
 
 ```
@@ -41,24 +45,28 @@ This document outlines the APIs for the Azure Iot Hub Service SDK
 </details>
 
 <details><summary><b>Twin APIs</b></summary>
+    
 ```csharp
 
 ```
 </details>
 
 <details><summary><b>Method APIs</b></summary>
+    
 ```csharp
 
 ```
 </details>
 
 <details><summary><b>Feedback Message APIs</b></summary>
+    
 ```csharp
 
 ```
 </details>
 
 <details><summary><b>Query APIs</b></summary>
+    
 ```csharp
 
 ```

--- a/sdk/iot/Azure.Iot.Hub.Service/src/API Design.md
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/API Design.md
@@ -8,35 +8,35 @@ This document outlines the APIs for the Azure Iot Hub Service SDK
 ```
 </details>
 
-<details><summary><b>Configuration APIs</b></summary>
+<details><summary><b>Configuration</b></summary>
     
 ```csharp
 
 ```
 </details>
 
-<details><summary><b>Statistics APIs</b></summary>
+<details><summary><b>Statistics</b></summary>
 
 ```csharp
 
 ```
 </details>
 
-<details><summary><b>Registry APIs</b></summary>
+<details><summary><b>Registry</b></summary>
     
 ```csharp
 
 ```
 </details>
 
-<details><summary><b>Job APIs</b></summary>
+<details><summary><b>Job</b></summary>
     
 ```csharp
 
 ```
 </details>
 
-<details><summary><b>V2 Job APIs</b></summary>
+<details><summary><b>V2 Job</b></summary>
 (maybe combine with job APIs, or maybe don't expose v1 job APIs. Talk with service about this)
 
 ```csharp
@@ -44,28 +44,28 @@ This document outlines the APIs for the Azure Iot Hub Service SDK
 ```
 </details>
 
-<details><summary><b>Twin APIs</b></summary>
+<details><summary><b>Twin</b></summary>
     
 ```csharp
 
 ```
 </details>
 
-<details><summary><b>Method APIs</b></summary>
+<details><summary><b>Method</b></summary>
     
 ```csharp
 
 ```
 </details>
 
-<details><summary><b>Feedback Message APIs</b></summary>
+<details><summary><b>Feedback Message</b></summary>
     
 ```csharp
 
 ```
 </details>
 
-<details><summary><b>Query APIs</b></summary>
+<details><summary><b>Query</b></summary>
     
 ```csharp
 

--- a/sdk/iot/Azure.Iot.Hub.Service/src/API Design.md
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/API Design.md
@@ -8,35 +8,35 @@ This document outlines the APIs for the Azure Iot Hub Service SDK
 ```
 </details>
 
-<details><summary><b>Configuration</b></summary>
-    
+<details><summary><b>Configurations</b></summary>
+APIs for managing configurations for devices and modules
 ```csharp
 
 ```
 </details>
 
 <details><summary><b>Statistics</b></summary>
-
+APIs for getting statistics about devices and modules, as well as service statistics
 ```csharp
 
 ```
 </details>
 
 <details><summary><b>Registry</b></summary>
-    
+APIs for managing device and module identities
 ```csharp
 
 ```
 </details>
 
-<details><summary><b>Job</b></summary>
-    
+<details><summary><b>Jobs</b></summary>
+APIs for using IotHub jobs
 ```csharp
 
 ```
 </details>
 
-<details><summary><b>V2 Job</b></summary>
+<details><summary><b>V2 Jobs</b></summary>
 (maybe combine with job APIs, or maybe don't expose v1 job APIs. Talk with service about this)
 
 ```csharp
@@ -45,14 +45,14 @@ This document outlines the APIs for the Azure Iot Hub Service SDK
 </details>
 
 <details><summary><b>Twin</b></summary>
-    
+Device and module twin operations
 ```csharp
 
 ```
 </details>
 
-<details><summary><b>Method</b></summary>
-    
+<details><summary><b>Methods</b></summary>
+Device and module direct methods
 ```csharp
 
 ```
@@ -66,7 +66,7 @@ No sign of this in the swagger
 </details>
 
 <details><summary><b>Feedback Message</b></summary>
-    
+APIs for getting feedback messages
 ```csharp
 
 ```
@@ -80,7 +80,7 @@ No sign of this in the swagger
 </details>
 
 <details><summary><b>Query</b></summary>
-    
+APIs for querying on device or module identities
 ```csharp
 
 ```

--- a/sdk/iot/Azure.Iot.Hub.Service/src/API Design.md
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/API Design.md
@@ -1,24 +1,64 @@
-﻿
-
-
-
-# Azure Iot Hub Service API Design Doc
+﻿# Azure Iot Hub Service API Design Doc
 This document outlines the APIs for the Azure Iot Hub Service SDK
 
-## Azure.Core usage
-Within this SDK, we will make use of several Azure.Core library classes
+<details><summary><b>Constructors</b></summary>
+```csharp
 
-[AsyncPageable\<T>](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core/src/AsyncPageable.cs): An enumerable set of items that are retrieved asynchronously over multiple http requests
+```
+</details>
 
-[Pageable\<T>](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core/src/Pageable.cs): An enumerable set of items that are retrieved synchronously over multiple http requests
+<details><summary><b>Configuration APIs</b></summary>
+```csharp
 
-[Page\<T>](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core/src/Page.cs): A single page within a Pageable. Should not be exposed to the user, since we strive to abstract out the pagination
+```
+</details>
 
-[Response](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core/src/Response.cs): Contains the raw HTTP response details
+<details><summary><b>Statistics APIs</b></summary>
 
-[Response\<T>](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core/src/Response%7BT%7D.cs): Contains a Response instance and a parsed type derived from that HTTP response (for instance, Response\<ModelData> when retrieving models)
-<details><summary><b>Sample</b></summary>
+```csharp
 
+```
+</details>
+
+<details><summary><b>Registry APIs</b></summary>
+```csharp
+
+```
+</details>
+
+<details><summary><b>Job APIs</b></summary>
+```csharp
+
+```
+</details>
+
+<details><summary><b>V2 Job APIs</b></summary>
+(maybe combine with job APIs, or maybe don't expose v1 job APIs. Talk with service about this)
+
+```csharp
+
+```
+</details>
+
+<details><summary><b>Twin APIs</b></summary>
+```csharp
+
+```
+</details>
+
+<details><summary><b>Method APIs</b></summary>
+```csharp
+
+```
+</details>
+
+<details><summary><b>Feedback Message APIs</b></summary>
+```csharp
+
+```
+</details>
+
+<details><summary><b>Query APIs</b></summary>
 ```csharp
 
 ```


### PR DESCRIPTION
A few notable things I discovered with this swagger:

No sign of file upload notification receiving. This was an AMQP API before, and I was expecting to see it here. Same issue with sending cloud to device messages. They did create an HTTP API for handling cloud to device feedback messages, which used to be AMQP.

There are two sets of Jobs APIs. I suspect the service folks would prefer we only expose the v2 APIs, but we should talk to them about this.

There are a couple of fault injection APIs. From my understanding, this aren't meant to be used by customers, so we should not expose them in our SDK

There are also digital twin APIs present in the swagger, but since we are refreshing them, I didn't include them here