### PR TITLE
Raise exception when there is an error.id == string.Empty 2nd approach

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
@@ -1547,7 +1547,14 @@ namespace Azure.AI.TextAnalytics
                 {
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(documents);
-                        return CreateLinkedEntityResponse(response, map);
+                        RecognizeLinkedEntitiesResultCollection results = CreateLinkedEntityResponse(response, map);
+                        if (results[0].HasError && string.IsNullOrEmpty(results[0].Id))
+                        {
+                            // InvalidDocumentBatch.
+                            TextAnalyticsError error = results[0].Error;
+                            throw new RequestFailedException(400, error.Message, error.ErrorCode.ToString(), default);
+                        }
+                        return Response.FromValue(results, response);
                     default:
                         throw _clientDiagnostics.CreateRequestFailedException(response);
                 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
@@ -329,11 +329,10 @@ namespace Azure.AI.TextAnalytics
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(documents);
                         DetectLanguageResultCollection results = await CreateDetectLanguageResponseAsync(response, map, cancellationToken).ConfigureAwait(false);
-                        if (results[0].HasError && string.IsNullOrEmpty(results[0].Id))
+                        if (results[0].HasError && results[0].Id.Length == 0)
                         {
                             // InvalidDocumentBatch.
-                            TextAnalyticsError error = results[0].Error;
-                            throw new RequestFailedException(400, error.Message, error.ErrorCode.ToString(), default);
+                            ThrowExceptionWhenErrorInBatch(results[0].Error);
                         }
                         return Response.FromValue(results, response);
                     default:
@@ -384,11 +383,10 @@ namespace Azure.AI.TextAnalytics
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(documents);
                         DetectLanguageResultCollection results = CreateDetectLanguageResponse(response, map);
-                        if (results[0].HasError && string.IsNullOrEmpty(results[0].Id))
+                        if (results[0].HasError && results[0].Id.Length == 0)
                         {
                             // InvalidDocumentBatch.
-                            TextAnalyticsError error = results[0].Error;
-                            throw new RequestFailedException(400, error.Message, error.ErrorCode.ToString(), default);
+                            ThrowExceptionWhenErrorInBatch(results[0].Error);
                         }
                         return Response.FromValue(results, response);
                     default:
@@ -640,11 +638,10 @@ namespace Azure.AI.TextAnalytics
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(documents);
                         RecognizeEntitiesResultCollection results = await CreateRecognizeEntitiesResponseAsync(response, map, cancellationToken).ConfigureAwait(false);
-                        if (results[0].HasError && string.IsNullOrEmpty(results[0].Id))
+                        if (results[0].HasError && results[0].Id.Length == 0)
                         {
                             // InvalidDocumentBatch.
-                            TextAnalyticsError error = results[0].Error;
-                            throw new RequestFailedException(400, error.Message, error.ErrorCode.ToString(), default);
+                            ThrowExceptionWhenErrorInBatch(results[0].Error);
                         }
                         return Response.FromValue(results, response);
                     default:
@@ -698,11 +695,10 @@ namespace Azure.AI.TextAnalytics
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(documents);
                         RecognizeEntitiesResultCollection results = CreateRecognizeEntitiesResponse(response, map);
-                        if (results[0].HasError && string.IsNullOrEmpty(results[0].Id))
+                        if (results[0].HasError && results[0].Id.Length == 0)
                         {
                             // InvalidDocumentBatch.
-                            TextAnalyticsError error = results[0].Error;
-                            throw new RequestFailedException(400, error.Message, error.ErrorCode.ToString(), default);
+                            ThrowExceptionWhenErrorInBatch(results[0].Error);
                         }
                         return Response.FromValue(results, response);
                     default:
@@ -939,11 +935,10 @@ namespace Azure.AI.TextAnalytics
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(documents);
                         AnalyzeSentimentResultCollection results = await CreateAnalyzeSentimentResponseAsync(response, map, cancellationToken).ConfigureAwait(false);
-                        if (results[0].HasError && string.IsNullOrEmpty(results[0].Id))
+                        if (results[0].HasError && results[0].Id.Length == 0)
                         {
                             // InvalidDocumentBatch.
-                            TextAnalyticsError error = results[0].Error;
-                            throw new RequestFailedException(400, error.Message, error.ErrorCode.ToString(), default);
+                            ThrowExceptionWhenErrorInBatch(results[0].Error);
                         }
                         return Response.FromValue(results, response);
                     default:
@@ -994,11 +989,10 @@ namespace Azure.AI.TextAnalytics
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(documents);
                         AnalyzeSentimentResultCollection results = CreateAnalyzeSentimentResponse(response, map);
-                        if (results[0].HasError && string.IsNullOrEmpty(results[0].Id))
+                        if (results[0].HasError && results[0].Id.Length == 0)
                         {
                             // InvalidDocumentBatch.
-                            TextAnalyticsError error = results[0].Error;
-                            throw new RequestFailedException(400, error.Message, error.ErrorCode.ToString(), default);
+                            ThrowExceptionWhenErrorInBatch(results[0].Error);
                         }
                         return Response.FromValue(results, response);
                     default:
@@ -1245,11 +1239,10 @@ namespace Azure.AI.TextAnalytics
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(documents);
                         ExtractKeyPhrasesResultCollection results = await CreateKeyPhraseResponseAsync(response, map, cancellationToken).ConfigureAwait(false);
-                        if (results[0].HasError && string.IsNullOrEmpty(results[0].Id))
+                        if (results[0].HasError && results[0].Id.Length == 0)
                         {
                             // InvalidDocumentBatch.
-                            TextAnalyticsError error = results[0].Error;
-                            throw new RequestFailedException(400, error.Message, error.ErrorCode.ToString(), default);
+                            ThrowExceptionWhenErrorInBatch(results[0].Error);
                         }
                         return Response.FromValue(results, response);
                     default:
@@ -1302,11 +1295,10 @@ namespace Azure.AI.TextAnalytics
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(documents);
                         ExtractKeyPhrasesResultCollection results = CreateKeyPhraseResponse(response, map);
-                        if (results[0].HasError && string.IsNullOrEmpty(results[0].Id))
+                        if (results[0].HasError && results[0].Id.Length == 0)
                         {
                             // InvalidDocumentBatch.
-                            TextAnalyticsError error = results[0].Error;
-                            throw new RequestFailedException(400, error.Message, error.ErrorCode.ToString(), default);
+                            ThrowExceptionWhenErrorInBatch(results[0].Error);
                         }
                         return Response.FromValue(results, response);
                     default:
@@ -1548,11 +1540,10 @@ namespace Azure.AI.TextAnalytics
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(documents);
                         RecognizeLinkedEntitiesResultCollection results = await CreateLinkedEntityResponseAsync(response, map, cancellationToken).ConfigureAwait(false);
-                        if (results[0].HasError && string.IsNullOrEmpty(results[0].Id))
+                        if (results[0].HasError && results[0].Id.Length == 0)
                         {
                             // InvalidDocumentBatch.
-                            TextAnalyticsError error = results[0].Error;
-                            throw new RequestFailedException(400, error.Message, error.ErrorCode.ToString(), default);
+                            ThrowExceptionWhenErrorInBatch(results[0].Error);
                         }
                         return Response.FromValue(results, response);
                     default:
@@ -1604,11 +1595,10 @@ namespace Azure.AI.TextAnalytics
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(documents);
                         RecognizeLinkedEntitiesResultCollection results = CreateLinkedEntityResponse(response, map);
-                        if (results[0].HasError && string.IsNullOrEmpty(results[0].Id))
+                        if (results[0].HasError && results[0].Id.Length == 0)
                         {
                             // InvalidDocumentBatch.
-                            TextAnalyticsError error = results[0].Error;
-                            throw new RequestFailedException(400, error.Message, error.ErrorCode.ToString(), default);
+                            ThrowExceptionWhenErrorInBatch(results[0].Error);
                         }
                         return Response.FromValue(results, response);
                     default:
@@ -1694,6 +1684,12 @@ namespace Azure.AI.TextAnalytics
                 return null;
             return new Dictionary<string, string> { { "Target", error.Target } };
         }
