### PR TITLE
ConnecitonString can be used with nullable ref types

### DIFF
--- a/sdk/core/Azure.Core/src/Shared/ConnectionString.cs
+++ b/sdk/core/Azure.Core/src/Shared/ConnectionString.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace Azure.Core
@@ -30,7 +31,7 @@ namespace Azure.Core
         public string GetRequired(string keyword) =>
             _pairs.TryGetValue(keyword, out var value) ? value : throw new InvalidOperationException($"Required keyword '{keyword}' is missing in connection string.");
 
-        public string GetNonRequired(string keyword) =>
+        public string? GetNonRequired(string keyword) =>
             _pairs.TryGetValue(keyword, out var value) ? value : null;
 
         public void Replace(string keyword, string value)


### PR DESCRIPTION
The code generated by autorest handles nullable ref type (technically it disable it, but still the nullable could be set to true in the csproj. But importing from Azure.Core/src/Shared/ConnectionString breaks as it is not explicitly disabled and it has an issue

```C#
public string GetNonRequired(string keyword) =>
    _pairs.TryGetValue(keyword, out var value) ? value : null;
```
should become
```C#
public string? GetNonRequired(string keyword) =>
    _pairs.TryGetValue(keyword, out var value) ? value : null;
```
Fix #11830 