### PR TITLE
[Event Hubs Client] Test Timing Tweaks

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConnectionScopeTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpConnectionScopeTests.cs
@@ -1382,7 +1382,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task AuthorizationTimerCallbackToleratesDisposal()
         {
             using var cancellationSource = new CancellationTokenSource();
-            cancellationSource.CancelAfter(TimeSpan.FromSeconds(15));
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var endpoint = new Uri("amqp://test.service.gov");
             var eventHub = "myHub";

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.PartitionProcessing.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.PartitionProcessing.cs
@@ -1167,7 +1167,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task CreatePartitionProcessorProcessingTaskDoesNotReplaceTheConsumerOnFatalExceptions()
         {
             using var cancellationSource = new CancellationTokenSource();
-            cancellationSource.CancelAfter(TimeSpan.FromSeconds(20));
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var expectedException = new TaskCanceledException("Like the others, but this one is special!");
             var retryOptions = new EventHubsRetryOptions { MaximumRetries = 0, MaximumDelay = TimeSpan.FromMilliseconds(5) };

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.StartStop.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.StartStop.cs
@@ -847,7 +847,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task StopProcessingIsSafeToCallInTheErrorHandler(bool async)
         {
             using var cancellationSource = new CancellationTokenSource();
-            cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             var capturedException = default(Exception);
             var expectedException = new DivideByZeroException("BOOM!");


### PR DESCRIPTION
# Summary

The focus of these changes is to fix some incorrect timeout values for test cancellation which potentially contributed to an aborted run due to hanging in CI.  Some of the synchronization points for partition processing were also adjusted to hook a more deterministic point and, hopefully, improve reliability.

# Last Upstream Rebase

Thursday, April 30, 4:46pm (EDT)