### PR TITLE
add ServiceDirectory to usages of remove-test-resources.yml

### DIFF
--- a/eng/pipelines/smoke-tests.yml
+++ b/eng/pipelines/smoke-tests.yml
@@ -101,3 +101,5 @@ jobs:
         displayName: "Run Smoke Tests"
 
       - template: ../common/TestResources/remove-test-resources.yml
+        parameters:
+          ServiceDirectory: '$(Build.SourcesDirectory)/common/SmokeTests/'

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -87,6 +87,8 @@ jobs:
           ${{ insert }}: ${{ parameters.EnvVars }}
 
       - template: /eng/common/TestResources/remove-test-resources.yml
+        parameters:
+          ServiceDirectory: '${{ parameters.ServiceDirectory }}'
 
       - task: PublishTestResults@2
         condition: always()


### PR DESCRIPTION
The change that this is merging ahead of is: https://github.com/Azure/azure-sdk-tools/pull/549 

If we don't add the `ServiceDirectory` we'll see failures during the de-provisioning step.