+
+        private static void ThrowExceptionWhenErrorInBatch(TextAnalyticsError error)
+        {
+            throw new RequestFailedException(400, error.Message, error.ErrorCode.ToString(), default);
+        }
+
         #endregion
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
@@ -328,7 +328,14 @@ namespace Azure.AI.TextAnalytics
                 {
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(documents);
-                        return await CreateDetectLanguageResponseAsync(response, map, cancellationToken).ConfigureAwait(false);
+                        DetectLanguageResultCollection results = await CreateDetectLanguageResponseAsync(response, map, cancellationToken).ConfigureAwait(false);
+                        if (results[0].HasError && string.IsNullOrEmpty(results[0].Id))
+                        {
+                            // InvalidDocumentBatch.
+                            TextAnalyticsError error = results[0].Error;
+                            throw new RequestFailedException(400, error.Message, error.ErrorCode.ToString(), default);
+                        }
+                        return Response.FromValue(results, response);
                     default:
                         throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response).ConfigureAwait(false);
                 }
@@ -376,7 +383,14 @@ namespace Azure.AI.TextAnalytics
                 {
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(documents);
-                        return CreateDetectLanguageResponse(response, map);
+                        DetectLanguageResultCollection results = CreateDetectLanguageResponse(response, map);
+                        if (results[0].HasError && string.IsNullOrEmpty(results[0].Id))
+                        {
+                            // InvalidDocumentBatch.
+                            TextAnalyticsError error = results[0].Error;
+                            throw new RequestFailedException(400, error.Message, error.ErrorCode.ToString(), default);
+                        }
+                        return Response.FromValue(results, response);
                     default:
                         throw _clientDiagnostics.CreateRequestFailedException(response);
                 }
@@ -625,7 +639,14 @@ namespace Azure.AI.TextAnalytics
                 {
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(documents);
-                        return await CreateRecognizeEntitiesResponseAsync(response, map, cancellationToken).ConfigureAwait(false);
+                        RecognizeEntitiesResultCollection results = await CreateRecognizeEntitiesResponseAsync(response, map, cancellationToken).ConfigureAwait(false);
+                        if (results[0].HasError && string.IsNullOrEmpty(results[0].Id))
+                        {
+                            // InvalidDocumentBatch.
+                            TextAnalyticsError error = results[0].Error;
+                            throw new RequestFailedException(400, error.Message, error.ErrorCode.ToString(), default);
+                        }
+                        return Response.FromValue(results, response);
                     default:
                         throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response).ConfigureAwait(false);
                 }
@@ -676,7 +697,14 @@ namespace Azure.AI.TextAnalytics
                 {
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(documents);
-                        return CreateRecognizeEntitiesResponse(response, map);
+                        RecognizeEntitiesResultCollection results = CreateRecognizeEntitiesResponse(response, map);
+                        if (results[0].HasError && string.IsNullOrEmpty(results[0].Id))
+                        {
+                            // InvalidDocumentBatch.
+                            TextAnalyticsError error = results[0].Error;
+                            throw new RequestFailedException(400, error.Message, error.ErrorCode.ToString(), default);
+                        }
+                        return Response.FromValue(results, response);
                     default:
                         throw _clientDiagnostics.CreateRequestFailedException(response);
                 }
@@ -910,7 +938,14 @@ namespace Azure.AI.TextAnalytics
                 {
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(documents);
-                        return await CreateAnalyzeSentimentResponseAsync(response, map, cancellationToken).ConfigureAwait(false);
+                        AnalyzeSentimentResultCollection results = await CreateAnalyzeSentimentResponseAsync(response, map, cancellationToken).ConfigureAwait(false);
+                        if (results[0].HasError && string.IsNullOrEmpty(results[0].Id))
+                        {
+                            // InvalidDocumentBatch.
+                            TextAnalyticsError error = results[0].Error;
+                            throw new RequestFailedException(400, error.Message, error.ErrorCode.ToString(), default);
+                        }
+                        return Response.FromValue(results, response);
                     default:
                         throw await _clientDiagnostics.CreateRequestFailedExceptionAsync(response).ConfigureAwait(false);
                 }
@@ -958,7 +993,14 @@ namespace Azure.AI.TextAnalytics
                 {
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(documents);
-                        return CreateAnalyzeSentimentResponse(response, map);
+                        AnalyzeSentimentResultCollection results = CreateAnalyzeSentimentResponse(response, map);
+                        if (results[0].HasError && string.IsNullOrEmpty(results[0].Id))
+                        {
+                            // InvalidDocumentBatch.
+                            TextAnalyticsError error = results[0].Error;
+                            throw new RequestFailedException(400, error.Message, error.ErrorCode.ToString(), default);
+                        }
+                        return Response.FromValue(results, response);
                     default:
                         throw _clientDiagnostics.CreateRequestFailedException(response);
                 }
