### PR TITLE
[Event Hub] Use ExceptionDispatchInfo consistently accross AqmpClient and Producer like in AmqpConsumer

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.Runtime.ExceptionServices;
 using System.Security.Authentication;
 using System.Threading;
 using System.Threading.Tasks;
@@ -242,7 +243,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                         }
                         else if (ex is AmqpException)
                         {
-                            throw activeEx;
+                            ExceptionDispatchInfo.Capture(activeEx).Throw();
                         }
                         else
                         {
@@ -342,7 +343,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                         }
                         else if (ex is AmqpException)
                         {
-                            throw activeEx;
+                            ExceptionDispatchInfo.Capture(activeEx).Throw();
                         }
                         else
                         {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
@@ -238,7 +238,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                         }
                         else if (ex is AmqpException)
                         {
-                            throw activeEx;
+                            ExceptionDispatchInfo.Capture(activeEx).Throw();
                         }
                         else
                         {
@@ -395,7 +395,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                         }
                         else if (ex is AmqpException)
                         {
-                            throw activeEx;
+                            ExceptionDispatchInfo.Capture(activeEx).Throw();
                         }
                         else
                         {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/ExceptionExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/ExceptionExtensions.cs
@@ -71,7 +71,7 @@ namespace Azure.Messaging.EventHubs.Amqp
 
                 default:
                     return instance;
-            };
+            }
         }
     }
 }


### PR DESCRIPTION
I'm not entirely sure why [AmqpConsumer does use ExceptionDispatchInfo](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs#L303) and AmqpClient and Producer don't so following the #11679 discussion I figured I align it. 

Happy to close if not valuable or reduce it down the the semicolon removal changes ;)