### PR TITLE
[Event Hubs Client] Test Adjustments

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -10,7 +10,7 @@
 Thank you to our developer community members who helped to make the Event Hubs client libraries better with their contributions to this release:
 
 - Alberto De Natale _([GitHub](https://github.com/albertodenatale))_
-- Daniel Marbach _([GitHub]((https://github.com/danielmarbach)))_
+- Daniel Marbach _([GitHub](https://github.com/danielmarbach))_
 
 ### Changes
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor{TPartition}.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor{TPartition}.cs
@@ -1334,7 +1334,8 @@ namespace Azure.Messaging.EventHubs.Primitives
                     }
                 }
 
-                // Create and register the partition processor.
+                // Create and register the partition processor.  Ownership of the cancellationSource is transferred
+                // to the processor upon creation, including the responsibility for disposal.
 
                 cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientLiveTests.cs
@@ -730,7 +730,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
                 var connectionString = EventHubsTestEnvironment.Instance.BuildConnectionStringForEventHub(scope.EventHubName);
-                var sourceEvents = EventGenerator.CreateEvents(15).ToList();
+                var sourceEvents = EventGenerator.CreateEvents(25).ToList();
 
                 await using (var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, connectionString))
                 {
@@ -744,7 +744,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     async Task<bool> closeAfterFiveRead(ReadState state)
                     {
-                        if (state.Events.Count >= 5)
+                        if (state.Events.Count >= 2)
                         {
                             await consumer.CloseAsync(cancellationSource.Token).ConfigureAwait(false);
                         }
@@ -1371,6 +1371,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     // The consumer should be able to read events from another partition after being superseded.  Start a new reader for the other partition,
                     // using the same lower level.  Wait for both readers to complete and then signal for cancellation.
 
+                    await Task.Delay(250);
                     var lowerReadState = await ReadEventsFromPartitionAsync(consumer, partitions[1], sourceEvents.Count, cancellationSource.Token, readOptions: lowerOptions);
 
                     await Task.WhenAny(higherMonitor.EndCompletion.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token));
@@ -1414,7 +1415,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     var readTime = TimeSpan
                         .FromSeconds(options.MaximumWaitTime.Value.TotalSeconds * desiredEmptyEvents)
-                        .Add(TimeSpan.FromSeconds(2));
+                        .Add(TimeSpan.FromSeconds(3));
 
                     // Attempt to read from the empty partition and verify that no events are observed.  Because no events are expected, the
                     // read operation will not naturally complete; limit the read to only a couple of seconds and trigger cancellation.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
@@ -461,6 +461,9 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ReadEventsFromPartitionAsyncThrowsIfConsumerClosedBeforeRead()
         {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
             var events = new List<EventData>
             {
                new EventData(Encoding.UTF8.GetBytes("One")),
@@ -473,28 +476,21 @@ namespace Azure.Messaging.EventHubs.Tests
             var transportConsumer = new PublishingTransportConsumerMock(events);
             var mockConnection = new MockConnection(() => transportConsumer);
             var consumer = new EventHubConsumerClient(EventHubConsumerClient.DefaultConsumerGroupName, mockConnection);
-            var receivedEvents = 0;
-
-            using var cancellation = new CancellationTokenSource();
-            cancellation.CancelAfter(250);
+            var receivedEvents = false;
 
             Assert.That(async () =>
             {
-                await consumer.CloseAsync(cancellation.Token);
+                await consumer.CloseAsync(cancellationSource.Token);
 
-                await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(12), cancellation.Token))
+                await foreach (PartitionEvent partitionEvent in consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(12), cancellationSource.Token))
                 {
-                    if (partitionEvent.Data == null)
-                    {
-                        break;
-                    }
-
-                    ++receivedEvents;
+                    receivedEvents = true;
+                    break;
                 }
             }, Throws.InstanceOf<EventHubsException>().And.Property(nameof(EventHubsException.Reason)).EqualTo(EventHubsException.FailureReason.ClientClosed), "The iterator should have indicated the consumer was closed.");
 
-            Assert.That(cancellation.IsCancellationRequested, Is.False, "The cancellation should not have been requested.");
-            Assert.That(receivedEvents, Is.EqualTo(0), "There should have been no events received.");
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "The cancellation should not have been requested.");
+            Assert.That(receivedEvents, Is.False, "There should have been no events received.");
         }
 
         /// <summary>
@@ -1288,7 +1284,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var receivedEvents = 0;
 
             using var cancellation = new CancellationTokenSource();
-            cancellation.CancelAfter(250);
+            cancellation.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
             Assert.That(async () =>
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/PartitionReceiverLiveTests.cs
@@ -788,7 +788,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
 
                 var connectionString = EventHubsTestEnvironment.Instance.BuildConnectionStringForEventHub(scope.EventHubName);
-                var sourceEvents = EventGenerator.CreateEvents(15).ToList();
+                var sourceEvents = EventGenerator.CreateEvents(25).ToList();
 
                 var partition = (await QueryPartitionsAsync(connectionString, cancellationSource.Token)).First();
                 await SendEventsAsync(connectionString, sourceEvents, new CreateBatchOptions { PartitionId = partition }, cancellationSource.Token);
@@ -800,7 +800,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     async Task<bool> closeAfterFiveRead(ReadState state)
                     {
-                        if (state.Events.Count >= 5)
+                        if (state.Events.Count >= 2)
                         {
                             await receiver.CloseAsync(cancellationSource.Token).ConfigureAwait(false);
                         }
@@ -1299,6 +1299,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     // there's no way to deterministically predict how many events it can read when restarted.  Validate only that
                     // the reader is able to read without error.
 
+                    await Task.Delay(250);
                     Assert.That(async () => await ReadNothingAsync(lowerReceiver, cancellationSource.Token), Throws.Nothing, "The lower receiver should have been able to read after the higher was closed.");
                 }
 
@@ -1330,7 +1331,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     var readTime = TimeSpan
                         .FromSeconds(waitTime.TotalSeconds * desiredEmptyBatches)
-                        .Add(TimeSpan.FromSeconds(2));
+                        .Add(TimeSpan.FromSeconds(3));
 
                     // Attempt to read from the empty partition and verify that no events are observed.  Because no events are expected, the
                     // read operation will not naturally complete; limit the read to only a couple of seconds and trigger cancellation.


### PR DESCRIPTION
# Summary

The focus of these changes is to address a race condition that was causing one test to intermittently hang curing CI runs and to make small adjustments
for improving stability of tests that have seen intermittent issues during nightly runs.

# Last Upstream Rebase

Wednesday, May 6, 9:41am (EDT)

# References and Related Issues 

- [ Investigate and fix test hang for `EventProcessorTests.MainProcessingLoop.BackgroundProcessingStopsProcessingAllPartitionsWhenShutdown`](https://github.com/Azure/azure-sdk-for-net/issues/11731) (#11731)