@@ -1202,7 +1244,14 @@ namespace Azure.AI.TextAnalytics
                 {
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(documents);
-                        return await CreateKeyPhraseResponseAsync(response, map, cancellationToken).ConfigureAwait(false);
+                        ExtractKeyPhrasesResultCollection results = await CreateKeyPhraseResponseAsync(response, map, cancellationToken).ConfigureAwait(false);
+                        if (results[0].HasError && string.IsNullOrEmpty(results[0].Id))
+                        {
+                            // InvalidDocumentBatch.
+                            TextAnalyticsError error = results[0].Error;
+                            throw new RequestFailedException(400, error.Message, error.ErrorCode.ToString(), default);
+                        }
+                        return Response.FromValue(results, response);
                     default:
                         throw _clientDiagnostics.CreateRequestFailedException(response);
                 }
@@ -1252,7 +1301,14 @@ namespace Azure.AI.TextAnalytics
                 {
                     case 200:
                         IDictionary<string, int> map = CreateIdToIndexMap(documents);
-                        return CreateKeyPhraseResponse(response, map);
+                        ExtractKeyPhrasesResultCollection results = CreateKeyPhraseResponse(response, map);
+                        if (results[0].HasError && string.IsNullOrEmpty(results[0].Id))
+                        {
+                            // InvalidDocumentBatch.
+                            TextAnalyticsError error = results[0].Error;
+                            throw new RequestFailedException(400, error.Message, error.ErrorCode.ToString(), default);
+                        }
+                        return Response.FromValue(results, response);
                     default:
                         throw _clientDiagnostics.CreateRequestFailedException(response);
                 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsServiceSerializer.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsServiceSerializer.cs
@@ -609,12 +609,24 @@ namespace Azure.AI.TextAnalytics
                 }
             }
 
+            bool invalidBatch = false;
+
             foreach (var error in ReadDocumentErrors(root))
             {
+                if (string.IsNullOrEmpty(error.Id))
+                {
+                    invalidBatch = true;
+                    collection.Clear();
+                    collection.Add(new RecognizeLinkedEntitiesResult(error.Id, error.Error));
+                    break;
+                }
                 collection.Add(new RecognizeLinkedEntitiesResult(error.Id, error.Error));
             }
 
-            collection = SortHeterogeneousCollection(collection, idToIndexMap);
+            if (!invalidBatch)
+            {
+                collection = SortHeterogeneousCollection(collection, idToIndexMap);
+            }
 
             TextDocumentBatchStatistics statistics = ReadDocumentBatchStatistics(root);
             string modelVersion = ReadModelVersion(root);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsServiceSerializer.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsServiceSerializer.cs
@@ -239,6 +239,18 @@ namespace Azure.AI.TextAnalytics
         private static DetectLanguageResultCollection ReadDetectLanguageResultCollection(JsonElement root, IDictionary<string, int> idToIndexMap)
         {
             var collection = new List<DetectLanguageResult>();
+            TextDocumentBatchStatistics statistics = ReadDocumentBatchStatistics(root);
+            string modelVersion = ReadModelVersion(root);
+
+            foreach (var error in ReadDocumentErrors(root))
+            {
+                collection.Add(new DetectLanguageResult(error.Id, error.Error));
+                if (error.Id.Length == 0)
+                {
+                    return new DetectLanguageResultCollection(collection, statistics, modelVersion);
+                }
+            }
+
             if (root.TryGetProperty("documents", out JsonElement documentsValue))
             {
                 foreach (JsonElement documentElement in documentsValue.EnumerateArray())
@@ -247,27 +259,7 @@ namespace Azure.AI.TextAnalytics
                 }
             }
 
-            bool invalidBatch = false;
-
-            foreach (var error in ReadDocumentErrors(root))
-            {
-                if (string.IsNullOrEmpty(error.Id))
-                {
-                    invalidBatch = true;
-                    collection.Clear();
-                    collection.Add(new DetectLanguageResult(error.Id, error.Error));
-                    break;
-                }
-                collection.Add(new DetectLanguageResult(error.Id, error.Error));
-            }
-
-            if (!invalidBatch)
-            {
-                collection = SortHeterogeneousCollection(collection, idToIndexMap);
-            }
-
-            TextDocumentBatchStatistics statistics = ReadDocumentBatchStatistics(root);
-            string modelVersion = ReadModelVersion(root);
+            collection = SortHeterogeneousCollection(collection, idToIndexMap);
 
             return new DetectLanguageResultCollection(collection, statistics, modelVersion);
         }
@@ -330,6 +322,19 @@ namespace Azure.AI.TextAnalytics
         private static RecognizeEntitiesResultCollection ReadRecognizeEntitiesResultCollection(JsonElement root, IDictionary<string, int> idToIndexMap)
         {
             var collection = new List<RecognizeEntitiesResult>();
+
+            TextDocumentBatchStatistics statistics = ReadDocumentBatchStatistics(root);
+            string modelVersion = ReadModelVersion(root);
+
+            foreach (var error in ReadDocumentErrors(root))
+            {
+                collection.Add(new RecognizeEntitiesResult(error.Id, error.Error));
+                if (error.Id.Length == 0)
+                {
+                    return new RecognizeEntitiesResultCollection(collection, statistics, modelVersion);
+                }
+            }
+
             if (root.TryGetProperty("documents", out JsonElement documentsValue))
             {
                 foreach (JsonElement documentElement in documentsValue.EnumerateArray())
@@ -338,27 +343,7 @@ namespace Azure.AI.TextAnalytics
                 }
             }
 
-            bool invalidBatch = false;
-
-            foreach (var error in ReadDocumentErrors(root))
-            {
-                if (string.IsNullOrEmpty(error.Id))
-                {
-                    invalidBatch = true;
-                    collection.Clear();
-                    collection.Add(new RecognizeEntitiesResult(error.Id, error.Error));
-                    break;
-                }
-                collection.Add(new RecognizeEntitiesResult(error.Id, error.Error));
-            }
-
-            if (!invalidBatch)
-            {
-                collection = SortHeterogeneousCollection(collection, idToIndexMap);
-            }
-
-            TextDocumentBatchStatistics statistics = ReadDocumentBatchStatistics(root);
-            string modelVersion = ReadModelVersion(root);
+            collection = SortHeterogeneousCollection(collection, idToIndexMap);
 
             return new RecognizeEntitiesResultCollection(collection, statistics, modelVersion);
         }
