### PR TITLE
Fixed storage bug where blob, file, and directory names were not url …

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlobUriBuilder.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobUriBuilder.cs
@@ -285,9 +285,9 @@ namespace Azure.Storage.Blobs
             if (!string.IsNullOrWhiteSpace(BlobContainerName))
             {
                 path.Append("/").Append(BlobContainerName);
-                if (!String.IsNullOrWhiteSpace(BlobName))
+                if (!string.IsNullOrWhiteSpace(BlobName))
                 {
-                    path.Append("/").Append(BlobName);
+                    path.Append("/").Append(Uri.EscapeDataString(BlobName));
                 }
             }
 

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -62,6 +62,28 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [Test]
+        [Ignore("Test framework doesn't allow recorded tests with connection string because the word 'Sanitized' is not base-64 encoded, so we can't pass connection string validation")]
+        public async Task Ctor_ConnectionStringEscapeBlobName()
+        {
+            // Arrange
+            await using DisposingContainer test = await GetTestContainerAsync();
+            string blobName = "!*'();[]:@&%=+$,/?#";
+
+            BlockBlobClient initalBlob = InstrumentClient(test.Container.GetBlockBlobClient(blobName));
+            var data = GetRandomBuffer(Constants.KB);
+
+            using var stream = new MemoryStream(data);
+            Response<BlobContentInfo> uploadResponse = await initalBlob.UploadAsync(stream);
+
+            // Act
+            BlobBaseClient blob = new BlobBaseClient(TestConfigDefault.ConnectionString, test.Container.Name, blobName, GetOptions());
+            Response<BlobProperties> propertiesResponse = await blob.GetPropertiesAsync();
+
+            // Assert
+            Assert.AreEqual(uploadResponse.Value.ETag, propertiesResponse.Value.ETag);
+        }
+
+        [Test]
         public void Ctor_Uri()
         {
             var accountName = "accountName";

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -62,12 +62,14 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [Test]
-        [Ignore("Test framework doesn't allow recorded tests with connection string because the word 'Sanitized' is not base-64 encoded, so we can't pass connection string validation")]
+        // Test framework doesn't allow recorded tests with connection string because the word 'Sanitized' is not base-64 encoded,
+        // so we can't pass connection string validation"
+        [LiveOnly]
         public async Task Ctor_ConnectionStringEscapeBlobName()
         {
             // Arrange
             await using DisposingContainer test = await GetTestContainerAsync();
-            string blobName = "!*'();[]:@&%=+$,/?#";
+            string blobName = "!*'();[]:@&%=+$,/?#äÄöÖüÜß";
 
             BlockBlobClient initalBlob = InstrumentClient(test.Container.GetBlockBlobClient(blobName));
             var data = GetRandomBuffer(Constants.KB);

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareUriBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareUriBuilder.cs
@@ -279,7 +279,7 @@ namespace Azure.Storage.Files.Shares
                 path.Append("/").Append(ShareName);
                 if (!string.IsNullOrWhiteSpace(DirectoryOrFilePath))
                 {
-                    path.Append("/").Append(DirectoryOrFilePath);
+                    path.Append("/").Append(Uri.EscapeDataString(DirectoryOrFilePath));
                 }
             }
 

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
@@ -45,6 +45,28 @@ namespace Azure.Storage.Files.Shares.Test
         }
 
         [Test]
+        [Ignore("Test framework doesn't allow recorded tests with connection string because the word 'Sanitized' is not base-64 encoded, so we can't pass connection string validation")]
+        public async Task Ctor_ConnectionStringEscapePath()
+        {
+            // Arrange
+            await using DisposingShare test = await GetTestShareAsync();
+            string directoryName = "!#@&=;";
+            ShareDirectoryClient initalDirectory = InstrumentClient(test.Share.GetDirectoryClient(directoryName));
+            Response<ShareDirectoryInfo> createResponse = await initalDirectory.CreateAsync();
+
+            // Act
+            ShareDirectoryClient directory = new ShareDirectoryClient(
+                TestConfigDefault.ConnectionString,
+                test.Share.Name,
+                directoryName,
+                GetOptions());
+            Response<ShareDirectoryProperties> propertiesResponse = await directory.GetPropertiesAsync();
+
+            // Assert
+            Assert.AreEqual(createResponse.Value.ETag, propertiesResponse.Value.ETag);
+        }
+
+        [Test]
         public void DirectoryPathsParsing()
         {
             // nested directories

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
@@ -45,12 +45,14 @@ namespace Azure.Storage.Files.Shares.Test
         }
 
         [Test]
