### PR TITLE
Use ReadOnlyDictionary for received message properties

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -80,7 +80,6 @@
     <PackageReference Update="System.Buffers" Version="4.5.0" />
     <PackageReference Update="System.Collections.Concurrent" Version="4.3.0" />
     <PackageReference Update="System.Collections" Version="4.3.0" />
-    <PackageReference Update="System.Collections.Immutable" Version="1.7.0" />
     <PackageReference Update="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Update="System.Data.SqlClient" Version="4.3.1" />
     <PackageReference Update="System.Diagnostics.DiagnosticSource" Version="4.5.1" />

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Azure.Messaging.ServiceBus.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Azure.Messaging.ServiceBus.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
-    <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="System.Reflection.TypeExtensions" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/ServiceBusMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/ServiceBusMessage.cs
@@ -56,7 +56,7 @@ namespace Azure.Messaging.ServiceBus
             Label = receivedMessage.Label;
             MessageId = receivedMessage.MessageId;
             PartitionKey = receivedMessage.PartitionKey;
-            Properties = new Dictionary<string, object>(receivedMessage.Properties);
+            Properties = new Dictionary<string, object>(receivedMessage.SentMessage.Properties);
             ReplyTo = receivedMessage.ReplyTo;
             ReplyToSessionId = receivedMessage.ReplyToSessionId;
             SessionId = receivedMessage.SessionId;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/ServiceBusReceivedMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/ServiceBusReceivedMessage.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Globalization;
 
 namespace Azure.Messaging.ServiceBus
@@ -154,7 +154,7 @@ namespace Azure.Messaging.ServiceBus
         /// byte, sbyte, char, short, ushort, int, uint, long, ulong, float, double, decimal,
         /// bool, Guid, string, Uri, DateTime, DateTimeOffset, TimeSpan
         /// </remarks>
-        public ImmutableDictionary<string, object> Properties => SentMessage.Properties.ToImmutableDictionary();
+        public IReadOnlyDictionary<string, object> Properties => new ReadOnlyDictionary<string, object> (SentMessage.Properties);
 
         /// <summary>
         /// User property key representing deadletter reason, when a message is received from a deadletter subqueue of an entity.


### PR DESCRIPTION
This will allow us to avoid pulling in an extra dependency. This was my mistake as I initially suggested we use ImmutableDictionary.