@@ -432,6 +417,19 @@ namespace Azure.AI.TextAnalytics
         private static AnalyzeSentimentResultCollection ReadSentimentResult(JsonElement root, IDictionary<string, int> idToIndexMap)
         {
             var collection = new List<AnalyzeSentimentResult>();
+
+            TextDocumentBatchStatistics statistics = ReadDocumentBatchStatistics(root);
+            string modelVersion = ReadModelVersion(root);
+
+            foreach (var error in ReadDocumentErrors(root))
+            {
+                collection.Add(new AnalyzeSentimentResult(error.Id, error.Error));
+                if (error.Id.Length == 0)
+                {
+                    return new AnalyzeSentimentResultCollection(collection, statistics, modelVersion);
+                }
+            }
+
             if (root.TryGetProperty("documents", out JsonElement documentsValue))
             {
                 foreach (JsonElement documentElement in documentsValue.EnumerateArray())
@@ -440,27 +438,7 @@ namespace Azure.AI.TextAnalytics
                 }
             }
 
-            bool invalidBatch = false;
-
-            foreach (var error in ReadDocumentErrors(root))
-            {
-                if (string.IsNullOrEmpty(error.Id))
-                {
-                    invalidBatch = true;
-                    collection.Clear();
-                    collection.Add(new AnalyzeSentimentResult(error.Id, error.Error));
-                    break;
-                }
-                collection.Add(new AnalyzeSentimentResult(error.Id, error.Error));
-            }
-
-            if (!invalidBatch)
-            {
-                collection = SortHeterogeneousCollection(collection, idToIndexMap);
-            }
-
-            TextDocumentBatchStatistics statistics = ReadDocumentBatchStatistics(root);
-            string modelVersion = ReadModelVersion(root);
+            collection = SortHeterogeneousCollection(collection, idToIndexMap);
 
             return new AnalyzeSentimentResultCollection(collection, statistics, modelVersion);
         }
@@ -571,6 +549,19 @@ namespace Azure.AI.TextAnalytics
         private static ExtractKeyPhrasesResultCollection ReadKeyPhraseResultCollection(JsonElement root, IDictionary<string, int> idToIndexMap)
         {
             var collection = new List<ExtractKeyPhrasesResult>();
+
+            TextDocumentBatchStatistics statistics = ReadDocumentBatchStatistics(root);
+            string modelVersion = ReadModelVersion(root);
+
+            foreach (var error in ReadDocumentErrors(root))
+            {
+                collection.Add(new ExtractKeyPhrasesResult(error.Id, error.Error));
+                if (error.Id.Length == 0)
+                {
+                    return new ExtractKeyPhrasesResultCollection(collection, statistics, modelVersion);
+                }
+            }
+
             if (root.TryGetProperty("documents", out JsonElement documentsValue))
             {
                 foreach (JsonElement documentElement in documentsValue.EnumerateArray())
@@ -579,27 +570,7 @@ namespace Azure.AI.TextAnalytics
                 }
             }
 
-            bool invalidBatch = false;
-
-            foreach (var error in ReadDocumentErrors(root))
-            {
-                if (string.IsNullOrEmpty(error.Id))
-                {
-                    invalidBatch = true;
-                    collection.Clear();
-                    collection.Add(new ExtractKeyPhrasesResult(error.Id, error.Error));
-                    break;
-                }
-                collection.Add(new ExtractKeyPhrasesResult(error.Id, error.Error));
-            }
-
-            if (!invalidBatch)
-            {
-                collection = SortHeterogeneousCollection(collection, idToIndexMap);
-            }
-
-            TextDocumentBatchStatistics statistics = ReadDocumentBatchStatistics(root);
-            string modelVersion = ReadModelVersion(root);
+            collection = SortHeterogeneousCollection(collection, idToIndexMap);
 
             return new ExtractKeyPhrasesResultCollection(collection, statistics, modelVersion);
         }
@@ -649,6 +620,19 @@ namespace Azure.AI.TextAnalytics
         private static RecognizeLinkedEntitiesResultCollection ReadLinkedEntityResultCollection(JsonElement root, IDictionary<string, int> idToIndexMap)
         {
             var collection = new List<RecognizeLinkedEntitiesResult>();
+
+            TextDocumentBatchStatistics statistics = ReadDocumentBatchStatistics(root);
+            string modelVersion = ReadModelVersion(root);
+
+            foreach (var error in ReadDocumentErrors(root))
+            {
+                collection.Add(new RecognizeLinkedEntitiesResult(error.Id, error.Error));
+                if (error.Id.Length == 0)
+                {
+                    return new RecognizeLinkedEntitiesResultCollection(collection, statistics, modelVersion);
+                }
+            }
+
             if (root.TryGetProperty("documents", out JsonElement documentsValue))
             {
                 foreach (JsonElement documentElement in documentsValue.EnumerateArray())
@@ -657,27 +641,7 @@ namespace Azure.AI.TextAnalytics
                 }
             }
 
-            bool invalidBatch = false;
-
-            foreach (var error in ReadDocumentErrors(root))
-            {
-                if (string.IsNullOrEmpty(error.Id))
-                {
-                    invalidBatch = true;
-                    collection.Clear();
-                    collection.Add(new RecognizeLinkedEntitiesResult(error.Id, error.Error));
-                    break;
-                }
-                collection.Add(new RecognizeLinkedEntitiesResult(error.Id, error.Error));
-            }
-
-            if (!invalidBatch)
-            {
-                collection = SortHeterogeneousCollection(collection, idToIndexMap);
-            }
-
-            TextDocumentBatchStatistics statistics = ReadDocumentBatchStatistics(root);
-            string modelVersion = ReadModelVersion(root);
+            collection = SortHeterogeneousCollection(collection, idToIndexMap);
 
             return new RecognizeLinkedEntitiesResultCollection(collection, statistics, modelVersion);
         }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsServiceSerializer.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsServiceSerializer.cs
@@ -247,12 +247,24 @@ namespace Azure.AI.TextAnalytics
                 }
             }
 
+            bool invalidBatch = false;
+
             foreach (var error in ReadDocumentErrors(root))
             {
+                if (string.IsNullOrEmpty(error.Id))
+                {
+                    invalidBatch = true;
+                    collection.Clear();
+                    collection.Add(new DetectLanguageResult(error.Id, error.Error));
+                    break;
+                }
                 collection.Add(new DetectLanguageResult(error.Id, error.Error));
             }
 
-            collection = SortHeterogeneousCollection(collection, idToIndexMap);
+            if (!invalidBatch)
+            {
+                collection = SortHeterogeneousCollection(collection, idToIndexMap);
+            }
 
             TextDocumentBatchStatistics statistics = ReadDocumentBatchStatistics(root);
             string modelVersion = ReadModelVersion(root);
@@ -326,12 +338,24 @@ namespace Azure.AI.TextAnalytics
                 }
             }
 
+            bool invalidBatch = false;
+
             foreach (var error in ReadDocumentErrors(root))
             {
+                if (string.IsNullOrEmpty(error.Id))
+                {
+                    invalidBatch = true;
+                    collection.Clear();
+                    collection.Add(new RecognizeEntitiesResult(error.Id, error.Error));
+                    break;
+                }
                 collection.Add(new RecognizeEntitiesResult(error.Id, error.Error));
             }
 
