### PR TITLE
[Service Bus] Avoid rethrowing exception with throw ex syntax when exception unchanged

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Net;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -512,11 +513,14 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 // the associated link as well.
 
                 session?.Abort();
-                throw AmqpExceptionHelper.TranslateException(
+                ExceptionDispatchInfo.Capture(AmqpExceptionHelper.TranslateException(
                     exception,
                     null,
                     session.GetInnerException(),
-                    connection.IsClosing());
+                    connection.IsClosing()))
+                .Throw();
+
+                throw; // will never be reached
             }
         }
 
@@ -629,11 +633,14 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 // the associated link as well.
 
                 session?.Abort();
-                throw AmqpExceptionHelper.TranslateException(
+                ExceptionDispatchInfo.Capture(AmqpExceptionHelper.TranslateException(
                     exception,
                     null,
                     session.GetInnerException(),
-                    connection.IsClosing());
+                    connection.IsClosing()))
+                .Throw();
+
+                throw; // will never be reached
             }
         }
 
@@ -754,11 +761,14 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 // the associated link as well.
 
                 session?.Abort();
-                throw AmqpExceptionHelper.TranslateException(
+                ExceptionDispatchInfo.Capture(AmqpExceptionHelper.TranslateException(
                     exception,
                     null,
                     session.GetInnerException(),
-                    connection.IsClosing());
+                    connection.IsClosing()))
+                .Throw();
+
+                throw; // will never be reached
             }
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
@@ -252,11 +253,14 @@ namespace Azure.Messaging.ServiceBus.Amqp
             }
             catch (Exception exception)
             {
-                throw AmqpExceptionHelper.TranslateException(
+                ExceptionDispatchInfo.Capture(AmqpExceptionHelper.TranslateException(
                     exception,
                     link?.GetTrackingId(),
                     null,
-                    link?.IsClosing() ?? false);
+                    link?.IsClosing() ?? false))
+                .Throw();
+
+                throw; // will never be reached
             }
         }
 
@@ -1169,7 +1173,10 @@ namespace Azure.Messaging.ServiceBus.Amqp
             }
             catch (Exception exception)
             {
-                throw AmqpExceptionHelper.TranslateException(exception);
+                ExceptionDispatchInfo.Capture(AmqpExceptionHelper.TranslateException(exception))
+                    .Throw();
+
+                throw; // will never be reached
             }
 
             return messages;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
@@ -269,11 +270,14 @@ namespace Azure.Messaging.ServiceBus.Amqp
             }
             catch (Exception exception)
             {
-                throw AmqpExceptionHelper.TranslateException(
+                ExceptionDispatchInfo.Capture(AmqpExceptionHelper.TranslateException(
                     exception,
                     link?.GetTrackingId(),
                     null,
-                    link?.IsClosing() ?? false);
+                    link?.IsClosing() ?? false))
+                .Throw();
+
+                throw; // will never be reached
             }
         }
 
@@ -448,11 +452,14 @@ namespace Azure.Messaging.ServiceBus.Amqp
             }
             catch (Exception exception)
             {
-                throw AmqpExceptionHelper.TranslateException(
+                ExceptionDispatchInfo.Capture(AmqpExceptionHelper.TranslateException(
                     exception,
                     sendLink?.GetTrackingId(),
                     null,
-                    sendLink?.IsClosing() ?? false);
+                    sendLink?.IsClosing() ?? false))
+                .Throw();
+
+                throw; // will never be reached
             }
         }
 
@@ -520,11 +527,14 @@ namespace Azure.Messaging.ServiceBus.Amqp
             }
             catch (Exception exception)
             {
-                throw AmqpExceptionHelper.TranslateException(
+                ExceptionDispatchInfo.Capture(AmqpExceptionHelper.TranslateException(
                     exception,
                     sendLink?.GetTrackingId(),
                     null,
-                    sendLink?.IsClosing() ?? false);
+                    sendLink?.IsClosing() ?? false))
+                .Throw();
+
+                throw; // will never be reached
             }
         }
 


### PR DESCRIPTION
Attempt to address #11639

