### PR TITLE
Text analytics warnings

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -166,7 +166,7 @@ Run a model to identify a collection of significant phrases found in the passed-
 ```C# Snippet:ExtractKeyPhrases
 string document = "My cat might need to see a veterinarian.";
 
-IReadOnlyCollection<string> keyPhrases = client.ExtractKeyPhrases(document).Value;
+KeyPhraseCollection keyPhrases = client.ExtractKeyPhrases(document);
 
 Console.WriteLine($"Extracted {keyPhrases.Count} key phrases:");
 foreach (string keyPhrase in keyPhrases)
@@ -184,7 +184,7 @@ Run a predictive model to identify a collection of named entities in the passed-
 ```C# Snippet:RecognizeEntities
 string document = "Microsoft was founded by Bill Gates and Paul Allen.";
 
-IReadOnlyCollection<CategorizedEntity> entities = client.RecognizeEntities(document).Value;
+CategorizedEntityCollection entities = client.RecognizeEntities(document);
 
 Console.WriteLine($"Recognized {entities.Count} entities:");
 foreach (CategorizedEntity entity in entities)
@@ -202,7 +202,7 @@ Run a predictive model to identify a collection of entities found in the passed-
 ```C# Snippet:RecognizeLinkedEntities
 string document = "Microsoft was founded by Bill Gates and Paul Allen.";
 
-IReadOnlyCollection<LinkedEntity> linkedEntities = client.RecognizeLinkedEntities(document).Value;
+LinkedEntityCollection linkedEntities = client.RecognizeLinkedEntities(document);
 
 Console.WriteLine($"Extracted {linkedEntities.Count} linked entit{(linkedEntities.Count > 1 ? "ies" : "y")}:");
 foreach (LinkedEntity linkedEntity in linkedEntities)
@@ -235,10 +235,10 @@ Run a predictive model to identify a collection of named entities in the passed-
 ```C# Snippet:RecognizeEntitiesAsync
 string document = "Microsoft was founded by Bill Gates and Paul Allen.";
 
-Response<IReadOnlyCollection<CategorizedEntity>> entities = await client.RecognizeEntitiesAsync(document);
+CategorizedEntityCollection entities = await client.RecognizeEntitiesAsync(document);
 
