### PR TITLE
[Event Hubs Client] Ignore Hanging Test

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.MainProcessingLoop.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.MainProcessingLoop.cs
@@ -562,7 +562,8 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [Timeout(300_000)] // TEMP:  Using 5 minutes as an arbitrary timeout while troubleshooting a suspected test hang.
+        [Ignore("Intermittently hanging during CI runs. Tracked by #11731")]
+        [Timeout(300_000)] // TEMP:  Using 5 minutes as an arbitrary safety timeout while troubleshooting a suspected test hang.
         public async Task BackgroundProcessingStopsProcessingAllPartitionsWhenShutdown()
         {
             using var cancellationSource = new CancellationTokenSource();


### PR DESCRIPTION
# Summary

The focus of these changes is to mark a test that has been intermittently hanging in CI runs to be ignored, pending deeper investigation.

# Last Upstream Rebase

Friday, May 1, 10:32am (EDT)

# References and Related Issues 

- [ Investigate and fix test hang for `EventProcessorTests.MainProcessingLoop.BackgroundProcessingStopsProcessingAllPartitionsWhenShutdown` ](https://github.com/Azure/azure-sdk-for-net/issues/11731) (#11731)