### PR TITLE
[Event Hubs Client] Publish Events Without Batch

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/api/Azure.Messaging.EventHubs.netstandard2.0.cs
@@ -409,12 +409,10 @@ namespace Azure.Messaging.EventHubs.Processor
 }
 namespace Azure.Messaging.EventHubs.Producer
 {
-    public partial class CreateBatchOptions
+    public partial class CreateBatchOptions : Azure.Messaging.EventHubs.Producer.SendEventOptions
     {
         public CreateBatchOptions() { }
         public long? MaximumSizeInBytes { get { throw null; } set { } }
-        public string PartitionId { get { throw null; } set { } }
-        public string PartitionKey { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -455,6 +453,8 @@ namespace Azure.Messaging.EventHubs.Producer
         public virtual System.Threading.Tasks.Task<string[]> GetPartitionIdsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Messaging.EventHubs.PartitionProperties> GetPartitionPropertiesAsync(string partitionId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task SendAsync(Azure.Messaging.EventHubs.Producer.EventDataBatch eventBatch, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task SendAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.EventData> eventBatch, Azure.Messaging.EventHubs.Producer.SendEventOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task SendAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.EventData> eventBatch, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override string ToString() { throw null; }
     }
@@ -463,6 +463,18 @@ namespace Azure.Messaging.EventHubs.Producer
         public EventHubProducerClientOptions() { }
         public Azure.Messaging.EventHubs.EventHubConnectionOptions ConnectionOptions { get { throw null; } set { } }
         public Azure.Messaging.EventHubs.EventHubsRetryOptions RetryOptions { get { throw null; } set { } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override string ToString() { throw null; }
+    }
+    public partial class SendEventOptions
+    {
+        public SendEventOptions() { }
+        public string PartitionId { get { throw null; } set { } }
+        public string PartitionKey { get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/CreateBatchOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/CreateBatchOptions.cs
@@ -11,7 +11,7 @@ namespace Azure.Messaging.EventHubs.Producer
     ///   behaves and is sent to the Event Hubs service.
     /// </summary>
     ///
-    public class CreateBatchOptions
+    public class CreateBatchOptions : SendEventOptions
     {
         /// <summary>The requested maximum size to allow for the batch, in bytes.</summary>
         private long? _maximumSizeInBytes = null;
@@ -41,58 +41,6 @@ namespace Azure.Messaging.EventHubs.Producer
         }
 
         /// <summary>
-        ///   Allows a hashing key to be provided for the batch of events, which instructs the Event Hubs
-        ///   service map this key to a specific partition but allowing the service to choose an arbitrary,
-        ///   partition for this batch of events and any other batches using the same partition hashing key.
-        ///
-        ///   The selection of a partition is stable for a given partition hashing key.  Should any other
-        ///   batches of events be sent using the same exact partition hashing key, the Event Hubs service will
-        ///   route them all to the same partition.
-        ///
-        ///   This should be specified only when there is a need to group events by partition, but there is
-        ///   flexibility into which partition they are routed. If ensuring that a batch of events is sent
-        ///   only to a specific partition, it is recommended that the identifier of the position be
-        ///   specified directly when sending the batch.
-        /// </summary>
-        ///
-        /// <value>
-        ///   If the producer wishes to influence the automatic routing of events to partitions, the partition
-        ///   hashing key to associate with the event or batch of events; otherwise, <c>null</c>.
-        /// </value>
-        ///
-        /// <remarks>
-        ///   If the <see cref="CreateBatchOptions.PartitionKey" /> is specified, then no <see cref="CreateBatchOptions.PartitionId" />
-        ///   may be set when sending.
-        /// </remarks>
-        ///
-        public string PartitionKey { get; set; }
-
-        /// <summary>
-        ///   If specified, events will be published to this specific partition.  If the identifier is not
-        ///   specified, the Event Hubs service will be responsible for routing events automatically to an available partition.
-        /// </summary>
-        ///
-        /// <value>
-        ///   If the producer wishes the events to be automatically routed to partitions, <c>null</c>; otherwise, the identifier
-        ///   of the desired partition.
-        /// </value>
-        ///
-        /// <remarks>
-        ///   If the <see cref="CreateBatchOptions.PartitionId" /> is specified, then no <see cref="CreateBatchOptions.PartitionKey" />
-        ///   may be set when sending.
-        ///
-        ///   <para>Allowing automatic routing of partitions is recommended when:</para>
-        ///   <para>- The sending of events needs to be highly available.</para>
-        ///   <para>- The event data should be evenly distributed among all available partitions.</para>
-        ///
-        ///   If no partition is specified, the following rules are used for automatically selecting one:
-        ///   <para>1) Distribute the events equally amongst all available partitions using a round-robin approach.</para>
-        ///   <para>2) If a partition becomes unavailable, the Event Hubs service will automatically detect it and forward the message to another available partition.</para>
-        /// </remarks>
-        ///
-        public string PartitionId { get; set; }
-
-        /// <summary>
         ///   Creates a new copy of the current <see cref="CreateBatchOptions" />, cloning its attributes into a new instance.
         /// </summary>
         ///
@@ -105,15 +53,6 @@ namespace Azure.Messaging.EventHubs.Producer
                 PartitionKey = PartitionKey,
                 _maximumSizeInBytes = MaximumSizeInBytes
             };
-
-        /// <summary>
-        ///   Converts the <see cref="CreateBatchOptions" /> into an equivalent
-        ///   <see cref="SendEventOptions" /> instance.
-        /// </summary>
-        ///
-        /// <returns>A set of sending options equivalent to those represented by the batch options.</returns>
-        ///
-        internal SendEventOptions ToSendOptions() => new SendEventOptions(PartitionId, PartitionKey);
 
         /// <summary>
         ///   Determines whether the specified <see cref="System.Object" /> is equal to this instance.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -370,53 +370,64 @@ namespace Azure.Messaging.EventHubs.Producer
         }
 
         /// <summary>
-        ///   Sends a set of events to the associated Event Hub using a batched approach.  If the size of events exceed the
-        ///   maximum size of a single batch, an exception will be triggered and the send will fail.
+        ///   Sends a set of events to the associated Event Hub using a batched approach.  Because the batch is implicitly created, the size of the event set is not
+        ///   validated until this method is invoked.  The call will fail if the size of the specified set of events exceeds the maximum allowable size of a single batch.
         /// </summary>
         ///
-        /// <param name="events">The set of event data to send.</param>
+        /// <param name="eventBatch">The set of event data to send.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///
-        /// <seealso cref="SendAsync(IEnumerable{EventData}, SendEventOptions, CancellationToken)"/>
+        /// <exception cref="EventHubsException">
+        ///   Occurs when the set of events exceeds the maximum size allowed in a single batch, as determined by the Event Hubs service.  The <see cref="EventHubsException.Reason" /> will be set to
+        ///   <see cref="EventHubsException.FailureReason.MessageSizeExceeded"/> in this case.
+        /// </exception>
         ///
-        internal virtual async Task SendAsync(IEnumerable<EventData> events,
-                                              CancellationToken cancellationToken = default) => await SendAsync(events, null, cancellationToken).ConfigureAwait(false);
+        /// <seealso cref="SendAsync(IEnumerable{EventData}, SendEventOptions, CancellationToken)" />
+        /// <seealso cref="SendAsync(EventDataBatch, CancellationToken)" />
+        /// <seealso cref="CreateBatchAsync(CancellationToken)" />
+        ///
+        public virtual async Task SendAsync(IEnumerable<EventData> eventBatch,
+                                            CancellationToken cancellationToken = default) => await SendAsync(eventBatch, null, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
-        ///   Sends a set of events to the associated Event Hub using a batched approach.  If the size of events exceed the
-        ///   maximum size of a single batch, an exception will be triggered and the send will fail.
+        ///   Sends a set of events to the associated Event Hub using a batched approach.  Because the batch is implicitly created, the size of the event set is not
+        ///   validated until this method is invoked.  The call will fail if the size of the specified set of events exceeds the maximum allowable size of a single batch.
         /// </summary>
         ///
-        /// <param name="events">The set of event data to send.</param>
+        /// <param name="eventBatch">The set of event data to send.</param>
         /// <param name="options">The set of options to consider when sending this batch.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///
-        /// <seealso cref="SendAsync(EventData, CancellationToken)" />
-        /// <seealso cref="SendAsync(EventData, SendEventOptions, CancellationToken)" />
+        /// <exception cref="EventHubsException">
+        ///   Occurs when the set of events exceeds the maximum size allowed in a single batch, as determined by the Event Hubs service.  The <see cref="EventHubsException.Reason" /> will be set to
+        ///   <see cref="EventHubsException.FailureReason.MessageSizeExceeded"/> in this case.
+        /// </exception>
+        ///
         /// <seealso cref="SendAsync(IEnumerable{EventData}, CancellationToken)" />
         /// <seealso cref="SendAsync(EventDataBatch, CancellationToken)" />
+        /// <seealso cref="CreateBatchAsync(CreateBatchOptions, CancellationToken)" />
         ///
-        internal virtual async Task SendAsync(IEnumerable<EventData> events,
-                                              SendEventOptions options,
-                                              CancellationToken cancellationToken = default)
+        public virtual async Task SendAsync(IEnumerable<EventData> eventBatch,
+                                            SendEventOptions options,
+                                            CancellationToken cancellationToken = default)
         {
             options ??= DefaultSendOptions;
 
-            Argument.AssertNotNull(events, nameof(events));
+            Argument.AssertNotNull(eventBatch, nameof(eventBatch));
             AssertSinglePartitionReference(options.PartitionId, options.PartitionKey);
 
             int attempts = 0;
 
-            events = (events as IList<EventData>) ?? events.ToList();
-            InstrumentMessages(events);
+            eventBatch = (eventBatch as IList<EventData>) ?? eventBatch.ToList();
+            InstrumentMessages(eventBatch);
 
             var diagnosticIdentifiers = new List<string>();
 
-            foreach (var eventData in events)
+            foreach (var eventData in eventBatch)
             {
                 if (EventDataInstrumentation.TryExtractDiagnosticId(eventData, out var identifier))
                 {
@@ -433,8 +444,7 @@ namespace Azure.Messaging.EventHubs.Producer
                 try
                 {
                     await using var _ = pooledProducer.ConfigureAwait(false);
-
-                    await pooledProducer.TransportProducer.SendAsync(events, options, cancellationToken).ConfigureAwait(false);
+                    await pooledProducer.TransportProducer.SendAsync(eventBatch, options, cancellationToken).ConfigureAwait(false);
 
                     return;
                 }
@@ -468,10 +478,6 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///
-        /// <seealso cref="SendAsync(EventData, CancellationToken)" />
-        /// <seealso cref="SendAsync(EventData, SendEventOptions, CancellationToken)" />
-        /// <seealso cref="SendAsync(IEnumerable{EventData}, CancellationToken)" />
-        /// <seealso cref="SendAsync(IEnumerable{EventData}, SendEventOptions, CancellationToken)" />
         /// <seealso cref="CreateBatchAsync(CancellationToken)" />
         ///
         public virtual async Task SendAsync(EventDataBatch eventBatch,
@@ -535,6 +541,7 @@ namespace Azure.Messaging.EventHubs.Producer
         /// <returns>An <see cref="EventDataBatch" /> with the default batch options.</returns>
         ///
         /// <seealso cref="CreateBatchAsync(CreateBatchOptions, CancellationToken)" />
+        /// <seealso cref="SendAsync(EventDataBatch, CancellationToken)" />
         ///
         public virtual async ValueTask<EventDataBatch> CreateBatchAsync(CancellationToken cancellationToken = default) => await CreateBatchAsync(null, cancellationToken).ConfigureAwait(false);
 
@@ -552,7 +559,8 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         /// <returns>An <see cref="EventDataBatch" /> with the requested <paramref name="options"/>.</returns>
         ///
-        /// <seealso cref="CreateBatchAsync(CreateBatchOptions, CancellationToken)" />
+        /// <seealso cref="CreateBatchAsync(CancellationToken)" />
+        /// <seealso cref="SendAsync(EventDataBatch, CancellationToken)" />
         ///
         public virtual async ValueTask<EventDataBatch> CreateBatchAsync(CreateBatchOptions options,
                                                                         CancellationToken cancellationToken = default)
@@ -561,7 +569,7 @@ namespace Azure.Messaging.EventHubs.Producer
             AssertSinglePartitionReference(options.PartitionId, options.PartitionKey);
 
             TransportEventBatch transportBatch = await PartitionProducerPool.EventHubProducer.CreateBatchAsync(options, cancellationToken).ConfigureAwait(false);
-            return new EventDataBatch(transportBatch, FullyQualifiedNamespace, EventHubName, options.ToSendOptions());
+            return new EventDataBatch(transportBatch, FullyQualifiedNamespace, EventHubName, options);
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/SendEventOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/SendEventOptions.cs
@@ -7,10 +7,10 @@ namespace Azure.Messaging.EventHubs.Producer
 {
     /// <summary>
     ///   The set of options that can be specified to influence the way in which events
-    ///   are sent to the Event Hubs service.
+    ///   are published to the Event Hubs service.
     /// </summary>
     ///
-    internal class SendEventOptions
+    public class SendEventOptions
     {
         /// <summary>
         ///   Allows a hashing key to be provided for the batch of events, which instructs the Event Hubs

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpProducerTests.cs
@@ -891,7 +891,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Verifiable();
 
             using TransportEventBatch batch = await producer.Object.CreateBatchAsync(options, default);
-            await producer.Object.SendAsync(new EventDataBatch(batch, "ns", "eh", options.ToSendOptions()), CancellationToken.None);
+            await producer.Object.SendAsync(new EventDataBatch(batch, "ns", "eh", options), CancellationToken.None);
 
             producer.VerifyAll();
         }
@@ -937,7 +937,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             using TransportEventBatch transportBatch = await producer.Object.CreateBatchAsync(options, default);
 
-            using var batch = new EventDataBatch(transportBatch, "ns", "eh", options.ToSendOptions());
+            using var batch = new EventDataBatch(transportBatch, "ns", "eh", options);
             batch.TryAdd(new EventData(new byte[] { 0x15 }));
 
             await producer.Object.SendAsync(batch, CancellationToken.None);
@@ -985,7 +985,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             using TransportEventBatch transportBatch = await producer.Object.CreateBatchAsync(options, default);
 
-            using var batch = new EventDataBatch(transportBatch, "ns", "eh", options.ToSendOptions());
+            using var batch = new EventDataBatch(transportBatch, "ns", "eh", options);
             batch.TryAdd(new EventData(new byte[] { 0x15 }));
 
             await producer.Object.SendAsync(batch, CancellationToken.None);
@@ -1024,7 +1024,7 @@ namespace Azure.Messaging.EventHubs.Tests
             using CancellationTokenSource cancellationSource = new CancellationTokenSource();
 
             cancellationSource.Cancel();
-            Assert.That(async () => await producer.Object.SendAsync(new EventDataBatch(batch, "ns", "eh", options.ToSendOptions()), cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
+            Assert.That(async () => await producer.Object.SendAsync(new EventDataBatch(batch, "ns", "eh", options), cancellationSource.Token), Throws.InstanceOf<TaskCanceledException>());
         }
 
         /// <summary>
@@ -1040,7 +1040,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new CreateBatchOptions { PartitionKey = partitionKey };
             var retriableException = new EventHubsException(true, "Test");
             var retryPolicy = new BasicRetryPolicy(retryOptions);
-            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options.ToSendOptions());
+            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options);
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
             {
@@ -1079,7 +1079,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new CreateBatchOptions { PartitionKey = partitionKey };
             var retriableException = new OperationCanceledException();
             var retryPolicy = new BasicRetryPolicy(retryOptions);
-            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options.ToSendOptions());
+            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options);
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
             {
@@ -1118,7 +1118,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new CreateBatchOptions { PartitionKey = partitionKey };
             var retriableException = AmqpError.CreateExceptionForError(new Error { Condition = AmqpError.ServerBusyError }, "dummy");
             var retryPolicy = new BasicRetryPolicy(retryOptions);
-            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options.ToSendOptions());
+            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options);
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
             {
@@ -1156,7 +1156,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new CreateBatchOptions { PartitionKey = partitionKey };
             var embeddedException = new OperationCanceledException("", new ArgumentNullException());
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
-            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options.ToSendOptions());
+            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options);
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
             {
@@ -1194,7 +1194,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new CreateBatchOptions { PartitionKey = partitionKey };
             var embeddedException = new OperationCanceledException("", new AmqpException(new Error { Condition = AmqpError.ArgumentError }));
             var retryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
-            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options.ToSendOptions());
+            var batch = new EventDataBatch(Mock.Of<TransportEventBatch>(), "ns", "eh", options);
 
             var producer = new Mock<AmqpProducer>("aHub", null, Mock.Of<AmqpConnectionScope>(), new AmqpMessageConverter(), retryPolicy)
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/CreateBatchOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/CreateBatchOptionsTests.cs
@@ -40,29 +40,6 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="CreateBatchOptions.ToSendOptions" />
-        ///   method.
-        /// </summary>
-        ///
-        [Test]
-        public void ToSendOptionsTranslatesProperly()
-        {
-            var options = new CreateBatchOptions
-            {
-                PartitionId = "0",
-                PartitionKey = "some_partition_123",
-                MaximumSizeInBytes = (int.MaxValue + 122L)
-            };
-
-            var sendOptions = options.ToSendOptions();
-            Assert.That(sendOptions, Is.Not.Null, "The send options should not be null.");
-            Assert.That(sendOptions, Is.TypeOf<SendEventOptions>(), "The send options should be a SendEventOptions instance.");
-            Assert.That(sendOptions, Is.Not.SameAs(options), "The send options should not the same reference as the options.");
-            Assert.That(sendOptions.PartitionId, Is.EqualTo(options.PartitionId), "The partition identifier of the send options should match.");
-            Assert.That(sendOptions.PartitionKey, Is.EqualTo(options.PartitionKey), "The partition key of the send options should match.");
-        }
-
-        /// <summary>
         ///   Verifies functionality of the <see cref="CreateBatchOptions.MaximumSizeInBytes" />
         ///   method.
         /// </summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
@@ -395,7 +395,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SendAllowsAPartitionHashKeyWithABatch()
         {
             var batchOptions = new CreateBatchOptions { PartitionKey = "testKey" };
-            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions.ToSendOptions());
+            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions);
             var transportProducer = new ObservableTransportProducerMock();
             var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
@@ -427,7 +427,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void SendForASpecificPartitionDoesNotAllowAPartitionHashKeyWithABatch()
         {
             var batchOptions = new CreateBatchOptions { PartitionKey = "testKey", PartitionId = "1" };
-            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions.ToSendOptions());
+            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions);
             var transportProducer = new ObservableTransportProducerMock();
             var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
@@ -484,7 +484,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task SendInvokesTheTransportProducerWithABatch()
         {
             var batchOptions = new CreateBatchOptions { PartitionKey = "testKey" };
-            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions.ToSendOptions());
+            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions);
             var transportProducer = new ObservableTransportProducerMock();
             var producer = new EventHubProducerClient(new MockConnection(() => transportProducer));
 
@@ -507,7 +507,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var mockTransportBatch = new Mock<TransportEventBatch>();
             var mockTransportProducer = new Mock<TransportProducer>();
-            var batch = new EventDataBatch(mockTransportBatch.Object, "ns", "eh", batchOptions.ToSendOptions());
+            var batch = new EventDataBatch(mockTransportBatch.Object, "ns", "eh", batchOptions);
             var producer = new EventHubProducerClient(new MockConnection(() => mockTransportProducer.Object));
 
             mockTransportBatch
@@ -719,7 +719,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task EventHubProducerClientShouldPickAnItemFromPoolWithABatch()
         {
             var batchOptions = new CreateBatchOptions { PartitionId = "0" };
-            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions.ToSendOptions());
+            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions);
             var transportProducer = new ObservableTransportProducerMock();
             var eventHubConnection = new MockConnection(() => transportProducer);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -747,7 +747,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task EventHubProducerClientShouldCloseAProducer()
         {
             var batchOptions = new CreateBatchOptions { PartitionId = "0" };
-            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions.ToSendOptions());
+            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions);
             var transportProducer = new ObservableTransportProducerMock();
             var eventHubConnection = new MockConnection(() => transportProducer);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -835,7 +835,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void EventHubProducerClientShouldRetrySendingWithABatch()
         {
             var batchOptions = new CreateBatchOptions { PartitionId = "0" };
-            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions.ToSendOptions());
+            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions);
             var transportProducer = new Mock<TransportProducer>();
             var eventHubConnection = new MockConnection(() => transportProducer.Object);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -900,7 +900,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void RetryLogicEndsWithABatch()
         {
             var batchOptions = new CreateBatchOptions { PartitionId = "0" };
-            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions.ToSendOptions());
+            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions);
             var transportProducer = new Mock<TransportProducer>();
             var eventHubConnection = new MockConnection(() => transportProducer.Object);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -963,7 +963,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void RetryLogicDoesNotStartWhenPartitionIdIsNullWithABatch()
         {
             var batchOptions = new CreateBatchOptions { PartitionId = "0" };
-            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions.ToSendOptions());
+            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions);
             var transportProducer = new Mock<TransportProducer>();
             var eventHubConnection = new MockConnection(() => transportProducer.Object);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -1029,7 +1029,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task RetryLogicDoesNotWorkForClosedConnectionsWithABatch()
         {
             var batchOptions = new CreateBatchOptions { PartitionId = "0" };
-            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions.ToSendOptions());
+            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions);
             var transportProducer = new Mock<TransportProducer>();
             var eventHubConnection = new MockConnection(() => transportProducer.Object);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -1101,7 +1101,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void RetryLogicDoesNotWorkForClosedEventHubProducerClientsWithABatch()
         {
             var batchOptions = new CreateBatchOptions { PartitionId = "0" };
-            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions.ToSendOptions());
+            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions);
             var transportProducer = new Mock<TransportProducer>();
             var eventHubConnection = new MockConnection(() => transportProducer.Object);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -1163,7 +1163,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void RetryLogicShouldNotStartWhenCancellationTriggeredWithABatch()
         {
             var batchOptions = new CreateBatchOptions { PartitionId = "0" };
-            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions.ToSendOptions());
+            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions);
             var transportProducer = new Mock<TransportProducer>();
             var eventHubConnection = new MockConnection(() => transportProducer.Object);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();