-        [Ignore("Test framework doesn't allow recorded tests with connection string because the word 'Sanitized' is not base-64 encoded, so we can't pass connection string validation")]
+        //Test framework doesn't allow recorded tests with connection string because the word 'Sanitized' is not base-64 encoded,
+        // so we can't pass connection string validation"
+        [LiveOnly]
         public async Task Ctor_ConnectionStringEscapePath()
         {
             // Arrange
             await using DisposingShare test = await GetTestShareAsync();
-            string directoryName = "!#@&=;";
+            string directoryName = "!#@&=;äÄöÖüÜß";
             ShareDirectoryClient initalDirectory = InstrumentClient(test.Share.GetDirectoryClient(directoryName));
             Response<ShareDirectoryInfo> createResponse = await initalDirectory.CreateAsync();
 

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
@@ -51,13 +51,15 @@ namespace Azure.Storage.Files.Shares.Test
         }
 
         [Test]
-        [Ignore("Test framework doesn't allow recorded tests with connection string because the word 'Sanitized' is not base-64 encoded, so we can't pass connection string validation")]
+        // "Test framework doesn't allow recorded tests with connection string because the word 'Sanitized' is not base-64 encoded,
+        // so we can't pass connection string validation"
+        [LiveOnly]
         public async Task Ctor_ConnectionStringEscapePath()
         {
             // Arrange
             await using DisposingShare test = await GetTestShareAsync();
-            string directoryName = "!#@&=;";
-            string fileName = "#$=;!";
+            string directoryName = "!#@&=;äÄ";
+            string fileName = "#$=;!öÖ";
             ShareDirectoryClient directory = InstrumentClient(test.Share.GetDirectoryClient(directoryName));
             await directory.CreateAsync();
             ShareFileClient initalFile = InstrumentClient(directory.GetFileClient(fileName));

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
@@ -51,6 +51,31 @@ namespace Azure.Storage.Files.Shares.Test
         }
 
         [Test]
+        [Ignore("Test framework doesn't allow recorded tests with connection string because the word 'Sanitized' is not base-64 encoded, so we can't pass connection string validation")]
+        public async Task Ctor_ConnectionStringEscapePath()
+        {
+            // Arrange
+            await using DisposingShare test = await GetTestShareAsync();
+            string directoryName = "!#@&=;";
+            string fileName = "#$=;!";
+            ShareDirectoryClient directory = InstrumentClient(test.Share.GetDirectoryClient(directoryName));
+            await directory.CreateAsync();
+            ShareFileClient initalFile = InstrumentClient(directory.GetFileClient(fileName));
+            Response<ShareFileInfo> createResponse = await initalFile.CreateAsync(Constants.KB);
+
+            // Act
+            ShareFileClient file = new ShareFileClient(
+                TestConfigDefault.ConnectionString,
+                test.Share.Name,
+                $"{directoryName}/{fileName}",
+                GetOptions());
+            Response<ShareFileProperties> propertiesResponse = await file.GetPropertiesAsync();
+
+            // Assert
+            Assert.AreEqual(createResponse.Value.ETag, propertiesResponse.Value.ETag);
+        }
+
+        [Test]
         public void FilePathsParsing()
         {
             // nested directories

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
@@ -25,7 +25,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public static Uri s_invalidUri = new Uri("https://error.file.core.windows.net");
 
         public FileTestBase(bool async, ShareClientOptions.ServiceVersion serviceVersion, RecordedTestMode? mode = null)
-            : base(async, mode)
+            : base(async, RecordedTestMode.Playback)
         {
             _serviceVersion = serviceVersion;
         }

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
@@ -25,7 +25,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public static Uri s_invalidUri = new Uri("https://error.file.core.windows.net");
 
         public FileTestBase(bool async, ShareClientOptions.ServiceVersion serviceVersion, RecordedTestMode? mode = null)
-            : base(async, RecordedTestMode.Playback)
+            : base(async, mode)
         {
             _serviceVersion = serviceVersion;
         }


### PR DESCRIPTION
…encoded

Resolves https://github.com/Azure/azure-sdk-for-net/issues/11602.

This is not an issue in Data Lake, because we don't have client constructors that take file or directory names, only Uris.  This is not an issue in Queues because '-' is the only symbol allowed in [queue names](https://docs.microsoft.com/en-us/rest/api/storageservices/naming-queues-and-metadata).