-            collection = SortHeterogeneousCollection(collection, idToIndexMap);
+            if (!invalidBatch)
+            {
+                collection = SortHeterogeneousCollection(collection, idToIndexMap);
+            }
 
             TextDocumentBatchStatistics statistics = ReadDocumentBatchStatistics(root);
             string modelVersion = ReadModelVersion(root);
@@ -416,12 +440,24 @@ namespace Azure.AI.TextAnalytics
                 }
             }
 
+            bool invalidBatch = false;
+
             foreach (var error in ReadDocumentErrors(root))
             {
+                if (string.IsNullOrEmpty(error.Id))
+                {
+                    invalidBatch = true;
+                    collection.Clear();
+                    collection.Add(new AnalyzeSentimentResult(error.Id, error.Error));
+                    break;
+                }
                 collection.Add(new AnalyzeSentimentResult(error.Id, error.Error));
             }
 
-            collection = SortHeterogeneousCollection(collection, idToIndexMap);
+            if (!invalidBatch)
+            {
+                collection = SortHeterogeneousCollection(collection, idToIndexMap);
+            }
 
             TextDocumentBatchStatistics statistics = ReadDocumentBatchStatistics(root);
             string modelVersion = ReadModelVersion(root);
@@ -543,12 +579,24 @@ namespace Azure.AI.TextAnalytics
                 }
             }
 
+            bool invalidBatch = false;
+
             foreach (var error in ReadDocumentErrors(root))
             {
+                if (string.IsNullOrEmpty(error.Id))
+                {
+                    invalidBatch = true;
+                    collection.Clear();
+                    collection.Add(new ExtractKeyPhrasesResult(error.Id, error.Error));
+                    break;
+                }
                 collection.Add(new ExtractKeyPhrasesResult(error.Id, error.Error));
             }
 
-            collection = SortHeterogeneousCollection(collection, idToIndexMap);
+            if (!invalidBatch)
+            {
+                collection = SortHeterogeneousCollection(collection, idToIndexMap);
+            }
 
             TextDocumentBatchStatistics statistics = ReadDocumentBatchStatistics(root);
             string modelVersion = ReadModelVersion(root);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizeEntitiesBatchWithInvalidDocumentBatch.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizeEntitiesBatchWithInvalidDocumentBatch.json