@@ -1218,7 +1218,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void RetryLogicDetectsAnEmbeddedAmqpErrorForOperationCanceledWithABatch()
         {
             var batchOptions = new CreateBatchOptions { PartitionId = "0" };
-            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions.ToSendOptions());
+            var batch = new EventDataBatch(new MockTransportBatch(), "ns", "eh", batchOptions);
             var transportProducer = new Mock<TransportProducer>();
             var eventHubConnection = new MockConnection(() => transportProducer.Object);
             var retryPolicy = new EventHubProducerClientOptions().RetryOptions.ToRetryPolicy();


### PR DESCRIPTION
# Summary

The focus of these changes is to allow the publishing of events without the overhead of creating an explicit batch.  In this scenario the caller assumes
the risk with respect to exceeding the maximum size allowed by the Event Hubs service, trading safety for lower overhead and higher throughput.  This operation has existed with `internal` visibility since early preview releases; existing tests cover the full set of functionality and do not appear in this set of changes.

**Note:** This change to the API was reviewed by the .NET architect; the approval has been annotated to reflect the current state.

# Last Upstream Rebase

Tuesday, April 28, 4:54pm (EDT)

# References and Related Issues 

- [ Implement the Smart Send Feature ](https://github.com/Azure/azure-sdk-for-net/issues/11075) (#11075)