### PR TITLE
Raise exception when there is an error.id == string.Empty

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsServiceSerializer.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsServiceSerializer.cs
@@ -558,6 +558,8 @@ namespace Azure.AI.TextAnalytics
 
             foreach (var error in ReadDocumentErrors(root))
             {
+                if (string.IsNullOrEmpty(error.Id))
+                    throw new RequestFailedException(400, error.Error.Message, error.Error.Code, default);
                 collection.Add(new RecognizeLinkedEntitiesResult(error.Id, error.Error));
             }
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
@@ -759,6 +759,26 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [Test]
+        public void RecognizeLinkedEntitiesBatchWithInvalidDocumentBatch()
+        {
+            TextAnalyticsClient client = GetClient();
+            var documents = new List<string>
+            {
+                "Microsoft was founded by Bill Gates and Paul Allen.",
+                "Hello world",
+                "Pike place market is my favorite Seattle attraction.",
+                "I had a wonderful trip to Seattle last week and even visited the Space Needle 2 times!",
+                "Unfortunately, it rained during my entire trip to Seattle. I didn't even get to visit the Space Needle",
+                "This should fail!"
+            };
+
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(
+                   async () => await client.RecognizeLinkedEntitiesBatchAsync(documents));
+            Assert.AreEqual(400, ex.Status);
+            Assert.AreEqual("InvalidDocumentBatch", ex.ErrorCode);
+        }
+
+        [Test]
         public async Task RecognizeLinkedEntitiesBatchConvenienceTest()
         {
             TextAnalyticsClient client = GetClient();


### PR DESCRIPTION
This is temporary as the service will start returning 400 for this scenario around July. We want to make sure we throw the same way now and then.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/10707

As a draft only in one endpoint to see if approach is correct