### PR TITLE
Update Autorest C#

### DIFF
--- a/eng/CodeGeneration.targets
+++ b/eng/CodeGeneration.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <_AutoRestVersion>https://github.com/Azure/autorest/releases/download/autorest-3.0.6222/autorest-3.0.6222.tgz</_AutoRestVersion>
     <_AutoRestCoreVersion>3.0.6282</_AutoRestCoreVersion>
-    <_AutoRestCSharpVersion>https://github.com/Azure/autorest.csharp/releases/download/3.0.0-dev.20200427.5/autorest-csharp-v3-3.0.0-dev.20200427.5.tgz</_AutoRestCSharpVersion>
+    <_AutoRestCSharpVersion>https://github.com/Azure/autorest.csharp/releases/download/3.0.0-dev.20200429.5/autorest-csharp-v3-3.0.0-dev.20200429.5.tgz</_AutoRestCSharpVersion>
     <_SupportsCodeGeneration Condition="'$(IsClientLibrary)' == 'true'">true</_SupportsCodeGeneration>
     <_DefaultInputName Condition="Exists('$(MSBuildProjectDirectory)/autorest.md')">$(MSBuildProjectDirectory)/autorest.md</_DefaultInputName>
     <AutoRestInput Condition="'$(AutoRestInput)' == ''">$(_DefaultInputName)</AutoRestInput>

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TrainRequest_internal.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/TrainRequest_internal.cs
@@ -37,7 +37,7 @@ namespace Azure.AI.FormRecognizer.Models
         }
 
         /// <summary> Source path containing the training documents. </summary>
-        public string Source { get; set; }
+        public string Source { get; }
         /// <summary> Filter to apply to the documents in the source path for training. </summary>
         public TrainingFileFilter SourceFilter { get; set; }
         /// <summary> Use label file for training a model. </summary>

--- a/sdk/search/Azure.Search.Documents/api/Azure.Search.Documents.netstandard2.0.cs
+++ b/sdk/search/Azure.Search.Documents/api/Azure.Search.Documents.netstandard2.0.cs
@@ -194,7 +194,7 @@ namespace Azure.Search.Documents.Models
         public AnalyzeRequest(string text) { }
         public Azure.Search.Documents.Models.AnalyzerName? Analyzer { get { throw null; } set { } }
         public System.Collections.Generic.IList<string> CharFilters { get { throw null; } set { } }
-        public string Text { get { throw null; } set { } }
+        public string Text { get { throw null; } }
         public System.Collections.Generic.IList<Azure.Search.Documents.Models.TokenFilterName> TokenFilters { get { throw null; } set { } }
         public Azure.Search.Documents.Models.TokenizerName? Tokenizer { get { throw null; } set { } }
     }

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/AnalyzeRequest.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/AnalyzeRequest.cs
@@ -41,7 +41,7 @@ namespace Azure.Search.Documents.Models
         }
 
         /// <summary> The text to break into tokens. </summary>
-        public string Text { get; set; }
+        public string Text { get; }
         /// <summary> The name of the analyzer to use to break the given text. If this parameter is not specified, you must specify a tokenizer instead. The tokenizer and analyzer parameters are mutually exclusive. </summary>
         public AnalyzerName? Analyzer { get; set; }
         /// <summary> The name of the tokenizer to use to break the given text. If this parameter is not specified, you must specify an analyzer instead. The tokenizer and analyzer parameters are mutually exclusive. </summary>

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/IndexBatch.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/IndexBatch.cs
@@ -34,6 +34,6 @@ namespace Azure.Search.Documents.Models
         }
 
         /// <summary> The actions in the batch. </summary>
-        public IList<IndexAction> Actions { get; set; }
+        public IList<IndexAction> Actions { get; }
     }
 }


### PR DESCRIPTION
Turned to many properties readonly in the last update, properties for pure input models are back to being readonly.