@@ -1,0 +1,193 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://westus2.ppe.cognitiveservices.azure.com/text/analytics/v3.0/entities/recognition/general",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "297",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-4a2639f5269f2a4cad234dde673eb226-a6e66fd0275bad43-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200508.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "d44a3eacd4647966beab4f078d164d7a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "language": "en",
+            "id": "0",
+            "text": "document 1"
+          },
+          {
+            "language": "en",
+            "id": "1",
+            "text": "document 2"
+          },
+          {
+            "language": "en",
+            "id": "2",
+            "text": "document 3"
+          },
+          {
+            "language": "en",
+            "id": "3",
+            "text": "document 4"
+          },
+          {
+            "language": "en",
+            "id": "4",
+            "text": "document 5"
+          },
+          {
+            "language": "en",
+            "id": "5",
+            "text": "document 6"
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a7bfdd36-56bd-4859-b879-c7777fa4eb3f",
+        "Content-Type": "application/json; charset=utf-8",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=6",
+        "Date": "Fri, 08 May 2020 17:35:08 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "554"
+      },
+      "ResponseBody": {
+        "documents": [
+          {
+            "id": "0",
+            "entities": [
+              {
+                "text": "1",
+                "category": "Quantity",
+                "subcategory": "Number",
+                "offset": 9,
+                "length": 1,
+                "confidenceScore": 0.8
+              }
+            ],
+            "warnings": []
+          },
+          {
+            "id": "1",
+            "entities": [
+              {
+                "text": "document 2",
+                "category": "Skill",
+                "offset": 0,
+                "length": 10,
+                "confidenceScore": 0.8
+              },
+              {
+                "text": "2",
+                "category": "Quantity",
+                "subcategory": "Number",
+                "offset": 9,
+                "length": 1,
+                "confidenceScore": 0.8
+              }
+            ],
+            "warnings": []
+          },
+          {
+            "id": "2",
+            "entities": [
+              {
+                "text": "document 3",
+                "category": "Skill",
+                "offset": 0,
+                "length": 10,
+                "confidenceScore": 0.8
+              },
+              {
+                "text": "3",
+                "category": "Quantity",
+                "subcategory": "Number",
+                "offset": 9,
+                "length": 1,
+                "confidenceScore": 0.8
+              }
+            ],
+            "warnings": []
+          },
+          {
+            "id": "3",
+            "entities": [
+              {
+                "text": "4",
+                "category": "Quantity",
+                "subcategory": "Number",
+                "offset": 9,
+                "length": 1,
+                "confidenceScore": 0.8
+              }
+            ],
+            "warnings": []
+          },
+          {
+            "id": "4",
+            "entities": [
+              {
+                "text": "document 5",
+                "category": "Skill",
+                "offset": 0,
+                "length": 10,
+                "confidenceScore": 0.8
+              },
+              {
+                "text": "5",
+                "category": "Quantity",
+                "subcategory": "Number",
+                "offset": 9,
+                "length": 1,
+                "confidenceScore": 0.8
+              }
+            ],
+            "warnings": []
+          },
+          {
+            "id": "5",
+            "entities": [
+              {
+                "text": "6",
+                "category": "Quantity",
+                "subcategory": "Number",
+                "offset": 9,
+                "length": 1,
+                "confidenceScore": 0.8
+              }
+            ],
+            "warnings": []
+          }
+        ],
+        "errors": [
+          {
+            "id": "",
+            "error": {
+              "code": "InvalidRequest",
+              "message": "The request has exceeded the allowed document limits.",
+              "innererror": {
+                "code": "InvalidDocumentBatch",
+                "message": "The number of documents in the request have exceeded the data limitations. See https://aka.ms/text-analytics-data-limits for additional information"
+              }
+            }
+          }
+        ],
+        "modelVersion": "2020-04-01"
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1608687665",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://westus2.ppe.cognitiveservices.azure.com/"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizeEntitiesBatchWithInvalidDocumentBatchAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizeEntitiesBatchWithInvalidDocumentBatchAsync.json
@@ -1,0 +1,193 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://westus2.ppe.cognitiveservices.azure.com/text/analytics/v3.0/entities/recognition/general",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "297",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-6c4997b03f78944188e2b5598cf16e97-2624e4171f0ee145-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200508.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "61bab9305b789cd5c62b896ba42cbf9b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "language": "en",
+            "id": "0",
+            "text": "document 1"
+          },
+          {
+            "language": "en",
+            "id": "1",
+            "text": "document 2"
+          },
+          {
+            "language": "en",
+            "id": "2",
+            "text": "document 3"
+          },
+          {
+            "language": "en",
+            "id": "3",
+            "text": "document 4"
+          },
+          {
+            "language": "en",
+            "id": "4",
+            "text": "document 5"
+          },
+          {
+            "language": "en",
+            "id": "5",
+            "text": "document 6"
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "58eb73b9-6451-4d2a-99e0-ded14f31617b",
+        "Content-Type": "application/json; charset=utf-8",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=6",
+        "Date": "Fri, 08 May 2020 17:35:08 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "88"
+      },
+      "ResponseBody": {
+        "documents": [
+          {
+            "id": "0",
+            "entities": [
+              {
+                "text": "1",
+                "category": "Quantity",
+                "subcategory": "Number",
+                "offset": 9,
+                "length": 1,
+                "confidenceScore": 0.8
+              }
+            ],
+            "warnings": []
+          },
+          {
+            "id": "1",
+            "entities": [
+              {
+                "text": "document 2",
+                "category": "Skill",
+                "offset": 0,
+                "length": 10,
+                "confidenceScore": 0.8
+              },
+              {
+                "text": "2",
+                "category": "Quantity",
+                "subcategory": "Number",
+                "offset": 9,
+                "length": 1,
+                "confidenceScore": 0.8
+              }
+            ],
+            "warnings": []
+          },
+          {
+            "id": "2",
+            "entities": [
+              {
+                "text": "document 3",
+                "category": "Skill",
+                "offset": 0,
+                "length": 10,
+                "confidenceScore": 0.8
+              },
+              {
+                "text": "3",
+                "category": "Quantity",
+                "subcategory": "Number",
+                "offset": 9,
+                "length": 1,
+                "confidenceScore": 0.8
+              }
+            ],
+            "warnings": []
+          },
+          {
+            "id": "3",
+            "entities": [
+              {
+                "text": "4",
+                "category": "Quantity",
+                "subcategory": "Number",
+                "offset": 9,
+                "length": 1,
+                "confidenceScore": 0.8
+              }
+            ],
+            "warnings": []
+          },
+          {
+            "id": "4",
+            "entities": [
+              {
+                "text": "document 5",
+                "category": "Skill",
+                "offset": 0,
+                "length": 10,
+                "confidenceScore": 0.8
+              },
+              {
+                "text": "5",
+                "category": "Quantity",
+                "subcategory": "Number",
+                "offset": 9,
+                "length": 1,
+                "confidenceScore": 0.8
+              }
+            ],
+            "warnings": []
+          },
+          {
+            "id": "5",
+            "entities": [
+              {
+                "text": "6",
+                "category": "Quantity",
+                "subcategory": "Number",
+                "offset": 9,
+                "length": 1,
+                "confidenceScore": 0.8
+              }
+            ],
+            "warnings": []
+          }
+        ],
+        "errors": [
+          {
+            "id": "",
+            "error": {
+              "code": "InvalidRequest",
+              "message": "The request has exceeded the allowed document limits.",
+              "innererror": {
+                "code": "InvalidDocumentBatch",
+                "message": "The number of documents in the request have exceeded the data limitations. See https://aka.ms/text-analytics-data-limits for additional information"
+              }
+            }
+          }
+        ],
+        "modelVersion": "2020-04-01"
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "767731057",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://westus2.ppe.cognitiveservices.azure.com/"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizeLinkedEntitiesBatchWithInvalidDocumentBatch.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizeLinkedEntitiesBatchWithInvalidDocumentBatch.json
@@ -1,0 +1,273 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://westus2.ppe.cognitiveservices.azure.com/text/analytics/v3.0/entities/linking",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "561",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1b098e7c9d15984b82f7d6a58b35953d-0e0b249569e97349-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200508.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "4d779a7a51313f9b3c0edbedb23fc9e2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "language": "en",
+            "id": "0",
+            "text": "Microsoft was founded by Bill Gates and Paul Allen."
+          },
+          {
+            "language": "en",
+            "id": "1",
+            "text": "Hello world"
+          },
+          {
+            "language": "en",
+            "id": "2",
+            "text": "Pike place market is my favorite Seattle attraction."
+          },
+          {
+            "language": "en",
+            "id": "3",
+            "text": "I had a wonderful trip to Seattle last week and even visited the Space Needle 2 times!"
+          },
+          {
+            "language": "en",
+            "id": "4",
+            "text": "Unfortunately, it rained during my entire trip to Seattle. I didn\u0027t even get to visit the Space Needle"
+          },
+          {
+            "language": "en",
+            "id": "5",
+            "text": "This should fail!"
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b29f5064-4285-4d2b-96e0-3e23be4c9262",
+        "Content-Type": "application/json; charset=utf-8",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=6",
+        "Date": "Fri, 08 May 2020 15:37:32 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "41"
+      },
+      "ResponseBody": {
+        "documents": [
+          {
+            "id": "0",
+            "entities": [
+              {
+                "name": "Bill Gates",
+                "matches": [
+                  {
+                    "text": "Bill Gates",
+                    "offset": 25,
+                    "length": 10,
+                    "confidenceScore": 0.52
+                  }
+                ],
+                "language": "en",
+                "id": "Bill Gates",
+                "url": "https://en.wikipedia.org/wiki/Bill_Gates",
+                "dataSource": "Wikipedia"
+              },
+              {
+                "name": "Paul Allen",
+                "matches": [
+                  {
+                    "text": "Paul Allen",
+                    "offset": 40,
+                    "length": 10,
+                    "confidenceScore": 0.54
+                  }
+                ],
+                "language": "en",
+                "id": "Paul Allen",
+                "url": "https://en.wikipedia.org/wiki/Paul_Allen",
+                "dataSource": "Wikipedia"
+              },
+              {
+                "name": "Microsoft",
+                "matches": [
+                  {
+                    "text": "Microsoft",
+                    "offset": 0,
+                    "length": 9,
+                    "confidenceScore": 0.49
+                  }
+                ],
+                "language": "en",
+                "id": "Microsoft",
+                "url": "https://en.wikipedia.org/wiki/Microsoft",
+                "dataSource": "Wikipedia"
+              }
+            ],
+            "warnings": []
+          },
+          {
+            "id": "1",
+            "entities": [
+              {
+                "name": "\u0022Hello, World!\u0022 program",
+                "matches": [
+                  {
+                    "text": "Hello world",
+                    "offset": 0,
+                    "length": 11,
+                    "confidenceScore": 0.03
+                  }
+                ],
+                "language": "en",
+                "id": "\u0022Hello, World!\u0022 program",
+                "url": "https://en.wikipedia.org/wiki/\u0022Hello,_World!\u0022_program",
+                "dataSource": "Wikipedia"
+              }
+            ],
+            "warnings": []
+          },
+          {
+            "id": "2",
+            "entities": [
+              {
+                "name": "Pike Place Market",
+                "matches": [
+                  {
+                    "text": "Pike place market",
+                    "offset": 0,
+                    "length": 17,
+                    "confidenceScore": 0.86
+                  }
+                ],
+                "language": "en",
+                "id": "Pike Place Market",
+                "url": "https://en.wikipedia.org/wiki/Pike_Place_Market",
+                "dataSource": "Wikipedia"
+              },
+              {
+                "name": "Seattle",
+                "matches": [
+                  {
+                    "text": "Seattle",
+                    "offset": 33,
+                    "length": 7,
+                    "confidenceScore": 0.27
+                  }
+                ],
+                "language": "en",
+                "id": "Seattle",
+                "url": "https://en.wikipedia.org/wiki/Seattle",
+                "dataSource": "Wikipedia"
+              }
+            ],
+            "warnings": []
+          },
+          {
+            "id": "3",
+            "entities": [
+              {
+                "name": "Space Needle",
+                "matches": [
+                  {
+                    "text": "Space Needle",
+                    "offset": 65,
+                    "length": 12,
+                    "confidenceScore": 0.42
+                  }
+                ],
+                "language": "en",
+                "id": "Space Needle",
+                "url": "https://en.wikipedia.org/wiki/Space_Needle",
+                "dataSource": "Wikipedia"
+              },
+              {
+                "name": "Seattle",
+                "matches": [
+                  {
+                    "text": "Seattle",
+                    "offset": 26,
+                    "length": 7,
+                    "confidenceScore": 0.21
+                  }
+                ],
+                "language": "en",
+                "id": "Seattle",
+                "url": "https://en.wikipedia.org/wiki/Seattle",
+                "dataSource": "Wikipedia"
+              }
+            ],
+            "warnings": []
+          },
+          {
+            "id": "4",
+            "entities": [
+              {
+                "name": "Space Needle",
+                "matches": [
+                  {
+                    "text": "Space Needle",
+                    "offset": 90,
+                    "length": 12,
+                    "confidenceScore": 0.36
+                  }
+                ],
+                "language": "en",
+                "id": "Space Needle",
+                "url": "https://en.wikipedia.org/wiki/Space_Needle",
+                "dataSource": "Wikipedia"
+              },
+              {
+                "name": "Seattle",
+                "matches": [
+                  {
+                    "text": "Seattle",
+                    "offset": 50,
+                    "length": 7,
+                    "confidenceScore": 0.2
+                  }
+                ],
+                "language": "en",
+                "id": "Seattle",
+                "url": "https://en.wikipedia.org/wiki/Seattle",
+                "dataSource": "Wikipedia"
+              }
+            ],
+            "warnings": []
+          },
+          {
+            "id": "5",
+            "entities": [],
+            "warnings": []
+          }
+        ],
+        "errors": [
+          {
+            "id": "",
+            "error": {
+              "code": "InvalidRequest",
+              "message": "The request has exceeded the allowed document limits.",
+              "innererror": {
+                "code": "InvalidDocumentBatch",
+                "message": "The number of documents in the request have exceeded the data limitations. See https://aka.ms/text-analytics-data-limits for additional information"
+              }
+            }
+          }
+        ],
+        "modelVersion": "2020-02-01"
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "756328253",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://westus2.ppe.cognitiveservices.azure.com/"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizeLinkedEntitiesBatchWithInvalidDocumentBatchAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/TextAnalyticsClientLiveTests/RecognizeLinkedEntitiesBatchWithInvalidDocumentBatchAsync.json
@@ -1,0 +1,273 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://westus2.ppe.cognitiveservices.azure.com/text/analytics/v3.0/entities/linking",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Content-Length": "561",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-f79bd92cfdefd749aeaffc0952838f9e-b66aeeca54f65a4a-00",
+        "User-Agent": [
+          "azsdk-net-AI.TextAnalytics/1.0.0-dev.20200508.1",
+          "(.NET Core 4.6.28516.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "2d29a5a97696fc299d613cb7e5e8b6cd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "documents": [
+          {
+            "language": "en",
+            "id": "0",
+            "text": "Microsoft was founded by Bill Gates and Paul Allen."
+          },
+          {
+            "language": "en",
+            "id": "1",
+            "text": "Hello world"
+          },
+          {
+            "language": "en",
+            "id": "2",
+            "text": "Pike place market is my favorite Seattle attraction."
+          },
+          {
+            "language": "en",
+            "id": "3",
+            "text": "I had a wonderful trip to Seattle last week and even visited the Space Needle 2 times!"
+          },
+          {
+            "language": "en",
+            "id": "4",
+            "text": "Unfortunately, it rained during my entire trip to Seattle. I didn\u0027t even get to visit the Space Needle"
+          },
+          {
+            "language": "en",
+            "id": "5",
+            "text": "This should fail!"
+          }
+        ]
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d8836242-c6ce-4187-b6a9-bb184f719b63",
+        "Content-Type": "application/json; charset=utf-8",
+        "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=6",
+        "Date": "Fri, 08 May 2020 15:37:32 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "40"
+      },
+      "ResponseBody": {
+        "documents": [
+          {
+            "id": "0",
+            "entities": [
+              {
+                "name": "Bill Gates",
+                "matches": [
+                  {
+                    "text": "Bill Gates",
+                    "offset": 25,
+                    "length": 10,
+                    "confidenceScore": 0.52
+                  }
+                ],
+                "language": "en",
+                "id": "Bill Gates",
+                "url": "https://en.wikipedia.org/wiki/Bill_Gates",
+                "dataSource": "Wikipedia"
+              },
+              {
+                "name": "Paul Allen",
+                "matches": [
+                  {
+                    "text": "Paul Allen",
+                    "offset": 40,
+                    "length": 10,
+                    "confidenceScore": 0.54
+                  }
+                ],
+                "language": "en",
+                "id": "Paul Allen",
+                "url": "https://en.wikipedia.org/wiki/Paul_Allen",
+                "dataSource": "Wikipedia"
+              },
+              {
+                "name": "Microsoft",
+                "matches": [
+                  {
+                    "text": "Microsoft",
+                    "offset": 0,
+                    "length": 9,
+                    "confidenceScore": 0.49
+                  }
+                ],
+                "language": "en",
+                "id": "Microsoft",
+                "url": "https://en.wikipedia.org/wiki/Microsoft",
+                "dataSource": "Wikipedia"
+              }
+            ],
+            "warnings": []
+          },
+          {
+            "id": "1",
+            "entities": [
+              {
+                "name": "\u0022Hello, World!\u0022 program",
+                "matches": [
+                  {
+                    "text": "Hello world",
+                    "offset": 0,
+                    "length": 11,
+                    "confidenceScore": 0.03
+                  }
+                ],
+                "language": "en",
+                "id": "\u0022Hello, World!\u0022 program",
+                "url": "https://en.wikipedia.org/wiki/\u0022Hello,_World!\u0022_program",
+                "dataSource": "Wikipedia"
+              }
+            ],
+            "warnings": []
+          },
+          {
+            "id": "2",
+            "entities": [
+              {
+                "name": "Pike Place Market",
+                "matches": [
+                  {
+                    "text": "Pike place market",
+                    "offset": 0,
+                    "length": 17,
+                    "confidenceScore": 0.86
+                  }
+                ],
+                "language": "en",
+                "id": "Pike Place Market",
+                "url": "https://en.wikipedia.org/wiki/Pike_Place_Market",
+                "dataSource": "Wikipedia"
+              },
+              {
+                "name": "Seattle",
+                "matches": [
+                  {
+                    "text": "Seattle",
+                    "offset": 33,
+                    "length": 7,
+                    "confidenceScore": 0.27
+                  }
+                ],
+                "language": "en",
+                "id": "Seattle",
+                "url": "https://en.wikipedia.org/wiki/Seattle",
+                "dataSource": "Wikipedia"
+              }
+            ],
+            "warnings": []
+          },
+          {
+            "id": "3",
+            "entities": [
+              {
+                "name": "Space Needle",
+                "matches": [
+                  {
+                    "text": "Space Needle",
+                    "offset": 65,
+                    "length": 12,
+                    "confidenceScore": 0.42
+                  }
+                ],
+                "language": "en",
+                "id": "Space Needle",
+                "url": "https://en.wikipedia.org/wiki/Space_Needle",
+                "dataSource": "Wikipedia"
+              },
+              {
+                "name": "Seattle",
+                "matches": [
+                  {
+                    "text": "Seattle",
+                    "offset": 26,
+                    "length": 7,
+                    "confidenceScore": 0.21
+                  }
+                ],
+                "language": "en",
+                "id": "Seattle",
+                "url": "https://en.wikipedia.org/wiki/Seattle",
+                "dataSource": "Wikipedia"
+              }
+            ],
+            "warnings": []
+          },
+          {
+            "id": "4",
+            "entities": [
+              {
+                "name": "Space Needle",
+                "matches": [
+                  {
+                    "text": "Space Needle",
+                    "offset": 90,
+                    "length": 12,
+                    "confidenceScore": 0.36
+                  }
+                ],
+                "language": "en",
+                "id": "Space Needle",
+                "url": "https://en.wikipedia.org/wiki/Space_Needle",
+                "dataSource": "Wikipedia"
+              },
+              {
+                "name": "Seattle",
+                "matches": [
+                  {
+                    "text": "Seattle",
+                    "offset": 50,
+                    "length": 7,
+                    "confidenceScore": 0.2
+                  }
+                ],
+                "language": "en",
+                "id": "Seattle",
+                "url": "https://en.wikipedia.org/wiki/Seattle",
+                "dataSource": "Wikipedia"
+              }
+            ],
+            "warnings": []
+          },
+          {
+            "id": "5",
+            "entities": [],
+            "warnings": []
+          }
+        ],
+        "errors": [
+          {
+            "id": "",
+            "error": {
+              "code": "InvalidRequest",
+              "message": "The request has exceeded the allowed document limits.",
+              "innererror": {
+                "code": "InvalidDocumentBatch",
+                "message": "The number of documents in the request have exceeded the data limitations. See https://aka.ms/text-analytics-data-limits for additional information"
+              }
+            }
+          }
+        ],
+        "modelVersion": "2020-02-01"
+      }
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "538775678",
+    "TEXT_ANALYTICS_API_KEY": "Sanitized",
+    "TEXT_ANALYTICS_ENDPOINT": "https://westus2.ppe.cognitiveservices.azure.com/"
+  }
+}

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
@@ -634,6 +634,26 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [Test]
+        public void RecognizeEntitiesBatchWithInvalidDocumentBatch()
+        {
+            TextAnalyticsClient client = GetClient();
+            var documents = new List<string>
+            {
+                "document 1",
+                "document 2",
+                "document 3",
+                "document 4",
+                "document 5",
+                "document 6"
+            };
+
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(
+                   async () => await client.RecognizeEntitiesBatchAsync(documents));
+            Assert.AreEqual(400, ex.Status);
+            Assert.AreEqual("InvalidDocumentBatch", ex.ErrorCode);
+        }
+
+        [Test]
         public async Task RecognizeEntitiesBatchConvenienceWithStatisticsTest()
         {
             TextAnalyticsClient client = GetClient();

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/TextAnalyticsClientLiveTests.cs
@@ -767,6 +767,26 @@ namespace Azure.AI.TextAnalytics.Tests
         }
 
         [Test]
+        public void RecognizeLinkedEntitiesBatchWithInvalidDocumentBatch()
+        {
+            TextAnalyticsClient client = GetClient();
+            var documents = new List<string>
+            {
+                "Microsoft was founded by Bill Gates and Paul Allen.",
+                "Hello world",
+                "Pike place market is my favorite Seattle attraction.",
+                "I had a wonderful trip to Seattle last week and even visited the Space Needle 2 times!",
+                "Unfortunately, it rained during my entire trip to Seattle. I didn't even get to visit the Space Needle",
+                "This should fail!"
+            };
+
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(
+                   async () => await client.RecognizeLinkedEntitiesBatchAsync(documents));
+            Assert.AreEqual(400, ex.Status);
+            Assert.AreEqual("InvalidDocumentBatch", ex.ErrorCode);
+        }
+
+        [Test]
         public async Task RecognizeLinkedEntitiesBatchConvenienceTest()
         {
             TextAnalyticsClient client = GetClient();


### PR DESCRIPTION
This is temporary as the service will start returning 400 for this scenario around July. We want to make sure we throw the same way now and then.

Fixes: #10707

Issue to undo this once the service returns status 400 => https://github.com/Azure/azure-sdk-for-net/issues/11946