### PR TITLE
Use Configuration=Release for management release pipeline

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-mgmt.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-mgmt.yml
@@ -1,6 +1,5 @@
 jobs:
   - job: Build
-
     pool:
       vmImage: windows-2019
     steps:
@@ -9,7 +8,9 @@ jobs:
         inputs:
           version: "$(DotNetCoreSDKVersion)"
       #- script: "echo $(system.pullrequest.pullrequestnumber), https://github.com/$(build.repository.id), https://github.com/$(build.repository.ID)"
-      - script: "dotnet msbuild mgmt.proj /v:m /t:CreateNugetPackage /p:PackageOutputPath=$(Build.ArtifactStagingDirectory) /p:Scope=${{parameters.Scope}} /p:ForPublishing=$(ShouldPublish) $(loggingArgs) $(RPScopeArgs)"
+      - script: |
+          if "$(BuildConfiguration)" == "Release" (set SkipTests=true) else (set SkipTests=false)
+          dotnet msbuild mgmt.proj /v:m /t:CreateNugetPackage /p:Configuration=$(BuildConfiguration) /p:SkipTests=%SkipTests% /p:PackageOutputPath=$(Build.ArtifactStagingDirectory) /p:Scope=${{parameters.Scope}} /p:ForPublishing=$(ShouldPublish) $(loggingArgs) $(RPScopeArgs)"
         displayName: "Build & Package"
         env:
           DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1


### PR DESCRIPTION
When building the SDK, Configuration was not set for management plane pipelines (for both PR validation and release). As a result, all mgmt SDKs were built and published with Configuration=Debug.
I added a variable "BuildConfiguration" to different pipelines with different values, and modified "archetype-sdk-mgmt.yml" to build with the configuration read from the variable:

|pipeline| BuildConfiguration| Test run|
|-|-|-|
|[net - mgmt](https://dev.azure.com/azure-sdk/internal/_build?definitionId=533&_a=summary)|Release| https://dev.azure.com/azure-sdk/internal/_build/results?buildId=376670&view=logs&j=ca395085-040a-526b-2ce8-bdc85f692774&t=3374e909-b3a0-5fde-4fba-1f1bb546637f |
|[net-pr - mgmt](https://dev.azure.com/azure-sdk/internal/_build?definitionId=535&_a=summary)|Release||
|[net - mgmt - ci](https://dev.azure.com/azure-sdk/public/_build?definitionId=529&_a=summary)|Debug|This PR|

I also added `SkipTests=true` when build configuration=Release, because otherwise it will try to run the tests and fail.