### PR TITLE
Disable RecognizeEntitiesCategories test

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
@@ -865,6 +865,7 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [Test]
+        [Ignore("Tracked by issue: https://github.com/Azure/azure-sdk-for-net/issues/11571")]
         public async Task RecognizeEntitiesCategories()
         {
             TextAnalyticsClient client = GetClient();


### PR DESCRIPTION
Although the recommendation from the service team was to use `ModelVersion = "2020-02-01"`, the model changed and now it returns:
```
{
    "text": "C |Software Engineer | Wedding | Microsoft Surface laptop | Coding | 127",
    "category": "Product",
    "offset": 170,
    "length": 72,
    "confidenceScore": 0.49
},
```
so disabling test for now to unblock the CI