### PR TITLE
Update Dotnet Core SDK and Runtime

### DIFF
--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,7 +1,7 @@
 variables:
   DocWardenVersion: '0.5.0'
-  DotNetCoreSDKVersion: '3.1.100'
-  DotNetCoreRuntimeVersion: '2.1.10'
+  DotNetCoreSDKVersion: '3.1.201'
+  DotNetCoreRuntimeVersion: '3.1.3'
   OfficialBuildId: $(Build.BuildNumber)
   ConvertToProjectReferenceOption: ''
   skipComponentGovernanceDetection: true


### PR DESCRIPTION
Update DotNet Core SDK and Runtime to the latest version on build agents
[Windows-2019](https://github.com/actions/virtual-environments/blob/master/images/win/Windows2019-Readme.md#net-core)
[Ubuntu 18.04.4](https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md#ubuntu-18044-lts)