### PR TITLE
[Event Hubs Client] Minor Improvements Collection

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.Designer.cs
@@ -692,16 +692,5 @@ namespace Azure.Messaging.EventHubs
                 return ResourceManager.GetString("AggregateEventProcessingExceptionMessage", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The test `{0}` has been aborted because it exceeded the maximum execution time limit of {1}..
-        /// </summary>
-        internal static string TestAbortTimeoutMask
-        {
-            get
-            {
-                return ResourceManager.GetString("TestAbortTimeoutMask", resourceCulture);
-            }
-        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Resources.resx
@@ -288,7 +288,4 @@
   <data name="AggregateEventProcessingExceptionMessage" xml:space="preserve">
     <value>One or more exceptions occured during event processing.  Please see the inner exceptions for more detail.</value>
   </data>
-  <data name="TestAbortTimeoutMask" xml:space="preserve">
-    <value>The test `{0}` has been aborted because it exceeded the maximum execution time limit of {1}.</value>
-  </data>
 </root>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpClient.cs
@@ -34,7 +34,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         private static TimeSpan CredentialRefreshBuffer { get; } = TimeSpan.FromMinutes(5);
 
         /// <summary>Indicates whether or not this instance has been closed.</summary>
-        private bool _closed = false;
+        private volatile bool _closed = false;
 
         /// <summary>The currently active token to use for authorization with the Event Hubs service.</summary>
         private AccessToken _accessToken;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConsumer.cs
@@ -33,7 +33,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         private static readonly IReadOnlyList<EventData> EmptyEventSet = Array.Empty<EventData>();
 
         /// <summary>Indicates whether or not this instance has been closed.</summary>
-        private bool _closed = false;
+        private volatile bool _closed = false;
 
         /// <summary>
         ///   Indicates whether or not this consumer has been closed.
@@ -411,9 +411,9 @@ namespace Azure.Messaging.EventHubs.Amqp
                     trackLastEnqueuedEventProperties,
                     cancellationToken).ConfigureAwait(false);
             }
-            catch (InvalidOperationException ex)
+            catch (Exception ex)
             {
-               ExceptionDispatchInfo.Capture(ex.TranslateConnectionCloseDuringLinkCreationException(EventHubName)).Throw();
+                ExceptionDispatchInfo.Capture(ex.TranslateConnectionCloseDuringLinkCreationException(EventHubName)).Throw();
             }
 
             return link;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpEventBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpEventBatch.cs
@@ -32,7 +32,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         private readonly long ReservedSize;
 
         /// <summary>A flag that indicates whether or not the instance has been disposed.</summary>
-        private bool _disposed = false;
+        private volatile bool _disposed = false;
 
         /// <summary>The size of the batch, in bytes, as it will be sent via the AMQP transport.</summary>
         private long _sizeBytes = 0;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpProducer.cs
@@ -28,7 +28,7 @@ namespace Azure.Messaging.EventHubs.Amqp
     internal class AmqpProducer : TransportProducer
     {
         /// <summary>Indicates whether or not this instance has been closed.</summary>
-        private bool _closed = false;
+        private volatile bool _closed = false;
 
         /// <summary>The count of send operations performed by this instance; this is used to tag deliveries for the AMQP link.</summary>
         private int _deliveryCount = 0;
@@ -467,7 +467,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                     MaximumMessageSize = (long)link.Settings.MaxMessageSize;
                 }
             }
