### PR TITLE
Update how we configure out DevOpsFeed

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -1,6 +1,8 @@
 parameters:
   Artifacts: []
   ArtifactName: 'not-specified'
+  # Publish to https://dev.azure.com/azure-sdk/public/_packaging?_a=feed&feed=azure-sdk-for-net
+  DevOpsFeedId: '29ec6040-b234-4e31-b139-33dc4287b756/fa8c16a3-dbe0-4de2-a297-03065ec1ba3f'
 
 stages:
   - stage: Signing
@@ -101,12 +103,11 @@ stages:
                           nuGetFeedType: external
                           publishFeedCredentials: Nuget.org
                       - task: NuGetCommand@2
-                        condition: and(succeeded(), ne(variables['DevOpsFeedID'], ''))
                         displayName: 'Publish to DevOps Feed'
                         inputs:
                           command: push
                           packagesToPush: '$(Pipeline.Workspace)/staging/**/*.nupkg;!$(Pipeline.Workspace)/staging/**/*.symbols.nupkg'
-                          publishVstsFeed: $(DevOpsFeedID)
+                          publishVstsFeed: ${{ parameters.DevOpsFeedID }}
 
           - ${{if ne(artifact.options.skipSymbolsUpload, 'true')}}:
             - deployment: UploadSymbols
@@ -211,8 +212,18 @@ stages:
       - template: tools/clone-buildtools/clone-buildtools.yml@azure-sdk-build-tools
       - download: current
         artifact: ${{parameters.ArtifactName}}-signed
+      - pwsh: |
+          # For safety default to publishing to the private feed.
+          # Publish to https://dev.azure.com/azure-sdk/internal/_packaging?_a=feed&feed=azure-sdk-for-net-pr
+          $devopsFeedId = '590cfd2a-581c-4dcb-a12e-6568ce786175/fa8b2d77-74d9-48d7-bb96-badb2b9c6ca4'
+          if ('$(Build.Repository.Name)' -eq 'Azure/azure-sdk-for-net') {
+            # Publish to https://dev.azure.com/azure-sdk/public/_packaging?_a=feed&feed=azure-sdk-for-net
+            $devopsFeedId = '${{ parameters.DevOpsFeedID }}'
+          }
+          echo "##vso[task.setvariable variable=DevOpsFeedID]$devopsFeedId"
+          echo "Using DevopsFeedId = $devopsFeedId"
+        displayName: Setup DevOpsFeedId
       - task: NuGetCommand@2
-        condition: and(succeeded(), ne(variables['DevOpsFeedID'], ''))
         displayName: 'Publish to DevOps Feed'
         inputs:
           command: push
@@ -220,6 +231,7 @@ stages:
           publishVstsFeed: $(DevOpsFeedID)
       - task: MSBuild@1
         displayName: 'Publish to blobfeed'
+        condition: and(succeeded(), eq('${{ parameters.DevOpsFeedID }}', variables['DevOpsFeedID']))
         inputs:
           solution: '$(AzureSDKBuildToolsPath)/tools/blobfeedtool/BlobFeedPublishHelper.proj'
           msbuildArguments: '/p:AccountKey=$(azuresdkartifacts-access-key) /p:ExpectedFeedUrl=$(BlobFeedUrl) /p:PackagesPath="$(Pipeline.Workspace)/packages-signed"'

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -9,9 +9,3 @@ variables:
     BuildConfiguration: 'Debug'
   ${{ if eq(variables['System.TeamProject'], 'internal') }}:
     BuildConfiguration: 'Release'
-  # Publish to https://dev.azure.com/azure-sdk/public/_packaging?_a=feed&feed=azure-sdk-for-net
-  ${{ if eq(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-net') }}:
-    DevOpsFeedID: '29ec6040-b234-4e31-b139-33dc4287b756/fa8c16a3-dbe0-4de2-a297-03065ec1ba3f'
-  # Publish to https://dev.azure.com/azure-sdk/internal/_packaging?_a=feed&feed=azure-sdk-for-net-pr
-  ${{ if eq(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-net-pr') }}:
-    DevOpsFeedID: '590cfd2a-581c-4dcb-a12e-6568ce786175/fa8b2d77-74d9-48d7-bb96-badb2b9c6ca4'


### PR DESCRIPTION
You cannot access "Build.Repository.Name" variable
at template expansion time so we never have a DevOpsFeedId
setup correctly with the current changes.

Instead we now have the DevOpsFeedId setup as a template parameter
that we override for nightly builds if we are not publishing from
the default public azure/azure-sdk-for-net repo. This will help us
not accidently publish something publicly that we don't want to.