### PR TITLE
Use Configuration=Release for management release pipeline

### DIFF
--- a/eng/pipelines/mgmt.yml
+++ b/eng/pipelines/mgmt.yml
@@ -147,6 +147,10 @@ variables:
   loggingArgs: '/clp:ShowtimeStamp /flp:LogFile=$(msBuildLogDir)/msbuild.normal.log;Verbosity=normal /flp1:Summary;Verbosity=minimal;LogFile=$(msBuildLogDir)/msbuild.sum.log /flp2:warningsonly;logfile=$(msBuildLogDir)/msbuild.wrn.log /flp3:errorsonly;logfile=$(msBuildLogDir)/msbuild.err.log'
   RPScopeArgs: '/p:PullRequestNumber=$(system.pullrequest.pullrequestnumber) /p:RepoHtmlUrl=https://github.com/$(build.repository.id) /p:CIBuildId=$(OfficialBuildId)'
   timeoutInMinutes: 120
+  ${{ if ne(variables['System.TeamProject'], 'internal') }}:
+    BuildConfiguration: 'Debug'
+  ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    BuildConfiguration: 'Release'
 jobs:
 - template: templates/jobs/archetype-sdk-mgmt.yml
   parameters:

--- a/eng/pipelines/templates/jobs/archetype-sdk-mgmt.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-mgmt.yml
@@ -9,7 +9,7 @@ jobs:
         inputs:
           version: "$(DotNetCoreSDKVersion)"
       #- script: "echo $(system.pullrequest.pullrequestnumber), https://github.com/$(build.repository.id), https://github.com/$(build.repository.ID)"
-      - script: "dotnet msbuild mgmt.proj /v:m /t:CreateNugetPackage /p:PackageOutputPath=$(Build.ArtifactStagingDirectory) /p:Scope=${{parameters.Scope}} /p:ForPublishing=$(ShouldPublish) $(loggingArgs) $(RPScopeArgs)"
+      - script: "dotnet msbuild mgmt.proj /v:m /t:CreateNugetPackage /p:Configuration=$(BuildConfiguration) /p:PackageOutputPath=$(Build.ArtifactStagingDirectory) /p:Scope=${{parameters.Scope}} /p:ForPublishing=$(ShouldPublish) $(loggingArgs) $(RPScopeArgs)"
         displayName: "Build & Package"
         env:
           DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1


### PR DESCRIPTION
When building the SDK, Configuration was not set for management plane pipelines (for both PR validation and release). As a result, all mgmt SDKs were built and published with Configuration=Debug.
I added a variable "BuildConfiguration" to different pipelines with different values, and modified "archetype-sdk-mgmt.yml" to build with the configuration read from the variable:

|pipeline| BuildConfiguration| Test run|
|-|-|-|
|[net - mgmt](https://dev.azure.com/azure-sdk/internal/_build?definitionId=533&_a=summary)|Release| https://dev.azure.com/azure-sdk/internal/_build/results?buildId=376670&view=logs&j=ca395085-040a-526b-2ce8-bdc85f692774&t=3374e909-b3a0-5fde-4fba-1f1bb546637f |
|[net-pr - mgmt](https://dev.azure.com/azure-sdk/internal/_build?definitionId=535&_a=summary)|Release||
|[net - mgmt - ci](https://dev.azure.com/azure-sdk/public/_build?definitionId=529&_a=summary)|Debug||