-            catch (InvalidOperationException ex)
+            catch (Exception ex)
             {
                ExceptionDispatchInfo.Capture(ex.TranslateConnectionCloseDuringLinkCreationException(EventHubName)).Throw();
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/ExceptionExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/ExceptionExtensions.cs
@@ -59,7 +59,7 @@ namespace Azure.Messaging.EventHubs.Amqp
         ///
         /// <returns>The <see cref="Exception" /> that corresponds to the <paramref name="instance" /> and which represents the service error.</returns>
         ///
-        public static Exception TranslateConnectionCloseDuringLinkCreationException(this InvalidOperationException instance,
+        public static Exception TranslateConnectionCloseDuringLinkCreationException(this Exception instance,
                                                                                     string eventHubName)
         {
             Argument.AssertNotNull(instance, nameof(instance));
@@ -67,6 +67,7 @@ namespace Azure.Messaging.EventHubs.Amqp
             switch (instance)
             {
                 case InvalidOperationException _ when (instance.Message.IndexOf("when the connection is closing", StringComparison.InvariantCultureIgnoreCase) >= 0):
+                case TaskCanceledException _:
                     return new EventHubsException(true, eventHubName, Resources.CouldNotCreateLink, EventHubsException.FailureReason.ServiceCommunicationProblem, instance);
 
                 default:

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Consumer/EventHubConsumerClient.cs
@@ -43,6 +43,9 @@ namespace Azure.Messaging.EventHubs.Consumer
         /// <summary>The maximum wait time for receiving an event batch for the background publishing operation used for subscriptions.</summary>
         private readonly TimeSpan BackgroundPublishingWaitTime = TimeSpan.FromMilliseconds(250);
 
+        /// <summary>Indicates whether or not this instance has been closed.</summary>
+        private volatile bool _closed = false;
+
         /// <summary>
         ///   The fully qualified Event Hubs namespace that the consumer is associated with.  This is likely
         ///   to be similar to <c>{yournamespace}.servicebus.windows.net</c>.
@@ -72,7 +75,11 @@ namespace Azure.Messaging.EventHubs.Consumer
         ///   <c>true</c> if the client is closed; otherwise, <c>false</c>.
         /// </value>
         ///
-        public bool IsClosed { get; protected set; } = false;
+        public bool IsClosed
+        {
+            get => _closed;
+            protected set => _closed = value;
+        }
 
         /// <summary>
         ///   Indicates whether the client has ownership of the associated <see cref="EventHubConnection" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/PartitionReceiver.cs
@@ -33,6 +33,9 @@ namespace Azure.Messaging.EventHubs.Primitives
     ///
     public class PartitionReceiver : IAsyncDisposable
     {
+        /// <summary>Indicates whether or not this instance has been closed.</summary>
+        private volatile bool _closed = false;
+
         /// <summary>
         ///   The fully qualified Event Hubs namespace that the client is associated with.  This is likely
         ///   to be similar to <c>{yournamespace}.servicebus.windows.net</c>.
@@ -75,7 +78,11 @@ namespace Azure.Messaging.EventHubs.Primitives
         ///   <c>true</c> if the client is closed; otherwise, <c>false</c>.
         /// </value>
         ///
-        public bool IsClosed { get; protected set; } = false;
+        public bool IsClosed
+        {
+            get => _closed;
+            protected set => _closed = value;
+        }
 
         /// <summary>
         ///   The instance of <see cref="EventHubsEventSource" /> which can be mocked for testing.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -47,6 +47,9 @@ namespace Azure.Messaging.EventHubs.Producer
         /// <summary>Sets how long a dedicated <see cref="TransportProducer" /> would sit in memory before its <see cref="TransportProducerPool" /> would remove and close it.</summary>
         private static readonly TimeSpan PartitionProducerLifespan = TimeSpan.FromMinutes(5);
 
+        /// <summary>Indicates whether or not this instance has been closed.</summary>
+        private volatile bool _closed = false;
+
         /// <summary>
         ///   The fully qualified Event Hubs namespace that the producer is associated with.  This is likely
         ///   to be similar to <c>{yournamespace}.servicebus.windows.net</c>.
@@ -69,7 +72,11 @@ namespace Azure.Messaging.EventHubs.Producer
         ///   <c>true</c> if the client is closed; otherwise, <c>false</c>.
         /// </value>
         ///
-        public bool IsClosed { get; protected set; } = false;
+        public bool IsClosed
+        {
+            get => _closed;
+            protected set => _closed = value;
+        }
 
         /// <summary>
         ///   Indicates whether the client has ownership of the associated <see cref="EventHubConnection" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpExceptionExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpExceptionExtensionsTests.cs
@@ -28,7 +28,6 @@ namespace Azure.Messaging.EventHubs.Tests
             yield return new[] { new ArgumentNullException("blah") };
             yield return new[] { new EventHubsException(false, "thing") };
             yield return new[] { new TimeoutException() };
-            yield return new[] { new TaskCanceledException() };
             yield return new[] { new Exception() };
         }
 
@@ -153,7 +152,24 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public void TranslateConnectionCloseDuringLinkCreationExceptionDetectsTheConnectionClosedException()
+        public void TranslateConnectionCloseDuringLinkCreationExceptionDetectsTheConnectionClosedTaskCanceledException()
+        {
+            var sourceException = new TaskCanceledException();
+            var exception = (sourceException.TranslateConnectionCloseDuringLinkCreationException("dummy") as EventHubsException);
+
+            Assert.That(exception, Is.Not.Null, "The exception should have been translated to an Event Hubs exception.");
+            Assert.That(exception.IsTransient, Is.True, "The translation exception should allow retries.");
+            Assert.That(exception.Reason, Is.EqualTo(EventHubsException.FailureReason.ServiceCommunicationProblem), "The translated exception should have the correct failure reason.");
+            Assert.That(exception.InnerException, Is.EqualTo(sourceException), "The translated exception should wrap the source exception.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ExceptionExtensions.TranslateConnectionCloseDuringLinkCreationException" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void TranslateConnectionCloseDuringLinkCreationExceptionDetectsTheConnectionClosedInvalidOperationException()
         {
             var sourceException = new InvalidOperationException("Can't create session when the connection is closing");
             var exception = (sourceException.TranslateConnectionCloseDuringLinkCreationException("dummy") as EventHubsException);
@@ -175,7 +191,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("nope")]
         [TestCase("when the connection is closed")]
         [TestCase("Can't create session")]
-        public void TranslateConnectionCloseDuringLinkCreationExceptionIgnoresNonMatchingExceptions(string sourceMessage)
+        public void TranslateConnectionCloseDuringLinkCreationExceptionIgnoresNonMatchingInvalidOperationExceptions(string sourceMessage)
         {
             var sourceException = new InvalidOperationException(sourceMessage);
             var exception = sourceException.TranslateConnectionCloseDuringLinkCreationException("dummy");


### PR DESCRIPTION
# Summary

The focus of these changes is to address some findings from recent stress runs around resilience against transient failures when creating AMQP links when the
authorization request fails or times out, and some oversight on ensuring that fields used as state flags are properly marked volatile.

# Last Upstream Rebase

Tuesday, May 5, 349pm (EDT)