### PR TITLE
[Engineering System] Enable Console Logging for CI Test Runs

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -148,7 +148,7 @@ jobs:
           packageType: sdk
           version: "$(DotNetCoreSDKVersion)"
       - script: >-
-          dotnet test eng/service.proj --filter TestCategory!=Live --framework $(TestTargetFramework) --logger "trx;LogFileName=$(TestTargetFramework).trx"
+          dotnet test eng/service.proj --filter TestCategory!=Live --framework $(TestTargetFramework) --logger "trx;LogFileName=$(TestTargetFramework).trx" --logger:"console;verbosity=normal"
           /p:ServiceDirectory=${{parameters.ServiceToBuild}} /p:IncludeSrc=false /p:IncludeSamples=false /p:Configuration=$(BuildConfiguration) $(ConvertToProjectReferenceOption)
         displayName: "Build & Test ($(TestTargetFramework))"
         env:


### PR DESCRIPTION
# Summary

The focus of these changes is to add console logging at `normal` verbosity for CI test runs, in order to aid debugging of test failures and hangs.  For additional context and rationale for this change, please see the related issue below.

# Last Upstream Rebase

Friday, May 1, 1:16pm (EDT)

# Related Issues 

- [[FEATURE REQ] Allow the option of `normal` verbosity for logging test runs during CI builds](https://github.com/Azure/azure-sdk-for-net/issues/11730) (#11730)