![image](https://user-images.githubusercontent.com/174258/80799029-0d2b6080-8ba6-11ea-96be-895e283f279c.png)

## Before

```
    [TestFixture]
    public class AmqpExceptionHelperTests
    {
        [Test]
        public void Translates()
        {
            try
            {
                MethodThatThrows();
            }
            catch (Exception e)
            {
                throw AmqpExceptionHelper.TranslateException(e);
            }
        }

        private static void MethodThatThrows()
        {
            throw new InvalidOperationException();
        }
     }
```

leads to 

```
Azure.Messaging.ServiceBus.Tests.Amqp.AmqpExceptionHelperTests.Translates

System.AggregateException : One or more errors occurred. (Rethrown)
  ----> NUnit.Framework.Internal.NUnitException : Rethrown
  ----> System.InvalidOperationException : Operation is not valid due to the current state of the object.
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at NUnit.Framework.Internal.Commands.TimeoutCommand.Execute(TestExecutionContext context) in D:\a\1\s\src\NUnitFramework\framework\Internal\Commands\TimeoutCommand.cs:line 102
--NUnitException
   at NUnit.Framework.Internal.Reflect.InvokeMethod(MethodInfo method, Object fixture, Object[] args) in D:\a\1\s\src\NUnitFramework\framework\Internal\Reflect.cs:line 274
   at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context) in D:\a\1\s\src\NUnitFramework\framework\Internal\Commands\TestMethodCommand.cs:line 64
   at NUnit.Framework.Internal.Commands.TimeoutCommand.<>c__DisplayClass2_0.<Execute>b__0() in D:\a\1\s\src\NUnitFramework\framework\Internal\Commands\TimeoutCommand.cs:line 102
   at System.Threading.Tasks.Task`1.InnerInvoke()
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location where exception was thrown ---
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot)
--InvalidOperationException
   at Azure.Messaging.ServiceBus.Tests.Amqp.AmqpExceptionHelperTests.Translates() in C:\p\azure-sdk-for-net\sdk\servicebus\Azure.Messaging.ServiceBus\tests\Amqp\AmqpExceptionHelperTests.cs:line 22


````

## After

```
    [TestFixture]
    public class AmqpExceptionHelperTests
    {
        [Test]
        public void Translates()
        {
            try
            {
                MethodThatThrows();
            }
            catch (Exception e)
            {
                ExceptionDispatchInfo.Capture(AmqpExceptionHelper.TranslateException(e))
                    .Throw();
                throw;
            }
        }

        private static void MethodThatThrows()
        {
            throw new InvalidOperationException();
        }
    }
```

leads to

```
Azure.Messaging.ServiceBus.Tests.Amqp.AmqpExceptionHelperTests.Translates

System.AggregateException : One or more errors occurred. (Rethrown)
  ----> NUnit.Framework.Internal.NUnitException : Rethrown
  ----> System.InvalidOperationException : Operation is not valid due to the current state of the object.
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at NUnit.Framework.Internal.Commands.TimeoutCommand.Execute(TestExecutionContext context) in D:\a\1\s\src\NUnitFramework\framework\Internal\Commands\TimeoutCommand.cs:line 102
--NUnitException
   at NUnit.Framework.Internal.Reflect.InvokeMethod(MethodInfo method, Object fixture, Object[] args) in D:\a\1\s\src\NUnitFramework\framework\Internal\Reflect.cs:line 274
   at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context) in D:\a\1\s\src\NUnitFramework\framework\Internal\Commands\TestMethodCommand.cs:line 64
   at NUnit.Framework.Internal.Commands.TimeoutCommand.<>c__DisplayClass2_0.<Execute>b__0() in D:\a\1\s\src\NUnitFramework\framework\Internal\Commands\TimeoutCommand.cs:line 102
   at System.Threading.Tasks.Task`1.InnerInvoke()
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location where exception was thrown ---
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot)
--InvalidOperationException
   at Azure.Messaging.ServiceBus.Tests.Amqp.AmqpExceptionHelperTests.MethodThatThrows() in C:\p\azure-sdk-for-net\sdk\servicebus\Azure.Messaging.ServiceBus\tests\Amqp\AmqpExceptionHelperTests.cs:line 31
   at Azure.Messaging.ServiceBus.Tests.Amqp.AmqpExceptionHelperTests.Translates() in C:\p\azure-sdk-for-net\sdk\servicebus\Azure.Messaging.ServiceBus\tests\Amqp\AmqpExceptionHelperTests.cs:line 19
--- End of stack trace from previous location where exception was thrown ---
   at Azure.Messaging.ServiceBus.Tests.Amqp.AmqpExceptionHelperTests.Translates() in C:\p\azure-sdk-for-net\sdk\servicebus\Azure.Messaging.ServiceBus\tests\Amqp\AmqpExceptionHelperTests.cs:line 23
```

The ugly part is the non-reachable throw statements to make the compiler happy