-Console.WriteLine($"Recognized {entities.Value.Count} entities:");
-foreach (CategorizedEntity entity in entities.Value)
+Console.WriteLine($"Recognized {entities.Count} entities:");
+foreach (CategorizedEntity entity in entities)
 {
     Console.WriteLine($"Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample3_ExtractKeyPhrases.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample3_ExtractKeyPhrases.md
@@ -19,7 +19,7 @@ To extract key phrases from a document, use the `ExtractKeyPhrases` method.  The
 ```C# Snippet:ExtractKeyPhrases
 string document = "My cat might need to see a veterinarian.";
 
-IReadOnlyCollection<string> keyPhrases = client.ExtractKeyPhrases(document).Value;
+KeyPhraseCollection keyPhrases = client.ExtractKeyPhrases(document);
 
 Console.WriteLine($"Extracted {keyPhrases.Count} key phrases:");
 foreach (string keyPhrase in keyPhrases)
@@ -62,6 +62,7 @@ To see the full example source files, see:
 
 * [Synchronous ExtractKeyPhrases](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrases.cs)
 * [Asynchronous ExtractKeyPhrases](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesAsync.cs)
+* [ExtractKeyPhrases with warnings](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesWithWarnings.cs)
 * [Synchronous ExtractKeyPhrasesBatch](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatch.cs)
 * [Asynchronous ExtractKeyPhrasesBatch](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatchAsync.cs)
 * [Synchronous ExtractKeyPhrasesBatchConvenience](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatchConvenience.cs)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample4_RecognizeEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample4_RecognizeEntities.md
@@ -18,7 +18,7 @@ To recognize entities in a document, use the `RecognizeEntities` method.  The re
 ```C# Snippet:RecognizeEntities
 string document = "Microsoft was founded by Bill Gates and Paul Allen.";
 
-IReadOnlyCollection<CategorizedEntity> entities = client.RecognizeEntities(document).Value;
+CategorizedEntityCollection entities = client.RecognizeEntities(document);
 
 Console.WriteLine($"Recognized {entities.Count} entities:");
 foreach (CategorizedEntity entity in entities)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
@@ -18,7 +18,7 @@ To recognize linked entities in a document, use the `RecognizeLinkedEntities` me
 ```C# Snippet:RecognizeLinkedEntities
 string document = "Microsoft was founded by Bill Gates and Paul Allen.";
 
-IReadOnlyCollection<LinkedEntity> linkedEntities = client.RecognizeLinkedEntities(document).Value;
+LinkedEntityCollection linkedEntities = client.RecognizeLinkedEntities(document);
 
 Console.WriteLine($"Extracted {linkedEntities.Count} linked entit{(linkedEntities.Count > 1 ? "ies" : "y")}:");
 foreach (LinkedEntity linkedEntity in linkedEntities)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/CategorizedEntityCollection.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/CategorizedEntityCollection.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Azure.AI.TextAnalytics
+{
+    /// <summary>
+    /// Collection of <see cref="CategorizedEntity"/> objects in a document.
+    /// </summary>
+    public class CategorizedEntityCollection : ReadOnlyCollection<CategorizedEntity>
+    {
+        internal CategorizedEntityCollection(IList<CategorizedEntity> entities, IList<TextAnalyticsWarning> warnings)
+            : base(entities)
+        {
+            Warnings = new ReadOnlyCollection<TextAnalyticsWarning>(warnings);
+        }
+
+        /// <summary>
+        /// Warnings encountered while processing the document.
+        /// </summary>
+        public IReadOnlyCollection<TextAnalyticsWarning> Warnings { get; }
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/DetectedLanguage.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/DetectedLanguage.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
 namespace Azure.AI.TextAnalytics
 {
     /// <summary>
@@ -8,11 +11,12 @@ namespace Azure.AI.TextAnalytics
     /// </summary>
     public readonly struct DetectedLanguage
     {
-        internal DetectedLanguage(string name, string iso6391Name, double score)
+        internal DetectedLanguage(string name, string iso6391Name, double score, IList<TextAnalyticsWarning> warnings)
         {
             Name = name;
             Iso6391Name = iso6391Name;
             ConfidenceScore = score;
+            Warnings = new ReadOnlyCollection<TextAnalyticsWarning>(warnings);
         }
 
         /// <summary>
@@ -32,5 +36,10 @@ namespace Azure.AI.TextAnalytics
         /// indicate high certainty that the identified language is correct.
         /// </summary>
         public double ConfidenceScore { get; }
+
+        /// <summary>
+        /// Gets the warnings encountered while processing the document.
+        /// </summary>
+        public IReadOnlyCollection<TextAnalyticsWarning> Warnings { get; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/DocumentSentiment.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/DocumentSentiment.cs
@@ -14,11 +14,12 @@ namespace Azure.AI.TextAnalytics
     /// </summary>
     public class DocumentSentiment
     {
-        internal DocumentSentiment(TextSentiment sentiment, double positiveScore, double neutralScore, double negativeScore, List<SentenceSentiment> sentenceSentiments)
+        internal DocumentSentiment(TextSentiment sentiment, double positiveScore, double neutralScore, double negativeScore, List<SentenceSentiment> sentenceSentiments, IList<TextAnalyticsWarning> warnings)
         {
             Sentiment = sentiment;
             ConfidenceScores = new SentimentConfidenceScores(positiveScore, neutralScore, negativeScore);
             Sentences = new ReadOnlyCollection<SentenceSentiment>(sentenceSentiments);
+            Warnings = new ReadOnlyCollection<TextAnalyticsWarning>(warnings);
         }
 
         /// <summary>
@@ -37,5 +38,10 @@ namespace Azure.AI.TextAnalytics
         /// document.
         /// </summary>
         public IReadOnlyCollection<SentenceSentiment> Sentences { get; }
+
+        /// <summary>
+        /// Gets the warnings encountered while processing the document.
+        /// </summary>
+        public IReadOnlyCollection<TextAnalyticsWarning> Warnings { get; }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractKeyPhrasesResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ExtractKeyPhrasesResult.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 namespace Azure.AI.TextAnalytics
 {
@@ -12,12 +10,12 @@ namespace Azure.AI.TextAnalytics
     /// </summary>
     public class ExtractKeyPhrasesResult : TextAnalyticsResult
     {
-        private readonly IReadOnlyCollection<string> _keyPhrases;
+        private readonly KeyPhraseCollection _keyPhrases;
 
-        internal ExtractKeyPhrasesResult(string id, TextDocumentStatistics statistics, IList<string> keyPhrases)
+        internal ExtractKeyPhrasesResult(string id, TextDocumentStatistics statistics, KeyPhraseCollection keyPhrases)
             : base(id, statistics)
         {
-            _keyPhrases = new ReadOnlyCollection<string>(keyPhrases);
+            _keyPhrases = keyPhrases;
         }
 
         internal ExtractKeyPhrasesResult(string id, TextAnalyticsError error) : base(id, error) { }
@@ -25,7 +23,7 @@ namespace Azure.AI.TextAnalytics
         /// <summary>
         /// Gets the collection of key phrases identified in the document.
         /// </summary>
-        public IReadOnlyCollection<string> KeyPhrases
+        public KeyPhraseCollection KeyPhrases
         {
             get
             {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/KeyPhraseCollection.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/KeyPhraseCollection.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Azure.AI.TextAnalytics
+{
+    /// <summary>
+    /// Collection of key phrases present in a document.
+    /// </summary>
+    public class KeyPhraseCollection : ReadOnlyCollection<string>
+    {
+        internal KeyPhraseCollection(IList<string> keyPhrases, IList<TextAnalyticsWarning> warnings)
+            : base(keyPhrases)
+        {
+            Warnings = new ReadOnlyCollection<TextAnalyticsWarning>(warnings);
+        }
+
+        /// <summary>
+        /// Warnings encountered while processing the document.
+        /// </summary>
+        public IReadOnlyCollection<TextAnalyticsWarning> Warnings { get; }
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/LinkedEntityCollection.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/LinkedEntityCollection.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Azure.AI.TextAnalytics
+{
+    /// <summary>
+    /// Collection of <see cref="LinkedEntity"/> objects in a document.
+    /// </summary>
+    public class LinkedEntityCollection : ReadOnlyCollection<LinkedEntity>
+    {
+        internal LinkedEntityCollection(IList<LinkedEntity> entities, IList<TextAnalyticsWarning> warnings)
+       : base(entities)
+        {
+            Warnings = new ReadOnlyCollection<TextAnalyticsWarning>(warnings);
+        }
+
+        /// <summary>
+        /// Gets the warnings encountered while processing the document.
+        /// </summary>
+        public IReadOnlyCollection<TextAnalyticsWarning> Warnings { get; }
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeEntitiesResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeEntitiesResult.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 namespace Azure.AI.TextAnalytics
 {
@@ -14,12 +12,12 @@ namespace Azure.AI.TextAnalytics
     /// </summary>
     public class RecognizeEntitiesResult : TextAnalyticsResult
     {
-        private readonly IReadOnlyCollection<CategorizedEntity> _entities;
+        private readonly CategorizedEntityCollection _entities;
 
-        internal RecognizeEntitiesResult(string id, TextDocumentStatistics statistics, IList<CategorizedEntity> entities)
+        internal RecognizeEntitiesResult(string id, TextDocumentStatistics statistics, CategorizedEntityCollection entities)
             : base(id, statistics)
         {
-            _entities = new ReadOnlyCollection<CategorizedEntity>(entities);
+            _entities = entities;
         }
 
         internal RecognizeEntitiesResult(string id, TextAnalyticsError error) : base(id, error) { }
@@ -27,7 +25,7 @@ namespace Azure.AI.TextAnalytics
         /// <summary>
         /// Gets the collection of named entities identified in the document.
         /// </summary>
-        public IReadOnlyCollection<CategorizedEntity> Entities
+        public CategorizedEntityCollection Entities
         {
             get
             {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeLinkedEntitiesResult.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/RecognizeLinkedEntitiesResult.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 namespace Azure.AI.TextAnalytics
 {
@@ -14,12 +12,12 @@ namespace Azure.AI.TextAnalytics
     /// </summary>
     public class RecognizeLinkedEntitiesResult : TextAnalyticsResult
     {
-        private readonly IReadOnlyCollection<LinkedEntity> _linkedEntities;
+        private readonly LinkedEntityCollection _linkedEntities;
 
-        internal RecognizeLinkedEntitiesResult(string id, TextDocumentStatistics statistics, IList<LinkedEntity> linkedEntities)
+        internal RecognizeLinkedEntitiesResult(string id, TextDocumentStatistics statistics, LinkedEntityCollection linkedEntities)
             : base(id, statistics)
         {
-            _linkedEntities = new ReadOnlyCollection<LinkedEntity>(linkedEntities);
+            _linkedEntities = linkedEntities;
         }
 
         internal RecognizeLinkedEntitiesResult(string id, TextAnalyticsError error) : base(id, error) { }
@@ -27,7 +25,7 @@ namespace Azure.AI.TextAnalytics
         /// <summary>
         /// Gets the collection of linked entities identified in the document.
         /// </summary>
-        public IReadOnlyCollection<LinkedEntity> Entities
+        public LinkedEntityCollection Entities
         {
             get
             {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
@@ -416,7 +416,7 @@ namespace Azure.AI.TextAnalytics
         /// that the entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<IReadOnlyCollection<CategorizedEntity>>> RecognizeEntitiesAsync(string document, string language = default, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<CategorizedEntityCollection>> RecognizeEntitiesAsync(string document, string language = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(document, nameof(document));
 
@@ -441,7 +441,7 @@ namespace Azure.AI.TextAnalytics
                             TextAnalyticsError error = results[0].Error;
                             throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response, error.Message, error.Code, CreateAdditionalInformation(error)).ConfigureAwait(false);
                         }
-                        return Response.FromValue((IReadOnlyCollection<CategorizedEntity>)results[0].Entities, response);
+                        return Response.FromValue((CategorizedEntityCollection)results[0].Entities, response);
                     default:
                         throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response).ConfigureAwait(false);
                 }
@@ -477,7 +477,7 @@ namespace Azure.AI.TextAnalytics
         /// that the entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<IReadOnlyCollection<CategorizedEntity>> RecognizeEntities(string document, string language = default, CancellationToken cancellationToken = default)
+        public virtual Response<CategorizedEntityCollection> RecognizeEntities(string document, string language = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(document, nameof(document));
 
@@ -502,7 +502,7 @@ namespace Azure.AI.TextAnalytics
                             TextAnalyticsError error = results[0].Error;
                             throw _clientDiagnostics.CreateRequestFailedException(response, error.Message, error.Code, CreateAdditionalInformation(error));
                         }
-                        return Response.FromValue((IReadOnlyCollection<CategorizedEntity>)results[0].Entities, response);
+                        return Response.FromValue((CategorizedEntityCollection)results[0].Entities, response);
                     default:
                         throw _clientDiagnostics.CreateRequestFailedException(response);
                 }
@@ -997,7 +997,7 @@ namespace Azure.AI.TextAnalytics
         /// in the document.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<IReadOnlyCollection<string>>> ExtractKeyPhrasesAsync(string document, string language = default, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<KeyPhraseCollection>> ExtractKeyPhrasesAsync(string document, string language = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(document, nameof(document));
 
@@ -1022,7 +1022,7 @@ namespace Azure.AI.TextAnalytics
                             TextAnalyticsError error = results[0].Error;
                             throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response, error.Message, error.Code, CreateAdditionalInformation(error)).ConfigureAwait(false);
                         }
-                        return Response.FromValue((IReadOnlyCollection<string>)results[0].KeyPhrases, response);
+                        return Response.FromValue((KeyPhraseCollection) results[0].KeyPhrases, response);
                     default:
                         throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response).ConfigureAwait(false);
                 }
@@ -1057,7 +1057,7 @@ namespace Azure.AI.TextAnalytics
         /// in the document.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<IReadOnlyCollection<string>> ExtractKeyPhrases(string document, string language = default, CancellationToken cancellationToken = default)
+        public virtual Response<KeyPhraseCollection> ExtractKeyPhrases(string document, string language = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(document, nameof(document));
 
@@ -1082,7 +1082,7 @@ namespace Azure.AI.TextAnalytics
                             TextAnalyticsError error = results[0].Error;
                             throw _clientDiagnostics.CreateRequestFailedException(response, error.Message, error.Code, CreateAdditionalInformation(error));
                         }
-                        return Response.FromValue((IReadOnlyCollection<string>)results[0].KeyPhrases, response);
+                        return Response.FromValue((KeyPhraseCollection)results[0].KeyPhrases, response);
                     default:
                         throw _clientDiagnostics.CreateRequestFailedException(response);
                 }
@@ -1290,7 +1290,7 @@ namespace Azure.AI.TextAnalytics
         /// that the entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual async Task<Response<IReadOnlyCollection<LinkedEntity>>> RecognizeLinkedEntitiesAsync(string document, string language = default, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<LinkedEntityCollection>> RecognizeLinkedEntitiesAsync(string document, string language = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(document, nameof(document));
 
@@ -1315,7 +1315,7 @@ namespace Azure.AI.TextAnalytics
                             TextAnalyticsError error = results[0].Error;
                             throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response, error.Message, error.Code, CreateAdditionalInformation(error)).ConfigureAwait(false);
                         }
-                        return Response.FromValue((IReadOnlyCollection<LinkedEntity>)results[0].Entities, response);
+                        return Response.FromValue((LinkedEntityCollection)results[0].Entities, response);
                     default:
                         throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response).ConfigureAwait(false);
                 }
@@ -1349,7 +1349,7 @@ namespace Azure.AI.TextAnalytics
         /// that the entity correctly matches the identified substring.</returns>
         /// <exception cref="RequestFailedException">Service returned a non-success
         /// status code.</exception>
-        public virtual Response<IReadOnlyCollection<LinkedEntity>> RecognizeLinkedEntities(string document, string language = default, CancellationToken cancellationToken = default)
+        public virtual Response<LinkedEntityCollection> RecognizeLinkedEntities(string document, string language = default, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(document, nameof(document));
 
@@ -1374,7 +1374,7 @@ namespace Azure.AI.TextAnalytics
                             TextAnalyticsError error = results[0].Error;
                             throw _clientDiagnostics.CreateRequestFailedException(response, error.Message, error.Code, CreateAdditionalInformation(error));
                         }
-                        return Response.FromValue((IReadOnlyCollection<LinkedEntity>)results[0].Entities, response);
+                        return Response.FromValue((LinkedEntityCollection)results[0].Entities, response);
                     default:
                         throw _clientDiagnostics.CreateRequestFailedException(response);
                 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsError.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsError.cs
@@ -4,7 +4,7 @@
 namespace Azure.AI.TextAnalytics
 {
     /// <summary>
-    /// Text Analitics Error.
+    /// Text Analytics Error.
     /// </summary>
     public struct TextAnalyticsError
     {

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsModelFactory.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsModelFactory.cs
@@ -50,6 +50,17 @@ namespace Azure.AI.TextAnalytics
             return new TextAnalyticsError(code, message, target);
         }
 
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.TextAnalyticsWarning"/> for mocking purposes.
+        /// </summary>
+        /// <param name="code">Sets the <see cref="TextAnalyticsWarning.WarningCode"/> property.</param>
+        /// <param name="message">Sets the <see cref="TextAnalyticsWarning.Message"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.TextAnalyticsWarning"/> for mocking purposes.</returns>
+        public static TextAnalyticsWarning TextAnalyticsWarning(string code, string message)
+        {
+            return new TextAnalyticsWarning(code, message);
+        }
+
         #endregion Common
 
         #region Analyze Sentiment
@@ -73,10 +84,12 @@ namespace Azure.AI.TextAnalytics
         /// <param name="neutralScore">Sets the <see cref="SentimentConfidenceScores.Neutral"/> property.</param>
         /// <param name="negativeScore">Sets the <see cref="SentimentConfidenceScores.Negative"/> property.</param>
         /// <param name="sentenceSentiments">Sets the <see cref="DocumentSentiment.Sentences"/> property.</param>
+        /// <param name="warnings">Sets the <see cref="DetectedLanguage.Warnings"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.DocumentSentiment"/> for mocking purposes.</returns>
-        public static DocumentSentiment DocumentSentiment(TextSentiment sentiment, double positiveScore, double neutralScore, double negativeScore, List<SentenceSentiment> sentenceSentiments)
+        public static DocumentSentiment DocumentSentiment(TextSentiment sentiment, double positiveScore, double neutralScore, double negativeScore, List<SentenceSentiment> sentenceSentiments, IList<TextAnalyticsWarning> warnings = default)
         {
-            return new DocumentSentiment(sentiment, positiveScore, neutralScore, negativeScore, sentenceSentiments);
+            warnings ??= new List<TextAnalyticsWarning>();
+            return new DocumentSentiment(sentiment, positiveScore, neutralScore, negativeScore, sentenceSentiments, warnings);
         }
 
         /// <summary>
@@ -137,10 +150,12 @@ namespace Azure.AI.TextAnalytics
         /// <param name="name">Sets the <see cref="DetectedLanguage.Name"/> property.</param>
         /// <param name="iso6391Name">Sets the <see cref="DetectedLanguage.Iso6391Name"/> property.</param>
         /// <param name="confidenceScore">Sets the <see cref="DetectedLanguage.ConfidenceScore"/> property.</param>
+        /// <param name="warnings">Sets the <see cref="DetectedLanguage.Warnings"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.DetectedLanguage"/> for mocking purposes.</returns>
-        public static DetectedLanguage DetectedLanguage(string name, string iso6391Name, double confidenceScore)
+        public static DetectedLanguage DetectedLanguage(string name, string iso6391Name, double confidenceScore, IList<TextAnalyticsWarning> warnings = default)
         {
-            return new DetectedLanguage(name, iso6391Name, confidenceScore);
+            warnings ??= new List<TextAnalyticsWarning>();
+            return new DetectedLanguage(name, iso6391Name, confidenceScore, warnings);
         }
 
         /// <summary>
@@ -195,13 +210,25 @@ namespace Azure.AI.TextAnalytics
         }
 
         /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.CategorizedEntityCollection"/> for mocking purposes.
+        /// </summary>
+        /// <param name="entities">Sets the collection of <see cref="TextAnalytics.CategorizedEntity"/>.</param>
+        /// <param name="warnings">Sets the <see cref="CategorizedEntityCollection.Warnings"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.CategorizedEntityCollection"/> for mocking purposes.</returns>
+        public static CategorizedEntityCollection CategorizedEntityCollection(IList<CategorizedEntity> entities, IList<TextAnalyticsWarning> warnings = default)
+        {
+            warnings ??= new List<TextAnalyticsWarning>();
+            return new CategorizedEntityCollection(entities, warnings);
+        }
+
+        /// <summary>
         /// Initializes a new instance of <see cref="TextAnalytics.RecognizeEntitiesResult"/> for mocking purposes.
         /// </summary>
         /// <param name="id">Sets the <see cref="TextAnalyticsResult.Id"/> property.</param>
         /// <param name="statistics">Sets the <see cref="TextAnalyticsResult.Statistics"/> property.</param>
         /// <param name="entities">Sets the collection of <see cref="TextAnalytics.CategorizedEntity"/>.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.RecognizeEntitiesResult"/> for mocking purposes.</returns>
-        public static RecognizeEntitiesResult RecognizeEntitiesResult(string id, TextDocumentStatistics statistics, IList<CategorizedEntity> entities)
+        public static RecognizeEntitiesResult RecognizeEntitiesResult(string id, TextDocumentStatistics statistics, CategorizedEntityCollection entities)
         {
             return new RecognizeEntitiesResult(id, statistics, entities);
         }
@@ -239,9 +266,21 @@ namespace Azure.AI.TextAnalytics
         /// <param name="statistics">Sets the <see cref="TextAnalyticsResult.Statistics"/> property.</param>
         /// <param name="keyPhrases">Sets the <see cref="ExtractKeyPhrasesResult.KeyPhrases"/> property.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.ExtractKeyPhrasesResult"/> for mocking purposes.</returns>
-        public static ExtractKeyPhrasesResult ExtractKeyPhrasesResult(string id, TextDocumentStatistics statistics, IList<string> keyPhrases)
+        public static ExtractKeyPhrasesResult ExtractKeyPhrasesResult(string id, TextDocumentStatistics statistics, KeyPhraseCollection keyPhrases)
         {
             return new ExtractKeyPhrasesResult(id, statistics, keyPhrases);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.KeyPhraseCollection"/> for mocking purposes.
+        /// </summary>
+        /// <param name="keyPhrases">Sets the collection of <see cref="string"/> key phrases.</param>
+        /// <param name="warnings">Sets the <see cref="KeyPhraseCollection.Warnings"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.KeyPhraseCollection"/> for mocking purposes.</returns>
+        public static KeyPhraseCollection KeyPhraseCollection(IList<string> keyPhrases, IList<TextAnalyticsWarning> warnings = default)
+        {
+            warnings ??= new List<TextAnalyticsWarning>();
+            return new KeyPhraseCollection(keyPhrases, warnings);
         }
 
         /// <summary>
@@ -297,13 +336,25 @@ namespace Azure.AI.TextAnalytics
         }
 
         /// <summary>
+        /// Initializes a new instance of <see cref="TextAnalytics.LinkedEntityCollection"/> for mocking purposes.
+        /// </summary>
+        /// <param name="entities">Sets the collection of <see cref="TextAnalytics.LinkedEntity"/>.</param>
+        /// <param name="warnings">Sets the <see cref="LinkedEntityCollection.Warnings"/> property.</param>
+        /// <returns>A new instance of <see cref="TextAnalytics.LinkedEntityCollection"/> for mocking purposes.</returns>
+        public static LinkedEntityCollection LinkedEntityCollection(IList<LinkedEntity> entities, IList<TextAnalyticsWarning> warnings = default)
+        {
+            warnings ??= new List<TextAnalyticsWarning>();
+            return new LinkedEntityCollection(entities, warnings);
+        }
+
+        /// <summary>
         /// Initializes a new instance of <see cref="TextAnalytics.RecognizeLinkedEntitiesResult"/> for mocking purposes.
         /// </summary>
         /// <param name="id">Sets the <see cref="TextAnalyticsResult.Id"/> property.</param>
         /// <param name="statistics">Sets the <see cref="TextAnalyticsResult.Statistics"/> property.</param>
         /// <param name="linkedEntities">Sets the collection of <see cref="TextAnalytics.LinkedEntity"/>.</param>
         /// <returns>A new instance of <see cref="TextAnalytics.RecognizeLinkedEntitiesResult"/> for mocking purposes.</returns>
-        public static RecognizeLinkedEntitiesResult RecognizeLinkedEntitiesResult(string id, TextDocumentStatistics statistics, IList<LinkedEntity> linkedEntities)
+        public static RecognizeLinkedEntitiesResult RecognizeLinkedEntitiesResult(string id, TextDocumentStatistics statistics, LinkedEntityCollection linkedEntities)
         {
             return new RecognizeLinkedEntitiesResult(id, statistics, linkedEntities);
         }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsWarning.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsWarning.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.AI.TextAnalytics
+{
+    /// <summary>
+    /// Text Analytics Warning.
+    /// </summary>
+    public struct TextAnalyticsWarning
+    {
+        internal TextAnalyticsWarning(string code, string message)
+        {
+            WarningCode = code;
+            Message = message;
+        }
+
+        /// <summary>
+        /// Code indicating the type of warning.
+        /// </summary>
+        public string WarningCode { get; }
+
+        /// <summary>
+        /// Message that contains more information about the reason of the warning.
+        /// </summary>
+        public string Message { get; }
+    }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/ExtractKeyPhrasesWithWarningTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/ExtractKeyPhrasesWithWarningTest.json
@@ -1,0 +1,65 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://westus2.ppe.cognitiveservices.azure.com/text/analytics/v3.0/keyPhrases",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "180",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-9f5680efae0c254daaff6564395f8ca0-e24bb325514fcb4c-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200505.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "c1114d59d0530dcf755150fc283a2537",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "language": "es",
+            "id": "0",
+            "text": "Anthony runs his own personal training business so thisisaverylongtokenwhichwillbetruncatedtoshowushowwarningsareemittedintheapi"
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8c124942-7d71-4540-8d43-ff81c3988fcb",
+        "Content-Type": "application/json; charset=utf-8",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1",
+        "Date": "Tue, 05 May 2020 21:02:14 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
+      },
+      "ResponseBody": {
+        "documents": [
+          {
+            "id": "0",
+            "keyPhrases": [
+              "own personal training business",
+              "Anthony runs",
+              "thisisaverylongtokenwhichwillbetruncatedtoshowushowwarningsareem"
+            ],
+            "warnings": [
+              {
+                "code": "LongWordsInDocument",
+                "message": "The document contains very long words (longer than 64 characters). These words will be truncated and may result in unreliable model predictions."
+              }
+            ]
+          }
+        ],
+        "errors": [],
+        "modelVersion": "2019-10-01"
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "344773770",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://westus2.ppe.cognitiveservices.azure.com/"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/ExtractKeyPhrasesWithWarningTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/ExtractKeyPhrasesWithWarningTestAsync.json
@@ -1,0 +1,65 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://westus2.ppe.cognitiveservices.azure.com/text/analytics/v3.0/keyPhrases",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "180",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-a541eeb9ef80b4409dca9b53f4aa2300-66aa6036ec6d7a49-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200505.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "e7b0961d52b4de12c6b417fac3e9c57f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "language": "es",
+            "id": "0",
+            "text": "Anthony runs his own personal training business so thisisaverylongtokenwhichwillbetruncatedtoshowushowwarningsareemittedintheapi"
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2dcbf512-2376-45b6-979f-a4ec6e70b3fe",
+        "Content-Type": "application/json; charset=utf-8",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1",
+        "Date": "Tue, 05 May 2020 21:02:14 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "6"
+      },
+      "ResponseBody": {
+        "documents": [
+          {
+            "id": "0",
+            "keyPhrases": [
+              "own personal training business",
+              "Anthony runs",
+              "thisisaverylongtokenwhichwillbetruncatedtoshowushowwarningsareem"
+            ],
+            "warnings": [
+              {
+                "code": "LongWordsInDocument",
+                "message": "The document contains very long words (longer than 64 characters). These words will be truncated and may result in unreliable model predictions."
+              }
+            ]
+          }
+        ],
+        "errors": [],
+        "modelVersion": "2019-10-01"
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1254603912",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://westus2.ppe.cognitiveservices.azure.com/"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
@@ -397,8 +397,7 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             string document = "My cat might need to see a veterinarian.";
 
-            Response<IReadOnlyCollection<string>> response = await client.ExtractKeyPhrasesAsync(document);
-            IReadOnlyCollection<string> keyPhrases = response.Value;
+            KeyPhraseCollection keyPhrases = await client.ExtractKeyPhrasesAsync(document);
 
             Assert.AreEqual(2, keyPhrases.Count);
             Assert.IsTrue(keyPhrases.Contains("cat"));
@@ -411,8 +410,7 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             string document = "Mi perro está en el veterinario";
 
-            Response<IReadOnlyCollection<string>> response = await client.ExtractKeyPhrasesAsync(document, "es");
-            IReadOnlyCollection<string> keyPhrases = response.Value;
+            KeyPhraseCollection keyPhrases = await client.ExtractKeyPhrasesAsync(document, "es");
 
             Assert.AreEqual(2, keyPhrases.Count);
         }
@@ -437,6 +435,21 @@ namespace Azure.AI.TextAnalytics.Tests
             Assert.IsTrue(results[1].HasError);
             InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => results[1].KeyPhrases.GetType());
             Assert.AreEqual(exceptionMessage, ex.Message);
+        }
+
+        [Test]
+        public async Task ExtractKeyPhrasesWithWarningTest()
+        {
+            TextAnalyticsClient client = GetClient();
+            string document = "Anthony runs his own personal training business so thisisaverylongtokenwhichwillbetruncatedtoshowushowwarningsareemittedintheapi";
+
+            KeyPhraseCollection keyPhrases = await client.ExtractKeyPhrasesAsync(document, "es");
+
+            Assert.IsNotNull(keyPhrases.Warnings);
+            Assert.GreaterOrEqual(keyPhrases.Warnings.Count, 0);
+            Assert.AreEqual("LongWordsInDocument", keyPhrases.Warnings.FirstOrDefault().WarningCode);
+
+            Assert.GreaterOrEqual(keyPhrases.Count, 1);
         }
 
         [Test]
@@ -539,8 +552,7 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             string document = "Microsoft was founded by Bill Gates and Paul Allen.";
 
-            Response<IReadOnlyCollection<CategorizedEntity>> response = await client.RecognizeEntitiesAsync(document);
-            IReadOnlyCollection<CategorizedEntity> entities = response.Value;
+            CategorizedEntityCollection entities = await client.RecognizeEntitiesAsync(document);
 
             Assert.AreEqual(3, entities.Count);
 
@@ -559,8 +571,7 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             string document = "Microsoft fue fundado por Bill Gates y Paul Allen.";
 
-            Response<IReadOnlyCollection<CategorizedEntity>> response = await client.RecognizeEntitiesAsync(document, "es");
-            IReadOnlyCollection<CategorizedEntity> entities = response.Value;
+            CategorizedEntityCollection entities = await client.RecognizeEntitiesAsync(document, "es");
 
             Assert.AreEqual(3, entities.Count);
         }
@@ -571,8 +582,7 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             string document = "I had a wonderful trip to Seattle last week.";
 
-            Response<IReadOnlyCollection<CategorizedEntity>> response = await client.RecognizeEntitiesAsync(document);
-            IReadOnlyCollection<CategorizedEntity> entities = response.Value;
+            CategorizedEntityCollection entities = await client.RecognizeEntitiesAsync(document);
 
             Assert.GreaterOrEqual(entities.Count, 3);
 
@@ -705,8 +715,7 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             string document = "Microsoft was founded by Bill Gates and Paul Allen.";
 
-            Response<IReadOnlyCollection<LinkedEntity>> response = await client.RecognizeLinkedEntitiesAsync(document);
-            IReadOnlyCollection<LinkedEntity> linkedEntities = response.Value;
+            LinkedEntityCollection linkedEntities = await client.RecognizeLinkedEntitiesAsync(document);
 
             Assert.AreEqual(3, linkedEntities.Count);
 
@@ -730,8 +739,7 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             string document = "Microsoft fue fundado por Bill Gates y Paul Allen.";
 
-            Response<IReadOnlyCollection<LinkedEntity>> response = await client.RecognizeLinkedEntitiesAsync(document, "es");
-            IReadOnlyCollection<LinkedEntity> linkedEntities = response.Value;
+            LinkedEntityCollection linkedEntities = await client.RecognizeLinkedEntitiesAsync(document, "es");
 
             Assert.GreaterOrEqual(linkedEntities.Count, 3);
         }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientMockTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientMockTests.cs
@@ -38,16 +38,27 @@ namespace Azure.AI.TextAnalytics.Tests
         {
             var mockResults = new List<RecognizeEntitiesResult>()
             {
-                new RecognizeEntitiesResult("1", new TextDocumentStatistics(), new List<CategorizedEntity>()
-                {
-                    new CategorizedEntity("EntityText0", "EntityCategory0", "EntitySubCategory0", 0.5),
-                    new CategorizedEntity("EntityText1", "EntityCategory1", "EntitySubCategory1", 0.5),
-                }),
-                new RecognizeEntitiesResult("2", new TextDocumentStatistics(), new List<CategorizedEntity>()
-                {
-                    new CategorizedEntity("EntityText0", "EntityCategory0", "EntitySubCategory0", 0.5),
-                    new CategorizedEntity("EntityText1", "EntityCategory1", "EntitySubCategory1", 0.5),
-                }),
+                TextAnalyticsModelFactory.RecognizeEntitiesResult("1", new TextDocumentStatistics(),
+                    new CategorizedEntityCollection
+                    (
+                        new List<CategorizedEntity>
+                        {
+                            new CategorizedEntity("EntityText0", "EntityCategory0", "EntitySubCategory0", 0.5),
+                            new CategorizedEntity("EntityText1", "EntityCategory1", "EntitySubCategory1", 0.5),
+                        },
+                        new List<TextAnalyticsWarning>()
+                    )),
+
+                TextAnalyticsModelFactory.RecognizeEntitiesResult("2", new TextDocumentStatistics(),
+                    new CategorizedEntityCollection
+                    (
+                        new List<CategorizedEntity>
+                        {
+                            new CategorizedEntity("EntityText0", "EntityCategory0", "EntitySubCategory0", 0.5),
+                            new CategorizedEntity("EntityText1", "EntityCategory1", "EntitySubCategory1", 0.5),
+                        },
+                        new List<TextAnalyticsWarning>()
+                    )),
             };
             var mockResultCollection = new RecognizeEntitiesResultCollection(mockResults,
                 new TextDocumentBatchStatistics(2, 2, 0, 2),
@@ -77,16 +88,26 @@ namespace Azure.AI.TextAnalytics.Tests
         {
             var mockResults = new List<RecognizeEntitiesResult>()
             {
-                new RecognizeEntitiesResult("2", new TextDocumentStatistics(), new List<CategorizedEntity>()
-                {
-                    new CategorizedEntity("EntityText0", "EntityCategory0", "EntitySubCategory0", 0.5),
-                    new CategorizedEntity("EntityText1", "EntityCategory1", "EntitySubCategory1", 0.5),
-                }),
-                new RecognizeEntitiesResult("3", new TextDocumentStatistics(), new List<CategorizedEntity>()
-                {
-                    new CategorizedEntity("EntityText0", "EntityCategory0", "EntitySubCategory0", 0.5),
-                    new CategorizedEntity("EntityText1", "EntityCategory1", "EntitySubCategory1", 0.5),
-                }),
+                TextAnalyticsModelFactory.RecognizeEntitiesResult("2", new TextDocumentStatistics(),
+                    new CategorizedEntityCollection
+                    (
+                        new List<CategorizedEntity>
+                        {
+                            new CategorizedEntity("EntityText0", "EntityCategory0", "EntitySubCategory0", 0.5),
+                            new CategorizedEntity("EntityText1", "EntityCategory1", "EntitySubCategory1", 0.5),
+                        },
+                        new List<TextAnalyticsWarning>()
+                    )),
+                TextAnalyticsModelFactory.RecognizeEntitiesResult("3", new TextDocumentStatistics(),
+                    new CategorizedEntityCollection
+                    (
+                        new List<CategorizedEntity>
+                        {
+                            new CategorizedEntity("EntityText0", "EntityCategory0", "EntitySubCategory0", 0.5),
+                            new CategorizedEntity("EntityText1", "EntityCategory1", "EntitySubCategory1", 0.5),
+                        },
+                        new List<TextAnalyticsWarning>()
+                    )),
                 new RecognizeEntitiesResult("4", new TextAnalyticsError("InvalidDocument", "Document is invalid.")),
                 new RecognizeEntitiesResult("5", new TextAnalyticsError("InvalidDocument", "Document is invalid.")),
             };
@@ -140,6 +161,15 @@ namespace Azure.AI.TextAnalytics.Tests
                             json.WriteEndObject();
                         }
                         json.WriteEndArray();
+                        json.WriteStartArray("warnings");
+                        foreach (var warning in result.Entities.Warnings)
+                        {
+                            json.WriteStartObject();
+                            json.WriteString("code", warning.WarningCode);
+                            json.WriteString("message", warning.Message);
+                            json.WriteEndObject();
+                        }
+                        json.WriteEndArray();
                         json.WriteEndObject();
                     }
                 }
@@ -156,7 +186,7 @@ namespace Azure.AI.TextAnalytics.Tests
                         json.WriteStartObject();
                         json.WriteString("id", result.Id);
                         json.WriteStartObject("error");
-                        json.WriteStartObject("innerError");
+                        json.WriteStartObject("innererror");
                         json.WriteString("message", result.Error.Message);
                         json.WriteEndObject();
                         json.WriteEndObject();

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrases.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrases.cs
@@ -4,7 +4,6 @@
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
@@ -24,7 +23,7 @@ namespace Azure.AI.TextAnalytics.Samples
             #region Snippet:ExtractKeyPhrases
             string document = "My cat might need to see a veterinarian.";
 
-            IReadOnlyCollection<string> keyPhrases = client.ExtractKeyPhrases(document).Value;
+            KeyPhraseCollection keyPhrases = client.ExtractKeyPhrases(document);
 
             Console.WriteLine($"Extracted {keyPhrases.Count} key phrases:");
             foreach (string keyPhrase in keyPhrases)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesWithWarnings.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesWithWarnings.cs
@@ -4,7 +4,6 @@
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 using System;
-using System.Threading.Tasks;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
@@ -12,16 +11,25 @@ namespace Azure.AI.TextAnalytics.Samples
     public partial class TextAnalyticsSamples
     {
         [Test]
-        public async Task ExtractKeyPhrasesAsync()
+        public void ExtractKeyPhrasesWithWarnins()
         {
             string endpoint = TestEnvironment.Endpoint;
             string apiKey = TestEnvironment.ApiKey;
 
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
-            string document = "My cat might need to see a veterinarian.";
+            string document = "Anthony runs his own personal training business so thisisaverylongtokenwhichwillbetruncatedtoshowushowwarningsareemittedintheapi";
 
-            KeyPhraseCollection keyPhrases = await client.ExtractKeyPhrasesAsync(document);
+            KeyPhraseCollection keyPhrases = client.ExtractKeyPhrases(document);
+
+            if (keyPhrases.Warnings.Count > 0)
+            {
+                Console.WriteLine("**Warnings:**");
+                foreach (TextAnalyticsWarning warning in keyPhrases.Warnings)
+                {
+                    Console.WriteLine($"    Warning: Code: {warning.WarningCode}, Message: {warning.Message}");
+                }
+            }
 
             Console.WriteLine($"Extracted {keyPhrases.Count} key phrases:");
             foreach (string keyPhrase in keyPhrases)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesWithWarnings.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesWithWarnings.cs
@@ -11,7 +11,7 @@ namespace Azure.AI.TextAnalytics.Samples
     public partial class TextAnalyticsSamples
     {
         [Test]
-        public void ExtractKeyPhrasesWithWarnins()
+        public void ExtractKeyPhrasesWithWarnings()
         {
             string endpoint = TestEnvironment.Endpoint;
             string apiKey = TestEnvironment.ApiKey;

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntities.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 
@@ -24,7 +23,7 @@ namespace Azure.AI.TextAnalytics.Samples
             #region Snippet:RecognizeEntities
             string document = "Microsoft was founded by Bill Gates and Paul Allen.";
 
-            IReadOnlyCollection<CategorizedEntity> entities = client.RecognizeEntities(document).Value;
+            CategorizedEntityCollection entities = client.RecognizeEntities(document);
 
             Console.WriteLine($"Recognized {entities.Count} entities:");
             foreach (CategorizedEntity entity in entities)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesAsync.cs
@@ -4,7 +4,6 @@
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Azure.AI.TextAnalytics.Samples
@@ -24,10 +23,10 @@ namespace Azure.AI.TextAnalytics.Samples
             #region Snippet:RecognizeEntitiesAsync
             string document = "Microsoft was founded by Bill Gates and Paul Allen.";
 
-            Response<IReadOnlyCollection<CategorizedEntity>> entities = await client.RecognizeEntitiesAsync(document);
+            CategorizedEntityCollection entities = await client.RecognizeEntitiesAsync(document);
 
-            Console.WriteLine($"Recognized {entities.Value.Count} entities:");
-            foreach (CategorizedEntity entity in entities.Value)
+            Console.WriteLine($"Recognized {entities.Count} entities:");
+            foreach (CategorizedEntity entity in entities)
             {
                 Console.WriteLine($"Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
             }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntities.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 
@@ -24,7 +23,7 @@ namespace Azure.AI.TextAnalytics.Samples
             #region Snippet:RecognizeLinkedEntities
             string document = "Microsoft was founded by Bill Gates and Paul Allen.";
 
-            IReadOnlyCollection<LinkedEntity> linkedEntities = client.RecognizeLinkedEntities(document).Value;
+            LinkedEntityCollection linkedEntities = client.RecognizeLinkedEntities(document);
 
             Console.WriteLine($"Extracted {linkedEntities.Count} linked entit{(linkedEntities.Count > 1 ? "ies" : "y")}:");
             foreach (LinkedEntity linkedEntity in linkedEntities)

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesAsync.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
@@ -22,12 +21,12 @@ namespace Azure.AI.TextAnalytics.Samples
 
             string document = "Microsoft was founded by Bill Gates and Paul Allen.";
 
-            Response<IReadOnlyCollection<LinkedEntity>> linkedEntities = await client.RecognizeLinkedEntitiesAsync(document);
+            LinkedEntityCollection linkedEntities = await client.RecognizeLinkedEntitiesAsync(document);
 
-            Console.WriteLine($"Extracted {linkedEntities.Value.Count} linked entit{(linkedEntities.Value.Count > 1 ? "ies" : "y")}:");
-            foreach (LinkedEntity linkedEntity in linkedEntities.Value)
+            Console.WriteLine($"Extracted {linkedEntities.Count} linked entit{(linkedEntities.Count > 1 ? "ies" : "y")}:");
+            foreach (LinkedEntity linkedEntity in linkedEntities)
             {
-                Console.WriteLine($"Name: {linkedEntity.Name}, Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}, Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
+                Console.WriteLine($"Name: {linkedEntity.Name}, Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url}, Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
                 foreach (LinkedEntityMatch match in linkedEntity.Matches)
                 {
                     Console.WriteLine($"    Match Text: {match.Text}, Confidence score: {match.ConfidenceScore}");


### PR DESCRIPTION
Service version 3.0 includes warnings at the document level. See [swagger](https://github.com/Azure/azure-rest-api-specs/blob/master/specification/cognitiveservices/data-plane/TextAnalytics/stable/v3.0/TextAnalytics.json#L427).

This PR implements the design of the warnings based on the proposal made by @annelo-msft in https://github.com/Azure/azure-sdk-for-net/pull/11674

Not included:
- Renaming `TextAnalyticsError.Code` to `ErrorCode` => https://github.com/Azure/azure-sdk-for-net/issues/11814
- Extensible enum for `TextAnalyticsError` => https://github.com/Azure/azure-sdk-for-net/issues/11815
- Extensible enum for `TextAnalyticsWarning` => https://github.com/Azure/azure-sdk-for-net/issues/11826