### PR TITLE
Create new indexes instead of Search services

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/PlaybackTransport.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/PlaybackTransport.cs
@@ -52,6 +52,9 @@ namespace Azure.Core.TestFramework
             }
 
             message.Response = GetResponse(_session.Lookup(requestEntry, _matcher, _sanitizer));
+
+            // Copy the ClientRequestId like the HTTP transport.
+            message.Response.ClientRequestId = message.Request.ClientRequestId;
         }
 
         public override async ValueTask ProcessAsync(HttpMessage message)
@@ -77,6 +80,9 @@ namespace Azure.Core.TestFramework
             }
 
             message.Response = GetResponse(_session.Lookup(requestEntry, _matcher, _sanitizer));
+
+            // Copy the ClientRequestId like the HTTP transport.
+            message.Response.ClientRequestId = message.Request.ClientRequestId;
         }
 
         public override Request CreateRequest()

--- a/sdk/search/Azure.Search.Documents/tests/Azure.Search.Documents.Tests.csproj
+++ b/sdk/search/Azure.Search.Documents/tests/Azure.Search.Documents.Tests.csproj
@@ -27,8 +27,6 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Azure.Identity" />
-    <PackageReference Include="Microsoft.Azure.Management.Search" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" />
 
     <!-- TODO: Remove this when https://github.com/Azure/azure-sdk-for-net/issues/10592 is resolved. -->
     <PackageReference Include="Microsoft.Spatial" />

--- a/sdk/search/Azure.Search.Documents/tests/Samples/Readme.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Samples/Readme.cs
@@ -182,7 +182,7 @@ namespace Azure.Search.Documents.Tests.Samples
         [SyncOnly]
         public async Task CreateIndex()
         {
-            await using SearchResources resources = await SearchResources.CreateWithNoIndexesAsync(this);
+            await using SearchResources resources = SearchResources.CreateWithNoIndexes(this);
             Environment.SetEnvironmentVariable("SEARCH_ENDPOINT", resources.Endpoint.ToString());
             Environment.SetEnvironmentVariable("SEARCH_API_KEY", resources.PrimaryApiKey);
 

--- a/sdk/search/Azure.Search.Documents/tests/SearchClientTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/SearchClientTests.cs
@@ -42,10 +42,7 @@ namespace Azure.Search.Documents.Tests
             Response<long> response = await client.GetDocumentCountAsync(
                 new SearchRequestOptions { ClientRequestId = id });
 
-            // TODO: #10604 - C# generator doesn't properly support ClientRequestId yet
-            // (Assertion is here to remind us to fix this when we do - just
-            // change to AreEqual and re-record)
-            Assert.AreNotEqual(id.ToString(), response.GetRawResponse().ClientRequestId);
+            Assert.AreEqual(id.ToString(), response.GetRawResponse().ClientRequestId);
         }
 
         [Test]

--- a/sdk/search/Azure.Search.Documents/tests/SearchServiceClientTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/SearchServiceClientTests.cs
@@ -88,10 +88,7 @@ namespace Azure.Search.Documents.Tests
                 await client.GetServiceStatisticsAsync(
                     new SearchRequestOptions { ClientRequestId = id });
 
-            // TODO: #10604 - C# generator doesn't properly support ClientRequestId yet
-            // (Assertion is here to remind us to fix this when we do - just
-            // change to AreEqual and re-record)
-            Assert.AreNotEqual(id.ToString(), response.GetRawResponse().ClientRequestId);
+            Assert.AreEqual(id.ToString(), response.GetRawResponse().ClientRequestId);
         }
 
         [Test]
@@ -139,7 +136,7 @@ namespace Azure.Search.Documents.Tests
             Assert.IsNotNull(response.Value.Limits);
 
             Assert.NotZero(response.Value.Counters.IndexCounter.Quota ?? 0L);
-            Assert.AreEqual(1, response.Value.Counters.IndexCounter.Usage);
+            Assert.NotZero(response.Value.Counters.IndexCounter.Usage);
         }
 
         [Test]
@@ -158,10 +155,10 @@ namespace Azure.Search.Documents.Tests
         [Test]
         public async Task CreateIndex()
         {
-            await using SearchResources resources = await SearchResources.CreateWithNoIndexesAsync(this);
+            await using SearchResources resources = SearchResources.CreateWithNoIndexes(this);
 
-            string indexName = Recording.Random.GetName(8);
-            SearchIndex expectedIndex = SearchResources.GetHotelIndex(indexName);
+            resources.IndexName = Recording.Random.GetName(8);
+            SearchIndex expectedIndex = SearchResources.GetHotelIndex(resources.IndexName);
 
             SearchServiceClient client = resources.GetServiceClient();
             SearchIndex actualIndex = await client.CreateIndexAsync(expectedIndex);
@@ -177,10 +174,10 @@ namespace Azure.Search.Documents.Tests
         [Test]
         public async Task UpdateIndex()
         {
-            await using SearchResources resources = await SearchResources.CreateWithNoIndexesAsync(this);
+            await using SearchResources resources = SearchResources.CreateWithNoIndexes(this);
 
-            string indexName = Recording.Random.GetName();
-            SearchIndex initialIndex = SearchResources.GetHotelIndex(indexName);
+            resources.IndexName = Recording.Random.GetName();
+            SearchIndex initialIndex = SearchResources.GetHotelIndex(resources.IndexName);
 
             SearchServiceClient client = resources.GetServiceClient();
             SearchIndex createdIndex = await client.CreateIndexAsync(initialIndex);
@@ -294,7 +291,7 @@ namespace Azure.Search.Documents.Tests
 
             // Create the Azure Blob data source and indexer.
             SearchIndexerDataSource dataSource = new SearchIndexerDataSource(
-                resources.StorageAccountName,
+                Recording.Random.GetName(),
                 SearchIndexerDataSourceType.AzureBlob,
                 resources.StorageAccountConnectionString,
                 new SearchIndexerDataContainer(resources.BlobContainerName));
@@ -304,7 +301,7 @@ namespace Azure.Search.Documents.Tests
                 GetOptions());
 
             SearchIndexer indexer = new SearchIndexer(
-                Recording.Random.GetName(8),
+                Recording.Random.GetName(),
                 dataSource.Name,
                 resources.IndexName);
 

--- a/sdk/search/Azure.Search.Documents/tests/SearchServiceClientTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/SearchServiceClientTests.cs
@@ -331,7 +331,9 @@ namespace Azure.Search.Documents.Tests
             long count = await client.GetDocumentCountAsync(
                 GetOptions());
 
-            Assert.AreEqual(SearchResources.TestDocuments.Length, count);
+            // While there should only be 10 documents and this data source uses a random name and should not be shared,
+            // occasionally we get back 20 documents. Since this still proves the indexer worked, do not fail the tests.
+            Assert.That(count, Is.GreaterThanOrEqualTo(SearchResources.TestDocuments.Length));
         }
 
         [Test]

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/ExcludesFieldsNotInSuggester.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/ExcludesFieldsNotInSuggester.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "94",
         "Content-Type": "application/json",
-        "traceparent": "00-c57e46eece73ff45b5fc4a6777a81adc-f5bc4b9204900540-00",
+        "traceparent": "00-5cab8b69aa4d8348b6767fb88f7e41b3-f5f2907f7743c041-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "6f3d77229cc71cc50b5eb3ad02218b24",
         "x-ms-return-client-request-id": "true"
@@ -27,8 +27,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "12",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:14 GMT",
-        "elapsed-time": "74",
+        "Date": "Fri, 08 May 2020 06:41:18 GMT",
+        "elapsed-time": "133",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -42,13 +42,10 @@
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1881067006",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/ExcludesFieldsNotInSuggesterAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/ExcludesFieldsNotInSuggesterAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "94",
         "Content-Type": "application/json",
-        "traceparent": "00-85d99cb0ed05e4479998d06f3f3ec35d-ef8ae92228817441-00",
+        "traceparent": "00-c3488f7aa7afc14e89f513fab5a62088-da89484d79ed164f-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "1879001f3bba4456832277712ba0dcff",
         "x-ms-return-client-request-id": "true"
@@ -27,8 +27,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "12",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:15 GMT",
-        "elapsed-time": "5",
+        "Date": "Fri, 08 May 2020 06:41:19 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -43,7 +43,8 @@
   ],
   "Variables": {
     "RandomSeed": "1394587558",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/Filter.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/Filter.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "112",
         "Content-Type": "application/json",
-        "traceparent": "00-454348b858c6c24d97e449abc025ce2a-e991af1c2784c444-00",
+        "traceparent": "00-6473fc91ac2c6d4ea52a7f119d7534f8-f3df1efb75946747-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "4c4f74ccc55692b9ef5f75074d36dcb0",
         "x-ms-return-client-request-id": "true"
@@ -27,8 +27,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "54",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:14 GMT",
-        "elapsed-time": "28",
+        "Date": "Fri, 08 May 2020 06:41:18 GMT",
+        "elapsed-time": "138",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -48,7 +48,8 @@
   ],
   "Variables": {
     "RandomSeed": "828291068",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/FilterAndFuzzy.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/FilterAndFuzzy.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "199",
         "Content-Type": "application/json",
-        "traceparent": "00-07b11140c1b0d24e8807764460bef4f3-493ebb51e66ece49-00",
+        "traceparent": "00-2ff4e484518fc44687cb14e68871e0be-aa0c2a61d1fe6947-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "f8c845e51731603e2e0f7960ce9d9038",
         "x-ms-return-client-request-id": "true"
@@ -28,8 +28,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "95",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:14 GMT",
-        "elapsed-time": "9",
+        "Date": "Fri, 08 May 2020 06:41:18 GMT",
+        "elapsed-time": "52",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -53,7 +53,8 @@
   ],
   "Variables": {
     "RandomSeed": "1645982235",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/FilterAndFuzzyAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/FilterAndFuzzyAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "199",
         "Content-Type": "application/json",
-        "traceparent": "00-07c11c7c8a25c044b3e53ebea3720187-9bacc278a162a743-00",
+        "traceparent": "00-8ceaedd36f33cc40b3ffd3a6c63d2bc4-b4af4108c53fcf41-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "eb0865a2838daba95fdcefa4899ea5f7",
         "x-ms-return-client-request-id": "true"
@@ -28,7 +28,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "95",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:15 GMT",
+        "Date": "Fri, 08 May 2020 06:41:19 GMT",
         "elapsed-time": "7",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -53,7 +53,8 @@
   ],
   "Variables": {
     "RandomSeed": "1398217694",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/FilterAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/FilterAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "112",
         "Content-Type": "application/json",
-        "traceparent": "00-9fed8db7e04a5d4a88b5a462136c6ac4-31533de03984ec4c-00",
+        "traceparent": "00-6f3ca505d59eda4b85c09b4b3fc1bb69-0b956d00aa02c646-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "64c8f2957acf4b9683b5923d9df5326a",
         "x-ms-return-client-request-id": "true"
@@ -27,8 +27,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "54",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:15 GMT",
-        "elapsed-time": "6",
+        "Date": "Fri, 08 May 2020 06:41:19 GMT",
+        "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -48,7 +48,8 @@
   ],
   "Variables": {
     "RandomSeed": "50280089",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/FuzzyIsOffByDefault.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/FuzzyIsOffByDefault.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "65",
         "Content-Type": "application/json",
-        "traceparent": "00-bb2a79f732b64c40be5b243c8a51524b-606bb699b3cb1142-00",
+        "traceparent": "00-c52d5cac37270049b3bec06b503fd70b-e868d8409d374343-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "bf3ba05d0f02bc14a10549a3a6a48398",
         "x-ms-return-client-request-id": "true"
@@ -26,8 +26,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "12",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:14 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 08 May 2020 06:41:18 GMT",
+        "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -42,7 +42,8 @@
   ],
   "Variables": {
     "RandomSeed": "1557663442",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/FuzzyIsOffByDefaultAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/FuzzyIsOffByDefaultAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "65",
         "Content-Type": "application/json",
-        "traceparent": "00-7629c0fa200cc8419e6d815777fcf4bb-c8f7e3f32875084e-00",
+        "traceparent": "00-d5eca493fe3d4a47a3c0a95c1c9b71a7-62ec761ca250c048-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "4ff0621fa620cff0b5598b44909565ea",
         "x-ms-return-client-request-id": "true"
@@ -26,8 +26,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "12",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:15 GMT",
-        "elapsed-time": "4",
+        "Date": "Fri, 08 May 2020 06:41:19 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -42,7 +42,8 @@
   ],
   "Variables": {
     "RandomSeed": "241835370",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/HitHighlighting.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/HitHighlighting.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "220",
         "Content-Type": "application/json",
-        "traceparent": "00-6b3b375f76d3724388f66631079b6348-302b3cd8f407ce43-00",
+        "traceparent": "00-5cdea62590898b4d89b49d7e01c533d7-4258cafca44d4f46-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "4837c8e58156ec941241d385a9cdc8fd",
         "x-ms-return-client-request-id": "true"
@@ -29,8 +29,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "109",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:14 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 08 May 2020 06:41:18 GMT",
+        "elapsed-time": "8",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -54,7 +54,8 @@
   ],
   "Variables": {
     "RandomSeed": "1397489542",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/HitHighlightingAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/HitHighlightingAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "220",
         "Content-Type": "application/json",
-        "traceparent": "00-ed3f63e9aa3a3e46858024b93588f98e-b01c6d44d9271048-00",
+        "traceparent": "00-dc2a81da9c5bf540becfc6b17646a6bc-ce4bd04784b26848-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "16b7964e2bcee97574968c9ce40596b1",
         "x-ms-return-client-request-id": "true"
@@ -29,8 +29,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "109",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:15 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 08 May 2020 06:41:19 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -54,7 +54,8 @@
   ],
   "Variables": {
     "RandomSeed": "1713520203",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/MultipleSelectedFields.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/MultipleSelectedFields.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "105",
         "Content-Type": "application/json",
-        "traceparent": "00-edc348924afe8645ac43c25952d72199-05ab952289eb8c48-00",
+        "traceparent": "00-8570f4d7624c1b49ac6d2d94556a8e03-6afabe1e29bbaf40-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "edfd09388ec2b6212774be5f65822d31",
         "x-ms-return-client-request-id": "true"
@@ -27,8 +27,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "95",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:14 GMT",
-        "elapsed-time": "5",
+        "Date": "Fri, 08 May 2020 06:41:18 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -52,7 +52,8 @@
   ],
   "Variables": {
     "RandomSeed": "360658384",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/MultipleSelectedFieldsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/MultipleSelectedFieldsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "105",
         "Content-Type": "application/json",
-        "traceparent": "00-9cd523f075678d4aa1e19867aec94942-dfdbc8d0be8a304d-00",
+        "traceparent": "00-5bee48e81bdc824fb382269ddd7ed125-25c5fea5e3c3814f-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "869339ba1914679e297de403a9df39dd",
         "x-ms-return-client-request-id": "true"
@@ -27,8 +27,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "95",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:15 GMT",
-        "elapsed-time": "23",
+        "Date": "Fri, 08 May 2020 06:41:19 GMT",
+        "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -52,7 +52,8 @@
   ],
   "Variables": {
     "RandomSeed": "1053158736",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/OneTerm.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/OneTerm.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "65",
         "Content-Type": "application/json",
-        "traceparent": "00-3d5505b04618244f8c42d3e2e2c3f9db-4c1f8738edaace49-00",
+        "traceparent": "00-f11a1b417e9979469ad85ee643fa7c35-9eb0b9fa955a9848-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "836405f774d01ce051263e9c5247117e",
         "x-ms-return-client-request-id": "true"
@@ -26,8 +26,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "222",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:14 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 08 May 2020 06:41:18 GMT",
+        "elapsed-time": "13",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -63,7 +63,8 @@
   ],
   "Variables": {
     "RandomSeed": "351280611",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/OneTermAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/OneTermAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "65",
         "Content-Type": "application/json",
-        "traceparent": "00-d3c2cc6750f49148a0d771a4804b9491-8f76c2687c91284b-00",
+        "traceparent": "00-a1c3a5326cbca74495580b9bdc3c727b-2b2a7b16cc8e5647-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "4dedd4c7726e4d35e45f1c715ba7d89a",
         "x-ms-return-client-request-id": "true"
@@ -26,8 +26,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "222",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:15 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 08 May 2020 06:41:19 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -63,7 +63,8 @@
   ],
   "Variables": {
     "RandomSeed": "1058886123",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/OneTermOnByDefault.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/OneTermOnByDefault.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "36",
         "Content-Type": "application/json",
-        "traceparent": "00-223a91fbcd5cd64397d2477de2b6b75e-140e6c08b86e0947-00",
+        "traceparent": "00-8ff980c9ad75504299893002a48d5315-84173b979c910c41-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "40ea6fcb4189c48fb4658454cf3b00a9",
         "x-ms-return-client-request-id": "true"
@@ -25,8 +25,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "222",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:14 GMT",
-        "elapsed-time": "4",
+        "Date": "Fri, 08 May 2020 06:41:18 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -62,7 +62,8 @@
   ],
   "Variables": {
     "RandomSeed": "1143673798",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/OneTermOnByDefaultAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/OneTermOnByDefaultAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "36",
         "Content-Type": "application/json",
-        "traceparent": "00-d576dbf0d94f9d44af43b4bfe7b960dd-8dfd5728c594b54d-00",
+        "traceparent": "00-daf7f34d8affe64788b28ba6c3fd61fe-a1acd9404f972141-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "7edde5813978a96d073fde61935be7fc",
         "x-ms-return-client-request-id": "true"
@@ -25,7 +25,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "222",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:15 GMT",
+        "Date": "Fri, 08 May 2020 06:41:19 GMT",
         "elapsed-time": "7",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -62,7 +62,8 @@
   ],
   "Variables": {
     "RandomSeed": "671885112",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/OneTermWithContext.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/OneTermWithContext.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "93",
         "Content-Type": "application/json",
-        "traceparent": "00-ac5dad0030f7384eac83e2ed9a76a94e-5ddef0054da22d45-00",
+        "traceparent": "00-ae26a6fb77ceeb4fa8e0720bf529f6ec-5615e581622ece45-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "0e64f365406cc7f5f3873703a106b469",
         "x-ms-return-client-request-id": "true"
@@ -26,7 +26,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "208",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:14 GMT",
+        "Date": "Fri, 08 May 2020 06:41:18 GMT",
         "elapsed-time": "7",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -55,7 +55,8 @@
   ],
   "Variables": {
     "RandomSeed": "417866891",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/OneTermWithContextAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/OneTermWithContextAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "93",
         "Content-Type": "application/json",
-        "traceparent": "00-b44315bf7d854244827ae028a570a1d1-ca11edb0519b364d-00",
+        "traceparent": "00-d43e455640185d4b8c8b1cdd767b9cf0-69452dd8527d8244-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "13f4ebfe4ca7795cde2ed18d91924aae",
         "x-ms-return-client-request-id": "true"
@@ -26,8 +26,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "208",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:15 GMT",
-        "elapsed-time": "10",
+        "Date": "Fri, 08 May 2020 06:41:19 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -55,7 +55,8 @@
   ],
   "Variables": {
     "RandomSeed": "253423147",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/OneTermWithContextWithFuzzy.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/OneTermWithContextWithFuzzy.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "97",
         "Content-Type": "application/json",
-        "traceparent": "00-8ea4aacb7abe9343bec673bbc4c3b781-9c419d3ea691d74c-00",
+        "traceparent": "00-7fa1eb5d87ed2041852f7ef7cd4457d9-b157fd2fedacd049-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "efc7a0aba29c103d801829a20981a518",
         "x-ms-return-client-request-id": "true"
@@ -27,7 +27,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "117",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:14 GMT",
+        "Date": "Fri, 08 May 2020 06:41:18 GMT",
         "elapsed-time": "8",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -52,7 +52,8 @@
   ],
   "Variables": {
     "RandomSeed": "1757180672",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/OneTermWithContextWithFuzzyAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/OneTermWithContextWithFuzzyAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "97",
         "Content-Type": "application/json",
-        "traceparent": "00-21157625c7567d44b84cbfd99b4b581d-3671c94b42056e42-00",
+        "traceparent": "00-964ef05a474e2242a8d382b8ce85c0b3-00a6789a2f021b49-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "0f66fcbeb1d6ef60b26a400a224651c9",
         "x-ms-return-client-request-id": "true"
@@ -27,7 +27,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "117",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:15 GMT",
+        "Date": "Fri, 08 May 2020 06:41:19 GMT",
         "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -52,7 +52,8 @@
   ],
   "Variables": {
     "RandomSeed": "1441381448",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/OneTermWithFuzzy.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/OneTermWithFuzzy.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "79",
         "Content-Type": "application/json",
-        "traceparent": "00-6fd4bb2ef5807f4ea4b9c8b67eb92679-4c1ebe38e66e8344-00",
+        "traceparent": "00-8630fd0f37c02a4ba5f8bb0b6b4cdf28-ec824ac30541f647-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "5ca86594e8d25f20dbb3c61763379935",
         "x-ms-return-client-request-id": "true"
@@ -27,8 +27,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "177",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:14 GMT",
-        "elapsed-time": "6",
+        "Date": "Fri, 08 May 2020 06:41:18 GMT",
+        "elapsed-time": "10",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -60,7 +60,8 @@
   ],
   "Variables": {
     "RandomSeed": "1963046740",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/OneTermWithFuzzyAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/OneTermWithFuzzyAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "79",
         "Content-Type": "application/json",
-        "traceparent": "00-67602e8f3746e6419b5f31ad42e94851-975c5cde40dfe942-00",
+        "traceparent": "00-590df94ebb9e9f4d9b95d79e36068658-57e36e48dfba8543-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "a08d464f4ac88446775cc8c10d333177",
         "x-ms-return-client-request-id": "true"
@@ -27,7 +27,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "177",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:15 GMT",
+        "Date": "Fri, 08 May 2020 06:41:19 GMT",
         "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -60,7 +60,8 @@
   ],
   "Variables": {
     "RandomSeed": "59185497",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/SelectedFields.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/SelectedFields.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "129",
         "Content-Type": "application/json",
-        "traceparent": "00-13053ee19c1c5e46b2b4acc635788a23-3442605faa74df4f-00",
+        "traceparent": "00-fcc9351911d0254e88e08e81cf9ab590-a4041bc8075a3e4a-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "e5c7d9b997a1b593ca55ff33ebda806b",
         "x-ms-return-client-request-id": "true"
@@ -28,8 +28,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "54",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:14 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 08 May 2020 06:41:18 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -49,7 +49,8 @@
   ],
   "Variables": {
     "RandomSeed": "2087664549",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/SelectedFieldsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/SelectedFieldsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "129",
         "Content-Type": "application/json",
-        "traceparent": "00-fd6e34799c5a8947b94972733ca2fb12-a2e509d5446c1c46-00",
+        "traceparent": "00-2db9f8f291f8cc43a3efc4980ddce76c-ea09d71de4d74b4a-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "69f62892c7dc580724c51cce1e00feb0",
         "x-ms-return-client-request-id": "true"
@@ -28,8 +28,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "54",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:15 GMT",
-        "elapsed-time": "148",
+        "Date": "Fri, 08 May 2020 06:41:19 GMT",
+        "elapsed-time": "10",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -49,7 +49,8 @@
   ],
   "Variables": {
     "RandomSeed": "912744819",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/SizeTrimsResults.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/SizeTrimsResults.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "73",
         "Content-Type": "application/json",
-        "traceparent": "00-2962a61fe85c9c4eb6e4b4066fa136ff-b35cfaaa2612f241-00",
+        "traceparent": "00-1d30c9848c79e44687a06a3ad2bfd182-e6c78305f3934a48-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "29c60ffc20158e0f544207fec06a07fb",
         "x-ms-return-client-request-id": "true"
@@ -27,7 +27,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "95",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:14 GMT",
+        "Date": "Fri, 08 May 2020 06:41:18 GMT",
         "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -52,7 +52,8 @@
   ],
   "Variables": {
     "RandomSeed": "1372502635",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/SizeTrimsResultsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/SizeTrimsResultsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "73",
         "Content-Type": "application/json",
-        "traceparent": "00-1ad60cb67f5e734688041743e37c468f-d0933c1d5ff8564c-00",
+        "traceparent": "00-a817436550c86c4b859d5bfcc7a20ec7-3d9313a29a6e664a-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "3dc4828d45d45e614c9b358bb2ee8cb7",
         "x-ms-return-client-request-id": "true"
@@ -27,8 +27,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "95",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:15 GMT",
-        "elapsed-time": "6",
+        "Date": "Fri, 08 May 2020 06:41:19 GMT",
+        "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -52,7 +52,8 @@
   ],
   "Variables": {
     "RandomSeed": "1444061374",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/StaticallyTypedDocuments.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/StaticallyTypedDocuments.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "84",
         "Content-Type": "application/json",
-        "traceparent": "00-080701c3b23260458b5acd6cb1e08682-c81b4787272a8a4d-00",
+        "traceparent": "00-fc4caf4611dfaf45a90db1237a179e57-4b6d93caffaacc48-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "f3c20d84a81656069c11f3761f03f2db",
         "x-ms-return-client-request-id": "true"
@@ -27,8 +27,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "247",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:14 GMT",
-        "elapsed-time": "5",
+        "Date": "Fri, 08 May 2020 06:41:18 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -64,7 +64,8 @@
   ],
   "Variables": {
     "RandomSeed": "633936821",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/StaticallyTypedDocumentsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/StaticallyTypedDocumentsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "84",
         "Content-Type": "application/json",
-        "traceparent": "00-8dd67b1e99ca9649baf52a3b8b5ebbbb-41730920d7b12744-00",
+        "traceparent": "00-d34b7cfdf5951b4680714d1eb54ba5b8-0513bd1714c40c4d-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "756ea08bb2000c2fa9b35ccc10deb879",
         "x-ms-return-client-request-id": "true"
@@ -27,8 +27,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "247",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:15 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 08 May 2020 06:41:19 GMT",
+        "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -64,7 +64,8 @@
   ],
   "Variables": {
     "RandomSeed": "1865371289",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/ThrowsWhenBadSuggesterName.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/ThrowsWhenBadSuggesterName.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "85",
         "Content-Type": "application/json",
-        "traceparent": "00-7114469470d4f442a2870c9548414f28-29ba10db2fa2ea46-00",
+        "traceparent": "00-09fc14a49300a64ba4d696fb748247f3-445fa5806645a942-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "d7c46533c9974e93ea4923442227c276",
         "x-ms-return-client-request-id": "true"
@@ -27,7 +27,7 @@
         "Content-Language": "en",
         "Content-Length": "147",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:14 GMT",
+        "Date": "Fri, 08 May 2020 06:41:19 GMT",
         "elapsed-time": "3",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -46,7 +46,8 @@
   ],
   "Variables": {
     "RandomSeed": "1535184382",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/ThrowsWhenBadSuggesterNameAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/ThrowsWhenBadSuggesterNameAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "85",
         "Content-Type": "application/json",
-        "traceparent": "00-cfd8199bc45bed49934d5850286eac8a-5f0220864c22624f-00",
+        "traceparent": "00-46d3138a706f7a4a9fd6844070a6064c-049cecf9fd1e1f4f-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "a6de12b3b513c4f1287b9c3f23817176",
         "x-ms-return-client-request-id": "true"
@@ -27,8 +27,8 @@
         "Content-Language": "en",
         "Content-Length": "147",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:15 GMT",
-        "elapsed-time": "3",
+        "Date": "Fri, 08 May 2020 06:41:19 GMT",
+        "elapsed-time": "2",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -46,7 +46,8 @@
   ],
   "Variables": {
     "RandomSeed": "1361948098",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/ThrowsWhenNoSuggesterName.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/ThrowsWhenNoSuggesterName.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "39",
         "Content-Type": "application/json",
-        "traceparent": "00-02cb351d128a83429eda278d59e41666-5d2ce404a535074f-00",
+        "traceparent": "00-b223b5185b01bb47a2ff2f98d55440db-820e005ce74d9f4e-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "86b9ad338e485267068298bef2de2881",
         "x-ms-return-client-request-id": "true"
@@ -26,7 +26,7 @@
         "Content-Language": "en",
         "Content-Length": "165",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:14 GMT",
+        "Date": "Fri, 08 May 2020 06:41:19 GMT",
         "elapsed-time": "4",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -45,7 +45,8 @@
   ],
   "Variables": {
     "RandomSeed": "1535324533",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/ThrowsWhenNoSuggesterNameAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/ThrowsWhenNoSuggesterNameAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "39",
         "Content-Type": "application/json",
-        "traceparent": "00-dfb307ef99458d47b50db0616d8cf4b4-2dba14f3e612184d-00",
+        "traceparent": "00-95d4e1cdf490a6429ba37e81859eab24-a8ffa5ea23378444-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "e94476538dd86087f12a56d5df48818f",
         "x-ms-return-client-request-id": "true"
@@ -26,8 +26,8 @@
         "Content-Language": "en",
         "Content-Length": "165",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:15 GMT",
-        "elapsed-time": "2",
+        "Date": "Fri, 08 May 2020 06:41:19 GMT",
+        "elapsed-time": "3",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -45,7 +45,8 @@
   ],
   "Variables": {
     "RandomSeed": "1550951357",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/TwoTerms.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/TwoTerms.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "66",
         "Content-Type": "application/json",
-        "traceparent": "00-78777c4206609e478f2d898abe724975-d89e7c99aea89648-00",
+        "traceparent": "00-c41bfa6bc4630848942f201aed0044a6-ddd1f6fc19a1414d-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "17d6ea87f57874a5023da5a7716cdfc4",
         "x-ms-return-client-request-id": "true"
@@ -26,8 +26,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "278",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:15 GMT",
-        "elapsed-time": "6",
+        "Date": "Fri, 08 May 2020 06:41:19 GMT",
+        "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -63,7 +63,8 @@
   ],
   "Variables": {
     "RandomSeed": "1006700618",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/TwoTermsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/TwoTermsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "66",
         "Content-Type": "application/json",
-        "traceparent": "00-9e9e782bdadc474096eea9b403b1c6cb-e0778b7bef05b849-00",
+        "traceparent": "00-41c6cab2e49c944e9708307bbd7e0fc3-a2ef66b15ad1434a-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "458ca740932cf39a52f4f2ec3f657f72",
         "x-ms-return-client-request-id": "true"
@@ -26,8 +26,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "278",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:15 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 08 May 2020 06:41:19 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -63,7 +63,8 @@
   ],
   "Variables": {
     "RandomSeed": "844093790",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/TwoTermsWithFuzzy.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/TwoTermsWithFuzzy.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "80",
         "Content-Type": "application/json",
-        "traceparent": "00-2ee2b4eacf8c1143a2addad37fa0d8e5-cf22f752c6d3a849-00",
+        "traceparent": "00-d37b14e603c33044ad9c5a132985902e-9e51cbc82b6bff45-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "ab4bffaddda8bac6d7b9511cd8f62fcf",
         "x-ms-return-client-request-id": "true"
@@ -27,7 +27,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "290",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:15 GMT",
+        "Date": "Fri, 08 May 2020 06:41:19 GMT",
         "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -64,7 +64,8 @@
   ],
   "Variables": {
     "RandomSeed": "1627275835",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/TwoTermsWithFuzzyAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/AutocompleteTests/TwoTermsWithFuzzyAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.autocomplete?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "80",
         "Content-Type": "application/json",
-        "traceparent": "00-560037c3c8d3e44483c55a006eeaf7ae-72bd9dadba4d2842-00",
+        "traceparent": "00-357ce097147d82428cf6e6bc70e3d894-3d6755f714c65e42-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "b82305e141df39207043d960114a3f30",
         "x-ms-return-client-request-id": "true"
@@ -27,7 +27,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "290",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:15 GMT",
+        "Date": "Fri, 08 May 2020 06:41:19 GMT",
         "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -64,7 +64,8 @@
   ],
   "Variables": {
     "RandomSeed": "1304635693",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/Base64Keys.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/Base64Keys.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-asswviqf.search.windows.net/indexes(\u0027sdandbnq\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027uvnunvny\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "60",
         "Content-Type": "application/json",
-        "traceparent": "00-721027264be8a641b635b8dae6aa2d8e-581c3a6f0f224443-00",
+        "traceparent": "00-b309c40e5385594bb38d214138393f85-2951743c28e53740-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "cd24350f9ede9fad02bbcf4ea0a9084c",
         "x-ms-return-client-request-id": "true"
@@ -29,8 +29,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "81",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:42 GMT",
-        "elapsed-time": "113",
+        "Date": "Fri, 08 May 2020 06:41:40 GMT",
+        "elapsed-time": "91",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -50,15 +50,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-asswviqf.search.windows.net/indexes(\u0027sdandbnq\u0027)/docs(\u0027AQIDBAU%3D\u0027)?$select=hotelId\u0026api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027uvnunvny\u0027)/docs(\u0027AQIDBAU%3D\u0027)?$select=hotelId\u0026api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-08837e0e5efe1649b6e4401a719a6757-d6a5fea665273a46-00",
+        "traceparent": "00-3111efb40c99534fa94c802d7cd3e9f7-ed8dd989d492d646-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "154595fd9d885b4732fac00032536feb",
         "x-ms-return-client-request-id": "true"
@@ -69,8 +69,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "22",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:49:44 GMT",
-        "elapsed-time": "43",
+        "Date": "Fri, 08 May 2020 06:41:42 GMT",
+        "elapsed-time": "11",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -81,16 +81,40 @@
       "ResponseBody": {
         "hotelId": "AQIDBAU="
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027uvnunvny\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-5f28a791221d044f8488976f924dfe03-d142ae1a4db0d34a-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "0ca0ff63dbe9ec7b0930de36774f162e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:41:42 GMT",
+        "elapsed-time": "231",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "0ca0ff63-dbe9-ec7b-0930-de36774f162e",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "844862299",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "sdandbnq",
-    "SearchServiceName": "azs-net-asswviqf",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "uvnunvny",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/Base64KeysAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/Base64KeysAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-tbwudprp.search.windows.net/indexes(\u0027tswtfbpg\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027aubvujwv\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "60",
         "Content-Type": "application/json",
-        "traceparent": "00-a62b0f2a1e9432418265c8c1f6b13b81-de1cb3c4ef2f0849-00",
+        "traceparent": "00-616ca169c4663f43b5202cebe6daa163-4c328d158e961846-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "5530b32662d2a5383c40be830872c390",
         "x-ms-return-client-request-id": "true"
@@ -29,8 +29,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "81",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:55:17 GMT",
-        "elapsed-time": "95",
+        "Date": "Fri, 08 May 2020 06:46:22 GMT",
+        "elapsed-time": "156",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -50,15 +50,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-tbwudprp.search.windows.net/indexes(\u0027tswtfbpg\u0027)/docs(\u0027AQIDBAU%3D\u0027)?$select=hotelId\u0026api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027aubvujwv\u0027)/docs(\u0027AQIDBAU%3D\u0027)?$select=hotelId\u0026api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-bd7eb0fccc035245b3ebb81a00e2815b-66219341db634e41-00",
+        "traceparent": "00-0e1087d1ba96e24cbe4676423b183434-d7d96a5daf20e448-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "6753fc019934107636cd2198c92e6871",
         "x-ms-return-client-request-id": "true"
@@ -69,7 +69,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "22",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:55:19 GMT",
+        "Date": "Fri, 08 May 2020 06:46:24 GMT",
         "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -81,16 +81,40 @@
       "ResponseBody": {
         "hotelId": "AQIDBAU="
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027aubvujwv\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-984427624120574da2214f456b6f91cc-c3700ee035b46d4d-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "b2f5f245ffccc5b3707f33a4647941bd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:46:24 GMT",
+        "elapsed-time": "219",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "b2f5f245-ffcc-c5b3-707f-33a4647941bd",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1260122787",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "tswtfbpg",
-    "SearchServiceName": "azs-net-tbwudprp",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "aubvujwv",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/CannotAlwaysDetermineCorrectType.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/CannotAlwaysDetermineCorrectType.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-lsnrvucq.search.windows.net/indexes(\u0027iwchpycu\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fjprueyo\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "117",
         "Content-Type": "application/json",
-        "traceparent": "00-436cd01e0eb0b84d8e574fef690b460e-c2dd12309b1f6440-00",
+        "traceparent": "00-62b175d7caeafa49a8a4e79117e5d4b1-6babf8780fcaac46-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "f2dea44eafbfa4b6ba735f3c93646f5e",
         "x-ms-return-client-request-id": "true"
@@ -35,8 +35,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:50:10 GMT",
-        "elapsed-time": "127",
+        "Date": "Fri, 08 May 2020 06:42:03 GMT",
+        "elapsed-time": "89",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -56,15 +56,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-lsnrvucq.search.windows.net/indexes(\u0027iwchpycu\u0027)/docs(\u00271\u0027)?$select=hotelId%2ChotelName%2Crooms%2FbaseRate\u0026api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fjprueyo\u0027)/docs(\u00271\u0027)?$select=hotelId%2ChotelName%2Crooms%2FbaseRate\u0026api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-6aa60022543f2b4f84008ac415d1abea-4e91ead5dce97245-00",
+        "traceparent": "00-fd73d0bf2b52344e878b5565c05a620a-8b91b98195217a44-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "9dfd77cc8a89de6cb092c4d1b6f43b5e",
         "x-ms-return-client-request-id": "true"
@@ -75,8 +75,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "79",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:50:13 GMT",
-        "elapsed-time": "27",
+        "Date": "Fri, 08 May 2020 06:42:05 GMT",
+        "elapsed-time": "8",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -93,16 +93,40 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fjprueyo\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-826e765e87b4cf448eb46a9154dd4545-50d9267485885048-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "116b93ec2c2861072de398e0d79b3562",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:42:05 GMT",
+        "elapsed-time": "170",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "116b93ec-2c28-6107-2de3-98e0d79b3562",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1073368072",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "iwchpycu",
-    "SearchServiceName": "azs-net-lsnrvucq",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "fjprueyo",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/CannotAlwaysDetermineCorrectTypeAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/CannotAlwaysDetermineCorrectTypeAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-vnpgitgs.search.windows.net/indexes(\u0027bbvfeath\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yeyxmdxb\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "117",
         "Content-Type": "application/json",
-        "traceparent": "00-179ba963ce5f7f4dbefbdd1a2b109fd8-bbb07c5308d31947-00",
+        "traceparent": "00-9528fa5cf1659541bef6788371b720a8-0c105aad0935c448-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "2fc6adffe4b6d5f88c266573078647dc",
         "x-ms-return-client-request-id": "true"
@@ -35,8 +35,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:55:45 GMT",
-        "elapsed-time": "119",
+        "Date": "Fri, 08 May 2020 06:46:44 GMT",
+        "elapsed-time": "77",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -56,15 +56,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-vnpgitgs.search.windows.net/indexes(\u0027bbvfeath\u0027)/docs(\u00271\u0027)?$select=hotelId%2ChotelName%2Crooms%2FbaseRate\u0026api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yeyxmdxb\u0027)/docs(\u00271\u0027)?$select=hotelId%2ChotelName%2Crooms%2FbaseRate\u0026api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-9ca81a6bbb74b54f95b29413ceaa48be-ac31df04ea0ae74d-00",
+        "traceparent": "00-9d12307619425c498fcedde1e63c1959-db7013a57c1edd4c-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "445154a46aeeea75e714de162175d29b",
         "x-ms-return-client-request-id": "true"
@@ -75,8 +75,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "79",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:55:46 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 08 May 2020 06:46:47 GMT",
+        "elapsed-time": "8",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -93,16 +93,40 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yeyxmdxb\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-ba972e8ec9563b448afc972379d67099-46ee25e2d734e44f-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "aa050cde6d8374c8781ce99399c98836",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:46:47 GMT",
+        "elapsed-time": "216",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "aa050cde-6d83-74c8-781c-e99399c98836",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "815861156",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "bbvfeath",
-    "SearchServiceName": "azs-net-vnpgitgs",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "yeyxmdxb",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/EmptyExpandedWithSubfields.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/EmptyExpandedWithSubfields.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-nerxivma.search.windows.net/indexes(\u0027lmejkojl\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027nsvitlqy\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "153",
         "Content-Type": "application/json",
-        "traceparent": "00-107dbe6c4d13844faed5d903b6c43b78-8aabe24e27152240-00",
+        "traceparent": "00-9fb191198f55cb48b43184550c65b0ec-1520d7e94fcd2e42-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "3cd4b4d13a707d1c9a15802c84f31845",
         "x-ms-return-client-request-id": "true"
@@ -39,8 +39,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:50:38 GMT",
-        "elapsed-time": "178",
+        "Date": "Fri, 08 May 2020 06:42:26 GMT",
+        "elapsed-time": "119",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -60,15 +60,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-nerxivma.search.windows.net/indexes(\u0027lmejkojl\u0027)/docs(\u00271\u0027)?$select=hotelId%2Crooms\u0026api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027nsvitlqy\u0027)/docs(\u00271\u0027)?$select=hotelId%2Crooms\u0026api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-05084de99d9453488b9d2fa157612d75-a1664d4bacf0b148-00",
+        "traceparent": "00-936693f18f415243a2cff14b3465e0a4-e01e6fc181f0e844-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "25023fe79da338161865932bea9979d1",
         "x-ms-return-client-request-id": "true"
@@ -79,8 +79,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "303",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:50:40 GMT",
-        "elapsed-time": "28",
+        "Date": "Fri, 08 May 2020 06:42:29 GMT",
+        "elapsed-time": "8",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -113,16 +113,40 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027nsvitlqy\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-5e16e5a83cf8e5408a122376a94c528e-a7f05cf306342041-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "f2cd1d7126755cd2e3778f1baba129ae",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:42:29 GMT",
+        "elapsed-time": "330",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "f2cd1d71-2675-5cd2-e377-8f1baba129ae",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "315955367",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "lmejkojl",
-    "SearchServiceName": "azs-net-nerxivma",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "nsvitlqy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/EmptyExpandedWithSubfieldsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/EmptyExpandedWithSubfieldsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jqlexfiq.search.windows.net/indexes(\u0027ehftxshv\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027gxiwxcyr\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "153",
         "Content-Type": "application/json",
-        "traceparent": "00-b33fd100782f394e8e999d272541855d-6ebccd330e027349-00",
+        "traceparent": "00-83ce13116237b440a9f69e83ecb2267b-200c8fea3721b041-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "71ed97ceae159e6a0e532497e039d77d",
         "x-ms-return-client-request-id": "true"
@@ -39,8 +39,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:56:11 GMT",
-        "elapsed-time": "97",
+        "Date": "Fri, 08 May 2020 06:47:08 GMT",
+        "elapsed-time": "93",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -60,15 +60,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-jqlexfiq.search.windows.net/indexes(\u0027ehftxshv\u0027)/docs(\u00271\u0027)?$select=hotelId%2Crooms\u0026api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027gxiwxcyr\u0027)/docs(\u00271\u0027)?$select=hotelId%2Crooms\u0026api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-554e6fa2684a2e41a074abe1abfb5f67-33f8595ee2acdc46-00",
+        "traceparent": "00-f8a166a4dadd6743a587a0e6345a61ab-39bc296c0c28664e-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "15e44950bf432eb7b3a770fb7c6a0521",
         "x-ms-return-client-request-id": "true"
@@ -79,8 +79,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "303",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:56:14 GMT",
-        "elapsed-time": "8",
+        "Date": "Fri, 08 May 2020 06:47:10 GMT",
+        "elapsed-time": "9",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -113,16 +113,40 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027gxiwxcyr\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-576d58e3c08e9045b2bce6c57f3eae81-107c8518a98bea46-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "1a30c6e00f9fecbe558bd7d80deb43b4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:47:10 GMT",
+        "elapsed-time": "234",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "1a30c6e0-0f9f-ecbe-558b-d7d80deb43b4",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "169067094",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "ehftxshv",
-    "SearchServiceName": "azs-net-jqlexfiq",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "gxiwxcyr",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/EmptyGetsOmittedWhenIgnoredBySubfields.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/EmptyGetsOmittedWhenIgnoredBySubfields.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-qbnlufne.search.windows.net/indexes(\u0027qboxfjos\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027wlwdgawu\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "66",
         "Content-Type": "application/json",
-        "traceparent": "00-959c5c27fcb2c6459f4c838a10eb14e0-5a6064902f6f6a4d-00",
+        "traceparent": "00-aa9290f4fd199d4bb0b9f2fd30cef694-7f3e17a6852a4645-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "696bce3f9eebe5daac4334cbc92301b1",
         "x-ms-return-client-request-id": "true"
@@ -30,8 +30,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:51:05 GMT",
-        "elapsed-time": "221",
+        "Date": "Fri, 08 May 2020 06:42:51 GMT",
+        "elapsed-time": "117",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -51,15 +51,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-qbnlufne.search.windows.net/indexes(\u0027qboxfjos\u0027)/docs(\u00271\u0027)?$select=hotelId%2Caddress\u0026api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027wlwdgawu\u0027)/docs(\u00271\u0027)?$select=hotelId%2Caddress\u0026api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-d18a7f835ef96f4e87c2b150497f47fd-ca88d95aec7b1941-00",
+        "traceparent": "00-75d90fde0550d14b80f43eebbc974e61-efc87de30ebce84b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "c7657cc6bb194bb27b6bca53df51a5f0",
         "x-ms-return-client-request-id": "true"
@@ -70,8 +70,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "114",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:51:07 GMT",
-        "elapsed-time": "6",
+        "Date": "Fri, 08 May 2020 06:42:52 GMT",
+        "elapsed-time": "27",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -89,16 +89,40 @@
           "postalCode": null
         }
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027wlwdgawu\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-c4cec3a4e5066d4eb4fd9b1e1f90d935-76efe326ac778043-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "38336bd79b6197415982a7622bf3aa36",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:42:52 GMT",
+        "elapsed-time": "313",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "38336bd7-9b61-9741-5982-a7622bf3aa36",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "2066000977",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "qboxfjos",
-    "SearchServiceName": "azs-net-qbnlufne",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "wlwdgawu",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/EmptyGetsOmittedWhenIgnoredBySubfieldsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/EmptyGetsOmittedWhenIgnoredBySubfieldsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-wwqkqsaa.search.windows.net/indexes(\u0027uetcslks\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vkcyygmn\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "66",
         "Content-Type": "application/json",
-        "traceparent": "00-e498072413e9ee4e8774c1d9ac158739-bb92c0b9a68f2444-00",
+        "traceparent": "00-256734ef10b20e40bcdf34b812d7d630-008428c33ad84e4c-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "65ce64a43b09e542be789e2294642d15",
         "x-ms-return-client-request-id": "true"
@@ -30,8 +30,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:56:40 GMT",
-        "elapsed-time": "134",
+        "Date": "Fri, 08 May 2020 06:47:32 GMT",
+        "elapsed-time": "128",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -51,15 +51,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-wwqkqsaa.search.windows.net/indexes(\u0027uetcslks\u0027)/docs(\u00271\u0027)?$select=hotelId%2Caddress\u0026api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vkcyygmn\u0027)/docs(\u00271\u0027)?$select=hotelId%2Caddress\u0026api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-c706ce1dab16884fbb90b4fd837c9412-8434003fd944724d-00",
+        "traceparent": "00-473e38bfd5817947b2a8bf17ccce763b-39ce53b90ce61e42-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "e998569315e4c42115fc8da4a7e10726",
         "x-ms-return-client-request-id": "true"
@@ -70,8 +70,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "114",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:56:42 GMT",
-        "elapsed-time": "6",
+        "Date": "Fri, 08 May 2020 06:47:34 GMT",
+        "elapsed-time": "8",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -89,16 +89,40 @@
           "postalCode": null
         }
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vkcyygmn\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-e12260cd219ba7428f8234a6ad9bc435-eb12d754c000a74e-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "6ecc2b52202417ff81e3db1c19db6bc0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:47:34 GMT",
+        "elapsed-time": "177",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "6ecc2b52-2024-17ff-81e3-db1c19db6bc0",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "399190745",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "uetcslks",
-    "SearchServiceName": "azs-net-wwqkqsaa",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "vkcyygmn",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/EmptyValuesBecomeNulls.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/EmptyValuesBecomeNulls.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-beyxiohp.search.windows.net/indexes(\u0027fngiqrgt\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027okgcxaqw\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "66",
         "Content-Type": "application/json",
-        "traceparent": "00-c42d1a0780457a4c90a460cef5bf2099-5f5aec6350b18e4d-00",
+        "traceparent": "00-6147681b064128458f78cbdf13b59092-b2e637bdce4bd24b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "41298b33ba87801183d4e63a5116f18c",
         "x-ms-return-client-request-id": "true"
@@ -30,8 +30,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:51:33 GMT",
-        "elapsed-time": "92",
+        "Date": "Fri, 08 May 2020 06:43:14 GMT",
+        "elapsed-time": "101",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -51,15 +51,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-beyxiohp.search.windows.net/indexes(\u0027fngiqrgt\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027okgcxaqw\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-e57bd0f61bdabc4ab8b3023ed4255d96-e9d32497cf7d794d-00",
+        "traceparent": "00-c4b264e0769a48458fb105c63bb296e9-0cd7e6b41895c94b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "9d0cb48abffadd494c0801195f598b73",
         "x-ms-return-client-request-id": "true"
@@ -70,8 +70,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "309",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:51:35 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 08 May 2020 06:43:16 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -100,16 +100,40 @@
         },
         "rooms": []
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027okgcxaqw\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-a40261cdc075fb4f96b0c3c306e917b9-a3d200e670175d48-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "145dbace99a6b5d6d67fe7cc994aa30f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:43:16 GMT",
+        "elapsed-time": "235",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "145dbace-99a6-b5d6-d67f-e7cc994aa30f",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1573078829",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "fngiqrgt",
-    "SearchServiceName": "azs-net-beyxiohp",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "okgcxaqw",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/EmptyValuesBecomeNullsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/EmptyValuesBecomeNullsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-xpknokhp.search.windows.net/indexes(\u0027fxbanlth\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027buaoblej\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "66",
         "Content-Type": "application/json",
-        "traceparent": "00-2d37ac2f0a217042ac94adf8293f5939-8d6b69243c9e7f43-00",
+        "traceparent": "00-30b604ba08f1a64888769c20d5c93b52-2c25b6b8ed906041-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "1f0de7652762769c327cfd51bc3fd759",
         "x-ms-return-client-request-id": "true"
@@ -30,8 +30,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:57:10 GMT",
-        "elapsed-time": "176",
+        "Date": "Fri, 08 May 2020 06:47:55 GMT",
+        "elapsed-time": "89",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -51,15 +51,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-xpknokhp.search.windows.net/indexes(\u0027fxbanlth\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027buaoblej\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-f39c5cb99e8cd04185c6c269b688d762-c46b0887222c6046-00",
+        "traceparent": "00-1dc01ba7bae8ab47bfe1af291f133761-6a563746827a5c40-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "e5585d15760ad5fc6d7f7db317c1f906",
         "x-ms-return-client-request-id": "true"
@@ -70,8 +70,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "309",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:57:12 GMT",
-        "elapsed-time": "14",
+        "Date": "Fri, 08 May 2020 06:47:57 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -100,16 +100,40 @@
         },
         "rooms": []
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027buaoblej\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-34ee30fa7b4f90419babab242bf2f3ed-f3b06ea8a67a1c47-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "b5f729fca7dc8f21672b2f2e2b5a4d43",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:47:57 GMT",
+        "elapsed-time": "184",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "b5f729fc-a7dc-8f21-672b-2f2e2b5a4d43",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "996781470",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "fxbanlth",
-    "SearchServiceName": "azs-net-xpknokhp",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "buaoblej",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/EmptyValuesDynamicDocument.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/EmptyValuesDynamicDocument.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-mqpnkpyi.search.windows.net/indexes(\u0027qmghgntb\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027xsbnqxsu\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "271",
         "Content-Type": "application/json",
-        "traceparent": "00-1ecec7e2b853df41afcf2958f21f72a8-e83ecbd1304aa04b-00",
+        "traceparent": "00-9b872614bb507a4e9781767c607f0988-5f4b3dcdabc15d4c-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "b9574961c9aa760b31d6c385b198a1df",
         "x-ms-return-client-request-id": "true"
@@ -45,8 +45,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:52:00 GMT",
-        "elapsed-time": "129",
+        "Date": "Fri, 08 May 2020 06:43:37 GMT",
+        "elapsed-time": "101",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -66,15 +66,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-mqpnkpyi.search.windows.net/indexes(\u0027qmghgntb\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027xsbnqxsu\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-a1919c49045afc49afed16a5e0eea7b0-1b135b2fa61d2a40-00",
+        "traceparent": "00-b7342e3167bae44c91c9074433bbf4a7-f764a8a7d2f53247-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "86d67118a7e903c06716cf2467397648",
         "x-ms-return-client-request-id": "true"
@@ -85,8 +85,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "363",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:52:02 GMT",
-        "elapsed-time": "16",
+        "Date": "Fri, 08 May 2020 06:43:40 GMT",
+        "elapsed-time": "10",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -120,16 +120,40 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027xsbnqxsu\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-139d4cf6cb4b504f82b6abc794b95cd2-bf2c489ff9b3d14f-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "1690e07639cdfbc3499eb1822567230e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:43:40 GMT",
+        "elapsed-time": "193",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "1690e076-39cd-fbc3-499e-b1822567230e",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "414325153",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "qmghgntb",
-    "SearchServiceName": "azs-net-mqpnkpyi",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "xsbnqxsu",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/EmptyValuesDynamicDocumentAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/EmptyValuesDynamicDocumentAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-tyhhiipq.search.windows.net/indexes(\u0027qljtlgxr\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027eoqbtafd\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "271",
         "Content-Type": "application/json",
-        "traceparent": "00-8788873298ea724eaf687bab9d93a857-73f65c5948ef2d49-00",
+        "traceparent": "00-75b557e9fe6c824ab1203558d84ff200-e68c9bbd0828ac4d-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "8593d425c542ce638f3cf3385e65346d",
         "x-ms-return-client-request-id": "true"
@@ -45,8 +45,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:57:39 GMT",
-        "elapsed-time": "95",
+        "Date": "Fri, 08 May 2020 06:48:18 GMT",
+        "elapsed-time": "82",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -66,15 +66,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-tyhhiipq.search.windows.net/indexes(\u0027qljtlgxr\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027eoqbtafd\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-56c2ec41fdb9c54f80c61e007c73aeb6-b3f3350ecb7c4c42-00",
+        "traceparent": "00-1e0ea7463a72c84282792ca633d019f8-cbfa590c065ea543-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "e69a2eb12a8de32e2d979df23babf734",
         "x-ms-return-client-request-id": "true"
@@ -85,7 +85,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "363",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:57:41 GMT",
+        "Date": "Fri, 08 May 2020 06:48:20 GMT",
         "elapsed-time": "10",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -120,16 +120,40 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027eoqbtafd\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-7aa9658f9f265d4898cb6c115abe57db-37990209a3426a45-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "85fddb1228300ecdf4f4af00cb41504a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:48:20 GMT",
+        "elapsed-time": "177",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "85fddb12-2830-0ecd-f4f4-af00cb41504a",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1106232816",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "qljtlgxr",
-    "SearchServiceName": "azs-net-tyhhiipq",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "eoqbtafd",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/GetDocumentDict.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/GetDocumentDict.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs(\u00273\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs(\u00273\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-1a172bb0afdbc640a471d4145033aef9-c2552807266c8a40-00",
+        "traceparent": "00-de70e0fede34fd4884604dd9d4becc08-753d6753cc69fa40-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "799b1890cb46f19f37ea469782ee6797",
         "x-ms-return-client-request-id": "true"
@@ -20,8 +20,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "326",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:52:05 GMT",
-        "elapsed-time": "64",
+        "Date": "Fri, 08 May 2020 06:43:40 GMT",
+        "elapsed-time": "107",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -51,7 +51,8 @@
   ],
   "Variables": {
     "RandomSeed": "1106318049",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/GetDocumentDictAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/GetDocumentDictAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs(\u00273\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs(\u00273\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-d601c07972eb2f489fda84a76f8bf0ee-649418b0e4b17342-00",
+        "traceparent": "00-95add1c5459e7448a047d445c87aaa90-477b7121c1f1cb43-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "b12bf8433d0f2619d56f5cefa1b09e5f",
         "x-ms-return-client-request-id": "true"
@@ -20,8 +20,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "326",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:57:42 GMT",
-        "elapsed-time": "56",
+        "Date": "Fri, 08 May 2020 06:48:20 GMT",
+        "elapsed-time": "117",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -51,7 +51,8 @@
   ],
   "Variables": {
     "RandomSeed": "554905365",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/GetDocumentDynamic.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/GetDocumentDynamic.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs(\u00273\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs(\u00273\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-98025e58339e2f429658ab58f5c04b30-2a6597dfc1e0674d-00",
+        "traceparent": "00-37f0bee86a92c643b22c344a04382479-c8020afa3e5a9741-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "b7677ebc93077dafb12861726e72bf67",
         "x-ms-return-client-request-id": "true"
@@ -20,8 +20,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "326",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:52:05 GMT",
-        "elapsed-time": "4",
+        "Date": "Fri, 08 May 2020 06:43:40 GMT",
+        "elapsed-time": "3",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -51,7 +51,8 @@
   ],
   "Variables": {
     "RandomSeed": "269565640",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/GetDocumentDynamicAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/GetDocumentDynamicAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs(\u00273\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs(\u00273\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-c4ec48c60dfdea46a76ce3c6864d50ce-9d048c801671584f-00",
+        "traceparent": "00-7e0ff442e4e56749a6dca301f6fbbb86-99bf694c54e0a042-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "059dc47a80330299d7595e2dd473e120",
         "x-ms-return-client-request-id": "true"
@@ -20,8 +20,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "326",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:57:42 GMT",
-        "elapsed-time": "3",
+        "Date": "Fri, 08 May 2020 06:48:20 GMT",
+        "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -51,7 +51,8 @@
   ],
   "Variables": {
     "RandomSeed": "307443657",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/GetDocumentStatic.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/GetDocumentStatic.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs(\u00273\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs(\u00273\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-ef452daf2b953a49aea311b3de180fb8-4543b25df6a05e4d-00",
+        "traceparent": "00-2fd0326aced16148840cabb972486dd8-f904bf547105bb4f-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "bf19f813f46341823350123eaadb38c7",
         "x-ms-return-client-request-id": "true"
@@ -20,8 +20,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "326",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:52:05 GMT",
-        "elapsed-time": "6",
+        "Date": "Fri, 08 May 2020 06:43:40 GMT",
+        "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -51,7 +51,8 @@
   ],
   "Variables": {
     "RandomSeed": "868892207",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/GetDocumentStaticAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/GetDocumentStaticAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs(\u00273\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs(\u00273\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-6bc5a827e8d2c24b868df73e3fef7525-23e8fcb8ffbcf045-00",
+        "traceparent": "00-11c6afee7b80324ab328bd08919bc98f-17c21fa57ef5ae4f-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "a813557250353459f176eb2e3113d05a",
         "x-ms-return-client-request-id": "true"
@@ -20,8 +20,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "326",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:57:43 GMT",
-        "elapsed-time": "4",
+        "Date": "Fri, 08 May 2020 06:48:20 GMT",
+        "elapsed-time": "3",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -51,7 +51,8 @@
   ],
   "Variables": {
     "RandomSeed": "2141683884",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/RecentlyIndexedDynamicDocument.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/RecentlyIndexedDynamicDocument.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-wkhfokcb.search.windows.net/indexes(\u0027txghyenx\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027spscwwei\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "1018",
         "Content-Type": "application/json",
-        "traceparent": "00-3fa519318926094f9744f0e367487816-d4e1b9ca436a874b-00",
+        "traceparent": "00-a1450d078e767c4e865e33c90bce789f-99051edeacd30840-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "26a6f1d5a3b239468a59914d90ca500b",
         "x-ms-return-client-request-id": "true"
@@ -58,8 +58,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:52:30 GMT",
-        "elapsed-time": "97",
+        "Date": "Fri, 08 May 2020 06:44:01 GMT",
+        "elapsed-time": "121",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -79,15 +79,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-wkhfokcb.search.windows.net/indexes(\u0027txghyenx\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027spscwwei\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-4247c859caa24942a2c7e5881373c3a6-6b2a501ae2b19f4c-00",
+        "traceparent": "00-9edbdf419ceb2f49adcec9a5c60eef19-a356eea487b2c644-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "5d990c2a343c51ee5341d72213255f52",
         "x-ms-return-client-request-id": "true"
@@ -98,7 +98,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "940",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:52:32 GMT",
+        "Date": "Fri, 08 May 2020 06:44:03 GMT",
         "elapsed-time": "9",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -139,16 +139,40 @@
         "address": null,
         "rooms": []
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027spscwwei\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-65aa91814fa17147a38b09477c1284cd-d8ec70da2d072142-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "a7e54185fafe352bf1bf7be371ac3975",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:44:03 GMT",
+        "elapsed-time": "218",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "a7e54185-fafe-352b-f1bf-7be371ac3975",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1347817798",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "txghyenx",
-    "SearchServiceName": "azs-net-wkhfokcb",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "spscwwei",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/RecentlyIndexedDynamicDocumentAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/RecentlyIndexedDynamicDocumentAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-wluihshl.search.windows.net/indexes(\u0027obfrqyli\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027avdcfapx\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "1018",
         "Content-Type": "application/json",
-        "traceparent": "00-b26e77afc6bdfd4aa5f3e8d2cb73cb06-31d3549fcbb0714f-00",
+        "traceparent": "00-352faff1f4a2974fba3bdc95d1d8624b-43e89ad3b14be940-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "8363316349f54d2b909cd08d181068ae",
         "x-ms-return-client-request-id": "true"
@@ -58,8 +58,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:58:08 GMT",
-        "elapsed-time": "168",
+        "Date": "Fri, 08 May 2020 06:48:41 GMT",
+        "elapsed-time": "72",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -79,15 +79,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-wluihshl.search.windows.net/indexes(\u0027obfrqyli\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027avdcfapx\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-7075f29924ab984e808863505b3db08b-f6051a88a7a63242-00",
+        "traceparent": "00-a23d0a66511a02418487bc5873bedfc9-9d1742dc652d9a4b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "ce0b4ac00085d030f1ea2ddc1d5a427d",
         "x-ms-return-client-request-id": "true"
@@ -98,8 +98,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "940",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:58:10 GMT",
-        "elapsed-time": "11",
+        "Date": "Fri, 08 May 2020 06:48:43 GMT",
+        "elapsed-time": "8",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -139,16 +139,40 @@
         "address": null,
         "rooms": []
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027avdcfapx\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-35c20c47d4d52c45ad916771833744b5-2771003b69083348-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "08f0ae6a80953d42543cf9077e3d28e5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:48:44 GMT",
+        "elapsed-time": "298",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "08f0ae6a-8095-3d42-543c-f9077e3d28e5",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1375466831",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "obfrqyli",
-    "SearchServiceName": "azs-net-wluihshl",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "avdcfapx",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/RecentlyIndexedStaticDocument.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/RecentlyIndexedStaticDocument.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-ttkotaik.search.windows.net/indexes(\u0027eqhviaiq\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027eoxbyjsf\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "879",
         "Content-Type": "application/json",
-        "traceparent": "00-8d4fe0acfbcd5e4eaa5bc59dc1c58319-b3ef222d7ce66a45-00",
+        "traceparent": "00-63b1a1a7453a2b429670f213b409c785-9bd324471952004f-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "45bd018deeee3a730ce795272c4bd29b",
         "x-ms-return-client-request-id": "true"
@@ -45,8 +45,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:52:57 GMT",
-        "elapsed-time": "95",
+        "Date": "Fri, 08 May 2020 06:44:25 GMT",
+        "elapsed-time": "108",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -66,15 +66,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-ttkotaik.search.windows.net/indexes(\u0027eqhviaiq\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027eoxbyjsf\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-e515e52007e90843a2e28956ac2d63a9-83e9468927c6bf48-00",
+        "traceparent": "00-30d7d8ed290d0f44b05c86c2b4ec506b-0014bfbc8e342746-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "2325cd1bf6fe19b379554259e2158a89",
         "x-ms-return-client-request-id": "true"
@@ -85,8 +85,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "834",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:53:00 GMT",
-        "elapsed-time": "9",
+        "Date": "Fri, 08 May 2020 06:44:27 GMT",
+        "elapsed-time": "10",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -114,16 +114,40 @@
         "address": null,
         "rooms": []
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027eoxbyjsf\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-dcf688e46520b04593f64453f326c559-7d1f0a7053fe3b4f-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "8ccdbfa27fd5941ac7078ce17f2dd5f6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:44:27 GMT",
+        "elapsed-time": "221",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "8ccdbfa2-7fd5-941a-c707-8ce17f2dd5f6",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "433827026",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "eqhviaiq",
-    "SearchServiceName": "azs-net-ttkotaik",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "eoxbyjsf",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/RecentlyIndexedStaticDocumentAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/RecentlyIndexedStaticDocumentAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jlhsecko.search.windows.net/indexes(\u0027ytwdbndx\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vjajgwvs\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "879",
         "Content-Type": "application/json",
-        "traceparent": "00-a483996683d1f54aaf6c9c7638040512-91d46ace515d9a49-00",
+        "traceparent": "00-c028d50c01bc0e4fb38db07f47ee7f54-34d5a108faa58946-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "aa5f713be58bf17803b0715e17f2aff2",
         "x-ms-return-client-request-id": "true"
@@ -45,8 +45,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:58:37 GMT",
-        "elapsed-time": "139",
+        "Date": "Fri, 08 May 2020 06:49:04 GMT",
+        "elapsed-time": "90",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -66,15 +66,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-jlhsecko.search.windows.net/indexes(\u0027ytwdbndx\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vjajgwvs\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-76a154a7d4ce9c4c9d891f1c26dca3a1-90ff4e7d615e0849-00",
+        "traceparent": "00-8a32adef8dcc9649bca694ba468b0954-db2a6e8ff80a4d47-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "93de715e8cce15b225b9af5b7103eb25",
         "x-ms-return-client-request-id": "true"
@@ -85,7 +85,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "834",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:58:39 GMT",
+        "Date": "Fri, 08 May 2020 06:49:06 GMT",
         "elapsed-time": "9",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -114,16 +114,40 @@
         "address": null,
         "rooms": []
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vjajgwvs\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-18cef57c19e05a428a2d64781389e4b6-fb90df528864464e-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "3c0735ca040bd9897a3c734084c58a72",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:49:06 GMT",
+        "elapsed-time": "227",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "3c0735ca-040b-d989-7a3c-734084c58a72",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1353165967",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "ytwdbndx",
-    "SearchServiceName": "azs-net-jlhsecko",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "vjajgwvs",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/RoundtripChangesToUtc.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/RoundtripChangesToUtc.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-sekfjafc.search.windows.net/indexes(\u0027ontmjrjl\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027mtcjwvpn\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "278",
         "Content-Type": "application/json",
-        "traceparent": "00-ab93110254bf96408ffcb26ad9ff18c8-49b61a75a5bf5d40-00",
+        "traceparent": "00-7b7a218972643f4593bfe947cdc2ec1f-30e389a0875d3845-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "f7a4c22c78dddacfb1d808b89b0aec32",
         "x-ms-return-client-request-id": "true"
@@ -40,8 +40,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:53:25 GMT",
-        "elapsed-time": "117",
+        "Date": "Fri, 08 May 2020 06:44:48 GMT",
+        "elapsed-time": "76",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -61,15 +61,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-sekfjafc.search.windows.net/indexes(\u0027ontmjrjl\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027mtcjwvpn\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-e86fa5c572c6ef4eabce3bec6dcbfc64-1f309f422a755f4e-00",
+        "traceparent": "00-b9c921bad06624478753093bb18d2b6e-b6cb349266515c4f-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "fd0641a31eab57b430547fefdad08e0b",
         "x-ms-return-client-request-id": "true"
@@ -80,8 +80,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "243",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:53:27 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 08 May 2020 06:44:50 GMT",
+        "elapsed-time": "8",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -104,16 +104,40 @@
         "address": null,
         "rooms": []
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027mtcjwvpn\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-e76c37dfc5442d47a4e108f63cd2e8a0-fad1b6b58a095340-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "9517b5720fdcf163424ab7950cc3a3d9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:44:50 GMT",
+        "elapsed-time": "170",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "9517b572-0fdc-f163-424a-b7950cc3a3d9",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "514352695",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "ontmjrjl",
-    "SearchServiceName": "azs-net-sekfjafc",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "mtcjwvpn",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/RoundtripChangesToUtcAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/RoundtripChangesToUtcAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-ajdcpkyb.search.windows.net/indexes(\u0027rushdxyr\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rlwqciat\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "278",
         "Content-Type": "application/json",
-        "traceparent": "00-75f94075eaf5104c9002df8e88383ae9-d932691a5d16af4c-00",
+        "traceparent": "00-152c922efded6f40afe2a3ee76dfd6c0-262b80216d8f3d4f-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "90ea827e2f761f83ac770431dcd23fc1",
         "x-ms-return-client-request-id": "true"
@@ -40,8 +40,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:59:06 GMT",
-        "elapsed-time": "102",
+        "Date": "Fri, 08 May 2020 06:49:28 GMT",
+        "elapsed-time": "134",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -61,15 +61,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-ajdcpkyb.search.windows.net/indexes(\u0027rushdxyr\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rlwqciat\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-cedda63f010e4c4885a91f61ca43fc9b-90236e1366f91044-00",
+        "traceparent": "00-4c5e36248750ba4ca26fd27e45e1df14-6a75d47c85a86a40-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "26d08ddb6c66331f89a7e6eef9859689",
         "x-ms-return-client-request-id": "true"
@@ -80,7 +80,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "243",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:59:08 GMT",
+        "Date": "Fri, 08 May 2020 06:49:30 GMT",
         "elapsed-time": "8",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -104,16 +104,40 @@
         "address": null,
         "rooms": []
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rlwqciat\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-7addf795b54b8d42a8089c354ded5ba9-e54ac78b627d8b44-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "c1c3aaec550ec72ede64a37b001da8ef",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:49:30 GMT",
+        "elapsed-time": "222",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "c1c3aaec-550e-c72e-de64-a37b001da8ef",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "144595203",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "rushdxyr",
-    "SearchServiceName": "azs-net-ajdcpkyb",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "rlwqciat",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/StaticDocumentWithNullsRoundtrips.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/StaticDocumentWithNullsRoundtrips.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-ximmdfhv.search.windows.net/indexes(\u0027cwawcfss\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027cyjbkciy\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "608",
         "Content-Type": "application/json",
-        "traceparent": "00-bd2c0b0a328be14890467d9e7952a4d2-b609e1d4fbfb6447-00",
+        "traceparent": "00-05bb4bd8fbb36e4192ab2fc5000f6a21-f4d537af3b817742-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "ba72cae48d6b18784cff3b464ee836d8",
         "x-ms-return-client-request-id": "true"
@@ -67,8 +67,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:53:53 GMT",
-        "elapsed-time": "128",
+        "Date": "Fri, 08 May 2020 06:45:11 GMT",
+        "elapsed-time": "94",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -88,15 +88,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-ximmdfhv.search.windows.net/indexes(\u0027cwawcfss\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027cyjbkciy\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-2b414f299eef8241823b7c98b0b2b9ba-94f747dcac2ca249-00",
+        "traceparent": "00-ba113262bd515949b12b958313f8d535-d406811a9cc04141-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "798ede94329eb9a297a83d07640f2343",
         "x-ms-return-client-request-id": "true"
@@ -107,8 +107,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "586",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:53:55 GMT",
-        "elapsed-time": "11",
+        "Date": "Fri, 08 May 2020 06:45:13 GMT",
+        "elapsed-time": "12",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -158,16 +158,40 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027cyjbkciy\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-b953dcd50d96c94590cbd049e1b279f3-7e85306592c4a74a-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "0096144fd0940abcb7d25585213b4dd6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:45:13 GMT",
+        "elapsed-time": "288",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "0096144f-d094-0abc-b7d2-5585213b4dd6",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "226392841",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "cwawcfss",
-    "SearchServiceName": "azs-net-ximmdfhv",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "cyjbkciy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/StaticDocumentWithNullsRoundtripsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/StaticDocumentWithNullsRoundtripsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-abjyxent.search.windows.net/indexes(\u0027bginveka\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027tyrjkwwv\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "608",
         "Content-Type": "application/json",
-        "traceparent": "00-566b782e6b7f9e4c83ed79a50766d498-22015d0632ded14a-00",
+        "traceparent": "00-656cd5231dc8334a884227b5c6c2fb48-75cd138a1490c845-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "2e413dc21dec5a9ca767cde11dd6490b",
         "x-ms-return-client-request-id": "true"
@@ -67,8 +67,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:59:33 GMT",
-        "elapsed-time": "85",
+        "Date": "Fri, 08 May 2020 06:49:51 GMT",
+        "elapsed-time": "75",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -88,15 +88,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-abjyxent.search.windows.net/indexes(\u0027bginveka\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027tyrjkwwv\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-8873ffcaa7ca4749a3cb191fe62b88b3-0c410410b7fab94f-00",
+        "traceparent": "00-29336f8adec9bc4d8710bde633e9a573-dcea7cad80c5114b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "cb53b580bced7b11d26d24c4ff60a775",
         "x-ms-return-client-request-id": "true"
@@ -107,8 +107,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "586",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:59:35 GMT",
-        "elapsed-time": "16",
+        "Date": "Fri, 08 May 2020 06:49:53 GMT",
+        "elapsed-time": "10",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -158,16 +158,40 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027tyrjkwwv\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-12985b9af76f614d8df2c442048b4336-3510e3e2916e4540-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "7a0fd72aa46936dc021a6df6098bddcc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:49:53 GMT",
+        "elapsed-time": "192",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "7a0fd72a-a469-36dc-021a-6df6098bddcc",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "136068368",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "bginveka",
-    "SearchServiceName": "azs-net-abjyxent",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "tyrjkwwv",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/Structs.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/Structs.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-ooottint.search.windows.net/indexes(\u0027oiaggubm\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027sckqgtxr\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "77",
         "Content-Type": "application/json",
-        "traceparent": "00-10c2cdb99d0f244eb4ab5b573003085e-b636f7d3a9ebc44c-00",
+        "traceparent": "00-ce4567ddd75ab840b2ff0146e8ea504d-d667e6100da3f548-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "eb3f3216b0de1bf6125f047abab79f2a",
         "x-ms-return-client-request-id": "true"
@@ -30,8 +30,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:54:20 GMT",
-        "elapsed-time": "127",
+        "Date": "Fri, 08 May 2020 06:45:35 GMT",
+        "elapsed-time": "142",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -51,15 +51,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-ooottint.search.windows.net/indexes(\u0027oiaggubm\u0027)/docs(\u00274\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027sckqgtxr\u0027)/docs(\u00274\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-85cf3353e525204ca8f5757c701892c0-6e516c910bbc1d43-00",
+        "traceparent": "00-54eecef9d554d048a609058bd2f69606-58bb24b60f3c4944-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "616d0353a8077dbe8775e6cb950c62f3",
         "x-ms-return-client-request-id": "true"
@@ -70,7 +70,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "232",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:54:23 GMT",
+        "Date": "Fri, 08 May 2020 06:45:37 GMT",
         "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -94,16 +94,40 @@
         "address": null,
         "rooms": []
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027sckqgtxr\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-92e2398c67942a43a6f608248601a026-4874d9a77f499d41-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "1445617c8ef38333059250742aeea463",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:45:37 GMT",
+        "elapsed-time": "252",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "1445617c-8ef3-8333-0592-50742aeea463",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "10321260",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "oiaggubm",
-    "SearchServiceName": "azs-net-ooottint",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "sckqgtxr",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/StructsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/StructsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-wgrhuirx.search.windows.net/indexes(\u0027lgaijclb\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fyyccjha\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "77",
         "Content-Type": "application/json",
-        "traceparent": "00-e91c4e4a037eda459d1533765b3d78cd-65ef0d828f70d241-00",
+        "traceparent": "00-51e4c3b43b801646be5b065da2d0f39d-46fc4db82e712c42-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "f8569a8bc0f887882f6e1e542d8f7ef1",
         "x-ms-return-client-request-id": "true"
@@ -30,8 +30,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:00:02 GMT",
-        "elapsed-time": "113",
+        "Date": "Fri, 08 May 2020 06:50:15 GMT",
+        "elapsed-time": "110",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -51,15 +51,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-wgrhuirx.search.windows.net/indexes(\u0027lgaijclb\u0027)/docs(\u00274\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fyyccjha\u0027)/docs(\u00274\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-f1c449984b71dc4284c6ac86b6b9a96e-63e83ac66b1e3940-00",
+        "traceparent": "00-334271cd82f53d4ea2f900c1154848c7-2ffa75f51d3e694d-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "08f24fcba546d2cdd5e339e31a9cdc02",
         "x-ms-return-client-request-id": "true"
@@ -70,8 +70,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "232",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:00:04 GMT",
-        "elapsed-time": "6",
+        "Date": "Fri, 08 May 2020 06:50:16 GMT",
+        "elapsed-time": "7",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -94,16 +94,40 @@
         "address": null,
         "rooms": []
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fyyccjha\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-766d9cd7ae5e2b4f88c96d4db7a74866-78f28df2a4eba046-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "4e1f75e881d9d1bc5cf56155c9c1070a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:50:16 GMT",
+        "elapsed-time": "194",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "4e1f75e8-81d9-d1bc-5cf5-6155c9c1070a",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1461814314",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "lgaijclb",
-    "SearchServiceName": "azs-net-wgrhuirx",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "fyyccjha",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/ThrowsWhenMalformed.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/ThrowsWhenMalformed.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs(\u00273\u0027)?$select=ThisFieldDoesNotExist\u0026api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs(\u00273\u0027)?$select=ThisFieldDoesNotExist\u0026api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-6fc765060fa29b4cb7fd3ebe41a86cec-a736b1e679e88849-00",
+        "traceparent": "00-3b4857a999273e4a841d8a80cb48f757-e3af2baf5f096949-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "c1ac8ecf967c99f1d9fe44cf54d99bb0",
         "x-ms-return-client-request-id": "true"
@@ -21,8 +21,8 @@
         "Content-Language": "en",
         "Content-Length": "163",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:54:25 GMT",
-        "elapsed-time": "63",
+        "Date": "Fri, 08 May 2020 06:45:37 GMT",
+        "elapsed-time": "77",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -40,7 +40,8 @@
   ],
   "Variables": {
     "RandomSeed": "1662283179",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/ThrowsWhenMalformedAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/ThrowsWhenMalformedAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs(\u00273\u0027)?$select=ThisFieldDoesNotExist\u0026api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs(\u00273\u0027)?$select=ThisFieldDoesNotExist\u0026api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-31debaa02bbfe341be0af6c82cc26522-db845a749108c84c-00",
+        "traceparent": "00-77259d45d6b3ca4a817dc153a3b57894-c930700347e98e42-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "bb82e378638212a3a45f376d050084d6",
         "x-ms-return-client-request-id": "true"
@@ -21,8 +21,8 @@
         "Content-Language": "en",
         "Content-Length": "163",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:00:07 GMT",
-        "elapsed-time": "56",
+        "Date": "Fri, 08 May 2020 06:50:16 GMT",
+        "elapsed-time": "75",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -40,7 +40,8 @@
   ],
   "Variables": {
     "RandomSeed": "335380653",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/ThrowsWhenNotFound.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/ThrowsWhenNotFound.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs(\u0027ThisDocumentDoesNotExist\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs(\u0027ThisDocumentDoesNotExist\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-7f667e3fd34218469a0f11e73671cc7c-111e83333cba5342-00",
+        "traceparent": "00-07af9a223e2ea946be091e570f75923b-18821c7c7c6e774b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "ba21e91c66faa803c9d44523eaf36c73",
         "x-ms-return-client-request-id": "true"
@@ -19,8 +19,8 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Sat, 25 Apr 2020 00:54:25 GMT",
-        "elapsed-time": "8",
+        "Date": "Fri, 08 May 2020 06:45:37 GMT",
+        "elapsed-time": "4",
         "Expires": "-1",
         "Pragma": "no-cache",
         "request-id": "ba21e91c-66fa-a803-c9d4-4523eaf36c73",
@@ -31,7 +31,8 @@
   ],
   "Variables": {
     "RandomSeed": "500232658",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/ThrowsWhenNotFoundAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/ThrowsWhenNotFoundAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs(\u0027ThisDocumentDoesNotExist\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs(\u0027ThisDocumentDoesNotExist\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-74af12ae1ac20245b2ca9828c52cc966-aaf21f2662d0f743-00",
+        "traceparent": "00-165676df0f692e4085ccbb37ebdf6690-4e14e67ddd225b42-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "aee8edee2b291e361337583140d47761",
         "x-ms-return-client-request-id": "true"
@@ -19,8 +19,8 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Sat, 25 Apr 2020 01:00:07 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 08 May 2020 06:50:16 GMT",
+        "elapsed-time": "5",
         "Expires": "-1",
         "Pragma": "no-cache",
         "request-id": "aee8edee-2b29-1e36-1337-583140d47761",
@@ -31,7 +31,8 @@
   ],
   "Variables": {
     "RandomSeed": "447408589",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/UnselectedFieldsNullStatic.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/UnselectedFieldsNullStatic.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-hvwymvnm.search.windows.net/indexes(\u0027wndmyhyi\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027gxwjbown\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "1384",
         "Content-Type": "application/json",
-        "traceparent": "00-f5d0c99a9446944a9f5fa31dc7f2a91a-bf9aa20852cf2e46-00",
+        "traceparent": "00-a369e0283e8e924e99bcb04a7d1c4d06-253254486a68e74b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "d39c287266957a8ebdbeb57b7564a066",
         "x-ms-return-client-request-id": "true"
@@ -75,8 +75,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:54:50 GMT",
-        "elapsed-time": "101",
+        "Date": "Fri, 08 May 2020 06:45:58 GMT",
+        "elapsed-time": "112",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -96,15 +96,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-hvwymvnm.search.windows.net/indexes(\u0027wndmyhyi\u0027)/docs(\u00272\u0027)?$select=description%2ChotelName%2Caddress%2Fcity%2Crooms%2FbaseRate\u0026api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027gxwjbown\u0027)/docs(\u00272\u0027)?$select=description%2ChotelName%2Caddress%2Fcity%2Crooms%2FbaseRate\u0026api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-c3372490a6872e4480b9aaec93dd7f2b-250e3a4d9d7c584e-00",
+        "traceparent": "00-b2141010476efc46b8378dd8eef678dc-3786d22bbd50ba4b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "3837244195ad9b6302a4eb63dab94f32",
         "x-ms-return-client-request-id": "true"
@@ -115,7 +115,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "288",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 00:54:52 GMT",
+        "Date": "Fri, 08 May 2020 06:46:00 GMT",
         "elapsed-time": "7",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -139,16 +139,40 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027gxwjbown\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-79b747968480d84bbabb3706aad42a35-a6ac1bade7d63e47-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "7252a83a77138fbb185a69f8f222e0a6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:46:00 GMT",
+        "elapsed-time": "320",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "7252a83a-7713-8fbb-185a-69f8f222e0a6",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1560836648",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "wndmyhyi",
-    "SearchServiceName": "azs-net-hvwymvnm",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "gxwjbown",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/UnselectedFieldsNullStaticAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/GetDocumentTests/UnselectedFieldsNullStaticAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-tfcyedav.search.windows.net/indexes(\u0027ujbjclen\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fcsqltcg\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "1384",
         "Content-Type": "application/json",
-        "traceparent": "00-b24d986665f30e4bbfd657955bf4118b-05359cae61f68441-00",
+        "traceparent": "00-0fb691263dc06546aa8874685a065e75-9da3005dba286247-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "4601d57268f632293dd1260264c08611",
         "x-ms-return-client-request-id": "true"
@@ -75,8 +75,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:00:34 GMT",
-        "elapsed-time": "172",
+        "Date": "Fri, 08 May 2020 06:50:38 GMT",
+        "elapsed-time": "112",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -96,15 +96,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-tfcyedav.search.windows.net/indexes(\u0027ujbjclen\u0027)/docs(\u00272\u0027)?$select=description%2ChotelName%2Caddress%2Fcity%2Crooms%2FbaseRate\u0026api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fcsqltcg\u0027)/docs(\u00272\u0027)?$select=description%2ChotelName%2Caddress%2Fcity%2Crooms%2FbaseRate\u0026api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-c3901e5843a08849b7e2b5c2d7af84f4-a2a10b2ff9b96445-00",
+        "traceparent": "00-829b00ba73c63147a08b337cd2821644-ca850814e1072543-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "630df8ec3f929a8179bffcb17ecb2dbb",
         "x-ms-return-client-request-id": "true"
@@ -115,7 +115,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "288",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:00:36 GMT",
+        "Date": "Fri, 08 May 2020 06:50:40 GMT",
         "elapsed-time": "7",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -139,16 +139,40 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fcsqltcg\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-ed86a7ee137e5f4492f6b5b84d3f940a-70513738c463e145-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "ffc541c8c037b5bd6ff1a35b4863fc4b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:50:40 GMT",
+        "elapsed-time": "262",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "ffc541c8-c037-b5bd-6ff1-a35b4863fc4b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "495263731",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "ujbjclen",
-    "SearchServiceName": "azs-net-tfcyedav",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "fcsqltcg",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/CreateClient.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/CreateClient.json
@@ -1,14 +1,14 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/servicestats?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/servicestats?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "4b6405bb4fdcb9544c0fdf174384b8eb",
         "x-ms-return-client-request-id": "true"
@@ -17,10 +17,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "586",
+        "Content-Length": "590",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 01:14:19 GMT",
-        "elapsed-time": "107",
+        "Date": "Fri, 08 May 2020 07:01:32 GMT",
+        "elapsed-time": "78",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -29,7 +29,7 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-jcswnkcn.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.ServiceStatistics",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.ServiceStatistics",
         "counters": {
           "documentCount": {
             "usage": 10,
@@ -48,7 +48,7 @@
             "quota": 3
           },
           "storageSize": {
-            "usage": 38732,
+            "usage": 35876,
             "quota": 52428800
           },
           "synonymMaps": {
@@ -71,7 +71,8 @@
   ],
   "Variables": {
     "RandomSeed": "2134332413",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/CreateClientAsyncAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/CreateClientAsyncAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/servicestats?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/servicestats?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-c71cab42efd02b41bfa031491882b11c-1b3cb6b08a963547-00",
+        "traceparent": "00-f5f5485afcc75f4e8dae005dec0966ca-9b19306a5355b04b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "a029684f073e794ac0638ad34807c434",
         "x-ms-return-client-request-id": "true"
@@ -18,10 +18,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "586",
+        "Content-Length": "590",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 01:14:19 GMT",
-        "elapsed-time": "47",
+        "Date": "Fri, 08 May 2020 07:01:33 GMT",
+        "elapsed-time": "50",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -30,7 +30,7 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-jcswnkcn.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.ServiceStatistics",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.ServiceStatistics",
         "counters": {
           "documentCount": {
             "usage": 10,
@@ -49,7 +49,7 @@
             "quota": 3
           },
           "storageSize": {
-            "usage": 38732,
+            "usage": 35876,
             "quota": 52428800
           },
           "synonymMaps": {
@@ -72,7 +72,8 @@
   ],
   "Variables": {
     "RandomSeed": "525186745",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/GetCountAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/GetCountAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-839f6f50c89e8f45871bab3fd0591370-e7333b5814bef74c-00",
+        "traceparent": "00-6f2be1b6d4b2d7498838d3516f3af4af-61d7cdc3bf7df84b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "236582ddb742189bb152143ee3f98722",
         "x-ms-return-client-request-id": "true"
@@ -20,8 +20,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "5",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:14:19 GMT",
-        "elapsed-time": "36",
+        "Date": "Fri, 08 May 2020 07:01:32 GMT",
+        "elapsed-time": "42",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -34,7 +34,8 @@
   ],
   "Variables": {
     "RandomSeed": "495571034",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/GetCountAsyncAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/GetCountAsyncAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-5297ba565e5ab242b9bab19bb6900e10-79f08175232f2349-00",
+        "traceparent": "00-330038e1f0d7cc449fd9af01498d45d6-2d70139c3b3b494c-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "6626ad329da6fd3193b5a92b98b5b74f",
         "x-ms-return-client-request-id": "true"
@@ -20,7 +20,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "5",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:14:19 GMT",
+        "Date": "Fri, 08 May 2020 07:01:33 GMT",
         "elapsed-time": "3",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -34,7 +34,8 @@
   ],
   "Variables": {
     "RandomSeed": "2104098183",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/GetStatisticsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/GetStatisticsAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/servicestats?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/servicestats?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-8efcc6242c83eb4289a5fa8ebdf85862-9bc1e5d717504848-00",
+        "traceparent": "00-7a2d5cfb93318f4e8b08862891243ff3-5e08fee9291e9e49-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "3a08bb2910952da418397c32fedb09c4",
         "x-ms-return-client-request-id": "true"
@@ -18,10 +18,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "586",
+        "Content-Length": "590",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 01:14:19 GMT",
-        "elapsed-time": "29",
+        "Date": "Fri, 08 May 2020 07:01:32 GMT",
+        "elapsed-time": "34",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -30,7 +30,7 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-jcswnkcn.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.ServiceStatistics",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.ServiceStatistics",
         "counters": {
           "documentCount": {
             "usage": 10,
@@ -49,7 +49,7 @@
             "quota": 3
           },
           "storageSize": {
-            "usage": 38732,
+            "usage": 35876,
             "quota": 52428800
           },
           "synonymMaps": {
@@ -72,7 +72,8 @@
   ],
   "Variables": {
     "RandomSeed": "1977008283",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/GetStatisticsAsyncAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/GetStatisticsAsyncAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/servicestats?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/servicestats?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-5e27e85a33f6b840b12c64fc470528bf-3c7c87d47a636242-00",
+        "traceparent": "00-a3a359e206c0044ca0bfb0a947ad6ba2-c91232d35b3edc4e-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "3557d1c80476f1dec2ba685ca5c4ef71",
         "x-ms-return-client-request-id": "true"
@@ -18,10 +18,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "586",
+        "Content-Length": "590",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 01:14:19 GMT",
-        "elapsed-time": "26",
+        "Date": "Fri, 08 May 2020 07:01:33 GMT",
+        "elapsed-time": "55",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -30,7 +30,7 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-jcswnkcn.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.ServiceStatistics",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.ServiceStatistics",
         "counters": {
           "documentCount": {
             "usage": 10,
@@ -49,7 +49,7 @@
             "quota": 3
           },
           "storageSize": {
-            "usage": 38732,
+            "usage": 35876,
             "quota": 52428800
           },
           "synonymMaps": {
@@ -72,7 +72,8 @@
   ],
   "Variables": {
     "RandomSeed": "180277775",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/HandleErrors.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/HandleErrors.json
@@ -1,14 +1,14 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027doesnotexist\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027doesnotexist\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "74da84cc969d91270b8cb602179371eb",
         "x-ms-return-client-request-id": "true"
@@ -18,10 +18,10 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Language": "en",
-        "Content-Length": "84",
+        "Content-Length": "88",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 25 Apr 2020 01:14:19 GMT",
-        "elapsed-time": "9",
+        "Date": "Fri, 08 May 2020 07:01:32 GMT",
+        "elapsed-time": "8",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
@@ -29,13 +29,14 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "Message": "The index \u0027doesnotexist\u0027 for service \u0027azs-net-jcswnkcn\u0027 was not found."
+        "Message": "The index \u0027doesnotexist\u0027 for service \u0027azs-net-heathsearch2\u0027 was not found."
       }
     }
   ],
   "Variables": {
     "RandomSeed": "266578448",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/HandleErrorsAsyncAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/HelloWorld/HandleErrorsAsyncAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027doesnotexist\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027doesnotexist\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-a9154c55c9651c48ba1409b5b9fdd636-666b2dbf56377747-00",
+        "traceparent": "00-68d00083f0264042b02650856ad55023-3a20ad5cc0e8524d-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "9641ca3ce0e80834b37771415da659ae",
         "x-ms-return-client-request-id": "true"
@@ -19,10 +19,10 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Language": "en",
-        "Content-Length": "84",
+        "Content-Length": "88",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 25 Apr 2020 01:14:19 GMT",
-        "elapsed-time": "13",
+        "Date": "Fri, 08 May 2020 07:01:33 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
@@ -30,13 +30,14 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "Message": "The index \u0027doesnotexist\u0027 for service \u0027azs-net-jcswnkcn\u0027 was not found."
+        "Message": "The index \u0027doesnotexist\u0027 for service \u0027azs-net-heathsearch2\u0027 was not found."
       }
     }
   ],
   "Variables": {
     "RandomSeed": "2017785311",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/CountStartsAtZero.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/CountStartsAtZero.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jsjvgrvq.search.windows.net/indexes(\u0027iknqdekx\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rxjicnaq\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-4ec42e1ba9490840ab1a98051e1d7d80-5948e7e95bb71840-00",
+        "traceparent": "00-a28de26d2357f642addf64d7749dc522-cb9b8bf63160f641-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "1c37d00995567ff4f9c8d2a72cb6e71b",
         "x-ms-return-client-request-id": "true"
@@ -20,8 +20,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "4",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:01:02 GMT",
-        "elapsed-time": "60",
+        "Date": "Fri, 08 May 2020 06:51:01 GMT",
+        "elapsed-time": "70",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -30,16 +30,39 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": "\uFEFF0"
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rxjicnaq\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-f4c0dd0c68074a46b183f667bddbb5fd-0b19131235ec454e-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "1cd9c3b379f7bd1fcf8488848e1fe2fa",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:51:01 GMT",
+        "elapsed-time": "195",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "1cd9c3b3-79f7-bd1f-cf84-88848e1fe2fa",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "486317286",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "iknqdekx",
-    "SearchServiceName": "azs-net-jsjvgrvq",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "rxjicnaq",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/CountStartsAtZeroAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/CountStartsAtZeroAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-frgrphbn.search.windows.net/indexes(\u0027whfkkvyo\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rcbpoeha\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-af400dc6537465488e314798449af821-d03bc8aec0cc0646-00",
+        "traceparent": "00-3e13d77f9a0900439deb60509c1e8ac5-6fe3b2eafef9c346-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "42cc42e8f3c91cbf52fa29d6d79b064e",
         "x-ms-return-client-request-id": "true"
@@ -20,8 +20,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "4",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:07:38 GMT",
-        "elapsed-time": "130",
+        "Date": "Fri, 08 May 2020 06:56:27 GMT",
+        "elapsed-time": "59",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -30,16 +30,39 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": "\uFEFF0"
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rcbpoeha\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-ab6ed9e894a4704a93998e7546eb6f3d-3007fc7f3e71b34d-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "68e454c45eea9d3f02f29757a9bd22bc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:56:27 GMT",
+        "elapsed-time": "261",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "68e454c4-5eea-9d3f-02f2-9757a9bd22bc",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1167851963",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "whfkkvyo",
-    "SearchServiceName": "azs-net-frgrphbn",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "rcbpoeha",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/DeleteByKeys.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/DeleteByKeys.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-thsqblus.search.windows.net/indexes(\u0027gullgivy\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027viighfmx\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "483",
         "Content-Type": "application/json",
-        "traceparent": "00-038a2b21d068314a9e7ff060d2d6f6c2-dccf30d172051a49-00",
+        "traceparent": "00-abb96ac99ba30641846b512a9f944fa6-459d9e1bd28a2c42-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "24a4f4785ace54d0676f90da72dde4e1",
         "x-ms-return-client-request-id": "true"
@@ -55,8 +55,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "137",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:01:27 GMT",
-        "elapsed-time": "117",
+        "Date": "Fri, 08 May 2020 06:51:23 GMT",
+        "elapsed-time": "95",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -82,15 +82,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-thsqblus.search.windows.net/indexes(\u0027gullgivy\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027viighfmx\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-21942f31400d7747b37c9a6f661330e9-54a39ae80e536f41-00",
+        "traceparent": "00-4978088489c7f34e91be7e1efea4936c-174fb120219f5e40-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "81c662216cffeed460af5d745e06a65b",
         "x-ms-return-client-request-id": "true"
@@ -101,8 +101,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "4",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:01:30 GMT",
-        "elapsed-time": "3",
+        "Date": "Fri, 08 May 2020 06:51:25 GMT",
+        "elapsed-time": "4",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -113,17 +113,17 @@
       "ResponseBody": "\uFEFF2"
     },
     {
-      "RequestUri": "https://azs-net-thsqblus.search.windows.net/indexes(\u0027gullgivy\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027viighfmx\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "95",
         "Content-Type": "application/json",
-        "traceparent": "00-d07450e889491d49bc62152dbe76f462-b3560b7c9b2e9c41-00",
+        "traceparent": "00-863188836f75554c908ec61ea52e4301-b20cf4b4cdd0524d-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "d842c065667af648595940b29f832ee7",
         "x-ms-return-client-request-id": "true"
@@ -145,7 +145,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "137",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:01:30 GMT",
+        "Date": "Fri, 08 May 2020 06:51:25 GMT",
         "elapsed-time": "29",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -172,15 +172,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-thsqblus.search.windows.net/indexes(\u0027gullgivy\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027viighfmx\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-5f8e071fbc1ef645b09e9b2fd764073a-b49bffdde9699245-00",
+        "traceparent": "00-33e77824c427b740aab499e5d5226fb6-40b6fcc28dfae940-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "3fcd5e96716e0b8820b6c41ffd5bf660",
         "x-ms-return-client-request-id": "true"
@@ -191,7 +191,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "4",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:01:32 GMT",
+        "Date": "Fri, 08 May 2020 06:51:26 GMT",
         "elapsed-time": "4",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -201,16 +201,39 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": "\uFEFF0"
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027viighfmx\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-a0bdb3272dd90b43aa96196eb38647f2-ee32c82a41599449-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "b17534c90c9bba6619cf28a52b214edc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:51:26 GMT",
+        "elapsed-time": "240",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "b17534c9-0c9b-ba66-19cf-28a52b214edc",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "432976220",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "gullgivy",
-    "SearchServiceName": "azs-net-thsqblus",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "viighfmx",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/DeleteByKeysAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/DeleteByKeysAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-enfkqgli.search.windows.net/indexes(\u0027chcemhcd\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vhswvwow\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "483",
         "Content-Type": "application/json",
-        "traceparent": "00-d4276c4a4de6d14abc7ca4f02d645555-68706c632eddca42-00",
+        "traceparent": "00-6c78ff6f9615da4983eeaacf594024e9-1639a8d64599784d-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "9a1bff16231abc751588e22f1bb62dd1",
         "x-ms-return-client-request-id": "true"
@@ -55,8 +55,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "137",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:08:04 GMT",
-        "elapsed-time": "120",
+        "Date": "Fri, 08 May 2020 06:56:48 GMT",
+        "elapsed-time": "75",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -82,15 +82,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-enfkqgli.search.windows.net/indexes(\u0027chcemhcd\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vhswvwow\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-d997f7ebf93704458fb16f8a3800c4bc-64064eb50280f242-00",
+        "traceparent": "00-0d26764757bc5c4db59029733c16ddc0-ea78223bff47bd4a-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "2a68e09fe70929f94e44de948f12181c",
         "x-ms-return-client-request-id": "true"
@@ -101,8 +101,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "4",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:08:07 GMT",
-        "elapsed-time": "4",
+        "Date": "Fri, 08 May 2020 06:56:50 GMT",
+        "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -113,17 +113,17 @@
       "ResponseBody": "\uFEFF2"
     },
     {
-      "RequestUri": "https://azs-net-enfkqgli.search.windows.net/indexes(\u0027chcemhcd\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vhswvwow\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "95",
         "Content-Type": "application/json",
-        "traceparent": "00-d4d47e8b8e3afb4fac6b728a843ad2a5-e051a21d0bfd0948-00",
+        "traceparent": "00-795527e0d5f55d4291164dba59756ff1-da0317fd0cc32349-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "2e8060ad12fd20dd69d256285fe0c3f1",
         "x-ms-return-client-request-id": "true"
@@ -145,8 +145,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "137",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:08:07 GMT",
-        "elapsed-time": "47",
+        "Date": "Fri, 08 May 2020 06:56:50 GMT",
+        "elapsed-time": "24",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -172,15 +172,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-enfkqgli.search.windows.net/indexes(\u0027chcemhcd\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vhswvwow\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-1f3d8651b4987c459007fb3b1d516752-23feb8593c078643-00",
+        "traceparent": "00-46e11dedff9a074b97f1066d8bd18fff-e6b304696a206c48-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "b614be8be5c02fbb05f14bd545e02d03",
         "x-ms-return-client-request-id": "true"
@@ -191,8 +191,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "4",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:08:08 GMT",
-        "elapsed-time": "4",
+        "Date": "Fri, 08 May 2020 06:56:52 GMT",
+        "elapsed-time": "3",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -201,16 +201,39 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": "\uFEFF0"
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vhswvwow\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-24e0efe1978aa247b4229e54c6f574fd-46c47fbd9da09e4f-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "bb82c56fff358dd30348c13790d0ca6d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:56:52 GMT",
+        "elapsed-time": "184",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "bb82c56f-ff35-8dd3-0348-c13790d0ca6d",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "282699616",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "chcemhcd",
-    "SearchServiceName": "azs-net-enfkqgli",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "vhswvwow",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/DoesNotThrowDeletingExtraDynamic.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/DoesNotThrowDeletingExtraDynamic.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-blxpsoub.search.windows.net/indexes(\u0027ikpspirp\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027mdehxtpi\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "73",
         "Content-Type": "application/json",
-        "traceparent": "00-950281fd1bd6474c82c56b7cd597a6b8-c8671f2d79e5014a-00",
+        "traceparent": "00-8221b60d2f63a944827f2e4e639d4723-cc208ac03c97e24c-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "0f053a14ec7785032a7274d470958cb4",
         "x-ms-return-client-request-id": "true"
@@ -30,8 +30,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:01:58 GMT",
-        "elapsed-time": "96",
+        "Date": "Fri, 08 May 2020 06:51:48 GMT",
+        "elapsed-time": "74",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -51,15 +51,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-blxpsoub.search.windows.net/indexes(\u0027ikpspirp\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027mdehxtpi\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-3396cc353c897e4b97d20b9b199dad9f-4dba61293c639748-00",
+        "traceparent": "00-c66518531096604e9679b0edcc64cd25-7b496beccd91d64b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "4a24e8378085131710dda09c4f12a081",
         "x-ms-return-client-request-id": "true"
@@ -70,8 +70,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "4",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:02:00 GMT",
-        "elapsed-time": "23",
+        "Date": "Fri, 08 May 2020 06:51:50 GMT",
+        "elapsed-time": "4",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -82,17 +82,17 @@
       "ResponseBody": "\uFEFF1"
     },
     {
-      "RequestUri": "https://azs-net-blxpsoub.search.windows.net/indexes(\u0027ikpspirp\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027mdehxtpi\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "74",
         "Content-Type": "application/json",
-        "traceparent": "00-4c9ffe88ec3ded4abd8c20ae4f60f239-3dab7abfc69f3f4a-00",
+        "traceparent": "00-f8946f9e1e3b3745a1c7efabd9703955-a784afc06ab59843-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "933f46319a92b55f57a970c880afe404",
         "x-ms-return-client-request-id": "true"
@@ -111,7 +111,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:02:00 GMT",
+        "Date": "Fri, 08 May 2020 06:51:50 GMT",
         "elapsed-time": "25",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -132,15 +132,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-blxpsoub.search.windows.net/indexes(\u0027ikpspirp\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027mdehxtpi\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-8a8153e30850fa4fa370f43938d6fd03-bdf1a5889a94434c-00",
+        "traceparent": "00-cd612cd52f0cb141acc7cf674e5d1b6d-61015d0535946848-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "7803a36451f0948a22f1ff994c673518",
         "x-ms-return-client-request-id": "true"
@@ -151,8 +151,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "4",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:02:02 GMT",
-        "elapsed-time": "4",
+        "Date": "Fri, 08 May 2020 06:51:52 GMT",
+        "elapsed-time": "3",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -161,16 +161,39 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": "\uFEFF0"
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027mdehxtpi\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-48b70121554c8949a9fad3f2e8667e39-0b6703ad52b3d24a-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "29a3f3d2f9569d22896ff3dc0f4f9360",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:51:53 GMT",
+        "elapsed-time": "259",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "29a3f3d2-f956-9d22-896f-f3dc0f4f9360",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1779014440",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "ikpspirp",
-    "SearchServiceName": "azs-net-blxpsoub",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "mdehxtpi",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/DoesNotThrowDeletingExtraDynamicAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/DoesNotThrowDeletingExtraDynamicAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-upushysq.search.windows.net/indexes(\u0027rhrnrvpn\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027xlirdoji\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "73",
         "Content-Type": "application/json",
-        "traceparent": "00-874e4b6888866142909b1707a5a3b4fc-d2452977e4668c4b-00",
+        "traceparent": "00-3cdb6eb51bc35941b1ba479465237660-cba8cc17ee508b4c-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "e20b8c2723563b98f8cd7393a9468c7b",
         "x-ms-return-client-request-id": "true"
@@ -30,8 +30,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:08:36 GMT",
-        "elapsed-time": "127",
+        "Date": "Fri, 08 May 2020 06:57:14 GMT",
+        "elapsed-time": "88",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -51,15 +51,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-upushysq.search.windows.net/indexes(\u0027rhrnrvpn\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027xlirdoji\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-61900ca9a431d24c98bbbd6321e27779-f7189d8e1dab0a41-00",
+        "traceparent": "00-597b6642b951164cbdd3d51cd7dc434d-d77324681dc9874c-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "b53a4cb685b533c5ff5ba200436ce48b",
         "x-ms-return-client-request-id": "true"
@@ -70,8 +70,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "4",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:08:38 GMT",
-        "elapsed-time": "25",
+        "Date": "Fri, 08 May 2020 06:57:16 GMT",
+        "elapsed-time": "3",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -82,17 +82,17 @@
       "ResponseBody": "\uFEFF1"
     },
     {
-      "RequestUri": "https://azs-net-upushysq.search.windows.net/indexes(\u0027rhrnrvpn\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027xlirdoji\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "74",
         "Content-Type": "application/json",
-        "traceparent": "00-3e56597a259ac24e8b254f4c36876552-dbb85abfb3e19e42-00",
+        "traceparent": "00-9bb0adde4b58ee469c64cb3591f687e5-7ae61085ccf17b4f-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "0fcb78ad841aa5fcde3b98af37867515",
         "x-ms-return-client-request-id": "true"
@@ -111,8 +111,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:08:38 GMT",
-        "elapsed-time": "52",
+        "Date": "Fri, 08 May 2020 06:57:16 GMT",
+        "elapsed-time": "26",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -132,15 +132,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-upushysq.search.windows.net/indexes(\u0027rhrnrvpn\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027xlirdoji\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-09801e1a3e360f4bae8a68adab085560-e06472445ee2b44d-00",
+        "traceparent": "00-3e738dae69f4bc4cb915cb6af5a45451-625d24f92f25a048-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "5e81da8b2f09a2bbc7d7e2fa8198f88b",
         "x-ms-return-client-request-id": "true"
@@ -151,7 +151,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "4",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:08:40 GMT",
+        "Date": "Fri, 08 May 2020 06:57:18 GMT",
         "elapsed-time": "4",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -161,16 +161,39 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": "\uFEFF0"
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027xlirdoji\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-2b46f73d11dcb542b296812cf9597f08-99796864a0b0ac46-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "30e5e7e97d7b32615094d779ec16fc79",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:57:18 GMT",
+        "elapsed-time": "208",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "30e5e7e9-7d7b-3261-5094-d779ec16fc79",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1755502886",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "rhrnrvpn",
-    "SearchServiceName": "azs-net-upushysq",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "xlirdoji",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/DoesNotThrowDeletingExtraStatic.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/DoesNotThrowDeletingExtraStatic.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-xdotsnmx.search.windows.net/indexes(\u0027wppkgjka\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027dvlapiia\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "251",
         "Content-Type": "application/json",
-        "traceparent": "00-5346e1ad2ba51d4dab201947846167f8-458263d03bfec343-00",
+        "traceparent": "00-b7d991d51515e941b8dcae354b4d2bd4-8e3342da93b78a48-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "cf1fd8bb01689a78c8f190efb0c92648",
         "x-ms-return-client-request-id": "true"
@@ -40,8 +40,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:02:28 GMT",
-        "elapsed-time": "96",
+        "Date": "Fri, 08 May 2020 06:52:14 GMT",
+        "elapsed-time": "79",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -61,15 +61,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-xdotsnmx.search.windows.net/indexes(\u0027wppkgjka\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027dvlapiia\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-e8ade63193f4e34cb33904b056eaa24c-c99214619c1b2d46-00",
+        "traceparent": "00-8622fa876d597c46b260db2f71be3f5a-d690b18d7d68c642-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "5d0d15f30a0e1bd97d67a268e54982b2",
         "x-ms-return-client-request-id": "true"
@@ -80,8 +80,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "4",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:02:30 GMT",
-        "elapsed-time": "3",
+        "Date": "Fri, 08 May 2020 06:52:16 GMT",
+        "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -92,17 +92,17 @@
       "ResponseBody": "\uFEFF1"
     },
     {
-      "RequestUri": "https://azs-net-xdotsnmx.search.windows.net/indexes(\u0027wppkgjka\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027dvlapiia\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "252",
         "Content-Type": "application/json",
-        "traceparent": "00-5c6b88c785973e458dda18b0677c548c-c335af8682a82740-00",
+        "traceparent": "00-a83570598540ca4fa51eb45862446656-fcc5d1a7ced7524d-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "5f4cc33dfde379a6066cc6a2ec65fe82",
         "x-ms-return-client-request-id": "true"
@@ -131,8 +131,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:02:31 GMT",
-        "elapsed-time": "38",
+        "Date": "Fri, 08 May 2020 06:52:16 GMT",
+        "elapsed-time": "28",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -152,15 +152,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-xdotsnmx.search.windows.net/indexes(\u0027wppkgjka\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027dvlapiia\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-7bff40a80311f3469843707fa00973dd-e18e08ccc2eb9e41-00",
+        "traceparent": "00-bfb98ba84d53f34d9430a33db3b25284-6a378a776ea37649-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "7ebc7de48b9ab094ff0451005e10b47e",
         "x-ms-return-client-request-id": "true"
@@ -171,8 +171,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "4",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:02:33 GMT",
-        "elapsed-time": "12",
+        "Date": "Fri, 08 May 2020 06:52:18 GMT",
+        "elapsed-time": "4",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -181,16 +181,39 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": "\uFEFF0"
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027dvlapiia\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-d70a72504ea3034ab9f661e01ab0c4c9-613e37afb5d7674c-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "ecb2de6fc67cf5656e9356a144372e18",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:52:18 GMT",
+        "elapsed-time": "162",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "ecb2de6f-c67c-f565-6e93-56a144372e18",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "170080043",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "wppkgjka",
-    "SearchServiceName": "azs-net-xdotsnmx",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "dvlapiia",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/DoesNotThrowDeletingExtraStaticAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/DoesNotThrowDeletingExtraStaticAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-tegjovjy.search.windows.net/indexes(\u0027fxpiewao\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027bvmydjqk\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "251",
         "Content-Type": "application/json",
-        "traceparent": "00-6288adb7817d1a4a892289f20e0a2578-9e09d3811b826445-00",
+        "traceparent": "00-4c787cf88ebd4f4b9a0d1c5d11326fc9-84afe56c946cde49-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "ef71c43eb239eb400f7b0539411e1a36",
         "x-ms-return-client-request-id": "true"
@@ -40,8 +40,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:09:15 GMT",
-        "elapsed-time": "281",
+        "Date": "Fri, 08 May 2020 06:57:39 GMT",
+        "elapsed-time": "109",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -61,15 +61,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-tegjovjy.search.windows.net/indexes(\u0027fxpiewao\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027bvmydjqk\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-55ccdc8adfa93749a1205d1e5ad6d996-a09a03354159634d-00",
+        "traceparent": "00-da4966ae170dfc43bdd702514aba823c-5697e1611473a147-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "edbe3f1d740eaf2e72ba0901f3d523b6",
         "x-ms-return-client-request-id": "true"
@@ -80,8 +80,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "4",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:09:17 GMT",
-        "elapsed-time": "4",
+        "Date": "Fri, 08 May 2020 06:57:41 GMT",
+        "elapsed-time": "3",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -92,17 +92,17 @@
       "ResponseBody": "\uFEFF1"
     },
     {
-      "RequestUri": "https://azs-net-tegjovjy.search.windows.net/indexes(\u0027fxpiewao\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027bvmydjqk\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "252",
         "Content-Type": "application/json",
-        "traceparent": "00-0a433d13aaa397499d79236ecbba9b0d-5afc66b31dea774a-00",
+        "traceparent": "00-d7402b3dd7407a4ab9542c6ddfd159df-6aa753820b264f4c-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "5c80a3c88e4ef62bcc2fb47d85b4ef83",
         "x-ms-return-client-request-id": "true"
@@ -131,8 +131,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:09:17 GMT",
-        "elapsed-time": "48",
+        "Date": "Fri, 08 May 2020 06:57:41 GMT",
+        "elapsed-time": "26",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -152,15 +152,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-tegjovjy.search.windows.net/indexes(\u0027fxpiewao\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027bvmydjqk\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-7676422ef8c8a44b9923ffbae5d6016e-b8dfa5bdfef56a44-00",
+        "traceparent": "00-599897cf6aa99b438196942a21a27e8d-521552c0b0ab2c44-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "95be6eda6d3bc97d95c17c7fa93ef839",
         "x-ms-return-client-request-id": "true"
@@ -171,8 +171,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "4",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:09:19 GMT",
-        "elapsed-time": "5",
+        "Date": "Fri, 08 May 2020 06:57:43 GMT",
+        "elapsed-time": "4",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -181,16 +181,39 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": "\uFEFF0"
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027bvmydjqk\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-d06a8470b9240e4fb56aa5e641fc43d4-c6857b0e34b0d345-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "9d714f57be9d8ee714c720debfb029be",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:57:43 GMT",
+        "elapsed-time": "191",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "9d714f57-be9d-8ee7-14c7-20debfb029be",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "836785609",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "fxpiewao",
-    "SearchServiceName": "azs-net-tegjovjy",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "bvmydjqk",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/DoesNotThrowOnPartialSuccess.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/DoesNotThrowOnPartialSuccess.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-nnorgtff.search.windows.net/indexes(\u0027lqhpubdw\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vlqmnnsq\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "482",
         "Content-Type": "application/json",
-        "traceparent": "00-4b2c1b5db4f73b45ab681db1161a0961-342997a56d5c9747-00",
+        "traceparent": "00-323183303138c14eba2e5969ffee9f69-a046e77e3d09be4e-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "6e910c0169b1aa35c735dc9af96c6957",
         "x-ms-return-client-request-id": "true"
@@ -55,8 +55,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "155",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:02:59 GMT",
-        "elapsed-time": "105",
+        "Date": "Fri, 08 May 2020 06:52:39 GMT",
+        "elapsed-time": "130",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -80,16 +80,39 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vlqmnnsq\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-38861e27ca08b7498fc753b37fc847f5-89102d7325a30046-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "68f1a98ae169fec5658ba5e97fcee7b7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:52:39 GMT",
+        "elapsed-time": "169",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "68f1a98a-e169-fec5-658b-a5e97fcee7b7",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "552340877",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "lqhpubdw",
-    "SearchServiceName": "azs-net-nnorgtff",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "vlqmnnsq",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/DoesNotThrowOnPartialSuccessAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/DoesNotThrowOnPartialSuccessAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-fcptaggf.search.windows.net/indexes(\u0027tnsinxpf\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fqtgkyic\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "482",
         "Content-Type": "application/json",
-        "traceparent": "00-cd4a303dc89dc24d818f2e018ed9533a-4d44fe39f7b0a34a-00",
+        "traceparent": "00-6e9ac19abc916a42a396177bda5ad072-dca593f46846fe49-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "7f9dfcb9835f94b6255a180359a28d05",
         "x-ms-return-client-request-id": "true"
@@ -55,8 +55,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "155",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:09:45 GMT",
-        "elapsed-time": "148",
+        "Date": "Fri, 08 May 2020 06:58:05 GMT",
+        "elapsed-time": "154",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -80,16 +80,39 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fqtgkyic\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-a744320a535f9e4db2dd342bece387d0-bf6d82d434945e45-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "7ed8d396f9e8061defb2d1e49dbe7014",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:58:05 GMT",
+        "elapsed-time": "249",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "7ed8d396-f9e8-061d-efb2-d1e49dbe7014",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1834614957",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "tnsinxpf",
-    "SearchServiceName": "azs-net-fcptaggf",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "fqtgkyic",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/DoesNotThrowOnSuccess.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/DoesNotThrowOnSuccess.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-dumdsbgn.search.windows.net/indexes(\u0027xascxkuy\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027xhgsabry\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "247",
         "Content-Type": "application/json",
-        "traceparent": "00-c0a493e56487b5408f363ccf5c2cbef1-72b21f8a726b6546-00",
+        "traceparent": "00-bb6994bf8f823444a9f10c996a9a4c93-ba3c218720961843-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "1e447e2f19ca569dc22e5e7fcb4b8ebd",
         "x-ms-return-client-request-id": "true"
@@ -40,8 +40,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:03:25 GMT",
-        "elapsed-time": "271",
+        "Date": "Fri, 08 May 2020 06:53:00 GMT",
+        "elapsed-time": "134",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -59,16 +59,39 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027xhgsabry\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-a8f524281283f74fbc0566c02f23b6a5-68dcb37a33e0154b-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "61f7043e44940beb50485010ec005ba3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:53:00 GMT",
+        "elapsed-time": "235",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "61f7043e-4494-0beb-5048-5010ec005ba3",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "683326896",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "xascxkuy",
-    "SearchServiceName": "azs-net-dumdsbgn",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "xhgsabry",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/DoesNotThrowOnSuccessAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/DoesNotThrowOnSuccessAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-qojhasox.search.windows.net/indexes(\u0027gvnjjkmu\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027mrvkcmrl\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "247",
         "Content-Type": "application/json",
-        "traceparent": "00-4fd38df00bfdc248bf109bd219b02c7b-8ed5adf4fa06cd4a-00",
+        "traceparent": "00-e21d49be064eca448c950aaf9dd00c08-03b0aec2f675bd4d-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "c055820da40e85843eade3fe89eb38c1",
         "x-ms-return-client-request-id": "true"
@@ -40,8 +40,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:10:12 GMT",
-        "elapsed-time": "165",
+        "Date": "Fri, 08 May 2020 06:58:26 GMT",
+        "elapsed-time": "80",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -59,16 +59,39 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027mrvkcmrl\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-7265b234228c704b92831a5d405cb901-a5c0fae4d4a7fc49-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "65b0cdbe1d286f2ca1f3272e2444350b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:58:26 GMT",
+        "elapsed-time": "199",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "65b0cdbe-1d28-6f2c-a1f3-272e2444350b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "109207449",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "gvnjjkmu",
-    "SearchServiceName": "azs-net-qojhasox",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "mrvkcmrl",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/DynamicDocuments.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/DynamicDocuments.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-aofcsaje.search.windows.net/indexes(\u0027xjibgwcu\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027otdhouhx\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "3611",
         "Content-Type": "application/json",
-        "traceparent": "00-53de9049d090354193c4b800ad24f27e-9b4b6c4af7a71748-00",
+        "traceparent": "00-14551297b9be9b409900a5bde9228d18-194282349fc95348-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "a7af2b74fd49d414bf6ea5e587749ab2",
         "x-ms-return-client-request-id": "true"
@@ -152,8 +152,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "344",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:03:52 GMT",
-        "elapsed-time": "170",
+        "Date": "Fri, 08 May 2020 06:53:22 GMT",
+        "elapsed-time": "140",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -197,15 +197,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-aofcsaje.search.windows.net/indexes(\u0027xjibgwcu\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027otdhouhx\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-08247e5743431c428fb7b4277099688a-65d777b561ba8348-00",
+        "traceparent": "00-e87730447af05544942d4641eb8312af-04ca626f19742845-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "73e8cc089da49d8c2b7873a9306c9898",
         "x-ms-return-client-request-id": "true"
@@ -216,8 +216,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "4",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:03:53 GMT",
-        "elapsed-time": "27",
+        "Date": "Fri, 08 May 2020 06:53:24 GMT",
+        "elapsed-time": "3",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -226,16 +226,39 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": "\uFEFF3"
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027otdhouhx\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-a7e1d6cacb448f45ac221e1e079dffa5-fe3893ef7240a34a-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "e8e6c8afd0812399ba28b88051dac8ee",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:53:24 GMT",
+        "elapsed-time": "274",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "e8e6c8af-d081-2399-ba28-b88051dac8ee",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1983224603",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "xjibgwcu",
-    "SearchServiceName": "azs-net-aofcsaje",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "otdhouhx",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/DynamicDocumentsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/DynamicDocumentsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-gdipgumn.search.windows.net/indexes(\u0027xbobdakh\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027pydyisjd\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "3611",
         "Content-Type": "application/json",
-        "traceparent": "00-666ecfeeca83c04691251c3f9c138bc4-d59d9a163cc9b44b-00",
+        "traceparent": "00-71fa4c724241754a8b9b0d3125a02d1e-8bc1100078c92a41-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "842adc2eefd236b7f3dd2173d1bbdd5c",
         "x-ms-return-client-request-id": "true"
@@ -152,8 +152,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "344",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:10:39 GMT",
-        "elapsed-time": "174",
+        "Date": "Fri, 08 May 2020 06:58:47 GMT",
+        "elapsed-time": "90",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -197,15 +197,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-gdipgumn.search.windows.net/indexes(\u0027xbobdakh\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027pydyisjd\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-f128e6b99179c442bfe03491062dd79c-944e49d1eca36746-00",
+        "traceparent": "00-07c1ba8efa33394998adf95a7c6fe725-39f4d783a776c047-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "64f08d5b49f31b48855a8f36b28f9b3e",
         "x-ms-return-client-request-id": "true"
@@ -216,8 +216,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "4",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:10:41 GMT",
-        "elapsed-time": "4",
+        "Date": "Fri, 08 May 2020 06:58:49 GMT",
+        "elapsed-time": "3",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -226,16 +226,39 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": "\uFEFF3"
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027pydyisjd\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-3c6aa8c71c6f244997b41c227ca261f5-9fbcda28f2444945-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "09a530da1c2d8ab913e49b209ca030b2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:58:49 GMT",
+        "elapsed-time": "300",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "09a530da-1c2d-8ab9-13e4-9b209ca030b2",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1113032202",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "xbobdakh",
-    "SearchServiceName": "azs-net-gdipgumn",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "pydyisjd",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/MergeDocumentsDynamic.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/MergeDocumentsDynamic.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-msgkvhhm.search.windows.net/indexes(\u0027gbsfbchb\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027iaefcaam\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "1680",
         "Content-Type": "application/json",
-        "traceparent": "00-e5c1637efd90d7408ae70f898c099bfa-6d9539b91db1a149-00",
+        "traceparent": "00-893b5ee7c547e045be89e909dc11a4c2-49581700f397b641-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "5de7cd27daaba6e6951bc0eddceaac08",
         "x-ms-return-client-request-id": "true"
@@ -77,8 +77,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:04:21 GMT",
-        "elapsed-time": "188",
+        "Date": "Fri, 08 May 2020 06:53:45 GMT",
+        "elapsed-time": "117",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -98,17 +98,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-msgkvhhm.search.windows.net/indexes(\u0027gbsfbchb\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027iaefcaam\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "378",
         "Content-Type": "application/json",
-        "traceparent": "00-f26c574ac68cb34da84d73c9b2f3f66c-d3002cd12581d447-00",
+        "traceparent": "00-964d3587988e694c894576c98d95e4a0-a8a9d46784fbac47-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "8638f76bb865265973c5f5169a34ec22",
         "x-ms-return-client-request-id": "true"
@@ -151,8 +151,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:04:23 GMT",
-        "elapsed-time": "57",
+        "Date": "Fri, 08 May 2020 06:53:47 GMT",
+        "elapsed-time": "29",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -172,15 +172,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-msgkvhhm.search.windows.net/indexes(\u0027gbsfbchb\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027iaefcaam\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-a5aa3997d899c1438291628d1419ea34-61424a2515b1004f-00",
+        "traceparent": "00-516365db8951f04db3e77b1d6ac86663-310b140d22b3e040-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "71a8a1f43dd9dc410cc30f0d308050fb",
         "x-ms-return-client-request-id": "true"
@@ -191,8 +191,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "894",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:04:25 GMT",
-        "elapsed-time": "31",
+        "Date": "Fri, 08 May 2020 06:53:49 GMT",
+        "elapsed-time": "10",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -240,17 +240,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-msgkvhhm.search.windows.net/indexes(\u0027gbsfbchb\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027iaefcaam\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "1680",
         "Content-Type": "application/json",
-        "traceparent": "00-56d4b4c5ba490044820ffbe0736703be-f8eb0831562fb047-00",
+        "traceparent": "00-787aa064f8f8184fb0e938f92c3a4146-1ee5a2e5a11e5b49-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "ebf2967c7a9e6fd973c1e9e6e4d00b61",
         "x-ms-return-client-request-id": "true"
@@ -316,8 +316,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:04:25 GMT",
-        "elapsed-time": "44",
+        "Date": "Fri, 08 May 2020 06:53:49 GMT",
+        "elapsed-time": "29",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -337,15 +337,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-msgkvhhm.search.windows.net/indexes(\u0027gbsfbchb\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027iaefcaam\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-12e8e8ae7f135e4d93126cecd6b62b46-b5d583224fb40340-00",
+        "traceparent": "00-bbd2a35c1503574f8aa3121771c6e406-4dc8fff67419ef40-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "3bf99d2e3b422e2eb65b79a1a94bf5f2",
         "x-ms-return-client-request-id": "true"
@@ -356,8 +356,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "1559",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:04:28 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 08 May 2020 06:53:52 GMT",
+        "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -416,16 +416,39 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027iaefcaam\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-8786b708978a6f43a41ee88ed34265ba-1ab8a8196af0dd43-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "049af97501417983c739fd18535af73c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:53:52 GMT",
+        "elapsed-time": "204",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "049af975-0141-7983-c739-fd18535af73c",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1403851089",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "gbsfbchb",
-    "SearchServiceName": "azs-net-msgkvhhm",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "iaefcaam",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/MergeDocumentsDynamicAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/MergeDocumentsDynamicAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-ijqpmsol.search.windows.net/indexes(\u0027mqnerwvj\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027ssosqhvl\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "1680",
         "Content-Type": "application/json",
-        "traceparent": "00-d2104f0ec711214ebe06a44cdc8d1b18-6a753d11ec3adc4f-00",
+        "traceparent": "00-6aa0e5ea2c8bda40a4d92baeb29e604f-0e29b0b180a00a48-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "aaded8341d193314acc7cc8e594a9eb0",
         "x-ms-return-client-request-id": "true"
@@ -77,8 +77,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:11:08 GMT",
-        "elapsed-time": "182",
+        "Date": "Fri, 08 May 2020 06:59:11 GMT",
+        "elapsed-time": "86",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -98,17 +98,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-ijqpmsol.search.windows.net/indexes(\u0027mqnerwvj\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027ssosqhvl\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "378",
         "Content-Type": "application/json",
-        "traceparent": "00-b0bea05cd7bd1146b86859ed825ba51a-bd10627c7a65bd45-00",
+        "traceparent": "00-9af8f0d6f7683a46a23f9f885283de12-b89d78f5a1f0544f-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "d137a2fc58d88813aacc117216d4d3d6",
         "x-ms-return-client-request-id": "true"
@@ -151,8 +151,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:11:10 GMT",
-        "elapsed-time": "49",
+        "Date": "Fri, 08 May 2020 06:59:13 GMT",
+        "elapsed-time": "27",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -172,15 +172,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-ijqpmsol.search.windows.net/indexes(\u0027mqnerwvj\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027ssosqhvl\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-3be19ce4425dd846a4a13c29c5abff58-00de2e1bfa296743-00",
+        "traceparent": "00-7aa0c8588084534782ef3db801538e3a-2a73eae665c0aa4e-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "f7125fc117c4ba3a654fd02ab3fee744",
         "x-ms-return-client-request-id": "true"
@@ -191,8 +191,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "894",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:11:12 GMT",
-        "elapsed-time": "33",
+        "Date": "Fri, 08 May 2020 06:59:15 GMT",
+        "elapsed-time": "29",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -240,17 +240,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-ijqpmsol.search.windows.net/indexes(\u0027mqnerwvj\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027ssosqhvl\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "1680",
         "Content-Type": "application/json",
-        "traceparent": "00-49ad549fce4aff478d32f3a419cd44ea-b72620c2d09b7c4d-00",
+        "traceparent": "00-c371bc6d63325f4cbc83f79b56f610a5-72b46cf1cae4984b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "3a50e2b9e73cdb67c556004d0ba11dd8",
         "x-ms-return-client-request-id": "true"
@@ -316,8 +316,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "74",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:11:12 GMT",
-        "elapsed-time": "49",
+        "Date": "Fri, 08 May 2020 06:59:15 GMT",
+        "elapsed-time": "41",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -337,15 +337,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-ijqpmsol.search.windows.net/indexes(\u0027mqnerwvj\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027ssosqhvl\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-17af2bb8907700438be5ef5d3c9ae183-efcdd2ba9ca13641-00",
+        "traceparent": "00-5c210ee441a836499dff6f46d613b2c2-f364dcdc66471441-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "facdf5f3a637e5ec677d6c8888e9d4ab",
         "x-ms-return-client-request-id": "true"
@@ -356,7 +356,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "1559",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:11:14 GMT",
+        "Date": "Fri, 08 May 2020 06:59:17 GMT",
         "elapsed-time": "7",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -416,16 +416,39 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027ssosqhvl\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-8ae9d5d939c9204ebb309011ae86bf32-deea4a2753010b4e-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "34b8cde49983d99af737326d17edaec3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:59:17 GMT",
+        "elapsed-time": "206",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "34b8cde4-9983-d99a-f737-326d17edaec3",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "660557965",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "mqnerwvj",
-    "SearchServiceName": "azs-net-ijqpmsol",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "ssosqhvl",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/RoundtripBoundaryValues.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/RoundtripBoundaryValues.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-vhofvaed.search.windows.net/indexes(\u0027lifjsfgb\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027ahjvoakx\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "2425",
         "Content-Type": "application/json",
-        "traceparent": "00-32be066610883a4485dfbc4699d661e0-747a4afcd860d343-00",
+        "traceparent": "00-26e70986fe91124c9f77921a20a9b8d2-51ec6d3d8765b646-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "04d36a16c97e66b037fb770aff04a144",
         "x-ms-return-client-request-id": "true"
@@ -184,8 +184,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "389",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:04:54 GMT",
-        "elapsed-time": "340",
+        "Date": "Fri, 08 May 2020 06:54:12 GMT",
+        "elapsed-time": "121",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -235,15 +235,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-vhofvaed.search.windows.net/indexes(\u0027lifjsfgb\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027ahjvoakx\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-76afb5497299424ab30662ac83242e1f-57c70dbc54930446-00",
+        "traceparent": "00-d3a9673c5f1c834687a97f01df07289f-025530eea8b94a47-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "8912016614f3ab8d8fa07c2e886b82ca",
         "x-ms-return-client-request-id": "true"
@@ -254,8 +254,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "491",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:04:56 GMT",
-        "elapsed-time": "10",
+        "Date": "Fri, 08 May 2020 06:54:15 GMT",
+        "elapsed-time": "18",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -297,15 +297,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-vhofvaed.search.windows.net/indexes(\u0027lifjsfgb\u0027)/docs(\u00272\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027ahjvoakx\u0027)/docs(\u00272\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-5af0654300f0d5439b36f1ebc23373d9-f7f544a89479834e-00",
+        "traceparent": "00-19569509b8286a439e2b748dba5e6da6-456dc7d6b6beb84b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "e960a71a2fdc418f552f994610082ea1",
         "x-ms-return-client-request-id": "true"
@@ -316,8 +316,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "507",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:04:56 GMT",
-        "elapsed-time": "5",
+        "Date": "Fri, 08 May 2020 06:54:15 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -361,15 +361,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-vhofvaed.search.windows.net/indexes(\u0027lifjsfgb\u0027)/docs(\u00273\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027ahjvoakx\u0027)/docs(\u00273\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-8bb7ecdb2bb44f428bec2c33e61f00db-a675f8d24650784d-00",
+        "traceparent": "00-9cd1f84b0356a74499873b52b7004254-938bad4eb0e4484a-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "a0ac7bbf95ce016bdd2875dd4d82decb",
         "x-ms-return-client-request-id": "true"
@@ -380,8 +380,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "365",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:04:56 GMT",
-        "elapsed-time": "5",
+        "Date": "Fri, 08 May 2020 06:54:15 GMT",
+        "elapsed-time": "4",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -417,15 +417,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-vhofvaed.search.windows.net/indexes(\u0027lifjsfgb\u0027)/docs(\u00274\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027ahjvoakx\u0027)/docs(\u00274\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-58c3bf8b6dcfdf4489b2bc0ae2b48413-9506d565c1eba24e-00",
+        "traceparent": "00-7c460bbd617cdc44af3eb563f4fdde05-f74c1d8b4e8fd541-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "58f0ac78b7a4366871d134c47b469a86",
         "x-ms-return-client-request-id": "true"
@@ -436,8 +436,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "364",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:04:56 GMT",
-        "elapsed-time": "4",
+        "Date": "Fri, 08 May 2020 06:54:15 GMT",
+        "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -473,15 +473,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-vhofvaed.search.windows.net/indexes(\u0027lifjsfgb\u0027)/docs(\u00275\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027ahjvoakx\u0027)/docs(\u00275\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-5450bcd9a52e3b409d798e756cd29b5e-a864ebf6df86f449-00",
+        "traceparent": "00-b465e3bd053f9f4aa96d19bc1e271359-5b0d7f3adac37449-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "0c6fda72e2bf84fc3b5e0bb4bab1f3d3",
         "x-ms-return-client-request-id": "true"
@@ -492,8 +492,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "364",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:04:56 GMT",
-        "elapsed-time": "8",
+        "Date": "Fri, 08 May 2020 06:54:15 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -529,15 +529,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-vhofvaed.search.windows.net/indexes(\u0027lifjsfgb\u0027)/docs(\u00276\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027ahjvoakx\u0027)/docs(\u00276\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-7d8a5e1b6092cd408c82cdb8bb61f37f-7616c2722b3b3744-00",
+        "traceparent": "00-17717b650e472745b9b9d059634c3ad7-d4374effb8efdf47-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "64cecd50d51807fc13752efd61a78597",
         "x-ms-return-client-request-id": "true"
@@ -548,8 +548,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "225",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:04:56 GMT",
-        "elapsed-time": "5",
+        "Date": "Fri, 08 May 2020 06:54:15 GMT",
+        "elapsed-time": "4",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -572,16 +572,39 @@
         "address": null,
         "rooms": []
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027ahjvoakx\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-f5547858feb35d4a97dcf28d3f4c8031-d27def927432514e-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "726bee8dd113960cb06c1c45acb37bbf",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:54:15 GMT",
+        "elapsed-time": "189",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "726bee8d-d113-960c-b06c-1c45acb37bbf",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1585493960",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "lifjsfgb",
-    "SearchServiceName": "azs-net-vhofvaed",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "ahjvoakx",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/RoundtripBoundaryValuesAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/RoundtripBoundaryValuesAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-bwbkpaxu.search.windows.net/indexes(\u0027bujxdntf\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027qhqfcilx\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "2425",
         "Content-Type": "application/json",
-        "traceparent": "00-19e2c1ef01c0c94c8142b6c58de9a0f6-29ae487a9edebd4a-00",
+        "traceparent": "00-79f27a3466d93344a385352c33359065-81bccee32a4a0645-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "266e1dfb8c0a70eae757f2c253b6bb2a",
         "x-ms-return-client-request-id": "true"
@@ -184,8 +184,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "389",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:12:00 GMT",
-        "elapsed-time": "239",
+        "Date": "Fri, 08 May 2020 06:59:38 GMT",
+        "elapsed-time": "125",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -235,15 +235,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-bwbkpaxu.search.windows.net/indexes(\u0027bujxdntf\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027qhqfcilx\u0027)/docs(\u00271\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-d94452ed84f8804580fba9e999a4a86b-5eb87364d3016d40-00",
+        "traceparent": "00-c266ad9d6afebe4f9308cdbe8cb091ba-10c8aaab09836f4b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "81ecb5b70e5ac29d617ad34b9959389c",
         "x-ms-return-client-request-id": "true"
@@ -254,8 +254,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "491",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:12:02 GMT",
-        "elapsed-time": "13",
+        "Date": "Fri, 08 May 2020 06:59:40 GMT",
+        "elapsed-time": "12",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -297,15 +297,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-bwbkpaxu.search.windows.net/indexes(\u0027bujxdntf\u0027)/docs(\u00272\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027qhqfcilx\u0027)/docs(\u00272\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-8a7ee7b3c337a440b6266ba918fde1d7-9ce2bf1d13500245-00",
+        "traceparent": "00-a8220665d412ae4688ffb8b8ee342ccf-0a2b88186ca6cd4f-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "ec4c78bad13408b7c2cb3ea22762c253",
         "x-ms-return-client-request-id": "true"
@@ -316,8 +316,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "507",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:12:02 GMT",
-        "elapsed-time": "4",
+        "Date": "Fri, 08 May 2020 06:59:40 GMT",
+        "elapsed-time": "3",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -361,15 +361,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-bwbkpaxu.search.windows.net/indexes(\u0027bujxdntf\u0027)/docs(\u00273\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027qhqfcilx\u0027)/docs(\u00273\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-a8f0572f53ffaf44a3376e2a20ae053f-5bb02a5fba98e849-00",
+        "traceparent": "00-280518a544977b4caeff2ce2d92d0c49-e1f7eae1370dd849-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "1605a8916cc2ed437facc490b89fd68d",
         "x-ms-return-client-request-id": "true"
@@ -380,8 +380,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "365",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:12:02 GMT",
-        "elapsed-time": "5",
+        "Date": "Fri, 08 May 2020 06:59:40 GMT",
+        "elapsed-time": "3",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -417,15 +417,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-bwbkpaxu.search.windows.net/indexes(\u0027bujxdntf\u0027)/docs(\u00274\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027qhqfcilx\u0027)/docs(\u00274\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-c0665a19cc38b345bbabd71c4c38e8bf-daf80c0c4251b040-00",
+        "traceparent": "00-f8c606924f667849b4ce5695a190f52a-82c3367e5989c54f-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "da07561fce69e5f6fee3bf8fcffb9bff",
         "x-ms-return-client-request-id": "true"
@@ -436,8 +436,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "364",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:12:02 GMT",
-        "elapsed-time": "5",
+        "Date": "Fri, 08 May 2020 06:59:40 GMT",
+        "elapsed-time": "4",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -473,15 +473,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-bwbkpaxu.search.windows.net/indexes(\u0027bujxdntf\u0027)/docs(\u00275\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027qhqfcilx\u0027)/docs(\u00275\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-6d350ff543147842b97a852f7b91870c-0bbadf7c1531454b-00",
+        "traceparent": "00-d883aba1a60c7e428c0fa371888e2115-af8353fe61523b4b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "f0b980b721544ed9355e6d880d265023",
         "x-ms-return-client-request-id": "true"
@@ -492,7 +492,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "364",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:12:02 GMT",
+        "Date": "Fri, 08 May 2020 06:59:40 GMT",
         "elapsed-time": "4",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -529,15 +529,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-bwbkpaxu.search.windows.net/indexes(\u0027bujxdntf\u0027)/docs(\u00276\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027qhqfcilx\u0027)/docs(\u00276\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-b1170a3a9c554140a82c05fc9964004f-2bdfa57b8a84694b-00",
+        "traceparent": "00-cca53c79cbff9546a91f5c3b3643f93e-c2417b044145ae42-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "d082b0f4e85ac2eab21f18deacb41e83",
         "x-ms-return-client-request-id": "true"
@@ -548,8 +548,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "225",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:12:02 GMT",
-        "elapsed-time": "4",
+        "Date": "Fri, 08 May 2020 06:59:40 GMT",
+        "elapsed-time": "3",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -572,16 +572,39 @@
         "address": null,
         "rooms": []
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027qhqfcilx\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-aef1ddbcab80da4198dca63ad0e377f7-74402bfe4094294b-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "38d9c411e6e5fd397cb9a40a616dd8d7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:59:40 GMT",
+        "elapsed-time": "192",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "38d9c411-e6e5-fd39-7cb9-a40a616dd8d7",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1917208391",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "bujxdntf",
-    "SearchServiceName": "azs-net-bwbkpaxu",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "qhqfcilx",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/StaticDocuments.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/StaticDocuments.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-wwofdkcs.search.windows.net/indexes(\u0027hruqgdcu\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027kmjpmvhb\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "3987",
         "Content-Type": "application/json",
-        "traceparent": "00-867f734194198546845388c2df3fb714-074d4829f1c5744b-00",
+        "traceparent": "00-6127eb213edc334aad13f6b6a58f6ef0-0d647f4be272e449-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "a0024a861f497bcd454835c9d5f04869",
         "x-ms-return-client-request-id": "true"
@@ -188,8 +188,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "344",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:05:21 GMT",
-        "elapsed-time": "266",
+        "Date": "Fri, 08 May 2020 06:54:36 GMT",
+        "elapsed-time": "272",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -233,15 +233,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-wwofdkcs.search.windows.net/indexes(\u0027hruqgdcu\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027kmjpmvhb\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-38afedf4523a364aba41e784cb72a03f-e33de4923263fd45-00",
+        "traceparent": "00-8915bb68e71814448645e8f85d9881e5-e5e1c7716cc21a45-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "5f6c2fedab3301fcb3d186229e3aefec",
         "x-ms-return-client-request-id": "true"
@@ -252,8 +252,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "4",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:05:23 GMT",
-        "elapsed-time": "23",
+        "Date": "Fri, 08 May 2020 06:54:38 GMT",
+        "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -262,16 +262,39 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": "\uFEFF3"
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027kmjpmvhb\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-e3815d248ae32346b614be888c069d9a-d899abf39323a649-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "2ea803d3fe165584f08121d368813050",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:54:39 GMT",
+        "elapsed-time": "284",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "2ea803d3-fe16-5584-f081-21d368813050",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "216418330",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "hruqgdcu",
-    "SearchServiceName": "azs-net-wwofdkcs",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "kmjpmvhb",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/StaticDocumentsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/StaticDocumentsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-kfbysvin.search.windows.net/indexes(\u0027nvcohiva\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027dffkrygn\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "3987",
         "Content-Type": "application/json",
-        "traceparent": "00-ce9a0d4433573048bba7636b6922911d-a3a2ce0395948a4e-00",
+        "traceparent": "00-3b3da68800703941a8e0b584b117d957-b87b3060f84a3d4e-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "29f6f4a77f5e31d972d6cd1564c8ad19",
         "x-ms-return-client-request-id": "true"
@@ -188,8 +188,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "344",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:12:28 GMT",
-        "elapsed-time": "128",
+        "Date": "Fri, 08 May 2020 07:00:02 GMT",
+        "elapsed-time": "90",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -233,15 +233,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-kfbysvin.search.windows.net/indexes(\u0027nvcohiva\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027dffkrygn\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-39e1c84f5ea86e4da20b1c1d897021ca-99e49d707078464e-00",
+        "traceparent": "00-b9f99d1200f3f84ca50f60d614426bff-0066f0850615ef43-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "af1f911a22849c17a2de57a0c0a6b790",
         "x-ms-return-client-request-id": "true"
@@ -252,8 +252,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "4",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:12:31 GMT",
-        "elapsed-time": "4",
+        "Date": "Fri, 08 May 2020 07:00:04 GMT",
+        "elapsed-time": "3",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -262,16 +262,39 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": "\uFEFF3"
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027dffkrygn\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-d70de6d0cdd29f458d88101afd34bf9d-3d124b572302ee47-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "2429633e754415328f09316c404368ac",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:00:04 GMT",
+        "elapsed-time": "207",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "2429633e-7544-1532-8f09-316c404368ac",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1761363080",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "nvcohiva",
-    "SearchServiceName": "azs-net-kfbysvin",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "dffkrygn",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/StructDocuments.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/StructDocuments.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-bgfyhvxm.search.windows.net/indexes(\u0027ncynbwsb\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027elkvfalb\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "1112",
         "Content-Type": "application/json",
-        "traceparent": "00-f9a82eaddddf75458274c052a90fb5bb-f398c31d83858b44-00",
+        "traceparent": "00-e2e10912321d0f47bb8d5fda0e1ecd87-f66517bcab0f3846-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "501db6d588ced0205f301700abe23d25",
         "x-ms-return-client-request-id": "true"
@@ -60,8 +60,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "344",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:05:51 GMT",
-        "elapsed-time": "166",
+        "Date": "Fri, 08 May 2020 06:55:00 GMT",
+        "elapsed-time": "178",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -105,15 +105,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-bgfyhvxm.search.windows.net/indexes(\u0027ncynbwsb\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027elkvfalb\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-4bace037b1d46043a8bf338529e9bceb-afa84c9b55c77a4a-00",
+        "traceparent": "00-ad839578eea5bc45bac5806a6638f947-1d19f31fbaf52f4a-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "9fd9e453d8455e329458757c578c9a23",
         "x-ms-return-client-request-id": "true"
@@ -124,8 +124,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "4",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:05:53 GMT",
-        "elapsed-time": "4",
+        "Date": "Fri, 08 May 2020 06:55:01 GMT",
+        "elapsed-time": "3",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -134,16 +134,39 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": "\uFEFF3"
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027elkvfalb\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-06049606fc1f7d4e93d6e58e581ff8cf-d57e215c1a587b4e-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "3e0a80fb0386762496901294112d7e55",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:55:01 GMT",
+        "elapsed-time": "210",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "3e0a80fb-0386-7624-9690-1294112d7e55",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1484375429",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "ncynbwsb",
-    "SearchServiceName": "azs-net-bgfyhvxm",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "elkvfalb",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/StructDocumentsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/StructDocumentsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-feafxarh.search.windows.net/indexes(\u0027lunqipiy\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027ebjegqcl\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "1112",
         "Content-Type": "application/json",
-        "traceparent": "00-1be97e70964f1843bed51b2e07a7f1db-108a0e9af02c3543-00",
+        "traceparent": "00-a83dac2667371644bee8af3ee924d158-4438418a4217cc49-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "f030d49b8b4987465338499c35df9763",
         "x-ms-return-client-request-id": "true"
@@ -60,8 +60,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "344",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:12:56 GMT",
-        "elapsed-time": "157",
+        "Date": "Fri, 08 May 2020 07:00:26 GMT",
+        "elapsed-time": "95",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -105,15 +105,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-feafxarh.search.windows.net/indexes(\u0027lunqipiy\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027ebjegqcl\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-bfcb639ab41724449cad50aad2f1cf2c-2f5609dc2197b44a-00",
+        "traceparent": "00-82311c78dfa9794385223c3ac79c6cc1-b0cded5e1bf89549-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "9dca118d52b3c674fae1a382b8a1e644",
         "x-ms-return-client-request-id": "true"
@@ -124,8 +124,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "4",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:12:58 GMT",
-        "elapsed-time": "4",
+        "Date": "Fri, 08 May 2020 07:00:28 GMT",
+        "elapsed-time": "3",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -134,16 +134,39 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": "\uFEFF3"
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027ebjegqcl\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-a0fb58ced0c3684e9a6645ea530659b3-1bf6cc1a622b9245-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "63cac7bca6446e05b01f4ec3ba205083",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:00:28 GMT",
+        "elapsed-time": "222",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "63cac7bc-a644-6e05-b01f-4ec3ba205083",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "126748610",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "lunqipiy",
-    "SearchServiceName": "azs-net-feafxarh",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "ebjegqcl",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/ThrowsOnInvalidDocument.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/ThrowsOnInvalidDocument.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-uqienbwk.search.windows.net/indexes(\u0027evxeemvh\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027drdmimow\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "39",
         "Content-Type": "application/json",
-        "traceparent": "00-4cc7dc610b3c074b851c8f1e0b20838a-52961ab3bb61214f-00",
+        "traceparent": "00-fabf19c87ce4854789ee0e01733ebdf2-a9f06b36d4ed8740-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "675687be5f4018261f4dd6c97e64c115",
         "x-ms-return-client-request-id": "true"
@@ -29,8 +29,8 @@
         "Content-Language": "en",
         "Content-Length": "124",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:06:19 GMT",
-        "elapsed-time": "132",
+        "Date": "Fri, 08 May 2020 06:55:22 GMT",
+        "elapsed-time": "62",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -44,16 +44,39 @@
           "message": "The request is invalid. Details: actions : 0: Document key cannot be missing or empty.\r\n"
         }
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027drdmimow\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-49aa79174201e2459d74c8aa1c973b1b-736f03f0a8786b46-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "4d64c218771b3b580d58d15764058397",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:55:23 GMT",
+        "elapsed-time": "246",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "4d64c218-771b-3b58-0d58-d15764058397",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "687109065",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "evxeemvh",
-    "SearchServiceName": "azs-net-uqienbwk",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "drdmimow",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/ThrowsOnInvalidDocumentAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/ThrowsOnInvalidDocumentAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-whsmvwpe.search.windows.net/indexes(\u0027onvswins\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027hqmrjpke\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "39",
         "Content-Type": "application/json",
-        "traceparent": "00-5caa022a2b6edd4ead4efb2319e83694-9abfe3f25a33ba4d-00",
+        "traceparent": "00-efbbbc0d742f034bb1709c8f78fe4c99-06f1e981c7e9204b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "671adb4c286def740ec75df15d888225",
         "x-ms-return-client-request-id": "true"
@@ -29,8 +29,8 @@
         "Content-Language": "en",
         "Content-Length": "124",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:13:25 GMT",
-        "elapsed-time": "126",
+        "Date": "Fri, 08 May 2020 07:00:48 GMT",
+        "elapsed-time": "69",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -44,16 +44,39 @@
           "message": "The request is invalid. Details: actions : 0: Document key cannot be missing or empty.\r\n"
         }
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027hqmrjpke\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-3958d7aef3a9f747bfd828913552e0c1-1a52a555b24a0b4d-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "5e694e5d4ec42448bf589ed00ab0ddd0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:00:50 GMT",
+        "elapsed-time": "177",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "5e694e5d-4ec4-2448-bf58-9ed00ab0ddd0",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1159546087",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "onvswins",
-    "SearchServiceName": "azs-net-whsmvwpe",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "hqmrjpke",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/ThrowsOnPartialSuccessWhenAsked.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/ThrowsOnPartialSuccessWhenAsked.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-gjhlyhta.search.windows.net/indexes(\u0027xcqbkoqj\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027htssruko\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "486",
         "Content-Type": "application/json",
-        "traceparent": "00-d8d73dbd0afdba468d470e7b27bdff51-ee1593a978934645-00",
+        "traceparent": "00-a97a604623afed45929e982bbac3795e-da508c3155183747-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "d5ce6a6c5c540ae091560e3e47589eb7",
         "x-ms-return-client-request-id": "true"
@@ -55,8 +55,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "155",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:06:46 GMT",
-        "elapsed-time": "206",
+        "Date": "Fri, 08 May 2020 06:55:44 GMT",
+        "elapsed-time": "136",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -80,16 +80,39 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027htssruko\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-501c0e5c7c03f04dab05961ea32bc6cb-9ef69c4c2bdd9546-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "b9cae2ededf3fe00a43fefa9d149d916",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:55:44 GMT",
+        "elapsed-time": "192",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "b9cae2ed-edf3-fe00-a43f-efa9d149d916",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "276729186",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "xcqbkoqj",
-    "SearchServiceName": "azs-net-gjhlyhta",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "htssruko",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/ThrowsOnPartialSuccessWhenAskedAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/ThrowsOnPartialSuccessWhenAskedAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-yisxmngk.search.windows.net/indexes(\u0027nsmxhqex\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vkstulig\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "486",
         "Content-Type": "application/json",
-        "traceparent": "00-6aaf509dfd4d8b43b4aaef69bfd14d4f-dd92f023c2755a44-00",
+        "traceparent": "00-ef4c1b6e87f7bb46b649741724da830f-5d20da9b69e0104c-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "04bc46f5376814253de8557a155fc3da",
         "x-ms-return-client-request-id": "true"
@@ -55,8 +55,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "155",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:13:50 GMT",
-        "elapsed-time": "202",
+        "Date": "Fri, 08 May 2020 07:01:11 GMT",
+        "elapsed-time": "94",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -80,16 +80,39 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vkstulig\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-d4b33bdccdcb17489a4b35e9d4b84653-71c44de2a019be42-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "bcb8b5d8fbdfb9ec92ad1c84186d8e7f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:01:11 GMT",
+        "elapsed-time": "180",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "bcb8b5d8-fbdf-b9ec-92ad-1c84186d8e7f",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "500651422",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "nsmxhqex",
-    "SearchServiceName": "azs-net-yisxmngk",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "vkstulig",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/ThrowsWhenMergingWithNewKey.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/ThrowsWhenMergingWithNewKey.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-xtvpuxha.search.windows.net/indexes(\u0027jttlxthb\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027ifwbkrlm\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "53",
         "Content-Type": "application/json",
-        "traceparent": "00-27face8e114cbc49b8a8605e2d84a930-a778c2fd687c3f42-00",
+        "traceparent": "00-5948c50997489040b87d7d051605c3e8-a185a264ac9baa4e-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "cbc31d4dbd8a2fc4e121ff629bd129b8",
         "x-ms-return-client-request-id": "true"
@@ -29,8 +29,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "93",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:07:11 GMT",
-        "elapsed-time": "57",
+        "Date": "Fri, 08 May 2020 06:56:06 GMT",
+        "elapsed-time": "79",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -48,16 +48,39 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027ifwbkrlm\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-c5a1f023bc914748bc9c24ae2b88697c-bad32e6c0033aa45-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "18d1f9c85e5e31dee9ebbbb4e360deb1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 06:56:06 GMT",
+        "elapsed-time": "180",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "18d1f9c8-5e5e-31de-e9eb-bbb4e360deb1",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1230788505",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "jttlxthb",
-    "SearchServiceName": "azs-net-xtvpuxha",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "ifwbkrlm",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/ThrowsWhenMergingWithNewKeyAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/IndexingTests/ThrowsWhenMergingWithNewKeyAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-ncryoiei.search.windows.net/indexes(\u0027ouqkexjc\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027mevcmyls\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "53",
         "Content-Type": "application/json",
-        "traceparent": "00-a4060a78edc4754ba9c85405b61d153a-9e0a9588aee7ab44-00",
+        "traceparent": "00-afa67eb87cdf62448a705efe85dcf281-59ce5132b3c6114a-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "9454778a86456b312a3ea4e6ea1645c0",
         "x-ms-return-client-request-id": "true"
@@ -29,8 +29,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "93",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:14:17 GMT",
-        "elapsed-time": "120",
+        "Date": "Fri, 08 May 2020 07:01:32 GMT",
+        "elapsed-time": "144",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -48,16 +48,39 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027mevcmyls\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-a61b4973b0683d45a8884a6567e05945-4e0db6a2cd436f44-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "1fdcabe2f3f0fd21e68342911b905551",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:01:32 GMT",
+        "elapsed-time": "425",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "1fdcabe2-f3f0-fd21-e683-42911b905551",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1670034816",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "ouqkexjc",
-    "SearchServiceName": "azs-net-ncryoiei",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "mevcmyls",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/Authenticate.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/Authenticate.json
@@ -1,12 +1,8 @@
 {
   "Entries": [],
   "Variables": {
-    "CLIENT_ID": "34869c6d-312e-406b-8f7a-033302ff3d20",
-    "LOCATION": "westus2",
-    "RESOURCE_GROUP": "rg-heaths2",
-    "SearchIndexName": "ufeloxcq",
-    "SearchServiceName": "azs-net-uqnsxavy",
-    "SUBSCRIPTION_ID": "c649122d-c5c8-40b0-b95c-e09da8dbfdf0",
-    "TENANT_ID": "96be4b7a-defb-4dc2-a31f-49ee6145d5ab"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/CreateAndQuery.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/CreateAndQuery.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
@@ -9,8 +9,8 @@
         "Content-Length": "54",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "a08172e48587447c359b02bce6a6aff1",
         "x-ms-return-client-request-id": "true"
@@ -25,8 +25,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "872",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:14:19 GMT",
-        "elapsed-time": "15",
+        "Date": "Fri, 08 May 2020 07:01:33 GMT",
+        "elapsed-time": "37",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -61,7 +61,7 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
@@ -69,8 +69,8 @@
         "Content-Length": "54",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "8abd3980f0f41cac28b93e138ca75f59",
         "x-ms-return-client-request-id": "true"
@@ -85,8 +85,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "872",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:14:19 GMT",
-        "elapsed-time": "6",
+        "Date": "Fri, 08 May 2020 07:01:33 GMT",
+        "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -123,7 +123,8 @@
   ],
   "Variables": {
     "RandomSeed": "1492439627",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/CreateIndex.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/CreateIndex.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-scqqhtyv.search.windows.net/indexes?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
@@ -9,8 +9,8 @@
         "Content-Length": "1505",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200502.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "ec8f1b224af8d9bff1f430bc1b15db2c",
         "x-ms-return-client-request-id": "true"
@@ -130,13 +130,13 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "2474",
+        "Content-Length": "2478",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 02 May 2020 08:32:45 GMT",
-        "elapsed-time": "690",
-        "ETag": "W/\u00220x8D7EE7363B1A5C7\u0022",
+        "Date": "Fri, 08 May 2020 07:01:34 GMT",
+        "elapsed-time": "756",
+        "ETag": "W/\u00220x8D7F31DA513EDAE\u0022",
         "Expires": "-1",
-        "Location": "https://azs-net-scqqhtyv.search.windows.net/indexes(\u0027wldfvoaj\u0027)?api-version=2019-05-06-Preview",
+        "Location": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027wldfvoaj\u0027)?api-version=2019-05-06-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
@@ -144,8 +144,8 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-scqqhtyv.search.windows.net/$metadata#indexes/$entity",
-        "@odata.etag": "\u00220x8D7EE7363B1A5C7\u0022",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#indexes/$entity",
+        "@odata.etag": "\u00220x8D7F31DA513EDAE\u0022",
         "name": "wldfvoaj",
         "defaultScoringProfile": null,
         "fields": [
@@ -304,12 +304,9 @@
     }
   ],
   "Variables": {
-    "CLIENT_ID": "34869c6d-312e-406b-8f7a-033302ff3d20",
-    "LOCATION": "westus2",
     "RandomSeed": "2102937546",
-    "RESOURCE_GROUP": "rg-heaths2",
-    "SearchServiceName": "azs-net-scqqhtyv",
-    "SUBSCRIPTION_ID": "c649122d-c5c8-40b0-b95c-e09da8dbfdf0",
-    "TENANT_ID": "96be4b7a-defb-4dc2-a31f-49ee6145d5ab"
+    "SearchIndexName": null,
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/Index.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/Index.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-huqavjli.search.windows.net/indexes(\u0027biycjrvx\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027manpwrey\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
@@ -9,8 +9,8 @@
         "Content-Length": "152",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "024524334adee593f5ff620e2e46cb84",
         "x-ms-return-client-request-id": "true"
@@ -35,8 +35,8 @@
         "Content-Language": "en",
         "Content-Length": "55",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:14:46 GMT",
-        "elapsed-time": "122",
+        "Date": "Fri, 08 May 2020 07:01:56 GMT",
+        "elapsed-time": "59",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -50,16 +50,40 @@
           "message": "Authorization failed."
         }
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027manpwrey\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-6780f2b3b09a5a468dc6796067a71c9a-33c39f62d1d6ac4c-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "a522fd35141b7174122ccf9c9ccbaae0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:01:56 GMT",
+        "elapsed-time": "171",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "a522fd35-141b-7174-122c-cf9c9ccbaae0",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "978400005",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "biycjrvx",
-    "SearchServiceName": "azs-net-huqavjli",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "manpwrey",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/Options.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/Options.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
@@ -9,8 +9,8 @@
         "Content-Length": "109",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "4cbbd33490420dee971451eace00649b",
         "x-ms-return-client-request-id": "true"
@@ -28,8 +28,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "872",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:14:48 GMT",
-        "elapsed-time": "121",
+        "Date": "Fri, 08 May 2020 07:01:56 GMT",
+        "elapsed-time": "107",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -66,7 +66,8 @@
   ],
   "Variables": {
     "RandomSeed": "1402132638",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/QueryStatic.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/QueryStatic.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
@@ -9,8 +9,8 @@
         "Content-Length": "54",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "3ca72ac76a8c267bd9f5e5c0f47395a4",
         "x-ms-return-client-request-id": "true"
@@ -25,8 +25,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "872",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:14:48 GMT",
-        "elapsed-time": "26",
+        "Date": "Fri, 08 May 2020 07:01:56 GMT",
+        "elapsed-time": "8",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -61,17 +61,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "54",
         "Content-Type": "application/json",
-        "traceparent": "00-2263e34bc5e049449467b5079d12762e-d0ab9de273cccc4c-00",
+        "traceparent": "00-9e39cd7c6f54ec4e829b10eab4f19733-8cec5c94398b0b48-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "c4773c05d66cb29c12ab04f8a2e9b0c8",
         "x-ms-return-client-request-id": "true"
@@ -86,8 +86,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "872",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:14:48 GMT",
-        "elapsed-time": "6",
+        "Date": "Fri, 08 May 2020 07:01:56 GMT",
+        "elapsed-time": "7",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -124,7 +124,8 @@
   ],
   "Variables": {
     "RandomSeed": "549811099",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/Troubleshooting.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/Readme/Troubleshooting.json
@@ -1,14 +1,14 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs(\u002712345\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs(\u002712345\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "7c34fbb2dd26e95ef8b150d6b9aa6381",
         "x-ms-return-client-request-id": "true"
@@ -18,8 +18,8 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Sat, 25 Apr 2020 01:14:48 GMT",
-        "elapsed-time": "3",
+        "Date": "Fri, 08 May 2020 07:01:56 GMT",
+        "elapsed-time": "4",
         "Expires": "-1",
         "Pragma": "no-cache",
         "request-id": "7c34fbb2-dd26-e95e-f8b1-50d6b9aa6381",
@@ -30,7 +30,8 @@
   ],
   "Variables": {
     "RandomSeed": "1565637229",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchClientTests/ClientRequestIdRountrips.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchClientTests/ClientRequestIdRountrips.json
@@ -1,20 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vqfmhdni\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-f7b71ce68ea29e4a8a86937ddf436802-99414607f09b684c-00",
+        "traceparent": "00-24391b60af16cf42a36228d25a1e1e81-bceb57a216656c44-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": [
-          "a424ae0d-2882-9bc5-4334-bdf36ab4310a",
-          "3624f7ef20d6099abd42a53795265db0"
-        ],
+        "x-ms-client-request-id": "a424ae0d-2882-9bc5-4334-bdf36ab4310a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -23,13 +20,13 @@
         "Cache-Control": "no-cache",
         "Content-Length": "5",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:14:48 GMT",
-        "elapsed-time": "3",
+        "Date": "Fri, 08 May 2020 07:14:53 GMT",
+        "elapsed-time": "75",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "1612f891-0878-4bd0-a967-3dd4cc8cf806",
+        "request-id": "a424ae0d-2882-9bc5-4334-bdf36ab4310a",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": "\uFEFF10"
@@ -37,7 +34,8 @@
   ],
   "Variables": {
     "RandomSeed": "330260530",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "vqfmhdni",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchClientTests/ClientRequestIdRountripsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchClientTests/ClientRequestIdRountripsAsync.json
@@ -1,20 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vqfmhdni\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-d0f01c98a09a9a4db1d8f41c098da36d-74ee1bc574a4e844-00",
+        "traceparent": "00-dad9f38faf36d74d8d18314c7c95fc8b-cbb1e919f825a248-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": [
-          "91c76819-2313-a36c-0754-b0e74ecf69b2",
-          "f9639059f378a041a707add8d55673e0"
-        ],
+        "x-ms-client-request-id": "91c76819-2313-a36c-0754-b0e74ecf69b2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -23,13 +20,13 @@
         "Cache-Control": "no-cache",
         "Content-Length": "5",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:14:48 GMT",
-        "elapsed-time": "3",
+        "Date": "Fri, 08 May 2020 07:14:53 GMT",
+        "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "317a1f56-505a-4425-9c58-00387a8ca5a5",
+        "request-id": "91c76819-2313-a36c-0754-b0e74ecf69b2",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": "\uFEFF10"
@@ -37,7 +34,8 @@
   ],
   "Variables": {
     "RandomSeed": "1684850376",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "vqfmhdni",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchClientTests/GetDocumentCount.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchClientTests/GetDocumentCount.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-6b83173a2c97ed4aa8cfdfe6db36bffd-af4171a0e9ae884f-00",
+        "traceparent": "00-ca8f4bfe1a9dc9459851418ea1fbb0c2-89c18e6a79e19c42-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "04ce36d25a63d7f396c87d6107fb3733",
         "x-ms-return-client-request-id": "true"
@@ -20,8 +20,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "5",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:14:48 GMT",
-        "elapsed-time": "5",
+        "Date": "Fri, 08 May 2020 07:01:56 GMT",
+        "elapsed-time": "3",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -34,7 +34,8 @@
   ],
   "Variables": {
     "RandomSeed": "1899812036",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchClientTests/GetDocumentCountAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchClientTests/GetDocumentCountAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
-        "traceparent": "00-f579f5b7c5e4c543a0ffa389bf9db186-599dd20c2d103f4d-00",
+        "traceparent": "00-c3393d3ceaab5a47b9c5ab535a9caa2a-00bb6ced321a6542-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "d3288d7ff70d1713de50a1c1dd2f20a8",
         "x-ms-return-client-request-id": "true"
@@ -20,8 +20,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "5",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:14:48 GMT",
-        "elapsed-time": "5",
+        "Date": "Fri, 08 May 2020 07:01:56 GMT",
+        "elapsed-time": "3",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -34,7 +34,8 @@
   ],
   "Variables": {
     "RandomSeed": "1772541862",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/ClientRequestIdRountrips.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/ClientRequestIdRountrips.json
@@ -1,46 +1,43 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/servicestats?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/servicestats?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-a90e367307aaff4d94c38a7b8f853ef8-5e3078a30938b744-00",
+        "traceparent": "00-4098fa1b50c3c341bd41043c141c1ef2-670b1d71563ef744-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": [
-          "68966ae8-323d-1ca5-12f0-8e47cdae07d4",
-          "c6c3a2814ac160d6ea0844f2dfe307d1"
-        ],
+        "x-ms-client-request-id": "68966ae8-323d-1ca5-12f0-8e47cdae07d4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "586",
+        "Content-Length": "590",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 01:14:48 GMT",
-        "elapsed-time": "29",
+        "Date": "Fri, 08 May 2020 07:01:57 GMT",
+        "elapsed-time": "50",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "09ceaa4f-b87d-4fe2-b74a-b47730ef361a",
+        "request-id": "68966ae8-323d-1ca5-12f0-8e47cdae07d4",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-jcswnkcn.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.ServiceStatistics",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.ServiceStatistics",
         "counters": {
           "documentCount": {
             "usage": 10,
             "quota": null
           },
           "indexesCount": {
-            "usage": 1,
+            "usage": 2,
             "quota": 3
           },
           "indexersCount": {
@@ -52,7 +49,7 @@
             "quota": 3
           },
           "storageSize": {
-            "usage": 38732,
+            "usage": 35876,
             "quota": 52428800
           },
           "synonymMaps": {
@@ -75,7 +72,8 @@
   ],
   "Variables": {
     "RandomSeed": "1622410931",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/ClientRequestIdRountripsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/ClientRequestIdRountripsAsync.json
@@ -1,58 +1,55 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/servicestats?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/servicestats?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-3d59838a8ddc1649b77f263885463206-a13cacf9457aec48-00",
+        "traceparent": "00-caf38ced70a5b04cb0414e4d5580b9f5-4e8b474a85eb094b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": [
-          "f32f3b11-7b2c-df0f-c417-672b2950b49a",
-          "ae62f142acd05cc49626d8dd5496daf7"
-        ],
+        "x-ms-client-request-id": "f32f3b11-7b2c-df0f-c417-672b2950b49a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "586",
+        "Content-Length": "590",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 01:16:44 GMT",
-        "elapsed-time": "46",
+        "Date": "Fri, 08 May 2020 07:03:26 GMT",
+        "elapsed-time": "146",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "298abe6c-2521-466e-8290-0ea20964ceaa",
+        "request-id": "f32f3b11-7b2c-df0f-c417-672b2950b49a",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-jcswnkcn.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.ServiceStatistics",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.ServiceStatistics",
         "counters": {
           "documentCount": {
             "usage": 10,
             "quota": null
           },
           "indexesCount": {
-            "usage": 1,
+            "usage": 2,
             "quota": 3
           },
           "indexersCount": {
-            "usage": 0,
+            "usage": 1,
             "quota": 3
           },
           "dataSourcesCount": {
-            "usage": 0,
+            "usage": 1,
             "quota": 3
           },
           "storageSize": {
-            "usage": 38732,
+            "usage": 35876,
             "quota": 52428800
           },
           "synonymMaps": {
@@ -75,7 +72,8 @@
   ],
   "Variables": {
     "RandomSeed": "1481307319",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/CreateAzureBlobIndexer.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/CreateAzureBlobIndexer.json
@@ -1,32 +1,29 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-xswopklx.search.windows.net/datasources?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/datasources?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "Content-Length": "220",
+        "Content-Length": "219",
         "Content-Type": "application/json",
-        "traceparent": "00-ca5a42eb9c5cb24f85b1871c065b8d71-be35230911f1eb4c-00",
+        "traceparent": "00-09e9c7977e73f0458d016eda24ddc16f-93689a46726f0640-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": [
-          "e4aa32b6-2e9e-efef-52d2-6a4830547090",
-          "9e3a08c8ef1cf0258840e7eedb7be977"
-        ],
+        "x-ms-client-request-id": "486ad252-5430-9070-c808-3a9e1cef25f0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "heathsrchstg",
+        "name": "frgsqbma",
         "type": "azureblob",
         "credentials": {
-          "connectionString": "DefaultEndpointsProtocol=https;AccountName=heathsrchstg;AccountKey=Sanitized;EndpointSuffix=core.windows.net"
+          "connectionString": "DefaultEndpointsProtocol=https;AccountName=heathsearch2stg;AccountKey=Sanitized;EndpointSuffix=core.windows.net"
         },
         "container": {
-          "name": "gdnixkxc"
+          "name": "uangflsr"
         }
       },
       "StatusCode": 201,
@@ -34,21 +31,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "360",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 03:17:29 GMT",
-        "elapsed-time": "113",
-        "ETag": "W/\u00220x8D7E8C72FC7E1C5\u0022",
+        "Date": "Fri, 08 May 2020 07:02:19 GMT",
+        "elapsed-time": "84",
+        "ETag": "W/\u00220x8D7F31DBF9AE2C9\u0022",
         "Expires": "-1",
-        "Location": "https://azs-net-xswopklx.search.windows.net/datasources(\u0027heathsrchstg\u0027)?api-version=2019-05-06-Preview",
+        "Location": "https://azs-net-heathsearch2.search.windows.net/datasources(\u0027frgsqbma\u0027)?api-version=2019-05-06-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "e2a229bc-ba2a-4ea4-bf2e-d3170ad64e6b",
+        "request-id": "486ad252-5430-9070-c808-3a9e1cef25f0",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-xswopklx.search.windows.net/$metadata#datasources/$entity",
-        "@odata.etag": "\u00220x8D7E8C72FC7E1C5\u0022",
-        "name": "heathsrchstg",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#datasources/$entity",
+        "@odata.etag": "\u00220x8D7F31DBF9AE2C9\u0022",
+        "name": "frgsqbma",
         "description": null,
         "type": "azureblob",
         "subtype": null,
@@ -56,7 +53,7 @@
           "connectionString": null
         },
         "container": {
-          "name": "gdnixkxc",
+          "name": "uangflsr",
           "query": null
         },
         "dataChangeDetectionPolicy": null,
@@ -64,53 +61,50 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-xswopklx.search.windows.net/indexers?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexers?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "Content-Length": "80",
+        "Content-Length": "76",
         "Content-Type": "application/json",
-        "traceparent": "00-e3c7f96ea2b6684faf52743979f54a5e-92416e9fdb42f24d-00",
+        "traceparent": "00-db63707a8e057746801600f3ce59c360-9446ea61c1ba9046-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": [
-          "3328967c-f4f7-dc56-64b8-397bddf7f9c6",
-          "5e5cb90d0046d713e9f22afbe44e4cbe"
-        ],
+        "x-ms-client-request-id": "7b39b864-f7dd-c6f9-0db9-5c5e460013d7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "jyhrmyol",
-        "dataSourceName": "heathsrchstg",
-        "targetIndexName": "tciydxfg"
+        "name": "sxyxrtqp",
+        "dataSourceName": "frgsqbma",
+        "targetIndexName": "fexlvtnn"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "354",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 03:17:39 GMT",
-        "elapsed-time": "10071",
-        "ETag": "W/\u00220x8D7E8C735AA9767\u0022",
+        "Date": "Fri, 08 May 2020 07:02:28 GMT",
+        "elapsed-time": "9815",
+        "ETag": "W/\u00220x8D7F31DC56CBB11\u0022",
         "Expires": "-1",
-        "Location": "https://azs-net-xswopklx.search.windows.net/indexers(\u0027jyhrmyol\u0027)?api-version=2019-05-06-Preview",
+        "Location": "https://azs-net-heathsearch2.search.windows.net/indexers(\u0027sxyxrtqp\u0027)?api-version=2019-05-06-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "83f023d3-e04d-42c3-aaae-4cc63533590c",
+        "request-id": "7b39b864-f7dd-c6f9-0db9-5c5e460013d7",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-xswopklx.search.windows.net/$metadata#indexers/$entity",
-        "@odata.etag": "\u00220x8D7E8C735AA9767\u0022",
-        "name": "jyhrmyol",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#indexers/$entity",
+        "@odata.etag": "\u00220x8D7F31DC56CBB11\u0022",
+        "name": "sxyxrtqp",
         "description": null,
-        "dataSourceName": "heathsrchstg",
+        "dataSourceName": "frgsqbma",
         "skillsetName": null,
-        "targetIndexName": "tciydxfg",
+        "targetIndexName": "fexlvtnn",
         "disabled": null,
         "schedule": null,
         "parameters": null,
@@ -120,58 +114,55 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-xswopklx.search.windows.net/indexers(\u0027jyhrmyol\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexers(\u0027sxyxrtqp\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "Content-Length": "206",
+        "Content-Length": "202",
         "Content-Type": "application/json",
-        "If-Match": "\u00220x8D7E8C735AA9767\u0022",
+        "If-Match": "\u00220x8D7F31DC56CBB11\u0022",
         "Prefer": "return=representation",
-        "traceparent": "00-a6d6d0f103fe314e8a38690d6ee0cf5e-fddb14f05f657342-00",
+        "traceparent": "00-6e4a5fa7b739864eab50687ccf4522e4-0d75a8f56dc21746-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": [
-          "8521c6c8-f1c6-93f8-ea0a-8a22416d9a26",
-          "8914a93be1ad7c2c83514a04ca5bf815"
-        ],
+        "x-ms-client-request-id": "228a0aea-6d41-269a-3ba9-1489ade12c7c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "jyhrmyol",
+        "name": "sxyxrtqp",
         "description": "Updated description",
-        "dataSourceName": "heathsrchstg",
-        "targetIndexName": "tciydxfg",
+        "dataSourceName": "frgsqbma",
+        "targetIndexName": "fexlvtnn",
         "fieldMappings": [],
         "outputFieldMappings": [],
-        "@odata.etag": "\u00220x8D7E8C735AA9767\u0022"
+        "@odata.etag": "\u00220x8D7F31DC56CBB11\u0022"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "371",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 03:17:39 GMT",
-        "elapsed-time": "115",
-        "ETag": "W/\u00220x8D7E8C735EE1981\u0022",
+        "Date": "Fri, 08 May 2020 07:02:28 GMT",
+        "elapsed-time": "112",
+        "ETag": "W/\u00220x8D7F31DC598DC19\u0022",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "aab703bc-4b1e-4422-9530-9e9cb90e8b5c",
+        "request-id": "228a0aea-6d41-269a-3ba9-1489ade12c7c",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-xswopklx.search.windows.net/$metadata#indexers/$entity",
-        "@odata.etag": "\u00220x8D7E8C735EE1981\u0022",
-        "name": "jyhrmyol",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#indexers/$entity",
+        "@odata.etag": "\u00220x8D7F31DC598DC19\u0022",
+        "name": "sxyxrtqp",
         "description": "Updated description",
-        "dataSourceName": "heathsrchstg",
+        "dataSourceName": "frgsqbma",
         "skillsetName": null,
-        "targetIndexName": "tciydxfg",
+        "targetIndexName": "fexlvtnn",
         "disabled": null,
         "schedule": null,
         "parameters": null,
@@ -181,45 +172,42 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-xswopklx.search.windows.net/indexers(\u0027jyhrmyol\u0027)/search.status?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexers(\u0027sxyxrtqp\u0027)/search.status?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-0c0a081a0d3a374aa4b9408cec473bcd-94452d806f14994e-00",
+        "traceparent": "00-0ce52b70210d8644990975e1934557b1-9ecf9ccb8204d64d-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": [
-          "16b37a6c-74d6-1cff-c0c8-743b76f0967c",
-          "3abf0358c33ae71099a50175a6f4c88e"
-        ],
+        "x-ms-client-request-id": "3b74c8c0-f076-7c96-5803-bf3a3ac310e7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "552",
+        "Content-Length": "556",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 03:17:49 GMT",
-        "elapsed-time": "86",
+        "Date": "Fri, 08 May 2020 07:02:38 GMT",
+        "elapsed-time": "14",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "89c844a9-a1f1-4302-9aac-69ece4f7589e",
+        "request-id": "3b74c8c0-f076-7c96-5803-bf3a3ac310e7",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-xswopklx.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
-        "name": "jyhrmyol",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
+        "name": "sxyxrtqp",
         "status": "running",
         "lastResult": {
           "status": "inProgress",
           "errorMessage": null,
-          "startTime": "2020-04-25T03:17:40.334Z",
+          "startTime": "2020-05-08T07:02:30.506Z",
           "endTime": null,
           "itemsProcessed": 0,
           "itemsFailed": 0,
@@ -238,50 +226,47 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-xswopklx.search.windows.net/indexers(\u0027jyhrmyol\u0027)/search.status?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexers(\u0027sxyxrtqp\u0027)/search.status?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-2a4c78c7052dd441bfdab835e7196c95-c417713a75942847-00",
+        "traceparent": "00-ac819c808d94cb4fb014d8179909cfa7-e3f3aa98a6e7dd4b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": [
-          "c6b67412-83ba-c750-aaf8-c9e56df10592",
-          "c7accebabd9ba9db69cb7d30728a75cc"
-        ],
+        "x-ms-client-request-id": "e5c9f8aa-f16d-9205-bace-acc79bbddba9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1515",
+        "Content-Length": "1521",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 03:18:00 GMT",
-        "elapsed-time": "62",
+        "Date": "Fri, 08 May 2020 07:02:49 GMT",
+        "elapsed-time": "29",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "810c30ce-849f-47ba-b142-9467a8428704",
+        "request-id": "e5c9f8aa-f16d-9205-bace-acc79bbddba9",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-xswopklx.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
-        "name": "jyhrmyol",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
+        "name": "sxyxrtqp",
         "status": "running",
         "lastResult": {
           "status": "success",
           "errorMessage": null,
-          "startTime": "2020-04-25T03:17:40.349Z",
-          "endTime": "2020-04-25T03:17:51.15Z",
+          "startTime": "2020-05-08T07:02:30.522Z",
+          "endTime": "2020-05-08T07:02:40.208Z",
           "itemsProcessed": 10,
           "itemsFailed": 0,
-          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-25T03:17:40.365Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-25T03:17:10.3655593\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-25T03:17:10.3655593\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-05-08T07:02:30.553Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-05-08T07:02:00.5534559\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-05-08T07:02:00.5534559\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
           "errors": [],
           "warnings": [],
           "metrics": null
@@ -290,12 +275,12 @@
           {
             "status": "success",
             "errorMessage": null,
-            "startTime": "2020-04-25T03:17:40.349Z",
-            "endTime": "2020-04-25T03:17:51.15Z",
+            "startTime": "2020-05-08T07:02:30.522Z",
+            "endTime": "2020-05-08T07:02:40.208Z",
             "itemsProcessed": 10,
             "itemsFailed": 0,
-            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-25T03:17:40.365Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-25T03:17:10.3655593\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-25T03:17:10.3655593\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-05-08T07:02:30.553Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-05-08T07:02:00.5534559\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-05-08T07:02:00.5534559\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
             "errors": [],
             "warnings": [],
             "metrics": null
@@ -309,20 +294,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-xswopklx.search.windows.net/indexers(\u0027jyhrmyol\u0027)/search.run?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexers(\u0027sxyxrtqp\u0027)/search.run?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-8d466478f446a947861180c9b1b69997-fec4aa629aff2947-00",
+        "traceparent": "00-9fecc864d155724ba64fdbae82b660e9-eef4a4143e88e247-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": [
-          "0129e5ff-cf3a-d4c2-b3f8-9041f92b79a8",
-          "d8ba6f9f014755f3990d5dee0620541f"
-        ],
+        "x-ms-client-request-id": "4190f8b3-2bf9-a879-9f6f-bad84701f355",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -330,60 +312,57 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Sat, 25 Apr 2020 03:18:00 GMT",
-        "elapsed-time": "178",
+        "Date": "Fri, 08 May 2020 07:02:49 GMT",
+        "elapsed-time": "37",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "f591e8ce-963b-4f3f-a78a-0935a677320b",
+        "request-id": "4190f8b3-2bf9-a879-9f6f-bad84701f355",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://azs-net-xswopklx.search.windows.net/indexers(\u0027jyhrmyol\u0027)/search.status?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexers(\u0027sxyxrtqp\u0027)/search.status?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-89855ca6721ab246a6c748728992ecde-6236a70006cb674d-00",
+        "traceparent": "00-74d0845b7d53264b8e603ab26f18f8e1-0de22a4af7ee2849-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": [
-          "88e5fc83-04c8-eb58-0bd7-14a22d99af3d",
-          "0390d4529ccffd85f1d3682c72d4ce93"
-        ],
+        "x-ms-client-request-id": "a214d70b-992d-3daf-52d4-9003cf9c85fd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "2121",
+        "Content-Length": "2122",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 03:18:10 GMT",
-        "elapsed-time": "87",
+        "Date": "Fri, 08 May 2020 07:02:59 GMT",
+        "elapsed-time": "13",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "bc98b395-c331-4175-91f8-7928c4dada25",
+        "request-id": "a214d70b-992d-3daf-52d4-9003cf9c85fd",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-xswopklx.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
-        "name": "jyhrmyol",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
+        "name": "sxyxrtqp",
         "status": "running",
         "lastResult": {
           "status": "success",
           "errorMessage": null,
-          "startTime": "2020-04-25T03:18:00.595Z",
-          "endTime": "2020-04-25T03:18:01.579Z",
+          "startTime": "2020-05-08T07:02:50.77Z",
+          "endTime": "2020-05-08T07:02:51.567Z",
           "itemsProcessed": 10,
           "itemsFailed": 0,
-          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00222020-04-25T03:17:10.365Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-25T03:18:00.595Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-25T03:17:30.5950233\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-25T03:17:30.5950233\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00222020-05-08T07:02:00.553Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-05-08T07:02:50.77Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-05-08T07:02:20.7709281\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-05-08T07:02:20.7709281\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
           "errors": [],
           "warnings": [],
           "metrics": null
@@ -392,12 +371,12 @@
           {
             "status": "success",
             "errorMessage": null,
-            "startTime": "2020-04-25T03:18:00.595Z",
-            "endTime": "2020-04-25T03:18:01.579Z",
+            "startTime": "2020-05-08T07:02:50.77Z",
+            "endTime": "2020-05-08T07:02:51.567Z",
             "itemsProcessed": 10,
             "itemsFailed": 0,
-            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00222020-04-25T03:17:10.365Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-25T03:18:00.595Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-25T03:17:30.5950233\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-25T03:17:30.5950233\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00222020-05-08T07:02:00.553Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-05-08T07:02:50.77Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-05-08T07:02:20.7709281\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-05-08T07:02:20.7709281\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
             "errors": [],
             "warnings": [],
             "metrics": null
@@ -405,12 +384,12 @@
           {
             "status": "success",
             "errorMessage": null,
-            "startTime": "2020-04-25T03:17:40.349Z",
-            "endTime": "2020-04-25T03:17:51.15Z",
+            "startTime": "2020-05-08T07:02:30.522Z",
+            "endTime": "2020-05-08T07:02:40.208Z",
             "itemsProcessed": 10,
             "itemsFailed": 0,
-            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-25T03:17:40.365Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-25T03:17:10.3655593\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-25T03:17:10.3655593\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-05-08T07:02:30.553Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-05-08T07:02:00.5534559\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-05-08T07:02:00.5534559\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
             "errors": [],
             "warnings": [],
             "metrics": null
@@ -424,19 +403,16 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-xswopklx.search.windows.net/indexes(\u0027tciydxfg\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fexlvtnn\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": [
-          "fdbe70a4-f146-9be0-16ce-cc6fed5127ff",
-          "319b1f5e508fe75077e796f49c2b7937"
-        ],
+        "x-ms-client-request-id": "6fccce16-51ed-ff27-5e1f-9b318f5050e7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -445,29 +421,52 @@
         "Cache-Control": "no-cache",
         "Content-Length": "5",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 03:18:10 GMT",
-        "elapsed-time": "199",
+        "Date": "Fri, 08 May 2020 07:02:59 GMT",
+        "elapsed-time": "3",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "8f1c6a91-4017-4761-85bc-47c89400aba5",
+        "request-id": "6fccce16-51ed-ff27-5e1f-9b318f5050e7",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": "\uFEFF10"
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fexlvtnn\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-c5e2b950bfa9104ea99a2492b86ab9a1-75b2e928f2071e49-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "00ecf5f415cfa010ac68ce52389c0353",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:02:59 GMT",
+        "elapsed-time": "168",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "00ecf5f4-15cf-a010-ac68-ce52389c0353",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "BlobContainerName": "gdnixkxc",
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
+    "BlobContainerName": "uangflsr",
     "RandomSeed": "1401021797",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "tciydxfg",
-    "SearchServiceName": "azs-net-xswopklx",
+    "SearchIndexName": "fexlvtnn",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2",
     "SEARCH_STORAGE_KEY": "Sanitized",
-    "SEARCH_STORAGE_NAME": "heathsrchstg",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SEARCH_STORAGE_NAME": "heathsearch2stg"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/CreateAzureBlobIndexerAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/CreateAzureBlobIndexerAsync.json
@@ -1,32 +1,29 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-fybcplca.search.windows.net/datasources?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/datasources?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "Content-Length": "220",
+        "Content-Length": "219",
         "Content-Type": "application/json",
-        "traceparent": "00-fd3ec9b3b8055b448ba68685868844ac-3c48246be59de942-00",
+        "traceparent": "00-542f3c5ac1cc6b49ad752b3dc8830b5c-8c9f2f9bc4484c4f-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": [
-          "f5274433-118f-9bbb-7697-416dfa14a0bf",
-          "fecd81e5c16edf0a09487bc3f8404bc1"
-        ],
+        "x-ms-client-request-id": "6d419776-14fa-bfa0-e581-cdfe6ec10adf",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "heathsrchstg",
+        "name": "tnufhitt",
         "type": "azureblob",
         "credentials": {
-          "connectionString": "DefaultEndpointsProtocol=https;AccountName=heathsrchstg;AccountKey=Sanitized;EndpointSuffix=core.windows.net"
+          "connectionString": "DefaultEndpointsProtocol=https;AccountName=heathsearch2stg;AccountKey=Sanitized;EndpointSuffix=core.windows.net"
         },
         "container": {
-          "name": "fivqpvsq"
+          "name": "ftnpmwkr"
         }
       },
       "StatusCode": 201,
@@ -34,21 +31,21 @@
         "Cache-Control": "no-cache",
         "Content-Length": "360",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 03:18:39 GMT",
-        "elapsed-time": "80",
-        "ETag": "W/\u00220x8D7E8C759A5744A\u0022",
+        "Date": "Fri, 08 May 2020 07:03:48 GMT",
+        "elapsed-time": "55",
+        "ETag": "W/\u00220x8D7F31DF4AE5517\u0022",
         "Expires": "-1",
-        "Location": "https://azs-net-fybcplca.search.windows.net/datasources(\u0027heathsrchstg\u0027)?api-version=2019-05-06-Preview",
+        "Location": "https://azs-net-heathsearch2.search.windows.net/datasources(\u0027tnufhitt\u0027)?api-version=2019-05-06-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "4ff789b0-1791-48fd-b428-e73dca7d8ecb",
+        "request-id": "6d419776-14fa-bfa0-e581-cdfe6ec10adf",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-fybcplca.search.windows.net/$metadata#datasources/$entity",
-        "@odata.etag": "\u00220x8D7E8C759A5744A\u0022",
-        "name": "heathsrchstg",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#datasources/$entity",
+        "@odata.etag": "\u00220x8D7F31DF4AE5517\u0022",
+        "name": "tnufhitt",
         "description": null,
         "type": "azureblob",
         "subtype": null,
@@ -56,7 +53,7 @@
           "connectionString": null
         },
         "container": {
-          "name": "fivqpvsq",
+          "name": "ftnpmwkr",
           "query": null
         },
         "dataChangeDetectionPolicy": null,
@@ -64,53 +61,50 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-fybcplca.search.windows.net/indexers?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexers?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "Content-Length": "80",
+        "Content-Length": "76",
         "Content-Type": "application/json",
-        "traceparent": "00-78ab0b54e65d0240b2d2ce037c893421-bcbaa008f6d8ac4b-00",
+        "traceparent": "00-1028ffa7e7d6d74aac33b357db444c9a-47f26bd611ca5240-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": [
-          "95f4308e-5178-81a5-43c1-6d586f0e5c71",
-          "46eb4839f89535a24b7f2b1c3061ef95"
-        ],
+        "x-ms-client-request-id": "586dc143-0e6f-715c-3948-eb4695f8a235",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "jgiorpcc",
-        "dataSourceName": "heathsrchstg",
-        "targetIndexName": "rmksbebb"
+        "name": "aeermkkh",
+        "dataSourceName": "tnufhitt",
+        "targetIndexName": "fsfjbuge"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "354",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 03:18:41 GMT",
-        "elapsed-time": "1666",
-        "ETag": "W/\u00220x8D7E8C75A8B9F46\u0022",
+        "Date": "Fri, 08 May 2020 07:03:48 GMT",
+        "elapsed-time": "199",
+        "ETag": "W/\u00220x8D7F31DF4C711AE\u0022",
         "Expires": "-1",
-        "Location": "https://azs-net-fybcplca.search.windows.net/indexers(\u0027jgiorpcc\u0027)?api-version=2019-05-06-Preview",
+        "Location": "https://azs-net-heathsearch2.search.windows.net/indexers(\u0027aeermkkh\u0027)?api-version=2019-05-06-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "5ca53712-9db5-4bb9-bd36-bb6b20a65477",
+        "request-id": "586dc143-0e6f-715c-3948-eb4695f8a235",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-fybcplca.search.windows.net/$metadata#indexers/$entity",
-        "@odata.etag": "\u00220x8D7E8C75A8B9F46\u0022",
-        "name": "jgiorpcc",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#indexers/$entity",
+        "@odata.etag": "\u00220x8D7F31DF4C711AE\u0022",
+        "name": "aeermkkh",
         "description": null,
-        "dataSourceName": "heathsrchstg",
+        "dataSourceName": "tnufhitt",
         "skillsetName": null,
-        "targetIndexName": "rmksbebb",
+        "targetIndexName": "fsfjbuge",
         "disabled": null,
         "schedule": null,
         "parameters": null,
@@ -120,58 +114,55 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-fybcplca.search.windows.net/indexers(\u0027jgiorpcc\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexers(\u0027aeermkkh\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "Content-Length": "206",
+        "Content-Length": "202",
         "Content-Type": "application/json",
-        "If-Match": "\u00220x8D7E8C75A8B9F46\u0022",
+        "If-Match": "\u00220x8D7F31DF4C711AE\u0022",
         "Prefer": "return=representation",
-        "traceparent": "00-1abde3252c281f4da00f1eef1e14b8db-8d78f03ba577674d-00",
+        "traceparent": "00-69595e3dac00b040845a8797707e44c9-93eda3b7a6333d4e-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": [
-          "3e70dbe5-75cd-b767-a3fa-8037d2f25133",
-          "870572815563955c8dbe49f8268950e1"
-        ],
+        "x-ms-client-request-id": "3780faa3-f2d2-3351-8172-058763555c95",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "name": "jgiorpcc",
+        "name": "aeermkkh",
         "description": "Updated description",
-        "dataSourceName": "heathsrchstg",
-        "targetIndexName": "rmksbebb",
+        "dataSourceName": "tnufhitt",
+        "targetIndexName": "fsfjbuge",
         "fieldMappings": [],
         "outputFieldMappings": [],
-        "@odata.etag": "\u00220x8D7E8C75A8B9F46\u0022"
+        "@odata.etag": "\u00220x8D7F31DF4C711AE\u0022"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "371",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 03:18:41 GMT",
-        "elapsed-time": "116",
-        "ETag": "W/\u00220x8D7E8C75AC11427\u0022",
+        "Date": "Fri, 08 May 2020 07:03:48 GMT",
+        "elapsed-time": "99",
+        "ETag": "W/\u00220x8D7F31DF4E8A97B\u0022",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "4867885b-2169-4b22-941a-3b748b564b13",
+        "request-id": "3780faa3-f2d2-3351-8172-058763555c95",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-fybcplca.search.windows.net/$metadata#indexers/$entity",
-        "@odata.etag": "\u00220x8D7E8C75AC11427\u0022",
-        "name": "jgiorpcc",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#indexers/$entity",
+        "@odata.etag": "\u00220x8D7F31DF4E8A97B\u0022",
+        "name": "aeermkkh",
         "description": "Updated description",
-        "dataSourceName": "heathsrchstg",
+        "dataSourceName": "tnufhitt",
         "skillsetName": null,
-        "targetIndexName": "rmksbebb",
+        "targetIndexName": "fsfjbuge",
         "disabled": null,
         "schedule": null,
         "parameters": null,
@@ -181,20 +172,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-fybcplca.search.windows.net/indexers(\u0027jgiorpcc\u0027)/search.status?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexers(\u0027aeermkkh\u0027)/search.status?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-af5551c60ca0b943975e1388ea00f981-b0900be071a1d348-00",
+        "traceparent": "00-3dce2bd08f8e6c408b902952df7967ae-ba85748afd7fd94c-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": [
-          "9473d8d1-1e9d-c4a4-e034-a39a776a6359",
-          "be9af72e685c8f317edab00f2b6e911a"
-        ],
+        "x-ms-client-request-id": "9aa334e0-6a77-5963-2ef7-9abe5c68318f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -203,28 +191,28 @@
         "Cache-Control": "no-cache",
         "Content-Length": "1517",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 03:18:51 GMT",
-        "elapsed-time": "19",
+        "Date": "Fri, 08 May 2020 07:03:58 GMT",
+        "elapsed-time": "18",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "03206a81-c929-426e-829a-2be55c25d9a6",
+        "request-id": "9aa334e0-6a77-5963-2ef7-9abe5c68318f",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-fybcplca.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
-        "name": "jgiorpcc",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
+        "name": "aeermkkh",
         "status": "running",
         "lastResult": {
           "status": "success",
           "errorMessage": null,
-          "startTime": "2020-04-25T03:18:44.256Z",
-          "endTime": "2020-04-25T03:18:46.131Z",
+          "startTime": "2020-05-08T07:03:51.504Z",
+          "endTime": "2020-05-08T07:03:52.02Z",
           "itemsProcessed": 10,
           "itemsFailed": 0,
-          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-25T03:18:44.272Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-25T03:18:14.2722955\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-25T03:18:14.2722955\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-05-08T07:03:51.52Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-05-08T07:03:21.5202412\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-05-08T07:03:21.5202412\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
           "errors": [],
           "warnings": [],
           "metrics": null
@@ -233,12 +221,12 @@
           {
             "status": "success",
             "errorMessage": null,
-            "startTime": "2020-04-25T03:18:44.256Z",
-            "endTime": "2020-04-25T03:18:46.131Z",
+            "startTime": "2020-05-08T07:03:51.504Z",
+            "endTime": "2020-05-08T07:03:52.02Z",
             "itemsProcessed": 10,
             "itemsFailed": 0,
-            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-25T03:18:44.272Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-25T03:18:14.2722955\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-25T03:18:14.2722955\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-05-08T07:03:51.52Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-05-08T07:03:21.5202412\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-05-08T07:03:21.5202412\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
             "errors": [],
             "warnings": [],
             "metrics": null
@@ -252,20 +240,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-fybcplca.search.windows.net/indexers(\u0027jgiorpcc\u0027)/search.run?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexers(\u0027aeermkkh\u0027)/search.run?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-3802ce9cd319a0448250a882ceab13c7-34fea66e8daddb41-00",
+        "traceparent": "00-be167dcc80c5ea47a2b710021161469c-ae2b0d7220788842-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": [
-          "fa669ea9-bc7e-6395-ce40-a62fb1c11d22",
-          "2ecaef5b92ee6985a6e416c36d959872"
-        ],
+        "x-ms-client-request-id": "2fa640ce-c1b1-221d-5bef-ca2eee928569",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -273,60 +258,57 @@
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
         "Content-Length": "0",
-        "Date": "Sat, 25 Apr 2020 03:18:51 GMT",
-        "elapsed-time": "68",
+        "Date": "Fri, 08 May 2020 07:03:58 GMT",
+        "elapsed-time": "44",
         "Expires": "-1",
         "Pragma": "no-cache",
-        "request-id": "f28b5071-8037-4368-9002-98f4314ef2d5",
+        "request-id": "2fa640ce-c1b1-221d-5bef-ca2eee928569",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://azs-net-fybcplca.search.windows.net/indexers(\u0027jgiorpcc\u0027)/search.status?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexers(\u0027aeermkkh\u0027)/search.status?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-771c043de544f549a0c21ccd1fd52d7e-d9826ad023459748-00",
+        "traceparent": "00-73f09becf5fe8847a1a6a5971c291387-486b4b6e7673254d-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": [
-          "d9f089a2-6804-71db-6137-f01bc102ddbc",
-          "3bb38ebc63a4172b19fd5499a6d2f539"
-        ],
+        "x-ms-client-request-id": "1bf03761-02c1-bcdd-bc8e-b33ba4632b17",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "2120",
+        "Content-Length": "1323",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 03:19:00 GMT",
-        "elapsed-time": "27",
+        "Date": "Fri, 08 May 2020 07:04:08 GMT",
+        "elapsed-time": "57",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "cddb385b-8879-4050-81bb-cbb8cb1dd84c",
+        "request-id": "1bf03761-02c1-bcdd-bc8e-b33ba4632b17",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-fybcplca.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
-        "name": "jgiorpcc",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
+        "name": "aeermkkh",
         "status": "running",
         "lastResult": {
-          "status": "success",
+          "status": "inProgress",
           "errorMessage": null,
-          "startTime": "2020-04-25T03:18:54.605Z",
-          "endTime": "2020-04-25T03:18:55.48Z",
-          "itemsProcessed": 10,
+          "startTime": "2020-05-08T07:04:02.046Z",
+          "endTime": null,
+          "itemsProcessed": 0,
           "itemsFailed": 0,
-          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00222020-04-25T03:18:14.272Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-25T03:18:54.621Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-25T03:18:24.6212683\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-25T03:18:24.6212683\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+          "initialTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-05-08T07:03:21.5202412\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-05-08T07:03:21.5202412\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+          "finalTrackingState": null,
           "errors": [],
           "warnings": [],
           "metrics": null
@@ -335,25 +317,12 @@
           {
             "status": "success",
             "errorMessage": null,
-            "startTime": "2020-04-25T03:18:54.605Z",
-            "endTime": "2020-04-25T03:18:55.48Z",
+            "startTime": "2020-05-08T07:03:51.504Z",
+            "endTime": "2020-05-08T07:03:52.02Z",
             "itemsProcessed": 10,
             "itemsFailed": 0,
-            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00222020-04-25T03:18:14.272Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-25T03:18:54.621Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-25T03:18:24.6212683\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-25T03:18:24.6212683\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
-            "errors": [],
-            "warnings": [],
-            "metrics": null
-          },
-          {
-            "status": "success",
-            "errorMessage": null,
-            "startTime": "2020-04-25T03:18:44.256Z",
-            "endTime": "2020-04-25T03:18:46.131Z",
-            "itemsProcessed": 10,
-            "itemsFailed": 0,
-            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-04-25T03:18:44.272Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
-            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-04-25T03:18:14.2722955\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-04-25T03:18:14.2722955\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-05-08T07:03:51.52Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-05-08T07:03:21.5202412\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-05-08T07:03:21.5202412\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
             "errors": [],
             "warnings": [],
             "metrics": null
@@ -367,19 +336,97 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-fybcplca.search.windows.net/indexes(\u0027rmksbebb\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexers(\u0027aeermkkh\u0027)/search.status?api-version=2019-05-06-Preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-9b3adeade462ca4cb3d2d2ec1200a213-7bfb584ac0529544-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "b6cc5814-69a2-a4a8-0659-06dfe15dcd3e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Length": "2122",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Fri, 08 May 2020 07:04:18 GMT",
+        "elapsed-time": "17",
+        "Expires": "-1",
+        "OData-Version": "4.0",
+        "Pragma": "no-cache",
+        "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
+        "request-id": "b6cc5814-69a2-a4a8-0659-06dfe15dcd3e",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.IndexerExecutionInfo",
+        "name": "aeermkkh",
+        "status": "running",
+        "lastResult": {
+          "status": "success",
+          "errorMessage": null,
+          "startTime": "2020-05-08T07:04:02.062Z",
+          "endTime": "2020-05-08T07:04:12.248Z",
+          "itemsProcessed": 10,
+          "itemsFailed": 0,
+          "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00222020-05-08T07:03:21.52Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-05-08T07:04:02.124Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+          "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-05-08T07:03:32.1249372\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-05-08T07:03:32.1249372\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+          "errors": [],
+          "warnings": [],
+          "metrics": null
+        },
+        "executionHistory": [
+          {
+            "status": "success",
+            "errorMessage": null,
+            "startTime": "2020-05-08T07:04:02.062Z",
+            "endTime": "2020-05-08T07:04:12.248Z",
+            "itemsProcessed": 10,
+            "itemsFailed": 0,
+            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00222020-05-08T07:03:21.52Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-05-08T07:04:02.124Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-05-08T07:03:32.1249372\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-05-08T07:03:32.1249372\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+            "errors": [],
+            "warnings": [],
+            "metrics": null
+          },
+          {
+            "status": "success",
+            "errorMessage": null,
+            "startTime": "2020-05-08T07:03:51.504Z",
+            "endTime": "2020-05-08T07:03:52.02Z",
+            "itemsProcessed": 10,
+            "itemsFailed": 0,
+            "initialTrackingState": "{\r\n  \u0022lastFullEnumerationStartTime\u0022: \u00220001-01-01T00:00:00Z\u0022,\r\n  \u0022lastAttemptedEnumerationStartTime\u0022: \u00222020-05-08T07:03:51.52Z\u0022,\r\n  \u0022nameHighWaterMark\u0022: null\r\n}",
+            "finalTrackingState": "{\u0022LastFullEnumerationStartTime\u0022:\u00222020-05-08T07:03:21.5202412\u002B00:00\u0022,\u0022LastAttemptedEnumerationStartTime\u0022:\u00222020-05-08T07:03:21.5202412\u002B00:00\u0022,\u0022NameHighWaterMark\u0022:null}",
+            "errors": [],
+            "warnings": [],
+            "metrics": null
+          }
+        ],
+        "limits": {
+          "maxRunTime": "PT2M",
+          "maxDocumentExtractionSize": 16777216,
+          "maxDocumentContentCharactersToExtract": 32768
+        }
+      }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fsfjbuge\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
-        "x-ms-client-request-id": [
-          "288d34a7-44d1-f21e-1458-ccb6a269a8a4",
-          "df0659065de13ecd5dd9c0071441ca8f"
-        ],
+        "x-ms-client-request-id": "4b27c070-7596-af75-54af-934ccc16574a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -388,29 +435,52 @@
         "Cache-Control": "no-cache",
         "Content-Length": "5",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 03:19:01 GMT",
-        "elapsed-time": "203",
+        "Date": "Fri, 08 May 2020 07:04:18 GMT",
+        "elapsed-time": "52",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
-        "request-id": "1203c6ab-393b-44e0-8a9b-cbf3d13cc2f9",
+        "request-id": "4b27c070-7596-af75-54af-934ccc16574a",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": "\uFEFF10"
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fsfjbuge\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-84080885e97dfa4c9296b98869339538-036d27654f39ef43-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "206e8d6e8135e7a86310b264ae7ec32b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:04:18 GMT",
+        "elapsed-time": "165",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "206e8d6e-8135-e7a8-6310-b264ae7ec32b",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "BlobContainerName": "fivqpvsq",
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
+    "BlobContainerName": "ftnpmwkr",
     "RandomSeed": "939854059",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "rmksbebb",
-    "SearchServiceName": "azs-net-fybcplca",
+    "SearchIndexName": "fsfjbuge",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2",
     "SEARCH_STORAGE_KEY": "Sanitized",
-    "SEARCH_STORAGE_NAME": "heathsrchstg",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SEARCH_STORAGE_NAME": "heathsearch2stg"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/CreateIndex.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/CreateIndex.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-qjxgjbyv.search.windows.net/indexes?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
         "Content-Length": "4032",
         "Content-Type": "application/json",
-        "traceparent": "00-0f6d64d25f502f489c792de36dd6a4f4-24701031b630d841-00",
+        "traceparent": "00-abda30517e26cd409b93a7cde976e642-4b06b30bfe8bf34c-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "5cad1ef4d125aded2bffeebfd431dec8",
         "x-ms-return-client-request-id": "true"
@@ -307,13 +307,13 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "6158",
+        "Content-Length": "6162",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 01:16:04 GMT",
-        "elapsed-time": "2221",
-        "ETag": "W/\u00220x8D7E8B63A28F0FD\u0022",
+        "Date": "Fri, 08 May 2020 07:03:00 GMT",
+        "elapsed-time": "779",
+        "ETag": "W/\u00220x8D7F31DD847747B\u0022",
         "Expires": "-1",
-        "Location": "https://azs-net-qjxgjbyv.search.windows.net/indexes(\u0027wvhobppu\u0027)?api-version=2019-05-06-Preview",
+        "Location": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027wvhobppu\u0027)?api-version=2019-05-06-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
@@ -321,8 +321,8 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-qjxgjbyv.search.windows.net/$metadata#indexes/$entity",
-        "@odata.etag": "\u00220x8D7E8B63A28F0FD\u0022",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#indexes/$entity",
+        "@odata.etag": "\u00220x8D7F31DD847747B\u0022",
         "name": "wvhobppu",
         "defaultScoringProfile": null,
         "fields": [
@@ -715,15 +715,39 @@
         "encryptionKey": null,
         "similarity": null
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027wvhobppu\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-01e4c841192ed34aa0344418befe77ea-105f552332881b40-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "d6e52008fe3a95c5a76f10680172906f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:03:00 GMT",
+        "elapsed-time": "267",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "d6e52008-fe3a-95c5-a76f-10680172906f",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "96077012",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchServiceName": "azs-net-qjxgjbyv",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "wvhobppu",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/CreateIndexAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/CreateIndexAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-xseyhyuo.search.windows.net/indexes?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
         "Content-Length": "4032",
         "Content-Type": "application/json",
-        "traceparent": "00-544e07bbc41e774786de548e8b529519-b6ee86b57ccee041-00",
+        "traceparent": "00-bcb645e649be7949912750ad0edee65a-cd8675044cd9d045-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "aa80379a73db164d8f4210e420ecefbc",
         "x-ms-return-client-request-id": "true"
@@ -307,13 +307,13 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "6158",
+        "Content-Length": "6162",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 01:17:37 GMT",
-        "elapsed-time": "1281",
-        "ETag": "W/\u00220x8D7E8B6712162AC\u0022",
+        "Date": "Fri, 08 May 2020 07:04:18 GMT",
+        "elapsed-time": "446",
+        "ETag": "W/\u00220x8D7F31E076CECE9\u0022",
         "Expires": "-1",
-        "Location": "https://azs-net-xseyhyuo.search.windows.net/indexes(\u0027tkubrcbf\u0027)?api-version=2019-05-06-Preview",
+        "Location": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027tkubrcbf\u0027)?api-version=2019-05-06-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
@@ -321,8 +321,8 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-xseyhyuo.search.windows.net/$metadata#indexes/$entity",
-        "@odata.etag": "\u00220x8D7E8B6712162AC\u0022",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#indexes/$entity",
+        "@odata.etag": "\u00220x8D7F31E076CECE9\u0022",
         "name": "tkubrcbf",
         "defaultScoringProfile": null,
         "fields": [
@@ -715,15 +715,39 @@
         "encryptionKey": null,
         "similarity": null
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027tkubrcbf\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-f41eaf643ac63040a69296b2b0430335-e7142f9ca1fc994b-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "48422d284ea7facf3728c9c3bc301ed9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:04:19 GMT",
+        "elapsed-time": "314",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "48422d28-4ea7-facf-3728-c9c3bc301ed9",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1121409174",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchServiceName": "azs-net-xseyhyuo",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "tkubrcbf",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/CrudSynonymMaps.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/CrudSynonymMaps.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/synonymmaps?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
         "Content-Length": "69",
         "Content-Type": "application/json",
-        "traceparent": "00-62ebef1327ee2e41a115f776984d6e49-9bdbe539d90c3943-00",
+        "traceparent": "00-aaebb1d130393c44b85181d0fcfdb39c-1ec83782d9258940-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200420.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "e774d64a0e1ee1ed26d81ec8b16be261",
         "x-ms-return-client-request-id": "true"
@@ -24,13 +24,13 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "216",
+        "Content-Length": "220",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Tue, 21 Apr 2020 03:13:22 GMT",
-        "elapsed-time": "71",
-        "ETag": "W/\u00220x8D7E5A1F324FEDE\u0022",
+        "Date": "Fri, 08 May 2020 07:03:00 GMT",
+        "elapsed-time": "73",
+        "ETag": "W/\u00220x8D7F31DD891D15D\u0022",
         "Expires": "-1",
-        "Location": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps(\u0027vsluedsr\u0027)?api-version=2019-05-06-Preview",
+        "Location": "https://azs-net-heathsearch2.search.windows.net/synonymmaps(\u0027vsluedsr\u0027)?api-version=2019-05-06-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
@@ -38,8 +38,8 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-upjoqfhr.search.windows.net/$metadata#synonymmaps/$entity",
-        "@odata.etag": "\u00220x8D7E5A1F324FEDE\u0022",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#synonymmaps/$entity",
+        "@odata.etag": "\u00220x8D7F31DD891D15D\u0022",
         "name": "vsluedsr",
         "format": "solr",
         "synonyms": "msft=\u003EMicrosoft",
@@ -47,19 +47,19 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps(\u0027vsluedsr\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/synonymmaps(\u0027vsluedsr\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
         "Content-Length": "118",
         "Content-Type": "application/json",
-        "If-Match": "\u00220x8D7E5A1F324FEDE\u0022",
+        "If-Match": "\u00220x8D7F31DD891D15D\u0022",
         "Prefer": "return=representation",
-        "traceparent": "00-4b420d5ce49aa04088a43880eacc0faa-e20acb1dbb02964c-00",
+        "traceparent": "00-0386b09e48390e4e8409216a3a8d0585-5e094b5d5fbb014d-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200420.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "890ba43bad9d8bc6db7ea8d0f34ce722",
         "x-ms-return-client-request-id": "true"
@@ -68,16 +68,16 @@
         "name": "vsluedsr",
         "format": "solr",
         "synonyms": "ms,msft=\u003EMicrosoft",
-        "@odata.etag": "\u00220x8D7E5A1F324FEDE\u0022"
+        "@odata.etag": "\u00220x8D7F31DD891D15D\u0022"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "219",
+        "Content-Length": "223",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Tue, 21 Apr 2020 03:13:22 GMT",
-        "elapsed-time": "29",
-        "ETag": "W/\u00220x8D7E5A1F339C315\u0022",
+        "Date": "Fri, 08 May 2020 07:03:00 GMT",
+        "elapsed-time": "18",
+        "ETag": "W/\u00220x8D7F31DD8A29D42\u0022",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -86,8 +86,8 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-upjoqfhr.search.windows.net/$metadata#synonymmaps/$entity",
-        "@odata.etag": "\u00220x8D7E5A1F339C315\u0022",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#synonymmaps/$entity",
+        "@odata.etag": "\u00220x8D7F31DD8A29D42\u0022",
         "name": "vsluedsr",
         "format": "solr",
         "synonyms": "ms,msft=\u003EMicrosoft",
@@ -95,19 +95,19 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps(\u0027vsluedsr\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/synonymmaps(\u0027vsluedsr\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
         "Content-Length": "118",
         "Content-Type": "application/json",
-        "If-Match": "\u00220x8D7E5A1F324FEDE\u0022",
+        "If-Match": "\u00220x8D7F31DD891D15D\u0022",
         "Prefer": "return=representation",
-        "traceparent": "00-8da18b0ae64d514397d0c835f0e18b69-dc3cb00c8970ee4c-00",
+        "traceparent": "00-ced9f0aa3eac4240b2704950b5c318f2-37011c8c414bad40-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200420.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "d6d9fa27c35a394621cb45794f7a1697",
         "x-ms-return-client-request-id": "true"
@@ -116,7 +116,7 @@
         "name": "vsluedsr",
         "format": "solr",
         "synonyms": "ms,msft=\u003EMicrosoft",
-        "@odata.etag": "\u00220x8D7E5A1F324FEDE\u0022"
+        "@odata.etag": "\u00220x8D7F31DD891D15D\u0022"
       },
       "StatusCode": 412,
       "ResponseHeaders": {
@@ -124,8 +124,8 @@
         "Content-Language": "en",
         "Content-Length": "160",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Tue, 21 Apr 2020 03:13:22 GMT",
-        "elapsed-time": "9",
+        "Date": "Fri, 08 May 2020 07:03:00 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -141,14 +141,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps?$select=name\u0026api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/synonymmaps?$select=name\u0026api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-6be419ea39ca964394f95689fca1ab0f-a4f87dab9a100549-00",
+        "traceparent": "00-bd170f1bfaeb374c95de533a204be1c9-1851e50bf2d67d48-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200420.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "9a86040cbd479da90fe80c9f661deeda",
         "x-ms-return-client-request-id": "true"
@@ -157,10 +158,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "122",
-        "Content-Type": "application/json; odata.metadata=minimal; odata.streaming=true",
-        "Date": "Tue, 21 Apr 2020 03:13:22 GMT",
-        "elapsed-time": "93",
+        "Content-Length": "126",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Fri, 08 May 2020 07:03:00 GMT",
+        "elapsed-time": "7",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -169,7 +170,7 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-upjoqfhr.search.windows.net/$metadata#synonymmaps(name)",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#synonymmaps(name)",
         "value": [
           {
             "name": "vsluedsr"
@@ -178,15 +179,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps(\u0027vsluedsr\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/synonymmaps(\u0027vsluedsr\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-75a2a36bc870834fabb36847d6ac726d-ac402f3d3ab2d64b-00",
+        "traceparent": "00-b73c7fea1d03894097fda00aab1d51e5-9eb902130641cf48-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200420.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "b7a0fcf00c9278065ed268d2674c3c60",
         "x-ms-return-client-request-id": "true"
@@ -195,11 +196,11 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "219",
-        "Content-Type": "application/json; odata.metadata=minimal; odata.streaming=true",
-        "Date": "Tue, 21 Apr 2020 03:13:22 GMT",
-        "elapsed-time": "26",
-        "ETag": "W/\u00220x8D7E5A1F339C315\u0022",
+        "Content-Length": "223",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Fri, 08 May 2020 07:03:00 GMT",
+        "elapsed-time": "6",
+        "ETag": "W/\u00220x8D7F31DD8A29D42\u0022",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -208,8 +209,8 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-upjoqfhr.search.windows.net/$metadata#synonymmaps/$entity",
-        "@odata.etag": "\u00220x8D7E5A1F339C315\u0022",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#synonymmaps/$entity",
+        "@odata.etag": "\u00220x8D7F31DD8A29D42\u0022",
         "name": "vsluedsr",
         "format": "solr",
         "synonyms": "ms,msft=\u003EMicrosoft",
@@ -217,16 +218,16 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps(\u0027vsluedsr\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/synonymmaps(\u0027vsluedsr\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "If-Match": "\u00220x8D7E5A1F339C315\u0022",
-        "traceparent": "00-f70e9f287e8cae4faa92d16c6d583a6c-545c8a684179b748-00",
+        "If-Match": "\u00220x8D7F31DD8A29D42\u0022",
+        "traceparent": "00-1e6c604e2aecca47bf9c93723c66b1d8-e3fc0738ddfb2d4d-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200420.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "efc311684dc569da513cc771b7a7d304",
         "x-ms-return-client-request-id": "true"
@@ -235,8 +236,8 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Tue, 21 Apr 2020 03:13:22 GMT",
-        "elapsed-time": "25",
+        "Date": "Fri, 08 May 2020 07:03:00 GMT",
+        "elapsed-time": "10",
         "Expires": "-1",
         "Pragma": "no-cache",
         "request-id": "efc31168-4dc5-69da-513c-c771b7a7d304",
@@ -247,7 +248,8 @@
   ],
   "Variables": {
     "RandomSeed": "1266633341",
-    "SearchIndexName": "tobsblqg",
-    "SearchServiceName": "azs-net-upjoqfhr"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/CrudSynonymMapsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/CrudSynonymMapsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/synonymmaps?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
         "Content-Length": "69",
         "Content-Type": "application/json",
-        "traceparent": "00-7f727d4e9cd7b04398a55987ed64d08b-53c9f4d83f256e42-00",
+        "traceparent": "00-7d6912ada1a58b4aac5a6d2d9c43335f-d835ed9fb306f541-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200420.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "c02069d540fd192627e03b9f134bed62",
         "x-ms-return-client-request-id": "true"
@@ -24,13 +24,13 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "216",
+        "Content-Length": "220",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Tue, 21 Apr 2020 03:13:23 GMT",
+        "Date": "Fri, 08 May 2020 07:04:19 GMT",
         "elapsed-time": "20",
-        "ETag": "W/\u00220x8D7E5A1F38CACFD\u0022",
+        "ETag": "W/\u00220x8D7F31E07B4FF4F\u0022",
         "Expires": "-1",
-        "Location": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps(\u0027byaqwdpt\u0027)?api-version=2019-05-06-Preview",
+        "Location": "https://azs-net-heathsearch2.search.windows.net/synonymmaps(\u0027byaqwdpt\u0027)?api-version=2019-05-06-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
@@ -38,8 +38,8 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-upjoqfhr.search.windows.net/$metadata#synonymmaps/$entity",
-        "@odata.etag": "\u00220x8D7E5A1F38CACFD\u0022",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#synonymmaps/$entity",
+        "@odata.etag": "\u00220x8D7F31E07B4FF4F\u0022",
         "name": "byaqwdpt",
         "format": "solr",
         "synonyms": "msft=\u003EMicrosoft",
@@ -47,19 +47,19 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps(\u0027byaqwdpt\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/synonymmaps(\u0027byaqwdpt\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
         "Content-Length": "118",
         "Content-Type": "application/json",
-        "If-Match": "\u00220x8D7E5A1F38CACFD\u0022",
+        "If-Match": "\u00220x8D7F31E07B4FF4F\u0022",
         "Prefer": "return=representation",
-        "traceparent": "00-7e6dd551d4aee1429c39aa5959ed78c1-6dea2a5606785246-00",
+        "traceparent": "00-d6a2479e7bb18b45bab678775bccedff-a5708ae4dd7ab44d-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200420.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "0b9c28133e0e9e04f52c78921f0b1fc4",
         "x-ms-return-client-request-id": "true"
@@ -68,16 +68,16 @@
         "name": "byaqwdpt",
         "format": "solr",
         "synonyms": "ms,msft=\u003EMicrosoft",
-        "@odata.etag": "\u00220x8D7E5A1F38CACFD\u0022"
+        "@odata.etag": "\u00220x8D7F31E07B4FF4F\u0022"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "219",
+        "Content-Length": "223",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Tue, 21 Apr 2020 03:13:23 GMT",
+        "Date": "Fri, 08 May 2020 07:04:19 GMT",
         "elapsed-time": "19",
-        "ETag": "W/\u00220x8D7E5A1F393B326\u0022",
+        "ETag": "W/\u00220x8D7F31E07BE4FCA\u0022",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -86,8 +86,8 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-upjoqfhr.search.windows.net/$metadata#synonymmaps/$entity",
-        "@odata.etag": "\u00220x8D7E5A1F393B326\u0022",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#synonymmaps/$entity",
+        "@odata.etag": "\u00220x8D7F31E07BE4FCA\u0022",
         "name": "byaqwdpt",
         "format": "solr",
         "synonyms": "ms,msft=\u003EMicrosoft",
@@ -95,19 +95,19 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps(\u0027byaqwdpt\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/synonymmaps(\u0027byaqwdpt\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
         "Content-Length": "118",
         "Content-Type": "application/json",
-        "If-Match": "\u00220x8D7E5A1F38CACFD\u0022",
+        "If-Match": "\u00220x8D7F31E07B4FF4F\u0022",
         "Prefer": "return=representation",
-        "traceparent": "00-02be3532633a38418ddda521ef20e338-6341a4636372c340-00",
+        "traceparent": "00-1407448a177ec84d84a8d527ac1e50d1-82045627a852484a-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200420.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "36a22e1a3354ac4d565b1f8fdf1033d3",
         "x-ms-return-client-request-id": "true"
@@ -116,7 +116,7 @@
         "name": "byaqwdpt",
         "format": "solr",
         "synonyms": "ms,msft=\u003EMicrosoft",
-        "@odata.etag": "\u00220x8D7E5A1F38CACFD\u0022"
+        "@odata.etag": "\u00220x8D7F31E07B4FF4F\u0022"
       },
       "StatusCode": 412,
       "ResponseHeaders": {
@@ -124,8 +124,8 @@
         "Content-Language": "en",
         "Content-Length": "160",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Tue, 21 Apr 2020 03:13:23 GMT",
-        "elapsed-time": "52",
+        "Date": "Fri, 08 May 2020 07:04:19 GMT",
+        "elapsed-time": "29",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -141,14 +141,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps?$select=name\u0026api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/synonymmaps?$select=name\u0026api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-1597a7c9a9cf9346b23341451f5ed194-d707a95597fba84f-00",
+        "traceparent": "00-3f4aefe15db8d34f87fed6d26bdff039-a2ee0371545f5841-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200420.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "5043667597c197906482cad0c793f91b",
         "x-ms-return-client-request-id": "true"
@@ -157,9 +158,9 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "122",
-        "Content-Type": "application/json; odata.metadata=minimal; odata.streaming=true",
-        "Date": "Tue, 21 Apr 2020 03:13:23 GMT",
+        "Content-Length": "126",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Fri, 08 May 2020 07:04:19 GMT",
         "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -169,7 +170,7 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-upjoqfhr.search.windows.net/$metadata#synonymmaps(name)",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#synonymmaps(name)",
         "value": [
           {
             "name": "byaqwdpt"
@@ -178,15 +179,15 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps(\u0027byaqwdpt\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/synonymmaps(\u0027byaqwdpt\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-224b638cb0d54346904bea57b795f07b-eaa4973ec0757146-00",
+        "traceparent": "00-511d329689eeb34e92a631329a8e2581-3b26da6b52c7944b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200420.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "e58477c0b6a8df0ddbf0b5b31e74bee5",
         "x-ms-return-client-request-id": "true"
@@ -195,11 +196,11 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "219",
-        "Content-Type": "application/json; odata.metadata=minimal; odata.streaming=true",
-        "Date": "Tue, 21 Apr 2020 03:13:23 GMT",
-        "elapsed-time": "5",
-        "ETag": "W/\u00220x8D7E5A1F393B326\u0022",
+        "Content-Length": "223",
+        "Content-Type": "application/json; odata.metadata=minimal",
+        "Date": "Fri, 08 May 2020 07:04:19 GMT",
+        "elapsed-time": "6",
+        "ETag": "W/\u00220x8D7F31E07BE4FCA\u0022",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -208,8 +209,8 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-upjoqfhr.search.windows.net/$metadata#synonymmaps/$entity",
-        "@odata.etag": "\u00220x8D7E5A1F393B326\u0022",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#synonymmaps/$entity",
+        "@odata.etag": "\u00220x8D7F31E07BE4FCA\u0022",
         "name": "byaqwdpt",
         "format": "solr",
         "synonyms": "ms,msft=\u003EMicrosoft",
@@ -217,16 +218,16 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-upjoqfhr.search.windows.net/synonymmaps(\u0027byaqwdpt\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/synonymmaps(\u0027byaqwdpt\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "If-Match": "\u00220x8D7E5A1F393B326\u0022",
-        "traceparent": "00-78d477d2fa1a1d4ba479a1330da7acc7-d4e6a0ae0d1afa40-00",
+        "If-Match": "\u00220x8D7F31E07BE4FCA\u0022",
+        "traceparent": "00-84ebcecb4c192c409f613205a61243a2-22fb83f66f45894d-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200420.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "b81ca4f9cfc882029d0bd1d2687ce4c3",
         "x-ms-return-client-request-id": "true"
@@ -235,8 +236,8 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Date": "Tue, 21 Apr 2020 03:13:23 GMT",
-        "elapsed-time": "21",
+        "Date": "Fri, 08 May 2020 07:04:19 GMT",
+        "elapsed-time": "28",
         "Expires": "-1",
         "Pragma": "no-cache",
         "request-id": "b81ca4f9-cfc8-8202-9d0b-d1d2687ce4c3",
@@ -247,7 +248,8 @@
   ],
   "Variables": {
     "RandomSeed": "43964750",
-    "SearchIndexName": "tobsblqg",
-    "SearchServiceName": "azs-net-upjoqfhr"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/GetIndex.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/GetIndex.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-yrbgrolr.search.windows.net/indexes(\u0027ravlytke\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rcrcuyyi\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-055317ca7a1b5c4ba035709777355f35-8f3d69068f13b349-00",
+        "traceparent": "00-9db1deb195bcd646a8ec96155b87f999-14b688e7f2cf7b4c-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "7b47ca4dbdfaf4d11dfd7df45a34096b",
         "x-ms-return-client-request-id": "true"
@@ -18,11 +18,11 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "6158",
+        "Content-Length": "6162",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 01:16:34 GMT",
-        "elapsed-time": "28",
-        "ETag": "W/\u00220x8D7E8B63E0DD31F\u0022",
+        "Date": "Fri, 08 May 2020 07:03:23 GMT",
+        "elapsed-time": "59",
+        "ETag": "W/\u00220x8D7F31DD93D998A\u0022",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -31,9 +31,9 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-yrbgrolr.search.windows.net/$metadata#indexes/$entity",
-        "@odata.etag": "\u00220x8D7E8B63E0DD31F\u0022",
-        "name": "ravlytke",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#indexes/$entity",
+        "@odata.etag": "\u00220x8D7F31DD93D998A\u0022",
+        "name": "rcrcuyyi",
         "defaultScoringProfile": null,
         "fields": [
           {
@@ -425,16 +425,39 @@
         "encryptionKey": null,
         "similarity": null
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rcrcuyyi\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-8330dbe1455b284981a0a8e00f055d40-7431cc001930d845-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "15b88db1fcf0c9e0caab98d491df36f3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:03:23 GMT",
+        "elapsed-time": "239",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "15b88db1-fcf0-c9e0-caab-98d491df36f3",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "436223391",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "ravlytke",
-    "SearchServiceName": "azs-net-yrbgrolr",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "rcrcuyyi",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/GetIndexAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/GetIndexAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-twlpkfbv.search.windows.net/indexes(\u0027ssambgjc\u0027)?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027phhlkena\u0027)?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-332b527efbcdff4cac61cb9341964632-fa5163a9e08af44f-00",
+        "traceparent": "00-81fabbb268719646bd21424e6cb709f1-db4f9ea3a8ed0b4a-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "94327a2c77d31fee9f75b5eab600bb4c",
         "x-ms-return-client-request-id": "true"
@@ -18,11 +18,11 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "6158",
+        "Content-Length": "6162",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 01:18:05 GMT",
-        "elapsed-time": "53",
-        "ETag": "W/\u00220x8D7E8B6746C0263\u0022",
+        "Date": "Fri, 08 May 2020 07:04:42 GMT",
+        "elapsed-time": "44",
+        "ETag": "W/\u00220x8D7F31E08314A6A\u0022",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -31,9 +31,9 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-twlpkfbv.search.windows.net/$metadata#indexes/$entity",
-        "@odata.etag": "\u00220x8D7E8B6746C0263\u0022",
-        "name": "ssambgjc",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#indexes/$entity",
+        "@odata.etag": "\u00220x8D7F31E08314A6A\u0022",
+        "name": "phhlkena",
         "defaultScoringProfile": null,
         "fields": [
           {
@@ -425,16 +425,39 @@
         "encryptionKey": null,
         "similarity": null
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027phhlkena\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-7e3d95eb291d1e42877af05bf3d92c91-bcf103ad9b48804e-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "3745fe0db607234e2dfcad90fda52b74",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:04:42 GMT",
+        "elapsed-time": "201",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "3745fe0d-b607-234e-2dfc-ad90fda52b74",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "256342603",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "ssambgjc",
-    "SearchServiceName": "azs-net-twlpkfbv",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "phhlkena",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/GetIndexes.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/GetIndexes.json
@@ -1,14 +1,14 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes?$select=%2A\u0026api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes?$select=%2A\u0026api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "e88bbfcc516ee73040fb1420e7a9ee12",
         "x-ms-return-client-request-id": "true"
@@ -17,10 +17,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "6165",
+        "Content-Length": "8555",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 01:16:36 GMT",
-        "elapsed-time": "48",
+        "Date": "Fri, 08 May 2020 07:03:24 GMT",
+        "elapsed-time": "68",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -29,11 +29,168 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-jcswnkcn.search.windows.net/$metadata#indexes(*)",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#indexes(*)",
         "value": [
           {
-            "@odata.etag": "\u00220x8D7E8B26C195970\u0022",
-            "name": "mesaejwj",
+            "@odata.etag": "\u00220x8D7F31DA513EDAE\u0022",
+            "name": "wldfvoaj",
+            "defaultScoringProfile": null,
+            "fields": [
+              {
+                "name": "hotelId",
+                "type": "Edm.String",
+                "searchable": false,
+                "filterable": true,
+                "retrievable": true,
+                "sortable": true,
+                "facetable": false,
+                "key": true,
+                "indexAnalyzer": null,
+                "searchAnalyzer": null,
+                "analyzer": null,
+                "synonymMaps": []
+              },
+              {
+                "name": "hotelName",
+                "type": "Edm.String",
+                "searchable": true,
+                "filterable": true,
+                "retrievable": true,
+                "sortable": true,
+                "facetable": false,
+                "key": false,
+                "indexAnalyzer": null,
+                "searchAnalyzer": null,
+                "analyzer": null,
+                "synonymMaps": []
+              },
+              {
+                "name": "description",
+                "type": "Edm.String",
+                "searchable": true,
+                "filterable": false,
+                "retrievable": true,
+                "sortable": false,
+                "facetable": false,
+                "key": false,
+                "indexAnalyzer": null,
+                "searchAnalyzer": null,
+                "analyzer": "en.lucene",
+                "synonymMaps": []
+              },
+              {
+                "name": "tags",
+                "type": "Collection(Edm.String)",
+                "searchable": true,
+                "filterable": true,
+                "retrievable": true,
+                "sortable": false,
+                "facetable": true,
+                "key": false,
+                "indexAnalyzer": null,
+                "searchAnalyzer": null,
+                "analyzer": null,
+                "synonymMaps": []
+              },
+              {
+                "name": "address",
+                "type": "Edm.ComplexType",
+                "fields": [
+                  {
+                    "name": "streetAddress",
+                    "type": "Edm.String",
+                    "searchable": true,
+                    "filterable": false,
+                    "retrievable": true,
+                    "sortable": false,
+                    "facetable": false,
+                    "key": false,
+                    "indexAnalyzer": null,
+                    "searchAnalyzer": null,
+                    "analyzer": null,
+                    "synonymMaps": []
+                  },
+                  {
+                    "name": "city",
+                    "type": "Edm.String",
+                    "searchable": true,
+                    "filterable": true,
+                    "retrievable": true,
+                    "sortable": true,
+                    "facetable": true,
+                    "key": false,
+                    "indexAnalyzer": null,
+                    "searchAnalyzer": null,
+                    "analyzer": null,
+                    "synonymMaps": []
+                  },
+                  {
+                    "name": "stateProvince",
+                    "type": "Edm.String",
+                    "searchable": true,
+                    "filterable": true,
+                    "retrievable": true,
+                    "sortable": true,
+                    "facetable": true,
+                    "key": false,
+                    "indexAnalyzer": null,
+                    "searchAnalyzer": null,
+                    "analyzer": null,
+                    "synonymMaps": []
+                  },
+                  {
+                    "name": "country",
+                    "type": "Edm.String",
+                    "searchable": true,
+                    "filterable": true,
+                    "retrievable": true,
+                    "sortable": true,
+                    "facetable": true,
+                    "key": false,
+                    "indexAnalyzer": null,
+                    "searchAnalyzer": null,
+                    "analyzer": null,
+                    "synonymMaps": []
+                  },
+                  {
+                    "name": "postalCode",
+                    "type": "Edm.String",
+                    "searchable": true,
+                    "filterable": true,
+                    "retrievable": true,
+                    "sortable": true,
+                    "facetable": true,
+                    "key": false,
+                    "indexAnalyzer": null,
+                    "searchAnalyzer": null,
+                    "analyzer": null,
+                    "synonymMaps": []
+                  }
+                ]
+              }
+            ],
+            "scoringProfiles": [],
+            "corsOptions": null,
+            "suggesters": [
+              {
+                "name": "sg",
+                "searchMode": "analyzingInfixMatching",
+                "sourceFields": [
+                  "hotelName",
+                  "description"
+                ]
+              }
+            ],
+            "analyzers": [],
+            "tokenizers": [],
+            "tokenFilters": [],
+            "charFilters": [],
+            "encryptionKey": null,
+            "similarity": null
+          },
+          {
+            "@odata.etag": "\u00220x8D7F31AC250461B\u0022",
+            "name": "yrehvsfy",
             "defaultScoringProfile": null,
             "fields": [
               {
@@ -431,7 +588,8 @@
   ],
   "Variables": {
     "RandomSeed": "230027432",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/GetIndexesAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/GetIndexesAsync.json
@@ -1,14 +1,14 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes?$select=%2A\u0026api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes?$select=%2A\u0026api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "df603cdb3a3b95a3bc0ad41634fa28f0",
         "x-ms-return-client-request-id": "true"
@@ -17,10 +17,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "6165",
+        "Content-Length": "8555",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 01:18:07 GMT",
-        "elapsed-time": "50",
+        "Date": "Fri, 08 May 2020 07:04:42 GMT",
+        "elapsed-time": "52",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -29,11 +29,168 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-jcswnkcn.search.windows.net/$metadata#indexes(*)",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#indexes(*)",
         "value": [
           {
-            "@odata.etag": "\u00220x8D7E8B26C195970\u0022",
-            "name": "mesaejwj",
+            "@odata.etag": "\u00220x8D7F31DA513EDAE\u0022",
+            "name": "wldfvoaj",
+            "defaultScoringProfile": null,
+            "fields": [
+              {
+                "name": "hotelId",
+                "type": "Edm.String",
+                "searchable": false,
+                "filterable": true,
+                "retrievable": true,
+                "sortable": true,
+                "facetable": false,
+                "key": true,
+                "indexAnalyzer": null,
+                "searchAnalyzer": null,
+                "analyzer": null,
+                "synonymMaps": []
+              },
+              {
+                "name": "hotelName",
+                "type": "Edm.String",
+                "searchable": true,
+                "filterable": true,
+                "retrievable": true,
+                "sortable": true,
+                "facetable": false,
+                "key": false,
+                "indexAnalyzer": null,
+                "searchAnalyzer": null,
+                "analyzer": null,
+                "synonymMaps": []
+              },
+              {
+                "name": "description",
+                "type": "Edm.String",
+                "searchable": true,
+                "filterable": false,
+                "retrievable": true,
+                "sortable": false,
+                "facetable": false,
+                "key": false,
+                "indexAnalyzer": null,
+                "searchAnalyzer": null,
+                "analyzer": "en.lucene",
+                "synonymMaps": []
+              },
+              {
+                "name": "tags",
+                "type": "Collection(Edm.String)",
+                "searchable": true,
+                "filterable": true,
+                "retrievable": true,
+                "sortable": false,
+                "facetable": true,
+                "key": false,
+                "indexAnalyzer": null,
+                "searchAnalyzer": null,
+                "analyzer": null,
+                "synonymMaps": []
+              },
+              {
+                "name": "address",
+                "type": "Edm.ComplexType",
+                "fields": [
+                  {
+                    "name": "streetAddress",
+                    "type": "Edm.String",
+                    "searchable": true,
+                    "filterable": false,
+                    "retrievable": true,
+                    "sortable": false,
+                    "facetable": false,
+                    "key": false,
+                    "indexAnalyzer": null,
+                    "searchAnalyzer": null,
+                    "analyzer": null,
+                    "synonymMaps": []
+                  },
+                  {
+                    "name": "city",
+                    "type": "Edm.String",
+                    "searchable": true,
+                    "filterable": true,
+                    "retrievable": true,
+                    "sortable": true,
+                    "facetable": true,
+                    "key": false,
+                    "indexAnalyzer": null,
+                    "searchAnalyzer": null,
+                    "analyzer": null,
+                    "synonymMaps": []
+                  },
+                  {
+                    "name": "stateProvince",
+                    "type": "Edm.String",
+                    "searchable": true,
+                    "filterable": true,
+                    "retrievable": true,
+                    "sortable": true,
+                    "facetable": true,
+                    "key": false,
+                    "indexAnalyzer": null,
+                    "searchAnalyzer": null,
+                    "analyzer": null,
+                    "synonymMaps": []
+                  },
+                  {
+                    "name": "country",
+                    "type": "Edm.String",
+                    "searchable": true,
+                    "filterable": true,
+                    "retrievable": true,
+                    "sortable": true,
+                    "facetable": true,
+                    "key": false,
+                    "indexAnalyzer": null,
+                    "searchAnalyzer": null,
+                    "analyzer": null,
+                    "synonymMaps": []
+                  },
+                  {
+                    "name": "postalCode",
+                    "type": "Edm.String",
+                    "searchable": true,
+                    "filterable": true,
+                    "retrievable": true,
+                    "sortable": true,
+                    "facetable": true,
+                    "key": false,
+                    "indexAnalyzer": null,
+                    "searchAnalyzer": null,
+                    "analyzer": null,
+                    "synonymMaps": []
+                  }
+                ]
+              }
+            ],
+            "scoringProfiles": [],
+            "corsOptions": null,
+            "suggesters": [
+              {
+                "name": "sg",
+                "searchMode": "analyzingInfixMatching",
+                "sourceFields": [
+                  "hotelName",
+                  "description"
+                ]
+              }
+            ],
+            "analyzers": [],
+            "tokenizers": [],
+            "tokenFilters": [],
+            "charFilters": [],
+            "encryptionKey": null,
+            "similarity": null
+          },
+          {
+            "@odata.etag": "\u00220x8D7F31AC250461B\u0022",
+            "name": "yrehvsfy",
             "defaultScoringProfile": null,
             "fields": [
               {
@@ -431,7 +588,8 @@
   ],
   "Variables": {
     "RandomSeed": "347410179",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/GetIndexesNextPageThrowsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/GetIndexesNextPageThrowsAsync.json
@@ -2,7 +2,8 @@
   "Entries": [],
   "Variables": {
     "RandomSeed": "1502897414",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/GetServiceStatistics.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/GetServiceStatistics.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/servicestats?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/servicestats?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-36773d736c49e642a7e77e3e01b07ca8-71352524387c3e4e-00",
+        "traceparent": "00-a778dd79df70b44e8d9b08a2abaab2ae-3e7264ca448cd542-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "352f4c5b46c6db9183c2d78ad0a51379",
         "x-ms-return-client-request-id": "true"
@@ -18,10 +18,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "586",
+        "Content-Length": "590",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 01:16:36 GMT",
-        "elapsed-time": "50",
+        "Date": "Fri, 08 May 2020 07:03:24 GMT",
+        "elapsed-time": "45",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -30,26 +30,26 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-jcswnkcn.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.ServiceStatistics",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.ServiceStatistics",
         "counters": {
           "documentCount": {
             "usage": 10,
             "quota": null
           },
           "indexesCount": {
-            "usage": 1,
+            "usage": 2,
             "quota": 3
           },
           "indexersCount": {
-            "usage": 0,
+            "usage": 1,
             "quota": 3
           },
           "dataSourcesCount": {
-            "usage": 0,
+            "usage": 1,
             "quota": 3
           },
           "storageSize": {
-            "usage": 38732,
+            "usage": 35876,
             "quota": 52428800
           },
           "synonymMaps": {
@@ -72,7 +72,8 @@
   ],
   "Variables": {
     "RandomSeed": "1735959094",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/GetServiceStatisticsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/GetServiceStatisticsAsync.json
@@ -1,15 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/servicestats?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/servicestats?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
-        "traceparent": "00-3d1ffd5efc20ec4ebc8f94c34e676893-e83d1f2b73c8f744-00",
+        "traceparent": "00-d040b71a3cd78743adca459a08ecfbff-547f821e30d0824c-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "c8229c16880f099da1539c8a7c7acb40",
         "x-ms-return-client-request-id": "true"
@@ -18,10 +18,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "586",
+        "Content-Length": "590",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 01:18:07 GMT",
-        "elapsed-time": "33",
+        "Date": "Fri, 08 May 2020 07:04:42 GMT",
+        "elapsed-time": "80",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -30,26 +30,26 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-jcswnkcn.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.ServiceStatistics",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#Microsoft.Azure.Search.V2019_05_06_Preview.ServiceStatistics",
         "counters": {
           "documentCount": {
             "usage": 10,
             "quota": null
           },
           "indexesCount": {
-            "usage": 1,
+            "usage": 2,
             "quota": 3
           },
           "indexersCount": {
-            "usage": 0,
+            "usage": 2,
             "quota": 3
           },
           "dataSourcesCount": {
-            "usage": 0,
+            "usage": 2,
             "quota": 3
           },
           "storageSize": {
-            "usage": 38732,
+            "usage": 35876,
             "quota": 52428800
           },
           "synonymMaps": {
@@ -72,7 +72,8 @@
   ],
   "Variables": {
     "RandomSeed": "1636339797",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/IndexSharesPipeline.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/IndexSharesPipeline.json
@@ -1,14 +1,14 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "bb0245badfc1f18ca36d44f127534217",
         "x-ms-return-client-request-id": "true"
@@ -19,8 +19,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "5",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:16:36 GMT",
-        "elapsed-time": "41",
+        "Date": "Fri, 08 May 2020 07:03:24 GMT",
+        "elapsed-time": "38",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -33,7 +33,8 @@
   ],
   "Variables": {
     "RandomSeed": "1344081635",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/IndexSharesPipelineAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/IndexSharesPipelineAsync.json
@@ -1,14 +1,14 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/$count?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/$count?api-version=2019-05-06-Preview",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "444a30982e06b9fae60e267a690b207f",
         "x-ms-return-client-request-id": "true"
@@ -19,8 +19,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "5",
         "Content-Type": "text/plain",
-        "Date": "Sat, 25 Apr 2020 01:18:07 GMT",
-        "elapsed-time": "35",
+        "Date": "Fri, 08 May 2020 07:04:42 GMT",
+        "elapsed-time": "39",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -33,7 +33,8 @@
   ],
   "Variables": {
     "RandomSeed": "551039053",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/UpdateIndex.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/UpdateIndex.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-cjsybjxe.search.windows.net/indexes?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
         "Content-Length": "4032",
         "Content-Type": "application/json",
-        "traceparent": "00-0ba6087d351b45409f9091d816003989-f7d995af1b7f5440-00",
+        "traceparent": "00-5c0dcaa5f4f54d4d8d123c2a5f127f56-d797b7211423f544-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "26f7066d315f5ab3f827c83cbd605a50",
         "x-ms-return-client-request-id": "true"
@@ -307,13 +307,13 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "6158",
+        "Content-Length": "6162",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 01:16:40 GMT",
-        "elapsed-time": "1305",
-        "ETag": "W/\u00220x8D7E8B64F61A0AE\u0022",
+        "Date": "Fri, 08 May 2020 07:03:24 GMT",
+        "elapsed-time": "563",
+        "ETag": "W/\u00220x8D7F31DE746F889\u0022",
         "Expires": "-1",
-        "Location": "https://azs-net-cjsybjxe.search.windows.net/indexes(\u0027ptbgbued\u0027)?api-version=2019-05-06-Preview",
+        "Location": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027ptbgbued\u0027)?api-version=2019-05-06-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
@@ -321,8 +321,8 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-cjsybjxe.search.windows.net/$metadata#indexes/$entity",
-        "@odata.etag": "\u00220x8D7E8B64F61A0AE\u0022",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#indexes/$entity",
+        "@odata.etag": "\u00220x8D7F31DE746F889\u0022",
         "name": "ptbgbued",
         "defaultScoringProfile": null,
         "fields": [
@@ -717,19 +717,19 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-cjsybjxe.search.windows.net/indexes(\u0027ptbgbued\u0027)?allowIndexDowntime=true\u0026api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027ptbgbued\u0027)?allowIndexDowntime=true\u0026api-version=2019-05-06-Preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
         "Content-Length": "4873",
         "Content-Type": "application/json",
-        "If-Match": "\u00220x8D7E8B64F61A0AE\u0022",
+        "If-Match": "\u00220x8D7F31DE746F889\u0022",
         "Prefer": "return=representation",
-        "traceparent": "00-c4c959c7479a274eb29dece2c735be46-6f4a906ad1ab2b44-00",
+        "traceparent": "00-96f7529c0eafce40aefc3b6140a7aa68-fe5b71c4e898e347-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "5c92b4cdda72b9dbb6ec10cb1f481d99",
         "x-ms-return-client-request-id": "true"
@@ -1070,16 +1070,16 @@
             "name": "asciiTags"
           }
         ],
-        "@odata.etag": "\u00220x8D7E8B64F61A0AE\u0022"
+        "@odata.etag": "\u00220x8D7F31DE746F889\u0022"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "6577",
+        "Content-Length": "6581",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 01:16:43 GMT",
-        "elapsed-time": "2466",
-        "ETag": "W/\u00220x8D7E8B650E31FAC\u0022",
+        "Date": "Fri, 08 May 2020 07:03:26 GMT",
+        "elapsed-time": "843",
+        "ETag": "W/\u00220x8D7F31DE7CE1B01\u0022",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -1088,8 +1088,8 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-cjsybjxe.search.windows.net/$metadata#indexes/$entity",
-        "@odata.etag": "\u00220x8D7E8B650E31FAC\u0022",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#indexes/$entity",
+        "@odata.etag": "\u00220x8D7F31DE7CE1B01\u0022",
         "name": "ptbgbued",
         "defaultScoringProfile": null,
         "fields": [
@@ -1509,15 +1509,39 @@
         "encryptionKey": null,
         "similarity": null
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027ptbgbued\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-75c8778e4e14ce44b7e125e7a48ff392-27614b9913936c40-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "bcb37215e67e50e3b4d10c4369758711",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:03:26 GMT",
+        "elapsed-time": "297",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "bcb37215-e67e-50e3-b4d1-0c4369758711",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1669853055",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchServiceName": "azs-net-cjsybjxe",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "ptbgbued",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/UpdateIndexAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchServiceClientTests/UpdateIndexAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-nybdpxve.search.windows.net/indexes?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
         "Content-Length": "4032",
         "Content-Type": "application/json",
-        "traceparent": "00-22d1d88d464eac439ef5778d8371f16c-b04160844da09d40-00",
+        "traceparent": "00-551b82784a85cb4696807a63724b4718-c0ed601407e6ac4d-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "62e943843b5a3dfda55d7936ea8d46fa",
         "x-ms-return-client-request-id": "true"
@@ -307,13 +307,13 @@
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "6158",
+        "Content-Length": "6162",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 01:18:11 GMT",
-        "elapsed-time": "1475",
-        "ETag": "W/\u00220x8D7E8B685DEA9F4\u0022",
+        "Date": "Fri, 08 May 2020 07:04:44 GMT",
+        "elapsed-time": "857",
+        "ETag": "W/\u00220x8D7F31E16591548\u0022",
         "Expires": "-1",
-        "Location": "https://azs-net-nybdpxve.search.windows.net/indexes(\u0027mvqfigik\u0027)?api-version=2019-05-06-Preview",
+        "Location": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027mvqfigik\u0027)?api-version=2019-05-06-Preview",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
         "Preference-Applied": "odata.include-annotations=\u0022*\u0022",
@@ -321,8 +321,8 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-nybdpxve.search.windows.net/$metadata#indexes/$entity",
-        "@odata.etag": "\u00220x8D7E8B685DEA9F4\u0022",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#indexes/$entity",
+        "@odata.etag": "\u00220x8D7F31E16591548\u0022",
         "name": "mvqfigik",
         "defaultScoringProfile": null,
         "fields": [
@@ -717,19 +717,19 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-nybdpxve.search.windows.net/indexes(\u0027mvqfigik\u0027)?allowIndexDowntime=true\u0026api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027mvqfigik\u0027)?allowIndexDowntime=true\u0026api-version=2019-05-06-Preview",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=minimal",
         "api-key": "Sanitized",
         "Content-Length": "4873",
         "Content-Type": "application/json",
-        "If-Match": "\u00220x8D7E8B685DEA9F4\u0022",
+        "If-Match": "\u00220x8D7F31E16591548\u0022",
         "Prefer": "return=representation",
-        "traceparent": "00-7e3a5f2ba3131142ab5eb76e8bfe91ac-19a476f2892d434f-00",
+        "traceparent": "00-d6bb0442cde45243862cdeb53f598e37-55cc01b22ff32a4d-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "b20370b178072cf624850527937d7829",
         "x-ms-return-client-request-id": "true"
@@ -1070,16 +1070,16 @@
             "name": "asciiTags"
           }
         ],
-        "@odata.etag": "\u00220x8D7E8B685DEA9F4\u0022"
+        "@odata.etag": "\u00220x8D7F31E16591548\u0022"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "6577",
+        "Content-Length": "6581",
         "Content-Type": "application/json; odata.metadata=minimal",
-        "Date": "Sat, 25 Apr 2020 01:18:14 GMT",
-        "elapsed-time": "2315",
-        "ETag": "W/\u00220x8D7E8B687496726\u0022",
+        "Date": "Fri, 08 May 2020 07:04:45 GMT",
+        "elapsed-time": "830",
+        "ETag": "W/\u00220x8D7F31E16DFC280\u0022",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -1088,8 +1088,8 @@
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
       },
       "ResponseBody": {
-        "@odata.context": "https://azs-net-nybdpxve.search.windows.net/$metadata#indexes/$entity",
-        "@odata.etag": "\u00220x8D7E8B687496726\u0022",
+        "@odata.context": "https://azs-net-heathsearch2.search.windows.net/$metadata#indexes/$entity",
+        "@odata.etag": "\u00220x8D7F31E16DFC280\u0022",
         "name": "mvqfigik",
         "defaultScoringProfile": null,
         "fields": [
@@ -1509,15 +1509,39 @@
         "encryptionKey": null,
         "similarity": null
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027mvqfigik\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-5b4426e384b18a4b9ab03dccacba9727-e307ce5a4d28c24a-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "2f006d0b543d6ef41f058a4a0d2e28c5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:04:45 GMT",
+        "elapsed-time": "367",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "2f006d0b-543d-6ef4-1f05-8a4a0d2e28c5",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1673829715",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchServiceName": "azs-net-nybdpxve",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "mvqfigik",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/CanContinueDynamic.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/CanContinueDynamic.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-xgiwrhul.search.windows.net/indexes(\u0027rdjwngir\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027guwtyceg\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "43933",
         "Content-Type": "application/json",
-        "traceparent": "00-097c33daadf6014eba2a1b2955cc5288-068e71b4d8e46547-00",
+        "traceparent": "00-fe80b9c4d850ee4e90b71219c460ebbc-5ae94f0698efda44-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "bfb788a4eaf0a5b00eee64847b2cf472",
         "x-ms-return-client-request-id": "true"
@@ -4025,8 +4025,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "64933",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:18:43 GMT",
-        "elapsed-time": "190",
+        "Date": "Fri, 08 May 2020 07:05:08 GMT",
+        "elapsed-time": "164",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -10040,17 +10040,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-xgiwrhul.search.windows.net/indexes(\u0027rdjwngir\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027guwtyceg\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "44606",
         "Content-Type": "application/json",
-        "traceparent": "00-2565d8367d903940ab596c8d5c5d64c9-0c794ddc8abb1440-00",
+        "traceparent": "00-6d8e4e1eedc7db4eb0018271ee784627-829c5364bd36fd40-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "8a50fa21d4e96bea3c39e70c4d36020f",
         "x-ms-return-client-request-id": "true"
@@ -14028,8 +14028,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "65417",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:18:45 GMT",
-        "elapsed-time": "172",
+        "Date": "Fri, 08 May 2020 07:05:11 GMT",
+        "elapsed-time": "121",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -19989,17 +19989,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-xgiwrhul.search.windows.net/indexes(\u0027rdjwngir\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027guwtyceg\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "103",
         "Content-Type": "application/json",
-        "traceparent": "00-f268083402737040b96783331efdd4c1-933c66be73e6994d-00",
+        "traceparent": "00-d9b55cc5262e3b49b89d4481fa607f40-21830d47f890dc43-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "0b170f8196009a5563028291b32b0dc5",
         "x-ms-return-client-request-id": "true"
@@ -20015,10 +20015,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "39184",
+        "Content-Length": "39188",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:18:47 GMT",
-        "elapsed-time": "90",
+        "Date": "Fri, 08 May 2020 07:05:14 GMT",
+        "elapsed-time": "79",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -24038,21 +24038,21 @@
             "hotelId": "1899"
           }
         ],
-        "@odata.nextLink": "https://azs-net-xgiwrhul.search.windows.net/indexes(\u0027rdjwngir\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027guwtyceg\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-xgiwrhul.search.windows.net/indexes(\u0027rdjwngir\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027guwtyceg\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "115",
         "Content-Type": "application/json",
-        "traceparent": "00-336c9f414ea2f34795fef7759fdf2bff-cbdb7d42c97c5746-00",
+        "traceparent": "00-aa1f00029276264f82f95acb4e116cd5-03139880c943e445-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "3aaab373eeb0cf879e4c82b602a358d7",
         "x-ms-return-client-request-id": "true"
@@ -24069,10 +24069,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "38300",
+        "Content-Length": "38304",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:18:47 GMT",
-        "elapsed-time": "86",
+        "Date": "Fri, 08 May 2020 07:05:14 GMT",
+        "elapsed-time": "64",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -28092,21 +28092,21 @@
             "hotelId": "998"
           }
         ],
-        "@odata.nextLink": "https://azs-net-xgiwrhul.search.windows.net/indexes(\u0027rdjwngir\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027guwtyceg\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-xgiwrhul.search.windows.net/indexes(\u0027rdjwngir\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027guwtyceg\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "115",
         "Content-Type": "application/json",
-        "traceparent": "00-56921e2871294e4ea16471c3f9045091-c669d1de9eb59445-00",
+        "traceparent": "00-9f026aae8ed2774d9b5894e856f48a9b-d6d3d75870487245-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "6b0354ebe8158a72a5b526e75259b811",
         "x-ms-return-client-request-id": "true"
@@ -28125,8 +28125,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "49",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:18:47 GMT",
-        "elapsed-time": "9",
+        "Date": "Fri, 08 May 2020 07:05:14 GMT",
+        "elapsed-time": "11",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -28142,16 +28142,40 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027guwtyceg\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-68ebef30bd2d5d4384242371c1b5abc5-3129ff673747ed44-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "9999212cc78c925f88476db4149e97bf",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:05:14 GMT",
+        "elapsed-time": "253",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "9999212c-c78c-925f-8847-6db4149e97bf",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "465025482",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "rdjwngir",
-    "SearchServiceName": "azs-net-xgiwrhul",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "guwtyceg",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/CanContinueDynamicAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/CanContinueDynamicAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-btsiphsk.search.windows.net/indexes(\u0027mnwwnnkm\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027viradbce\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "43933",
         "Content-Type": "application/json",
-        "traceparent": "00-4c95df037c18dc4092e1c0207215eafa-3459ecebf6aa0042-00",
+        "traceparent": "00-0744cb1aa6459e4dbe23172798dbbf72-9f2c148b13213245-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "125fbebe1274e1744f1543c8bb2c0e4e",
         "x-ms-return-client-request-id": "true"
@@ -4025,8 +4025,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "64933",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:22:01 GMT",
-        "elapsed-time": "275",
+        "Date": "Fri, 08 May 2020 07:07:57 GMT",
+        "elapsed-time": "213",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -10040,17 +10040,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-btsiphsk.search.windows.net/indexes(\u0027mnwwnnkm\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027viradbce\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "44606",
         "Content-Type": "application/json",
-        "traceparent": "00-8f05364c1fa9a644bea6be09e886a082-f3b4aba58ad6c144-00",
+        "traceparent": "00-c023539b3b0a314498e54374ba8dceca-3b54b1f097990e46-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "00b2cc9d3252ea63c8008c0d674967cd",
         "x-ms-return-client-request-id": "true"
@@ -14028,8 +14028,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "65417",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:22:04 GMT",
-        "elapsed-time": "164",
+        "Date": "Fri, 08 May 2020 07:07:59 GMT",
+        "elapsed-time": "123",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -19989,17 +19989,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-btsiphsk.search.windows.net/indexes(\u0027mnwwnnkm\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027viradbce\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "103",
         "Content-Type": "application/json",
-        "traceparent": "00-1c8a5e1635b8aa42b83609b8d6221515-3140af17ef74584b-00",
+        "traceparent": "00-98fa216bbeb9f948b69afa052ffce2e5-9c71915680208b4e-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "f5c95fa9994e80fe18fedc7e2318de34",
         "x-ms-return-client-request-id": "true"
@@ -20015,10 +20015,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "39184",
+        "Content-Length": "39188",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:22:05 GMT",
-        "elapsed-time": "143",
+        "Date": "Fri, 08 May 2020 07:08:02 GMT",
+        "elapsed-time": "130",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -24038,21 +24038,21 @@
             "hotelId": "1899"
           }
         ],
-        "@odata.nextLink": "https://azs-net-btsiphsk.search.windows.net/indexes(\u0027mnwwnnkm\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027viradbce\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-btsiphsk.search.windows.net/indexes(\u0027mnwwnnkm\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027viradbce\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "115",
         "Content-Type": "application/json",
-        "traceparent": "00-8be572cccb1d1041b8de12b96c3b44de-db58549137842e49-00",
+        "traceparent": "00-aa50636a114d884b90b00971be9bc44e-aefc496417164042-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "f11388be82178b065a744a7385677a06",
         "x-ms-return-client-request-id": "true"
@@ -24069,10 +24069,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "38300",
+        "Content-Length": "38304",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:22:06 GMT",
-        "elapsed-time": "68",
+        "Date": "Fri, 08 May 2020 07:08:02 GMT",
+        "elapsed-time": "67",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -28092,21 +28092,21 @@
             "hotelId": "998"
           }
         ],
-        "@odata.nextLink": "https://azs-net-btsiphsk.search.windows.net/indexes(\u0027mnwwnnkm\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027viradbce\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-btsiphsk.search.windows.net/indexes(\u0027mnwwnnkm\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027viradbce\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "115",
         "Content-Type": "application/json",
-        "traceparent": "00-096cb66d69e38a4fb0d9ef654abf4519-095f2fef288f6841-00",
+        "traceparent": "00-faee8f4ade4f564588deb0d56583cc94-14dacb7fe1118147-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "5c1f75ad18630400cd31e85456e5c6af",
         "x-ms-return-client-request-id": "true"
@@ -28125,8 +28125,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "49",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:22:06 GMT",
-        "elapsed-time": "12",
+        "Date": "Fri, 08 May 2020 07:08:02 GMT",
+        "elapsed-time": "14",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -28142,16 +28142,40 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027viradbce\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-b3607dd2c5128040b2b5db8fa3a3c7b8-6fa909e8edd0d84b-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "de4e5722753627b6583d9bda4f8afab0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:08:02 GMT",
+        "elapsed-time": "213",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "de4e5722-7536-27b6-583d-9bda4f8afab0",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1771240683",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "mnwwnnkm",
-    "SearchServiceName": "azs-net-btsiphsk",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "viradbce",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/CanContinueStatic.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/CanContinueStatic.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-vxgppquq.search.windows.net/indexes(\u0027jblhxryv\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fpgcoely\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "43933",
         "Content-Type": "application/json",
-        "traceparent": "00-fe0b55326a4a4e47a8dc3e8f9ab9ea24-548a567002df9e4b-00",
+        "traceparent": "00-7103cd4002ef5845b5d78789d75a5649-6881e08d75692448-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "2c6015e835f521ca6c2720b8ac87037f",
         "x-ms-return-client-request-id": "true"
@@ -4025,8 +4025,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "64933",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:19:16 GMT",
-        "elapsed-time": "285",
+        "Date": "Fri, 08 May 2020 07:05:38 GMT",
+        "elapsed-time": "243",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -10040,17 +10040,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-vxgppquq.search.windows.net/indexes(\u0027jblhxryv\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fpgcoely\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "44606",
         "Content-Type": "application/json",
-        "traceparent": "00-7a4579d13cdb654e8443a7f21c5e18de-b890d507e5281649-00",
+        "traceparent": "00-1234ea7b74be6445bcf199e74c9fdcbd-950e9dc9f83df64d-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "0f9e38f61f822ff50bfdfa7414cd09d1",
         "x-ms-return-client-request-id": "true"
@@ -14028,8 +14028,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "65417",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:19:19 GMT",
-        "elapsed-time": "160",
+        "Date": "Fri, 08 May 2020 07:05:40 GMT",
+        "elapsed-time": "157",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -19989,17 +19989,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-vxgppquq.search.windows.net/indexes(\u0027jblhxryv\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fpgcoely\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "103",
         "Content-Type": "application/json",
-        "traceparent": "00-c2da8fc8504f4d4fb688937d379ef20b-6538f627d52bc54f-00",
+        "traceparent": "00-becd2b5de5ffcc41b4de48c4df38df33-8b1a7308113ecb4e-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "a7f7b83ea963a54557c7332aa10fae73",
         "x-ms-return-client-request-id": "true"
@@ -20015,10 +20015,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "39184",
+        "Content-Length": "39188",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:19:20 GMT",
-        "elapsed-time": "117",
+        "Date": "Fri, 08 May 2020 07:05:42 GMT",
+        "elapsed-time": "105",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -24038,21 +24038,21 @@
             "hotelId": "1899"
           }
         ],
-        "@odata.nextLink": "https://azs-net-vxgppquq.search.windows.net/indexes(\u0027jblhxryv\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fpgcoely\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-vxgppquq.search.windows.net/indexes(\u0027jblhxryv\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fpgcoely\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "115",
         "Content-Type": "application/json",
-        "traceparent": "00-9d3029a00ed45b489697291261ffb5ae-2faad8fd1228384a-00",
+        "traceparent": "00-b1e13dc38550744a8b66a72cda28356d-89653b131ddb1d45-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "e6405735a9b3c84e1f3120f73a560d9e",
         "x-ms-return-client-request-id": "true"
@@ -24069,10 +24069,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "38300",
+        "Content-Length": "38304",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:19:20 GMT",
-        "elapsed-time": "70",
+        "Date": "Fri, 08 May 2020 07:05:43 GMT",
+        "elapsed-time": "87",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -28092,21 +28092,21 @@
             "hotelId": "998"
           }
         ],
-        "@odata.nextLink": "https://azs-net-vxgppquq.search.windows.net/indexes(\u0027jblhxryv\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fpgcoely\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-vxgppquq.search.windows.net/indexes(\u0027jblhxryv\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fpgcoely\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "115",
         "Content-Type": "application/json",
-        "traceparent": "00-7b021c4ffa9f854c9fdc3a2d70458e90-d3e289269d306547-00",
+        "traceparent": "00-172d43d6bbad2848a6457060d4e20c0c-3ea06d22622bed4e-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "f4794e1e5b904d1cf2f9b7baebcb8dfb",
         "x-ms-return-client-request-id": "true"
@@ -28125,8 +28125,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "49",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:19:21 GMT",
-        "elapsed-time": "11",
+        "Date": "Fri, 08 May 2020 07:05:43 GMT",
+        "elapsed-time": "22",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -28142,16 +28142,40 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fpgcoely\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-738604a75ff09d4da843d2dd305d2b13-dd2dbba2f09b184b-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "bd3e864f238d941e692e8831884e6a01",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:05:43 GMT",
+        "elapsed-time": "226",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "bd3e864f-238d-941e-692e-8831884e6a01",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1252796088",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "jblhxryv",
-    "SearchServiceName": "azs-net-vxgppquq",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "fpgcoely",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/CanContinueStaticAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/CanContinueStaticAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-vpequvov.search.windows.net/indexes(\u0027jbpdlobh\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027pccapqps\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "43933",
         "Content-Type": "application/json",
-        "traceparent": "00-20394bdd43275947906e1ed20360e417-fa4dc0ebf64f1c41-00",
+        "traceparent": "00-c0586aa09173f94f92ca06687dd827dd-3448cca94a43ee46-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "634278f9039a44b2a6b4e6cc28369b7a",
         "x-ms-return-client-request-id": "true"
@@ -4025,8 +4025,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "64933",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:22:35 GMT",
-        "elapsed-time": "240",
+        "Date": "Fri, 08 May 2020 07:08:25 GMT",
+        "elapsed-time": "268",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -10040,17 +10040,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-vpequvov.search.windows.net/indexes(\u0027jbpdlobh\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027pccapqps\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "44606",
         "Content-Type": "application/json",
-        "traceparent": "00-4a7dad4ed088774d9639ff69b93dd119-2b4fecf744042844-00",
+        "traceparent": "00-29deb1877dcd124395154c37552b2684-f018ba5ea48f5d4d-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "fe20c7913bf06794253635ee907b395b",
         "x-ms-return-client-request-id": "true"
@@ -14028,8 +14028,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "65417",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:22:38 GMT",
-        "elapsed-time": "178",
+        "Date": "Fri, 08 May 2020 07:08:28 GMT",
+        "elapsed-time": "154",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -19989,17 +19989,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-vpequvov.search.windows.net/indexes(\u0027jbpdlobh\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027pccapqps\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "103",
         "Content-Type": "application/json",
-        "traceparent": "00-7c3fb195dd79ec459c033df665928b43-ee5f85a748328a47-00",
+        "traceparent": "00-a30170fe933cd044818ba67b141df27f-7e0d260cd1d4bf4a-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "a7147c3455297fd1e8dcd5fce400f6ab",
         "x-ms-return-client-request-id": "true"
@@ -20015,10 +20015,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "39184",
+        "Content-Length": "39188",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:22:40 GMT",
-        "elapsed-time": "109",
+        "Date": "Fri, 08 May 2020 07:08:30 GMT",
+        "elapsed-time": "66",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -24038,21 +24038,21 @@
             "hotelId": "1899"
           }
         ],
-        "@odata.nextLink": "https://azs-net-vpequvov.search.windows.net/indexes(\u0027jbpdlobh\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027pccapqps\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-vpequvov.search.windows.net/indexes(\u0027jbpdlobh\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027pccapqps\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "115",
         "Content-Type": "application/json",
-        "traceparent": "00-a97e6e11e998db4aaf931de215fb63e6-84dddcdb88aa8d4b-00",
+        "traceparent": "00-671fcfe77254b7499aaa982c3a39e1da-7c61dde39ff5504f-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "d440dd58923abdb1e4da3d64cec4b32b",
         "x-ms-return-client-request-id": "true"
@@ -24069,10 +24069,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "38300",
+        "Content-Length": "38304",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:22:40 GMT",
-        "elapsed-time": "65",
+        "Date": "Fri, 08 May 2020 07:08:30 GMT",
+        "elapsed-time": "61",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -28092,21 +28092,21 @@
             "hotelId": "998"
           }
         ],
-        "@odata.nextLink": "https://azs-net-vpequvov.search.windows.net/indexes(\u0027jbpdlobh\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027pccapqps\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-vpequvov.search.windows.net/indexes(\u0027jbpdlobh\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027pccapqps\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "115",
         "Content-Type": "application/json",
-        "traceparent": "00-5ebfd3eb6240e341bedbe221861dba88-d3ed93f52a18f741-00",
+        "traceparent": "00-170f85ec832aeb46b37fe2e2ff6f6731-ddc9e815413d0748-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "ac988a7bf4213c50f5a0151366988224",
         "x-ms-return-client-request-id": "true"
@@ -28125,8 +28125,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "49",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:22:40 GMT",
-        "elapsed-time": "8",
+        "Date": "Fri, 08 May 2020 07:08:30 GMT",
+        "elapsed-time": "9",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -28142,16 +28142,40 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027pccapqps\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-3a701480cf59a245a3151ab857a73823-6097f832459c4246-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "b395893f653aa220ca57c24e186db024",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:08:30 GMT",
+        "elapsed-time": "220",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "b395893f-653a-a220-ca57-c24e186db024",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1158078461",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "jbpdlobh",
-    "SearchServiceName": "azs-net-vpequvov",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "pccapqps",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/CanContinueWithoutSize.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/CanContinueWithoutSize.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-bgrdwedl.search.windows.net/indexes(\u0027wotwvloh\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027tjblxceu\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "6830",
         "Content-Type": "application/json",
-        "traceparent": "00-02424006dbca17459eef5c81930364e6-e486b341ace4aa46-00",
+        "traceparent": "00-647f860abd935243bf5fe4365c3869f7-3e52b56158a95443-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "143128a3b6549d0c319609d835272ac6",
         "x-ms-return-client-request-id": "true"
@@ -653,8 +653,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "10127",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:19:49 GMT",
-        "elapsed-time": "67",
+        "Date": "Fri, 08 May 2020 07:06:07 GMT",
+        "elapsed-time": "95",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -1610,17 +1610,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-bgrdwedl.search.windows.net/indexes(\u0027wotwvloh\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027tjblxceu\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "92",
         "Content-Type": "application/json",
-        "traceparent": "00-c591290308369145a3e7e462cba69f93-faa6b119c4199049-00",
+        "traceparent": "00-d35015d1fba8314ea4b4d419d18cdca7-023301889954b74f-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "24ec8e84827e109ee80f0e92f47943f4",
         "x-ms-return-client-request-id": "true"
@@ -1635,10 +1635,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "2175",
+        "Content-Length": "2179",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:19:52 GMT",
-        "elapsed-time": "19",
+        "Date": "Fri, 08 May 2020 07:06:08 GMT",
+        "elapsed-time": "21",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -1857,21 +1857,21 @@
             "hotelId": "143"
           }
         ],
-        "@odata.nextLink": "https://azs-net-bgrdwedl.search.windows.net/indexes(\u0027wotwvloh\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027tjblxceu\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-bgrdwedl.search.windows.net/indexes(\u0027wotwvloh\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027tjblxceu\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "102",
         "Content-Type": "application/json",
-        "traceparent": "00-ca1d1008bd647a4d9c8486a8540f9e31-066475414567144a-00",
+        "traceparent": "00-9610fe31212a5e48b2d748b4e9505ab8-c270e5848f82ad44-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "b76faf0a21e8d900b906e6b5158e2c00",
         "x-ms-return-client-request-id": "true"
@@ -1887,9 +1887,9 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "2155",
+        "Content-Length": "2159",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:19:52 GMT",
+        "Date": "Fri, 08 May 2020 07:06:08 GMT",
         "elapsed-time": "8",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -2109,21 +2109,21 @@
             "hotelId": "38"
           }
         ],
-        "@odata.nextLink": "https://azs-net-bgrdwedl.search.windows.net/indexes(\u0027wotwvloh\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027tjblxceu\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-bgrdwedl.search.windows.net/indexes(\u0027wotwvloh\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027tjblxceu\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "103",
         "Content-Type": "application/json",
-        "traceparent": "00-5470f486aefec44cab11ec206f184604-1fcecaea66801c4c-00",
+        "traceparent": "00-1c7ee2728cd5e94cb5c03ce0d20fb842-d44ac043085c2f4e-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "543b81e2e8f6213089202b44a879a9b8",
         "x-ms-return-client-request-id": "true"
@@ -2139,10 +2139,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "2128",
+        "Content-Length": "2132",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:19:52 GMT",
-        "elapsed-time": "9",
+        "Date": "Fri, 08 May 2020 07:06:08 GMT",
+        "elapsed-time": "8",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -2361,21 +2361,21 @@
             "hotelId": "83"
           }
         ],
-        "@odata.nextLink": "https://azs-net-bgrdwedl.search.windows.net/indexes(\u0027wotwvloh\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027tjblxceu\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-bgrdwedl.search.windows.net/indexes(\u0027wotwvloh\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027tjblxceu\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "103",
         "Content-Type": "application/json",
-        "traceparent": "00-79b1deb2b670c04896fc4da46147eaad-543c2da63aea7244-00",
+        "traceparent": "00-24ef51d00135704bb76af08aff1c3d0c-6ee80d7c3897e641-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "86ce145273b763de8d136a789be9fb59",
         "x-ms-return-client-request-id": "true"
@@ -2393,8 +2393,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "639",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:19:52 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 08 May 2020 07:06:08 GMT",
+        "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -2474,16 +2474,40 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027tjblxceu\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-1f70d488227b874bb10b1f9c573b517c-713dc2461a59ec4d-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "72b00de3ee3d21fe7e4e2dc7f5bb303f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:06:08 GMT",
+        "elapsed-time": "199",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "72b00de3-ee3d-21fe-7e4e-2dc7f5bb303f",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "2136761083",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "wotwvloh",
-    "SearchServiceName": "azs-net-bgrdwedl",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "tjblxceu",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/CanContinueWithoutSizeAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/CanContinueWithoutSizeAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-diybelhe.search.windows.net/indexes(\u0027lgcwkggd\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rfvkbfbh\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "6830",
         "Content-Type": "application/json",
-        "traceparent": "00-59bab9c327f6bf4f9333b443230b599f-96a38be0c676d44f-00",
+        "traceparent": "00-433fd3c0c78b2c41bc3ed9478db0b52e-1e5938343a260a45-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "26c7e4d37d542c947b8c82566387c512",
         "x-ms-return-client-request-id": "true"
@@ -653,8 +653,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "10127",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:23:08 GMT",
-        "elapsed-time": "165",
+        "Date": "Fri, 08 May 2020 07:08:54 GMT",
+        "elapsed-time": "114",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -1610,17 +1610,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-diybelhe.search.windows.net/indexes(\u0027lgcwkggd\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rfvkbfbh\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "92",
         "Content-Type": "application/json",
-        "traceparent": "00-058e9f34396acf4ca4cf564797511d1e-5cf285f991f81d49-00",
+        "traceparent": "00-34e3375379db364ca2c3bd40a69a9b1a-804d2b8c5a450c46-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "3c92c6b9a55af734786142bac7cf03c3",
         "x-ms-return-client-request-id": "true"
@@ -1635,10 +1635,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "2175",
+        "Content-Length": "2179",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:23:10 GMT",
-        "elapsed-time": "20",
+        "Date": "Fri, 08 May 2020 07:08:55 GMT",
+        "elapsed-time": "17",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -1857,21 +1857,21 @@
             "hotelId": "143"
           }
         ],
-        "@odata.nextLink": "https://azs-net-diybelhe.search.windows.net/indexes(\u0027lgcwkggd\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rfvkbfbh\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-diybelhe.search.windows.net/indexes(\u0027lgcwkggd\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rfvkbfbh\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "102",
         "Content-Type": "application/json",
-        "traceparent": "00-0b9760c7ca737f40b5c997cc655968ee-56159f69bd097243-00",
+        "traceparent": "00-2e734d6d43b46d4cb9abb82f928c34c5-5bac33beeec65f49-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "e6d350064d6a475bafcf271925a51bf3",
         "x-ms-return-client-request-id": "true"
@@ -1887,10 +1887,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "2155",
+        "Content-Length": "2159",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:23:10 GMT",
-        "elapsed-time": "12",
+        "Date": "Fri, 08 May 2020 07:08:56 GMT",
+        "elapsed-time": "9",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -2109,21 +2109,21 @@
             "hotelId": "38"
           }
         ],
-        "@odata.nextLink": "https://azs-net-diybelhe.search.windows.net/indexes(\u0027lgcwkggd\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rfvkbfbh\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-diybelhe.search.windows.net/indexes(\u0027lgcwkggd\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rfvkbfbh\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "103",
         "Content-Type": "application/json",
-        "traceparent": "00-a0c1a2eb3681794a92cd57980e575cab-68be5d0a9c618c41-00",
+        "traceparent": "00-bd198c83976aac459c88b88b97960ea0-0ee7845fbe97d841-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "9b69ed6da2022eb4afcfadf33bd965ab",
         "x-ms-return-client-request-id": "true"
@@ -2139,10 +2139,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "2128",
+        "Content-Length": "2132",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:23:11 GMT",
-        "elapsed-time": "8",
+        "Date": "Fri, 08 May 2020 07:08:56 GMT",
+        "elapsed-time": "10",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -2361,21 +2361,21 @@
             "hotelId": "83"
           }
         ],
-        "@odata.nextLink": "https://azs-net-diybelhe.search.windows.net/indexes(\u0027lgcwkggd\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rfvkbfbh\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-diybelhe.search.windows.net/indexes(\u0027lgcwkggd\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rfvkbfbh\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "103",
         "Content-Type": "application/json",
-        "traceparent": "00-ac2177888a01b1429f65cb5456dc8b8b-7a3e51ed8aa71c43-00",
+        "traceparent": "00-63b814c3a9651941a34d8d42838e4bed-c22baf81141d144d-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "124fbf88dfb46ca76a4b8d8b7d1bd1d2",
         "x-ms-return-client-request-id": "true"
@@ -2393,8 +2393,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "639",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:23:11 GMT",
-        "elapsed-time": "10",
+        "Date": "Fri, 08 May 2020 07:08:56 GMT",
+        "elapsed-time": "8",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -2474,16 +2474,40 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rfvkbfbh\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-146c7bb0f09a1741861718308c2a9d70-be87f409015abc41-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "d94d4f45686664c19ba5369a9f680bd5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:08:56 GMT",
+        "elapsed-time": "190",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "d94d4f45-6866-64c1-9ba5-369a9f680bd5",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "555900954",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "lgcwkggd",
-    "SearchServiceName": "azs-net-diybelhe",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "rfvkbfbh",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/DefaultSearchModeIsAny.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/DefaultSearchModeIsAny.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "62",
         "Content-Type": "application/json",
-        "traceparent": "00-529ecf629ffa2042a1ebd7109ee11fba-c25a9fc56d32aa46-00",
+        "traceparent": "00-485d5bee327ca44480cb204c7109c23d-f63519e4c9a5a248-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "a03f9a25bc31a01a36c04ceb302bbee3",
         "x-ms-return-client-request-id": "true"
@@ -26,8 +26,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "5194",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:19:53 GMT",
-        "elapsed-time": "102",
+        "Date": "Fri, 08 May 2020 07:06:09 GMT",
+        "elapsed-time": "105",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -243,7 +243,8 @@
   ],
   "Variables": {
     "RandomSeed": "100396070",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/DefaultSearchModeIsAnyAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/DefaultSearchModeIsAnyAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "62",
         "Content-Type": "application/json",
-        "traceparent": "00-0b9ce11dea05c140b80f4138eacfac03-6423cef964f6ee42-00",
+        "traceparent": "00-db1bf52b6b0c094faded7b7de474f141-1dc35f778a0a2b40-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "d166a7fadfc6bdab8c593ef48d813a9b",
         "x-ms-return-client-request-id": "true"
@@ -26,8 +26,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "5194",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:23:13 GMT",
-        "elapsed-time": "76",
+        "Date": "Fri, 08 May 2020 07:08:56 GMT",
+        "elapsed-time": "83",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -243,7 +243,8 @@
   ],
   "Variables": {
     "RandomSeed": "1142184435",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/Filter.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/Filter.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "106",
         "Content-Type": "application/json",
-        "traceparent": "00-ef75b871f1841e4cb0354aee4ffc095b-1bfcb5854d8c3341-00",
+        "traceparent": "00-e32b275be85e564897746c4a4a26e3b9-3da8d794c7505a46-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "07a3c50b3edb39a6194807ff352b8e6c",
         "x-ms-return-client-request-id": "true"
@@ -26,8 +26,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "1193",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:19:53 GMT",
-        "elapsed-time": "13",
+        "Date": "Fri, 08 May 2020 07:06:09 GMT",
+        "elapsed-time": "14",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -83,7 +83,8 @@
   ],
   "Variables": {
     "RandomSeed": "1956187125",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/FilterAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/FilterAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "106",
         "Content-Type": "application/json",
-        "traceparent": "00-bf571d63edc3af4d93e9a77a36dac7a0-4120e05627b50a4b-00",
+        "traceparent": "00-1088384fe107fd4a870fdf9360687546-83833c24c8624b45-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "dd16b3eba0826aec7c0eb5a7d63f766c",
         "x-ms-return-client-request-id": "true"
@@ -26,8 +26,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "1193",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:23:13 GMT",
-        "elapsed-time": "5",
+        "Date": "Fri, 08 May 2020 07:08:56 GMT",
+        "elapsed-time": "8",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -83,7 +83,8 @@
   ],
   "Variables": {
     "RandomSeed": "94111913",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/HitHighlighting.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/HitHighlighting.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "188",
         "Content-Type": "application/json",
-        "traceparent": "00-097aac930cd0474db1e9d144502bfe7e-50667916495b714c-00",
+        "traceparent": "00-4b46832c6a26824a883c1a1436020491-5dbaebd0369b6646-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "158d50b0f88f6f2d22874a374cb4873b",
         "x-ms-return-client-request-id": "true"
@@ -28,10 +28,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1050",
+        "Content-Length": "1049",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:19:53 GMT",
-        "elapsed-time": "15",
+        "Date": "Fri, 08 May 2020 07:06:09 GMT",
+        "elapsed-time": "16",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -42,7 +42,7 @@
       "ResponseBody": {
         "value": [
           {
-            "@search.score": 0.6247139,
+            "@search.score": 0.624714,
             "@search.highlights": {
               "category": [
                 "\u003Cb\u003ELuxury\u003C/b\u003E"
@@ -77,7 +77,8 @@
   ],
   "Variables": {
     "RandomSeed": "2066752673",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/HitHighlightingAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/HitHighlightingAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "188",
         "Content-Type": "application/json",
-        "traceparent": "00-53dbd4817a201a4fb1d016193dca0dcb-139f9d18ea79d047-00",
+        "traceparent": "00-365549fc0bbd5a4d8e58248560bc7a60-c457c999a9696f4a-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "72baba7db5f6ee4f1f027196fc81deab",
         "x-ms-return-client-request-id": "true"
@@ -28,10 +28,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1050",
+        "Content-Length": "1049",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:23:13 GMT",
-        "elapsed-time": "11",
+        "Date": "Fri, 08 May 2020 07:08:56 GMT",
+        "elapsed-time": "7",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -42,7 +42,7 @@
       "ResponseBody": {
         "value": [
           {
-            "@search.score": 0.6247139,
+            "@search.score": 0.624714,
             "@search.highlights": {
               "category": [
                 "\u003Cb\u003ELuxury\u003C/b\u003E"
@@ -77,7 +77,8 @@
   ],
   "Variables": {
     "RandomSeed": "1321798646",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/LuceneSyntax.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/LuceneSyntax.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "110",
         "Content-Type": "application/json",
-        "traceparent": "00-72a178e2c98df847a8b082b5e1053b4c-4a5650de0cf44b4a-00",
+        "traceparent": "00-9a55609f4a698a498fb2275c3d57e9b5-ad7a8063800c9b4b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "2d0225a107f197e3c7d80141a0cbc932",
         "x-ms-return-client-request-id": "true"
@@ -28,8 +28,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "76",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:19:53 GMT",
-        "elapsed-time": "20",
+        "Date": "Fri, 08 May 2020 07:06:09 GMT",
+        "elapsed-time": "55",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -50,7 +50,8 @@
   ],
   "Variables": {
     "RandomSeed": "1305604714",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/LuceneSyntaxAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/LuceneSyntaxAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "110",
         "Content-Type": "application/json",
-        "traceparent": "00-b3e794b4c0e6d640afa0b3c92fa2bef2-2cce3aefbd765843-00",
+        "traceparent": "00-e3f4ecd91dcb3544be4fefef45571a44-d8064ac6b871eb4b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "547bdca856ac6b95fbe8f0f9687543ee",
         "x-ms-return-client-request-id": "true"
@@ -28,8 +28,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "76",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:23:13 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 08 May 2020 07:08:56 GMT",
+        "elapsed-time": "11",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -50,7 +50,8 @@
   ],
   "Variables": {
     "RandomSeed": "1340537138",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/MinimumCoverage.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/MinimumCoverage.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "70",
         "Content-Type": "application/json",
-        "traceparent": "00-ce8ef6c08043b24a9d9d5a6bb92632ac-2c0f5352d46ec449-00",
+        "traceparent": "00-fce9d7d89ca64648ae55f5f960b4cab6-96523d7a00e8be47-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "e3ce0ea2689207604ed9301360389e2d",
         "x-ms-return-client-request-id": "true"
@@ -27,8 +27,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "6362",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:19:53 GMT",
-        "elapsed-time": "8",
+        "Date": "Fri, 08 May 2020 07:06:09 GMT",
+        "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -293,7 +293,8 @@
   ],
   "Variables": {
     "RandomSeed": "1407765009",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/MinimumCoverageAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/MinimumCoverageAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "70",
         "Content-Type": "application/json",
-        "traceparent": "00-b801cde582b9fd4db22bc8e72ae604b3-ef7f8293eba68b42-00",
+        "traceparent": "00-69b8419670d0d842bf000cc9ea9ca9f8-426f0ee191058c47-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "2f588dc52dbacd39693487e8d6cba384",
         "x-ms-return-client-request-id": "true"
@@ -27,7 +27,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "6362",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:23:13 GMT",
+        "Date": "Fri, 08 May 2020 07:08:56 GMT",
         "elapsed-time": "8",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -293,7 +293,8 @@
   ],
   "Variables": {
     "RandomSeed": "640477458",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/NoOrderBySortsByScore.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/NoOrderBySortsByScore.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "93",
         "Content-Type": "application/json",
-        "traceparent": "00-e452001d944d2b49a59b30652e3d4f40-29eb85861ed24f4e-00",
+        "traceparent": "00-4f6dea5f83cbca43a490c08bd9eef3c3-09088b82a932434f-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "51839d6300b974b44332f5bf90cf6254",
         "x-ms-return-client-request-id": "true"
@@ -27,8 +27,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "1725",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:19:53 GMT",
-        "elapsed-time": "9",
+        "Date": "Fri, 08 May 2020 07:06:09 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -114,7 +114,8 @@
   ],
   "Variables": {
     "RandomSeed": "1970769932",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/NoOrderBySortsByScoreAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/NoOrderBySortsByScoreAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "93",
         "Content-Type": "application/json",
-        "traceparent": "00-6bcd95038373ab48830177e48a854159-d5f3b7c779233445-00",
+        "traceparent": "00-45cfba41a2fc1f428199b52680e1a545-e0ac086967f9d540-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "08e33c279b0342752b62202427bad24e",
         "x-ms-return-client-request-id": "true"
@@ -27,8 +27,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "1725",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:23:13 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 08 May 2020 07:08:56 GMT",
+        "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -114,7 +114,8 @@
   ],
   "Variables": {
     "RandomSeed": "317676426",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/PagingDynamicDocuments.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/PagingDynamicDocuments.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-pigqrgoh.search.windows.net/indexes(\u0027kqmqumma\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rymmqmwa\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "43933",
         "Content-Type": "application/json",
-        "traceparent": "00-0ca1ec15ddb5a941beb62cb83b6c3eea-c22db3224a956d4f-00",
+        "traceparent": "00-02c9be149c6f5545ac2a57066a11f773-161ef6748748c14c-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "f902170b5f6982db30c334500832f83e",
         "x-ms-return-client-request-id": "true"
@@ -4025,8 +4025,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "64933",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:20:21 GMT",
-        "elapsed-time": "326",
+        "Date": "Fri, 08 May 2020 07:06:33 GMT",
+        "elapsed-time": "195",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -10040,17 +10040,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-pigqrgoh.search.windows.net/indexes(\u0027kqmqumma\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rymmqmwa\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "44606",
         "Content-Type": "application/json",
-        "traceparent": "00-bb6cb9faae758b4f8e31da99a4cc77be-0178793e6e377f42-00",
+        "traceparent": "00-95a3ca2dcf1cf94fac413883b1d9d5a0-f72349b2359afa46-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "90bae7f3decf0a33e3adc707e20db7b1",
         "x-ms-return-client-request-id": "true"
@@ -14028,8 +14028,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "65417",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:20:23 GMT",
-        "elapsed-time": "162",
+        "Date": "Fri, 08 May 2020 07:06:35 GMT",
+        "elapsed-time": "107",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -19989,17 +19989,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-pigqrgoh.search.windows.net/indexes(\u0027kqmqumma\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rymmqmwa\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "103",
         "Content-Type": "application/json",
-        "traceparent": "00-32ef24893d9e154181c7a66bde0c4057-c3e4634e4211c945-00",
+        "traceparent": "00-470c4b1e94764448aa2062e4b8e8ab2e-07079ff734f6b647-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "1de60394e06a048713226216d5b1bb2e",
         "x-ms-return-client-request-id": "true"
@@ -20015,10 +20015,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "39184",
+        "Content-Length": "39188",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:20:26 GMT",
-        "elapsed-time": "80",
+        "Date": "Fri, 08 May 2020 07:06:38 GMT",
+        "elapsed-time": "68",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -24038,11 +24038,11 @@
             "hotelId": "1899"
           }
         ],
-        "@odata.nextLink": "https://azs-net-pigqrgoh.search.windows.net/indexes(\u0027kqmqumma\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rymmqmwa\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-pigqrgoh.search.windows.net/indexes(\u0027kqmqumma\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rymmqmwa\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
@@ -24050,8 +24050,8 @@
         "Content-Length": "115",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "b2a29505a1092c1ee3f715bc97d3a022",
         "x-ms-return-client-request-id": "true"
@@ -24068,10 +24068,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "38300",
+        "Content-Length": "38304",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:20:26 GMT",
-        "elapsed-time": "75",
+        "Date": "Fri, 08 May 2020 07:06:38 GMT",
+        "elapsed-time": "123",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -28091,11 +28091,11 @@
             "hotelId": "998"
           }
         ],
-        "@odata.nextLink": "https://azs-net-pigqrgoh.search.windows.net/indexes(\u0027kqmqumma\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rymmqmwa\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-pigqrgoh.search.windows.net/indexes(\u0027kqmqumma\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rymmqmwa\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
@@ -28103,8 +28103,8 @@
         "Content-Length": "115",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "05bb820cdb4b13d35fb57dac7c1c3432",
         "x-ms-return-client-request-id": "true"
@@ -28123,8 +28123,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "49",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:20:26 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 08 May 2020 07:06:38 GMT",
+        "elapsed-time": "8",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -28140,16 +28140,40 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027rymmqmwa\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-7e81555f57ad174cac7b84dde390ac81-5c61279c83f7ea45-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "4c0299f2056bf2a8e5ba3973cacb6c40",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:06:38 GMT",
+        "elapsed-time": "429",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "4c0299f2-056b-f2a8-e5ba-3973cacb6c40",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "965034096",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "kqmqumma",
-    "SearchServiceName": "azs-net-pigqrgoh",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "rymmqmwa",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/PagingDynamicDocumentsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/PagingDynamicDocumentsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-yfkbhynf.search.windows.net/indexes(\u0027fwynqoxx\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fwvqrhej\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "43933",
         "Content-Type": "application/json",
-        "traceparent": "00-8f1b7c5d98f2144ca8001f385d4ae59a-0db1c90eb4cf5846-00",
+        "traceparent": "00-9c60e30989483d43b631d9a8986b8e92-7e0fa4a6f31a4c49-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "6c1cd894bc0b232c5f30bdb16e8dd153",
         "x-ms-return-client-request-id": "true"
@@ -4025,8 +4025,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "64933",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:23:40 GMT",
-        "elapsed-time": "160",
+        "Date": "Fri, 08 May 2020 07:09:20 GMT",
+        "elapsed-time": "198",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -10040,17 +10040,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-yfkbhynf.search.windows.net/indexes(\u0027fwynqoxx\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fwvqrhej\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "44606",
         "Content-Type": "application/json",
-        "traceparent": "00-c064c06fde53a44e908149bc2b06b4ff-f9240852004b4748-00",
+        "traceparent": "00-8d625500de0c4c45afdc7db6f5b02f0a-9bbcd1af697cd94e-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "c3c78e0a3ca3a7e71527be41ab56635b",
         "x-ms-return-client-request-id": "true"
@@ -14028,8 +14028,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "65417",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:23:43 GMT",
-        "elapsed-time": "172",
+        "Date": "Fri, 08 May 2020 07:09:23 GMT",
+        "elapsed-time": "114",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -19989,17 +19989,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-yfkbhynf.search.windows.net/indexes(\u0027fwynqoxx\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fwvqrhej\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "103",
         "Content-Type": "application/json",
-        "traceparent": "00-ad9411239fa45d4babe293dd12656c86-866dde0b4738de41-00",
+        "traceparent": "00-633059268ea8754cae25e9f125596891-2c20e47e0b683d40-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "d5efcdae8bd77c4def6c5da7f8b4a2c6",
         "x-ms-return-client-request-id": "true"
@@ -20015,10 +20015,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "39184",
+        "Content-Length": "39188",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:23:45 GMT",
-        "elapsed-time": "96",
+        "Date": "Fri, 08 May 2020 07:09:25 GMT",
+        "elapsed-time": "72",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -24038,11 +24038,11 @@
             "hotelId": "1899"
           }
         ],
-        "@odata.nextLink": "https://azs-net-yfkbhynf.search.windows.net/indexes(\u0027fwynqoxx\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fwvqrhej\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-yfkbhynf.search.windows.net/indexes(\u0027fwynqoxx\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fwvqrhej\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
@@ -24050,8 +24050,8 @@
         "Content-Length": "115",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "f0b6a605c1925761f17557e4feea7808",
         "x-ms-return-client-request-id": "true"
@@ -24068,10 +24068,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "38300",
+        "Content-Length": "38304",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:23:45 GMT",
-        "elapsed-time": "75",
+        "Date": "Fri, 08 May 2020 07:09:25 GMT",
+        "elapsed-time": "95",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -28091,11 +28091,11 @@
             "hotelId": "998"
           }
         ],
-        "@odata.nextLink": "https://azs-net-yfkbhynf.search.windows.net/indexes(\u0027fwynqoxx\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fwvqrhej\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-yfkbhynf.search.windows.net/indexes(\u0027fwynqoxx\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fwvqrhej\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
@@ -28103,8 +28103,8 @@
         "Content-Length": "115",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "a00362ccfb9e7e7b414ad437de40ae61",
         "x-ms-return-client-request-id": "true"
@@ -28123,8 +28123,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "49",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:23:45 GMT",
-        "elapsed-time": "17",
+        "Date": "Fri, 08 May 2020 07:09:25 GMT",
+        "elapsed-time": "7",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -28140,16 +28140,40 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fwvqrhej\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-73bb03f2f9992a4ca1f2f619c1637ade-1d703a7d67d7b546-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "043cf88472a0edc86c98e46234687e04",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:09:25 GMT",
+        "elapsed-time": "273",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "043cf884-72a0-edc8-6c98-e46234687e04",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1530289457",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "fwynqoxx",
-    "SearchServiceName": "azs-net-yfkbhynf",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "fwvqrhej",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/PagingStaticDocuments.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/PagingStaticDocuments.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-dnvhneur.search.windows.net/indexes(\u0027ttrbvxuw\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fecfwled\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "43933",
         "Content-Type": "application/json",
-        "traceparent": "00-a13d1936df5f36419ebda566f1b164db-2003b68d2ad3b848-00",
+        "traceparent": "00-52b0e696b42b0a42b029df4b9c95595f-f045416062a33741-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "f5e4b2e9b3b2bbc04351915ecd7581a4",
         "x-ms-return-client-request-id": "true"
@@ -4025,8 +4025,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "64933",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:20:55 GMT",
-        "elapsed-time": "333",
+        "Date": "Fri, 08 May 2020 07:07:02 GMT",
+        "elapsed-time": "205",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -10040,17 +10040,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-dnvhneur.search.windows.net/indexes(\u0027ttrbvxuw\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fecfwled\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "44606",
         "Content-Type": "application/json",
-        "traceparent": "00-b5f1e4732ee75843bf0f444505bbeca1-869e70a3b1590a47-00",
+        "traceparent": "00-5812ab7f6a90924fa0345eea1bd7dc13-c6a974dada260d42-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "c4a74eff0e26b572696c7711e0e91b72",
         "x-ms-return-client-request-id": "true"
@@ -14028,8 +14028,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "65417",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:20:58 GMT",
-        "elapsed-time": "178",
+        "Date": "Fri, 08 May 2020 07:07:04 GMT",
+        "elapsed-time": "100",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -19989,17 +19989,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-dnvhneur.search.windows.net/indexes(\u0027ttrbvxuw\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fecfwled\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "103",
         "Content-Type": "application/json",
-        "traceparent": "00-d476ef04c8a9194586482675dc590b1b-b46ea00a3232be48-00",
+        "traceparent": "00-50faf971f3d6024aa2ab317c3cafd4ef-45dedb5d79138546-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "ba6291c562f3eead2d9d4e9ff1b5ac53",
         "x-ms-return-client-request-id": "true"
@@ -20015,10 +20015,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "39184",
+        "Content-Length": "39188",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:21:00 GMT",
-        "elapsed-time": "100",
+        "Date": "Fri, 08 May 2020 07:07:06 GMT",
+        "elapsed-time": "85",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -24038,11 +24038,11 @@
             "hotelId": "1899"
           }
         ],
-        "@odata.nextLink": "https://azs-net-dnvhneur.search.windows.net/indexes(\u0027ttrbvxuw\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fecfwled\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-dnvhneur.search.windows.net/indexes(\u0027ttrbvxuw\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fecfwled\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
@@ -24050,8 +24050,8 @@
         "Content-Length": "115",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "9c5b10458de4daaf402f8b453bafdb59",
         "x-ms-return-client-request-id": "true"
@@ -24068,10 +24068,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "38300",
+        "Content-Length": "38304",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:21:00 GMT",
-        "elapsed-time": "76",
+        "Date": "Fri, 08 May 2020 07:07:06 GMT",
+        "elapsed-time": "59",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -28091,11 +28091,11 @@
             "hotelId": "998"
           }
         ],
-        "@odata.nextLink": "https://azs-net-dnvhneur.search.windows.net/indexes(\u0027ttrbvxuw\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fecfwled\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-dnvhneur.search.windows.net/indexes(\u0027ttrbvxuw\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fecfwled\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
@@ -28103,8 +28103,8 @@
         "Content-Length": "115",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "3c981e36c7129db1a1b89788c0d2c3b4",
         "x-ms-return-client-request-id": "true"
@@ -28123,7 +28123,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "49",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:21:00 GMT",
+        "Date": "Fri, 08 May 2020 07:07:06 GMT",
         "elapsed-time": "10",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -28140,16 +28140,40 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027fecfwled\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-cd5b047c4083a24eaee36bb23a34bc98-e2f47d17130c0d41-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "d0cc24c07e8e388ee18879c3d667b27d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:07:07 GMT",
+        "elapsed-time": "220",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "d0cc24c0-7e8e-388e-e188-79c3d667b27d",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "803774682",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "ttrbvxuw",
-    "SearchServiceName": "azs-net-dnvhneur",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "fecfwled",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/PagingStaticDocumentsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/PagingStaticDocumentsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-moteoihj.search.windows.net/indexes(\u0027hafnsqkd\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vbqitwwd\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "43933",
         "Content-Type": "application/json",
-        "traceparent": "00-0615d10d2cbc3d49a2d45be8cb200e44-66f659337b61484c-00",
+        "traceparent": "00-af9e3b03695c7b4f8eef20d1cba9bd52-cefc6de9a776e249-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "25badf7625e4e590537891d8131df88b",
         "x-ms-return-client-request-id": "true"
@@ -4025,8 +4025,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "64933",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:14 GMT",
-        "elapsed-time": "321",
+        "Date": "Fri, 08 May 2020 07:09:49 GMT",
+        "elapsed-time": "168",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -10040,17 +10040,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-moteoihj.search.windows.net/indexes(\u0027hafnsqkd\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vbqitwwd\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "44606",
         "Content-Type": "application/json",
-        "traceparent": "00-9db230c446506844b775bd7bd0763430-4ee0c8574b227441-00",
+        "traceparent": "00-f0fce56eb8f1004b9854cf8a8c33c34f-15fbc72ddfa79042-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "e3431df9a98ef535e5499a4b88e8c054",
         "x-ms-return-client-request-id": "true"
@@ -14028,8 +14028,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "65417",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:16 GMT",
-        "elapsed-time": "175",
+        "Date": "Fri, 08 May 2020 07:09:50 GMT",
+        "elapsed-time": "133",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -19989,17 +19989,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-moteoihj.search.windows.net/indexes(\u0027hafnsqkd\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vbqitwwd\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "103",
         "Content-Type": "application/json",
-        "traceparent": "00-558aa03dd5eb7b48a7ea222e4d4dbab0-11313892ba57f546-00",
+        "traceparent": "00-082538bd15bb4b4582d7e76a93cd5c5d-211a7dc91e175546-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "b0ddc258791d80ee430bdf5d381ffc96",
         "x-ms-return-client-request-id": "true"
@@ -20015,10 +20015,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "39184",
+        "Content-Length": "39188",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:19 GMT",
-        "elapsed-time": "84",
+        "Date": "Fri, 08 May 2020 07:09:53 GMT",
+        "elapsed-time": "66",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -24038,11 +24038,11 @@
             "hotelId": "1899"
           }
         ],
-        "@odata.nextLink": "https://azs-net-moteoihj.search.windows.net/indexes(\u0027hafnsqkd\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vbqitwwd\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-moteoihj.search.windows.net/indexes(\u0027hafnsqkd\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vbqitwwd\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
@@ -24050,8 +24050,8 @@
         "Content-Length": "115",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "06d2ee22638fccbea9c43f9a8b445c6a",
         "x-ms-return-client-request-id": "true"
@@ -24068,10 +24068,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "38300",
+        "Content-Length": "38304",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:19 GMT",
-        "elapsed-time": "74",
+        "Date": "Fri, 08 May 2020 07:09:53 GMT",
+        "elapsed-time": "59",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -28091,11 +28091,11 @@
             "hotelId": "998"
           }
         ],
-        "@odata.nextLink": "https://azs-net-moteoihj.search.windows.net/indexes(\u0027hafnsqkd\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vbqitwwd\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-moteoihj.search.windows.net/indexes(\u0027hafnsqkd\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vbqitwwd\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
@@ -28103,8 +28103,8 @@
         "Content-Length": "115",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "517f3cb848407f6d2fc39f83cad7bcc6",
         "x-ms-return-client-request-id": "true"
@@ -28123,7 +28123,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "49",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:19 GMT",
+        "Date": "Fri, 08 May 2020 07:09:53 GMT",
         "elapsed-time": "9",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -28140,16 +28140,40 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027vbqitwwd\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-3bd4b600fa12ca48bb944e28fa03f7dd-895e71fa885b9948-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "9929034cb915f5c5031006593953f5fe",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:09:53 GMT",
+        "elapsed-time": "224",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "9929034c-b915-f5c5-0310-06593953f5fe",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "1931089632",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "hafnsqkd",
-    "SearchServiceName": "azs-net-moteoihj",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "vbqitwwd",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/PagingWithoutSize.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/PagingWithoutSize.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-lerplheu.search.windows.net/indexes(\u0027qksgqmpj\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027phjwqidl\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "6830",
         "Content-Type": "application/json",
-        "traceparent": "00-193650b30ffa764984bc62479975da77-1559e0a2938d704e-00",
+        "traceparent": "00-099a2e6d3d89db42924821295104785a-189c1f7752751449-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "5c63aeb286354da593d3ba4250db02c6",
         "x-ms-return-client-request-id": "true"
@@ -653,8 +653,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "10127",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:21:29 GMT",
-        "elapsed-time": "64",
+        "Date": "Fri, 08 May 2020 07:07:30 GMT",
+        "elapsed-time": "142",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -1610,17 +1610,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-lerplheu.search.windows.net/indexes(\u0027qksgqmpj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027phjwqidl\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "92",
         "Content-Type": "application/json",
-        "traceparent": "00-3fa35fa5ee35f741bc40f19ebe857017-6808e4aec0691944-00",
+        "traceparent": "00-42047b7727caba4f86fb9786b047e253-b6bc11f4d81d1847-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "008ca289d6b923f0d534bfde2ccf66e0",
         "x-ms-return-client-request-id": "true"
@@ -1635,10 +1635,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "2175",
+        "Content-Length": "2179",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:21:31 GMT",
-        "elapsed-time": "25",
+        "Date": "Fri, 08 May 2020 07:07:32 GMT",
+        "elapsed-time": "19",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -1857,11 +1857,11 @@
             "hotelId": "143"
           }
         ],
-        "@odata.nextLink": "https://azs-net-lerplheu.search.windows.net/indexes(\u0027qksgqmpj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027phjwqidl\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-lerplheu.search.windows.net/indexes(\u0027qksgqmpj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027phjwqidl\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
@@ -1869,8 +1869,8 @@
         "Content-Length": "102",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "bd4430c95eb338f41bfe5cd622be84d6",
         "x-ms-return-client-request-id": "true"
@@ -1886,10 +1886,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "2155",
+        "Content-Length": "2159",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:21:31 GMT",
-        "elapsed-time": "10",
+        "Date": "Fri, 08 May 2020 07:07:32 GMT",
+        "elapsed-time": "9",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -2108,11 +2108,11 @@
             "hotelId": "38"
           }
         ],
-        "@odata.nextLink": "https://azs-net-lerplheu.search.windows.net/indexes(\u0027qksgqmpj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027phjwqidl\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-lerplheu.search.windows.net/indexes(\u0027qksgqmpj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027phjwqidl\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
@@ -2120,8 +2120,8 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "bf55aa85a643dbf9bd408701c6c620c3",
         "x-ms-return-client-request-id": "true"
@@ -2137,10 +2137,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "2128",
+        "Content-Length": "2132",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:21:31 GMT",
-        "elapsed-time": "11",
+        "Date": "Fri, 08 May 2020 07:07:32 GMT",
+        "elapsed-time": "9",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -2359,11 +2359,11 @@
             "hotelId": "83"
           }
         ],
-        "@odata.nextLink": "https://azs-net-lerplheu.search.windows.net/indexes(\u0027qksgqmpj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027phjwqidl\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-lerplheu.search.windows.net/indexes(\u0027qksgqmpj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027phjwqidl\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
@@ -2371,8 +2371,8 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "2079da6d45972b12ae54e4bb7a1a0016",
         "x-ms-return-client-request-id": "true"
@@ -2390,8 +2390,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "639",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:21:31 GMT",
-        "elapsed-time": "9",
+        "Date": "Fri, 08 May 2020 07:07:32 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -2471,16 +2471,40 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027phjwqidl\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-b25aeaf4d686754a9d9c1168349824c6-3379755d40a5234b-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "8258e9b0a67a229d3668ff73d6f37155",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:07:32 GMT",
+        "elapsed-time": "213",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "8258e9b0-a67a-229d-3668-ff73d6f37155",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "862653823",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "qksgqmpj",
-    "SearchServiceName": "azs-net-lerplheu",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "phjwqidl",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/PagingWithoutSizeAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/PagingWithoutSizeAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-tlegeaad.search.windows.net/indexes(\u0027tsvhmtmv\u0027)/docs/search.index?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027cxpujdnx\u0027)/docs/search.index?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "6830",
         "Content-Type": "application/json",
-        "traceparent": "00-2f42ec641788404f91cf21ed7b7b8b32-6700d6070e783346-00",
+        "traceparent": "00-10013573fc28b64392280f8d3605be2d-2b5f64e14b652a4f-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "c6da286d68e4a77510f6d12ab928fcf9",
         "x-ms-return-client-request-id": "true"
@@ -653,8 +653,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "10127",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:48 GMT",
-        "elapsed-time": "64",
+        "Date": "Fri, 08 May 2020 07:10:17 GMT",
+        "elapsed-time": "90",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -1610,17 +1610,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-tlegeaad.search.windows.net/indexes(\u0027tsvhmtmv\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027cxpujdnx\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "92",
         "Content-Type": "application/json",
-        "traceparent": "00-8200d08a538a2d4ba8193e1d01fd23a2-e3c3458914d77840-00",
+        "traceparent": "00-88181e377ef6464a835c6d4964ab8cfe-718a9d9ae542a94a-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "46f58ece534e8fc2dfdc14db394c1d57",
         "x-ms-return-client-request-id": "true"
@@ -1635,10 +1635,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "2175",
+        "Content-Length": "2179",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:50 GMT",
-        "elapsed-time": "20",
+        "Date": "Fri, 08 May 2020 07:10:19 GMT",
+        "elapsed-time": "18",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -1857,11 +1857,11 @@
             "hotelId": "143"
           }
         ],
-        "@odata.nextLink": "https://azs-net-tlegeaad.search.windows.net/indexes(\u0027tsvhmtmv\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027cxpujdnx\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-tlegeaad.search.windows.net/indexes(\u0027tsvhmtmv\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027cxpujdnx\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
@@ -1869,8 +1869,8 @@
         "Content-Length": "102",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "d98f51e20a0d6b70c8d696f1866205b3",
         "x-ms-return-client-request-id": "true"
@@ -1886,9 +1886,9 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "2155",
+        "Content-Length": "2159",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:50 GMT",
+        "Date": "Fri, 08 May 2020 07:10:19 GMT",
         "elapsed-time": "8",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -2108,11 +2108,11 @@
             "hotelId": "38"
           }
         ],
-        "@odata.nextLink": "https://azs-net-tlegeaad.search.windows.net/indexes(\u0027tsvhmtmv\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027cxpujdnx\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-tlegeaad.search.windows.net/indexes(\u0027tsvhmtmv\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027cxpujdnx\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
@@ -2120,8 +2120,8 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "8317ee020ee41a3b654ae608549a6ec3",
         "x-ms-return-client-request-id": "true"
@@ -2137,10 +2137,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "2128",
+        "Content-Length": "2132",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:50 GMT",
-        "elapsed-time": "10",
+        "Date": "Fri, 08 May 2020 07:10:19 GMT",
+        "elapsed-time": "38",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -2359,11 +2359,11 @@
             "hotelId": "83"
           }
         ],
-        "@odata.nextLink": "https://azs-net-tlegeaad.search.windows.net/indexes(\u0027tsvhmtmv\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
+        "@odata.nextLink": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027cxpujdnx\u0027)/docs/search.post.search?api-version=2019-05-06-Preview"
       }
     },
     {
-      "RequestUri": "https://azs-net-tlegeaad.search.windows.net/indexes(\u0027tsvhmtmv\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027cxpujdnx\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
@@ -2371,8 +2371,8 @@
         "Content-Length": "103",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "674879d92299c3ec1e897e77bdd1097d",
         "x-ms-return-client-request-id": "true"
@@ -2390,8 +2390,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "639",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:50 GMT",
-        "elapsed-time": "10",
+        "Date": "Fri, 08 May 2020 07:10:19 GMT",
+        "elapsed-time": "7",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -2471,16 +2471,40 @@
           }
         ]
       }
+    },
+    {
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027cxpujdnx\u0027)?api-version=2019-05-06-Preview",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json; odata.metadata=minimal",
+        "api-key": "Sanitized",
+        "traceparent": "00-6e3382cdeb278145963c120471fbf37f-e1f40db8c9728d43-00",
+        "User-Agent": [
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
+        ],
+        "x-ms-client-request-id": "4ad860d69935d372157574c22367172e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Date": "Fri, 08 May 2020 07:10:19 GMT",
+        "elapsed-time": "209",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "request-id": "4ad860d6-9935-d372-1575-74c22367172e",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains"
+      },
+      "ResponseBody": []
     }
   ],
   "Variables": {
-    "CLIENT_ID": "f9ab11db-b032-44b3-af0a-44713541cc40",
-    "LOCATION": "westus2",
     "RandomSeed": "2041220412",
-    "RESOURCE_GROUP": "heaths-search",
-    "SearchIndexName": "tsvhmtmv",
-    "SearchServiceName": "azs-net-tlegeaad",
-    "SUBSCRIPTION_ID": "faa080af-c1d8-40ad-9cce-e1a450ca5b57",
-    "TENANT_ID": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "SearchIndexName": "cxpujdnx",
+    "SEARCH_ADMIN_API_KEY": "Sanitized",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/RangeFacets.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/RangeFacets.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "128",
         "Content-Type": "application/json",
-        "traceparent": "00-bfb5de0420bd1c469b114a3dd5917f9c-83edf879ebf9f94a-00",
+        "traceparent": "00-35ac3e032e62924b9b5ea0f119f9912d-8732d540950ebe46-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "d4f7f71a4e616f30a50a994591b9bc06",
         "x-ms-return-client-request-id": "true"
@@ -29,8 +29,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "6606",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:21:33 GMT",
-        "elapsed-time": "142",
+        "Date": "Fri, 08 May 2020 07:07:32 GMT",
+        "elapsed-time": "134",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -326,7 +326,8 @@
   ],
   "Variables": {
     "RandomSeed": "1958082955",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/RangeFacetsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/RangeFacetsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "128",
         "Content-Type": "application/json",
-        "traceparent": "00-8f7f007cea7fa14fb892f2f610f2d707-10b603511299194d-00",
+        "traceparent": "00-47ee3f3761ef5f4986149d229eacdeea-9fdc846b6130094f-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "b6098f300a3dfc7c11745ebcade6cf5d",
         "x-ms-return-client-request-id": "true"
@@ -29,8 +29,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "6606",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:53 GMT",
-        "elapsed-time": "88",
+        "Date": "Fri, 08 May 2020 07:10:19 GMT",
+        "elapsed-time": "110",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -326,7 +326,8 @@
   ],
   "Variables": {
     "RandomSeed": "16759243",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/RegexSearch.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/RegexSearch.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "119",
         "Content-Type": "application/json",
-        "traceparent": "00-b21c59d8f7270943af43ecf28e68e467-0a2ecc340ade2340-00",
+        "traceparent": "00-c9591c4763fc7149a013a968d7f2f551-0a1b72cb31b0ea46-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "7743db6bbc42e61ea005c3fb312641d3",
         "x-ms-return-client-request-id": "true"
@@ -28,8 +28,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "70",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:21:33 GMT",
-        "elapsed-time": "8",
+        "Date": "Fri, 08 May 2020 07:07:32 GMT",
+        "elapsed-time": "7",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -50,7 +50,8 @@
   ],
   "Variables": {
     "RandomSeed": "867751402",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/RegexSearchAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/RegexSearchAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "119",
         "Content-Type": "application/json",
-        "traceparent": "00-25943182eae8904699623342c982db36-b554ba3f778b2149-00",
+        "traceparent": "00-8f18bc2bc3850946a7e93e619b52f361-9eda6f404073e242-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "013d1ca4d19ece4956bfa35f180b83c7",
         "x-ms-return-client-request-id": "true"
@@ -28,8 +28,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "70",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:53 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 08 May 2020 07:10:19 GMT",
+        "elapsed-time": "8",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -50,7 +50,8 @@
   ],
   "Variables": {
     "RandomSeed": "780300718",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/RegexSpecialChars.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/RegexSpecialChars.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "144",
         "Content-Type": "application/json",
-        "traceparent": "00-7de18bb6bfa1ab468aba58c1e1579f1d-d9d165512e70424e-00",
+        "traceparent": "00-a08f74ceced4e54ca71493abfd1e9423-beabe1b7b67e4949-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "41666bf80fb2d16593377ffe9606f6a8",
         "x-ms-return-client-request-id": "true"
@@ -27,8 +27,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "12",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:21:33 GMT",
-        "elapsed-time": "20",
+        "Date": "Fri, 08 May 2020 07:07:32 GMT",
+        "elapsed-time": "38",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -43,7 +43,8 @@
   ],
   "Variables": {
     "RandomSeed": "822803816",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/RegexSpecialCharsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/RegexSpecialCharsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "144",
         "Content-Type": "application/json",
-        "traceparent": "00-9b0e335d39383a4abac3cd72a83927c9-2870ab2280fa754c-00",
+        "traceparent": "00-75c6013c2cefe841877527c9d6c8c5e1-31e3e31d62b62744-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "32ff1956c352f9e2e40ce3c1624ffb9d",
         "x-ms-return-client-request-id": "true"
@@ -27,8 +27,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "12",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:53 GMT",
-        "elapsed-time": "20",
+        "Date": "Fri, 08 May 2020 07:10:19 GMT",
+        "elapsed-time": "33",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -43,7 +43,8 @@
   ],
   "Variables": {
     "RandomSeed": "739320000",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/RegexSpecialCharsUnescapedThrows.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/RegexSpecialCharsUnescapedThrows.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "74",
         "Content-Type": "application/json",
-        "traceparent": "00-7441bce98baeec4187c84d047e3e089b-0c6ac31dd88e7448-00",
+        "traceparent": "00-5f6e11b7def9764eb35cf4d0f690fcc1-1677e9b9450eef43-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "773a68d9fe8c603d317db3ec2c347eef",
         "x-ms-return-client-request-id": "true"
@@ -28,8 +28,8 @@
         "Content-Language": "en",
         "Content-Length": "148",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:21:33 GMT",
-        "elapsed-time": "33",
+        "Date": "Fri, 08 May 2020 07:07:32 GMT",
+        "elapsed-time": "32",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -47,7 +47,8 @@
   ],
   "Variables": {
     "RandomSeed": "1082736906",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/RegexSpecialCharsUnescapedThrowsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/RegexSpecialCharsUnescapedThrowsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "74",
         "Content-Type": "application/json",
-        "traceparent": "00-ffb4b98188a7cf4da44db80cff02077b-a776608142bd0d4d-00",
+        "traceparent": "00-d1f44fc3613ea448a9383d6daedbf8c7-516029145c613645-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "bf8cc4a405e089e0f690d708880c3947",
         "x-ms-return-client-request-id": "true"
@@ -28,8 +28,8 @@
         "Content-Language": "en",
         "Content-Length": "148",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:53 GMT",
-        "elapsed-time": "19",
+        "Date": "Fri, 08 May 2020 07:10:19 GMT",
+        "elapsed-time": "15",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -47,7 +47,8 @@
   ],
   "Variables": {
     "RandomSeed": "1564667618",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/SearchModeAll.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/SearchModeAll.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "102",
         "Content-Type": "application/json",
-        "traceparent": "00-964b8ea2df56584290ec3a5bf0785ff2-8776fc5ac294ae4d-00",
+        "traceparent": "00-1e13b17e77fa764baf1d2198a85b7759-98302a27035c1447-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "5246c30c2fc5166062073847e24aecb4",
         "x-ms-return-client-request-id": "true"
@@ -28,8 +28,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "396",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:21:33 GMT",
-        "elapsed-time": "8",
+        "Date": "Fri, 08 May 2020 07:07:32 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -64,7 +64,8 @@
   ],
   "Variables": {
     "RandomSeed": "2122308432",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/SearchModeAllAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/SearchModeAllAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "102",
         "Content-Type": "application/json",
-        "traceparent": "00-f39d886baf91a64183acf17649f35a05-9acbd03142cd7f4c-00",
+        "traceparent": "00-9b6c092e771889419e2451194b345e62-fb6e00f0cb2f554a-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "e1351a5bbc8b244d32e5d5fa7d7ac951",
         "x-ms-return-client-request-id": "true"
@@ -28,8 +28,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "396",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:53 GMT",
-        "elapsed-time": "6",
+        "Date": "Fri, 08 May 2020 07:10:19 GMT",
+        "elapsed-time": "34",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -64,7 +64,8 @@
   ],
   "Variables": {
     "RandomSeed": "1552992714",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/SelectedFields.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/SelectedFields.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "155",
         "Content-Type": "application/json",
-        "traceparent": "00-ac1ce9206bfcab47a0742b96f0c58187-6b2f752618b4414f-00",
+        "traceparent": "00-3a7a2576d5795e4db25f0e2c5daeba5e-87b4b4bb91959f4f-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "976c7c35862a4db0638a786eaa22c282",
         "x-ms-return-client-request-id": "true"
@@ -28,8 +28,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "260",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:21:33 GMT",
-        "elapsed-time": "5",
+        "Date": "Fri, 08 May 2020 07:07:32 GMT",
+        "elapsed-time": "68",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -68,7 +68,8 @@
   ],
   "Variables": {
     "RandomSeed": "28556768",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/SelectedFieldsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/SelectedFieldsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "155",
         "Content-Type": "application/json",
-        "traceparent": "00-783de9da4824684aaa3311899b074d7e-2f8388bf9d1f2a4e-00",
+        "traceparent": "00-cd32df482eeb714698af271a7c2f1177-60fe065a8dd26b43-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "3f1bb1dd35221989dc01b4801da37148",
         "x-ms-return-client-request-id": "true"
@@ -28,8 +28,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "260",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:53 GMT",
-        "elapsed-time": "6",
+        "Date": "Fri, 08 May 2020 07:10:19 GMT",
+        "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -68,7 +68,8 @@
   ],
   "Variables": {
     "RandomSeed": "1278407184",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/SizeAndSkipForPaging.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/SizeAndSkipForPaging.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "86",
         "Content-Type": "application/json",
-        "traceparent": "00-99fcec8474f493459f8b3c6d144cf27f-a81069527e61d542-00",
+        "traceparent": "00-eafdf41906828147af8178b56129fe4c-96e8060f9e48af40-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "943874a0a80aa2a6a01accb8f84c3db7",
         "x-ms-return-client-request-id": "true"
@@ -29,8 +29,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "2567",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:21:33 GMT",
-        "elapsed-time": "8",
+        "Date": "Fri, 08 May 2020 07:07:33 GMT",
+        "elapsed-time": "7",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -135,17 +135,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "86",
         "Content-Type": "application/json",
-        "traceparent": "00-3d4e5062fefa9a44a2925766becb5d8f-63d32f3557fb554e-00",
+        "traceparent": "00-51fad49b4fdbbf4c8e63f3df441000c4-2523e956de13c148-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "96ac0b04cf88a5af76be6cb10318eb36",
         "x-ms-return-client-request-id": "true"
@@ -163,8 +163,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "1010",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:21:33 GMT",
-        "elapsed-time": "9",
+        "Date": "Fri, 08 May 2020 07:07:33 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -237,7 +237,8 @@
   ],
   "Variables": {
     "RandomSeed": "777577952",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/SizeAndSkipForPagingAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/SizeAndSkipForPagingAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "86",
         "Content-Type": "application/json",
-        "traceparent": "00-2f3b63067828a84d9c58ee125d1e03a9-1e9aa98ed57add42-00",
+        "traceparent": "00-04c2805640cb814088d58cd7c0764019-4c2beaa477da0c42-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "3cf063fa37842845712502311e7afb0b",
         "x-ms-return-client-request-id": "true"
@@ -29,8 +29,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "2567",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:53 GMT",
-        "elapsed-time": "24",
+        "Date": "Fri, 08 May 2020 07:10:19 GMT",
+        "elapsed-time": "7",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -135,17 +135,17 @@
       }
     },
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "86",
         "Content-Type": "application/json",
-        "traceparent": "00-e4ada4f06a4adb48bac9f31c8e93a3f2-1bef4c2d41d9c244-00",
+        "traceparent": "00-b530bc28913574408f6fc63c18c9399f-fb8b4e982d728d4b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "95d80ea638dce1209f1a7d2135ce0bdb",
         "x-ms-return-client-request-id": "true"
@@ -163,8 +163,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "1010",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:53 GMT",
-        "elapsed-time": "6",
+        "Date": "Fri, 08 May 2020 07:10:20 GMT",
+        "elapsed-time": "38",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -237,7 +237,8 @@
   ],
   "Variables": {
     "RandomSeed": "171018898",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/ThrowsWhenRequestIsMalformed.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/ThrowsWhenRequestIsMalformed.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "88",
         "Content-Type": "application/json",
-        "traceparent": "00-5122a09de8221349a01c75e94aba50ba-1428e8564cf7dd45-00",
+        "traceparent": "00-7f10253bbeeaf74a9abfede8dd60618f-064846eae4985048-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "5ce2f2d871868dbadfdf3c78e9ae7044",
         "x-ms-return-client-request-id": "true"
@@ -28,7 +28,7 @@
         "Content-Language": "en",
         "Content-Length": "141",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:21:33 GMT",
+        "Date": "Fri, 08 May 2020 07:07:33 GMT",
         "elapsed-time": "2",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -47,7 +47,8 @@
   ],
   "Variables": {
     "RandomSeed": "455367892",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/ThrowsWhenRequestIsMalformedAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/ThrowsWhenRequestIsMalformedAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "88",
         "Content-Type": "application/json",
-        "traceparent": "00-87b09e1373b88c4c95878f09358f3a8e-78f86194efd2bd43-00",
+        "traceparent": "00-cc66baa04372ec47926b1ffcd1eebaaa-7d7267abee33dd4b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "f18dbf637d46a3edd29262677b02b0cd",
         "x-ms-return-client-request-id": "true"
@@ -28,7 +28,7 @@
         "Content-Language": "en",
         "Content-Length": "141",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:53 GMT",
+        "Date": "Fri, 08 May 2020 07:10:20 GMT",
         "elapsed-time": "2",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -47,7 +47,8 @@
   ],
   "Variables": {
     "RandomSeed": "1660709923",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/TotalCount.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/TotalCount.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "62",
         "Content-Type": "application/json",
-        "traceparent": "00-096efd143bb1d946989d9374ee6589f3-c200a61647ac444a-00",
+        "traceparent": "00-dbd4016665127a40948689d39de2150b-4f508dca11078743-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "ee0ca512248c0de779599998022281eb",
         "x-ms-return-client-request-id": "true"
@@ -27,7 +27,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "6355",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:21:33 GMT",
+        "Date": "Fri, 08 May 2020 07:07:33 GMT",
         "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -293,7 +293,8 @@
   ],
   "Variables": {
     "RandomSeed": "942192075",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/TotalCountAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/TotalCountAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "62",
         "Content-Type": "application/json",
-        "traceparent": "00-c55c642ec1642b4f9eb37a85b03729fc-38de40f70648644c-00",
+        "traceparent": "00-c99aa28c15190d4698cc3ca60980c84c-e9d6f9012237c146-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "ec36c2156b803da08be8e3b0e36b5e03",
         "x-ms-return-client-request-id": "true"
@@ -27,8 +27,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "6355",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:53 GMT",
-        "elapsed-time": "9",
+        "Date": "Fri, 08 May 2020 07:10:20 GMT",
+        "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -293,7 +293,8 @@
   ],
   "Variables": {
     "RandomSeed": "1386788363",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/ValueFacets.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/ValueFacets.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "197",
         "Content-Type": "application/json",
-        "traceparent": "00-6318b0ce33d3d84cb518629ef89c4edb-3a4e3adc84567847-00",
+        "traceparent": "00-a1362fc1a1196f40909566cffdc01ad5-edd9fa680e25e84f-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "965c538fc5411c6fdd487a92d9b9906e",
         "x-ms-return-client-request-id": "true"
@@ -33,8 +33,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "7321",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:21:33 GMT",
-        "elapsed-time": "17",
+        "Date": "Fri, 08 May 2020 07:07:33 GMT",
+        "elapsed-time": "16",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -420,7 +420,8 @@
   ],
   "Variables": {
     "RandomSeed": "110101261",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/ValueFacetsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SearchTests/ValueFacetsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.search?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "197",
         "Content-Type": "application/json",
-        "traceparent": "00-17b6967d81caef488a27b9d71cc2e168-a4a6ab5b7a624142-00",
+        "traceparent": "00-cef6261f35986942a7d720950c508091-a4711ae4f1caf64d-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "16adb1f6d36bac3c651ff0daca82a1d8",
         "x-ms-return-client-request-id": "true"
@@ -33,8 +33,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "7321",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:53 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 08 May 2020 07:10:20 GMT",
+        "elapsed-time": "10",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -420,7 +420,8 @@
   ],
   "Variables": {
     "RandomSeed": "316706226",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/ExcludeFieldsFromSuggest.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/ExcludeFieldsFromSuggest.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "67",
         "Content-Type": "application/json",
-        "traceparent": "00-583aff289b2bd54f968b705a50883dc5-3a949f0859d17647-00",
+        "traceparent": "00-f474e7cbfad51e49ad2cb85d3da9336e-a8137c8bab436d40-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "41ddfe30e0034827c87719e46d01721a",
         "x-ms-return-client-request-id": "true"
@@ -26,8 +26,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "12",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:53 GMT",
-        "elapsed-time": "39",
+        "Date": "Fri, 08 May 2020 07:10:20 GMT",
+        "elapsed-time": "32",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -42,7 +42,8 @@
   ],
   "Variables": {
     "RandomSeed": "1436621410",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/ExcludeFieldsFromSuggestAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/ExcludeFieldsFromSuggestAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "67",
         "Content-Type": "application/json",
-        "traceparent": "00-b568abffaeae3a409569364b3b36f757-58ed6aea6259e740-00",
+        "traceparent": "00-1b54186832ea0a4faf480d5bfd1e9e07-b8f34bae0da46a46-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "c86e99798766c4b9c0561853279d9329",
         "x-ms-return-client-request-id": "true"
@@ -26,7 +26,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "12",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:54 GMT",
+        "Date": "Fri, 08 May 2020 07:10:20 GMT",
         "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -42,7 +42,8 @@
   ],
   "Variables": {
     "RandomSeed": "121381126",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/Filter.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/Filter.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "129",
         "Content-Type": "application/json",
-        "traceparent": "00-0b4ccf12aa1f1a41be4baaaafd63bb86-c7327705ad8af04b-00",
+        "traceparent": "00-dcee205a279de74eb137eece89f0da2c-73bac3fadd723444-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "30514a78ff01748af3ca8bcba92a7563",
         "x-ms-return-client-request-id": "true"
@@ -27,8 +27,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "330",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:53 GMT",
-        "elapsed-time": "16",
+        "Date": "Fri, 08 May 2020 07:10:20 GMT",
+        "elapsed-time": "13",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -52,7 +52,8 @@
   ],
   "Variables": {
     "RandomSeed": "110296479",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/FilterAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/FilterAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "129",
         "Content-Type": "application/json",
-        "traceparent": "00-71592a113cc2b74da89a7cbc8a920fe2-3ff4158624adcd4f-00",
+        "traceparent": "00-4459aafd21b9e345a3df64535d736b6b-972281f76eba7f42-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "5ec719d50b83670287b542650f09d244",
         "x-ms-return-client-request-id": "true"
@@ -27,8 +27,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "330",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:54 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 08 May 2020 07:10:20 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -52,7 +52,8 @@
   ],
   "Variables": {
     "RandomSeed": "1932974835",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/Fuzzy.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/Fuzzy.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "52",
         "Content-Type": "application/json",
-        "traceparent": "00-525c29c8df64ba4f9fafc6f80548955c-3c6575232bf1e340-00",
+        "traceparent": "00-b89f09fa66c75f4db59d98788d6dc07c-c3ea2e9f0dbd5444-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "6f210e6706adc4673713dcb4686ee1a1",
         "x-ms-return-client-request-id": "true"
@@ -26,8 +26,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "300",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:53 GMT",
-        "elapsed-time": "9",
+        "Date": "Fri, 08 May 2020 07:10:20 GMT",
+        "elapsed-time": "10",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -63,7 +63,8 @@
   ],
   "Variables": {
     "RandomSeed": "171521149",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/FuzzyAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/FuzzyAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "52",
         "Content-Type": "application/json",
-        "traceparent": "00-2e56702ae65dbc40b9e9455947cf5c9f-d2d954d85ac64a4d-00",
+        "traceparent": "00-12e760d1c721ec4b96c2a4db9ded86a3-d9f206383bcf5343-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "005f5d74b17ed29f1f448cd542419d2f",
         "x-ms-return-client-request-id": "true"
@@ -26,8 +26,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "300",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:54 GMT",
-        "elapsed-time": "11",
+        "Date": "Fri, 08 May 2020 07:10:21 GMT",
+        "elapsed-time": "8",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -63,7 +63,8 @@
   ],
   "Variables": {
     "RandomSeed": "1819874471",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/FuzzyOffByDefault.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/FuzzyOffByDefault.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "39",
         "Content-Type": "application/json",
-        "traceparent": "00-d129126cdb685e4da9cda692886bf83f-420316ee4f39cc4b-00",
+        "traceparent": "00-618fb53d3ffd7b4a99c04e9edcd40157-8858a6b4d8b1b441-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "a64d6cc0a0ab2bb72beceacef8866324",
         "x-ms-return-client-request-id": "true"
@@ -25,8 +25,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "12",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:53 GMT",
-        "elapsed-time": "6",
+        "Date": "Fri, 08 May 2020 07:10:20 GMT",
+        "elapsed-time": "4",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -41,7 +41,8 @@
   ],
   "Variables": {
     "RandomSeed": "1333988927",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/FuzzyOffByDefaultAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/FuzzyOffByDefaultAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "39",
         "Content-Type": "application/json",
-        "traceparent": "00-69da60f27d6f104594bf4b3cf617600e-f5ad1a0cb117064b-00",
+        "traceparent": "00-5f0ae2d37e4d2347a9f83a874af7e9bf-41f0784999b89c49-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "56ac557ee92414d470619bf75896109a",
         "x-ms-return-client-request-id": "true"
@@ -25,7 +25,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "12",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:54 GMT",
+        "Date": "Fri, 08 May 2020 07:10:21 GMT",
         "elapsed-time": "4",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -41,7 +41,8 @@
   ],
   "Variables": {
     "RandomSeed": "752411689",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/HitHighlighting.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/HitHighlighting.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "159",
         "Content-Type": "application/json",
-        "traceparent": "00-818fb3eeb06ca54c8fbd64c0a4d6a6b4-5f2d3c678c4e3247-00",
+        "traceparent": "00-910251bb03b3a645860a863d728148ac-e2866c0f321ffa46-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "0387e2d36fbcb030f57c066150877d06",
         "x-ms-return-client-request-id": "true"
@@ -29,8 +29,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "299",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:53 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 08 May 2020 07:10:20 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -50,7 +50,8 @@
   ],
   "Variables": {
     "RandomSeed": "1967020220",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/HitHighlightingAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/HitHighlightingAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "159",
         "Content-Type": "application/json",
-        "traceparent": "00-f4051ee88421e949b18ed52e49334b31-dbf7e8ecfb899c45-00",
+        "traceparent": "00-08136e26465fe54cb373f2ccf8cea0cc-4e23d313c1f0e340-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "58765b39dfd7902762f8f07e1710563b",
         "x-ms-return-client-request-id": "true"
@@ -29,8 +29,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "299",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:54 GMT",
-        "elapsed-time": "8",
+        "Date": "Fri, 08 May 2020 07:10:21 GMT",
+        "elapsed-time": "7",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -50,7 +50,8 @@
   ],
   "Variables": {
     "RandomSeed": "756773262",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/MinimumCoverage.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/MinimumCoverage.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "61",
         "Content-Type": "application/json",
-        "traceparent": "00-c4c1e569025c9f42939871ec8d644f50-d2d7e8bb0cee2948-00",
+        "traceparent": "00-f0a62f9f92f76f4f9f3a7fee59f07cc2-c629dd7754488841-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "63dd7aed7b5561be2080a9c3bb921533",
         "x-ms-return-client-request-id": "true"
@@ -26,7 +26,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "303",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:53 GMT",
+        "Date": "Fri, 08 May 2020 07:10:20 GMT",
         "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -48,7 +48,8 @@
   ],
   "Variables": {
     "RandomSeed": "58034553",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/MinimumCoverageAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/MinimumCoverageAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "61",
         "Content-Type": "application/json",
-        "traceparent": "00-d465480928fa1e44abc2ce0b035c44bf-cf29a61eab4ae74c-00",
+        "traceparent": "00-5f40dc049f372145bc595ff9c7d9f7bb-93a165b9137d8445-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "ae08a93cc04157c1ed077c1d413dff2c",
         "x-ms-return-client-request-id": "true"
@@ -26,8 +26,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "303",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:54 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 08 May 2020 07:10:21 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -48,7 +48,8 @@
   ],
   "Variables": {
     "RandomSeed": "85825459",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/OrderByProgressivelyBreaksTies.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/OrderByProgressivelyBreaksTies.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "150",
         "Content-Type": "application/json",
-        "traceparent": "00-853f38ae15c5e44c826bd211be803076-ea33cc85ad76dc4d-00",
+        "traceparent": "00-f2d7b3e5063f774bb3f040958713fc15-c6f6429923148b49-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "c005437f5bfa125b3dd553af1e9c6eb6",
         "x-ms-return-client-request-id": "true"
@@ -26,8 +26,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "757",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:53 GMT",
-        "elapsed-time": "16",
+        "Date": "Fri, 08 May 2020 07:10:20 GMT",
+        "elapsed-time": "42",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -63,7 +63,8 @@
   ],
   "Variables": {
     "RandomSeed": "1406065597",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/OrderByProgressivelyBreaksTiesAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/OrderByProgressivelyBreaksTiesAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "150",
         "Content-Type": "application/json",
-        "traceparent": "00-aca83e497ae31043abff0f3cf8229e01-e0ed03a396f0cd48-00",
+        "traceparent": "00-c6cf7c684e460144b7246152d8c788bf-7b907dedd29dc14b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "d1b2faf219913e4332eab23606965304",
         "x-ms-return-client-request-id": "true"
@@ -26,7 +26,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "757",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:54 GMT",
+        "Date": "Fri, 08 May 2020 07:10:21 GMT",
         "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -63,7 +63,8 @@
   ],
   "Variables": {
     "RandomSeed": "53198105",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/SelectedFields.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/SelectedFields.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "92",
         "Content-Type": "application/json",
-        "traceparent": "00-1af39fd3d719784f8c24616d552a0a6e-17ff6011ba67294f-00",
+        "traceparent": "00-819d6c477c0fc24c9d919797f4c62344-a6af242f7556ce4b-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "5d07e8d3ed806aabe001e6eb2ce02dc7",
         "x-ms-return-client-request-id": "true"
@@ -26,8 +26,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "179",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:53 GMT",
-        "elapsed-time": "8",
+        "Date": "Fri, 08 May 2020 07:10:20 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -59,7 +59,8 @@
   ],
   "Variables": {
     "RandomSeed": "1333403613",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/SelectedFieldsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/SelectedFieldsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "92",
         "Content-Type": "application/json",
-        "traceparent": "00-0cdb6e1683200047a9c19e0c37769d52-a2da312c277e0c41-00",
+        "traceparent": "00-e6f3bf831ebc524881ad1db81336f8b4-e29543eeb0a03b43-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "85b7c493e146d7e6cc030dc045845c8d",
         "x-ms-return-client-request-id": "true"
@@ -26,8 +26,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "179",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:54 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 08 May 2020 07:10:21 GMT",
+        "elapsed-time": "5",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -59,7 +59,8 @@
   ],
   "Variables": {
     "RandomSeed": "83938125",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/SizeTrimsResults.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/SizeTrimsResults.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "67",
         "Content-Type": "application/json",
-        "traceparent": "00-d164a6a23b983e458ae2a6f9b9ef7a5f-c43f16672d626d48-00",
+        "traceparent": "00-051ab8089aace94da9dbf9694dc62deb-d735ba533794624e-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "44b116808507066b7104fa5565440add",
         "x-ms-return-client-request-id": "true"
@@ -27,8 +27,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "551",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:53 GMT",
-        "elapsed-time": "8",
+        "Date": "Fri, 08 May 2020 07:10:20 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -56,7 +56,8 @@
   ],
   "Variables": {
     "RandomSeed": "2021917347",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/SizeTrimsResultsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/SizeTrimsResultsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "67",
         "Content-Type": "application/json",
-        "traceparent": "00-06fb868cc99d7a4581f269817347fa15-669e6f67d8f53a45-00",
+        "traceparent": "00-eb924cf4d1e9864db983c10a1d71144d-28a23419b637f443-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "f2920ec48064c1d50a0ecf326c97535e",
         "x-ms-return-client-request-id": "true"
@@ -27,8 +27,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "551",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:54 GMT",
-        "elapsed-time": "9",
+        "Date": "Fri, 08 May 2020 07:10:21 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -56,7 +56,8 @@
   ],
   "Variables": {
     "RandomSeed": "1959444883",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/SuggestDynamicDocuments.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/SuggestDynamicDocuments.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "58",
         "Content-Type": "application/json",
-        "traceparent": "00-a43cb0d0dc78fe489b94bed85c1d2674-3ebd9181e4ea6543-00",
+        "traceparent": "00-451d09431be91746b6c7d909da906e8b-6797c2a2cc87604a-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "3a6d7ff45109c28a122f45e4f31e0868",
         "x-ms-return-client-request-id": "true"
@@ -26,8 +26,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "334",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:53 GMT",
-        "elapsed-time": "6",
+        "Date": "Fri, 08 May 2020 07:10:20 GMT",
+        "elapsed-time": "7",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -51,7 +51,8 @@
   ],
   "Variables": {
     "RandomSeed": "1377017195",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/SuggestDynamicDocumentsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/SuggestDynamicDocumentsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "58",
         "Content-Type": "application/json",
-        "traceparent": "00-55e0759a6e628f4bb68919da2ddd9d38-9938d1e8115c4946-00",
+        "traceparent": "00-0a764925f0bc9c4bb0e153ea1a748cae-d8245dd9780d404a-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "8aea32486b8e73b463e7b6ba609fe73d",
         "x-ms-return-client-request-id": "true"
@@ -26,8 +26,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "334",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:54 GMT",
-        "elapsed-time": "8",
+        "Date": "Fri, 08 May 2020 07:10:21 GMT",
+        "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -51,7 +51,8 @@
   ],
   "Variables": {
     "RandomSeed": "1512668849",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/SuggestStaticDocuments.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/SuggestStaticDocuments.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "58",
         "Content-Type": "application/json",
-        "traceparent": "00-87e30c20df271f42aa1368300a9c35d9-3274dea5b3f7f44e-00",
+        "traceparent": "00-8e03bb071dca3441bf679fb5b4d15952-bfc1d89765e2a049-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "81b8a3d9bab6944220aed8b336142413",
         "x-ms-return-client-request-id": "true"
@@ -26,7 +26,7 @@
         "Cache-Control": "no-cache",
         "Content-Length": "334",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:53 GMT",
+        "Date": "Fri, 08 May 2020 07:10:20 GMT",
         "elapsed-time": "6",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -51,7 +51,8 @@
   ],
   "Variables": {
     "RandomSeed": "861171183",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/SuggestStaticDocumentsAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/SuggestStaticDocumentsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "58",
         "Content-Type": "application/json",
-        "traceparent": "00-3fcc89f7ce36dd42a62e3cd0ab9fbd9f-8d15db678f372a4a-00",
+        "traceparent": "00-1d6fe4f7ce96654581cd091cece28165-c3d9cc4fefa22342-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "5ed4e615262c9336eedc0e0158df5f99",
         "x-ms-return-client-request-id": "true"
@@ -26,8 +26,8 @@
         "Cache-Control": "no-cache",
         "Content-Length": "334",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:54 GMT",
-        "elapsed-time": "7",
+        "Date": "Fri, 08 May 2020 07:10:21 GMT",
+        "elapsed-time": "8",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -51,7 +51,8 @@
   ],
   "Variables": {
     "RandomSeed": "310565316",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/ThrowsWhenGivenBadSuggesterName.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/ThrowsWhenGivenBadSuggesterName.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "54",
         "Content-Type": "application/json",
-        "traceparent": "00-c70f949e811e134db4fbc3bf91afab6d-b45589ecea038b47-00",
+        "traceparent": "00-582a0c4e3be2fa44b3ae68d6a72e9401-89dfef80f7fb5e4a-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "82280cacac79a2d1f134fdc3c67e19e6",
         "x-ms-return-client-request-id": "true"
@@ -26,8 +26,8 @@
         "Content-Language": "en",
         "Content-Length": "147",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:53 GMT",
-        "elapsed-time": "2",
+        "Date": "Fri, 08 May 2020 07:10:20 GMT",
+        "elapsed-time": "4",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -45,7 +45,8 @@
   ],
   "Variables": {
     "RandomSeed": "1418306410",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/ThrowsWhenGivenBadSuggesterNameAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/ThrowsWhenGivenBadSuggesterNameAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "54",
         "Content-Type": "application/json",
-        "traceparent": "00-97655c752905504198fde3dcb76ca2b4-ced3f8de5da36f46-00",
+        "traceparent": "00-8612102e10452f4a89f160d4b537ce2f-74d79d6fc083f148-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "bcadf003578d82f6430593e81346ab31",
         "x-ms-return-client-request-id": "true"
@@ -26,8 +26,8 @@
         "Content-Language": "en",
         "Content-Length": "147",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:54 GMT",
-        "elapsed-time": "2",
+        "Date": "Fri, 08 May 2020 07:10:21 GMT",
+        "elapsed-time": "3",
         "Expires": "-1",
         "OData-Version": "4.0",
         "Pragma": "no-cache",
@@ -45,7 +45,8 @@
   ],
   "Variables": {
     "RandomSeed": "931425957",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/ThrowsWhenRequestIsMalformed.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/ThrowsWhenRequestIsMalformed.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "80",
         "Content-Type": "application/json",
-        "traceparent": "00-e617ef15d1c8b848a46fe2591807f3f7-aeaa9f3c69d0a440-00",
+        "traceparent": "00-4d28adc1463fd947a57bce7002117aa7-1ac22d15f4a9204a-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "1cd2d2b1034fc6dee7c6001c8d1088ce",
         "x-ms-return-client-request-id": "true"
@@ -27,7 +27,7 @@
         "Content-Language": "en",
         "Content-Length": "143",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:54 GMT",
+        "Date": "Fri, 08 May 2020 07:10:20 GMT",
         "elapsed-time": "2",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -46,7 +46,8 @@
   ],
   "Variables": {
     "RandomSeed": "1402415131",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/ThrowsWhenRequestIsMalformedAsync.json
+++ b/sdk/search/Azure.Search.Documents/tests/SessionRecords/SuggestTests/ThrowsWhenRequestIsMalformedAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://azs-net-jcswnkcn.search.windows.net/indexes(\u0027mesaejwj\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
+      "RequestUri": "https://azs-net-heathsearch2.search.windows.net/indexes(\u0027yrehvsfy\u0027)/docs/search.post.suggest?api-version=2019-05-06-Preview",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json; odata.metadata=none",
         "api-key": "Sanitized",
         "Content-Length": "80",
         "Content-Type": "application/json",
-        "traceparent": "00-e9516b49d91712468c574147be558979-9a789166c444194c-00",
+        "traceparent": "00-99687f1e5b566d41b3af69d53e0a1a66-fe68f0b3f3ec024c-00",
         "User-Agent": [
-          "azsdk-net-Search.Documents/1.0.0-dev.20200424.1",
-          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-Search.Documents/1.0.0-dev.20200507.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.19041 )"
         ],
         "x-ms-client-request-id": "f59f7a8885a1f362618688d19579334d",
         "x-ms-return-client-request-id": "true"
@@ -27,7 +27,7 @@
         "Content-Language": "en",
         "Content-Length": "143",
         "Content-Type": "application/json; odata.metadata=none",
-        "Date": "Sat, 25 Apr 2020 01:24:54 GMT",
+        "Date": "Fri, 08 May 2020 07:10:21 GMT",
         "elapsed-time": "3",
         "Expires": "-1",
         "OData-Version": "4.0",
@@ -46,7 +46,8 @@
   ],
   "Variables": {
     "RandomSeed": "1081499379",
-    "SearchIndexName": "mesaejwj",
-    "SearchServiceName": "azs-net-jcswnkcn"
+    "SearchIndexName": "yrehvsfy",
+    "SEARCH_QUERY_API_KEY": "Sanitized",
+    "SEARCH_SERVICE_NAME": "azs-net-heathsearch2"
   }
 }

--- a/sdk/search/Azure.Search.Documents/tests/Utilities/SearchRecordedTestSanitizer.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Utilities/SearchRecordedTestSanitizer.cs
@@ -102,6 +102,13 @@ namespace Azure.Search.Documents.Tests
                 return SanitizeValue;
             }
 
+            if (SearchTestEnvironment.SearchAdminKeyVariableName.Equals(name, StringComparison.OrdinalIgnoreCase) ||
+                SearchTestEnvironment.SearchQueryKeyVariableName.Equals(name, StringComparison.OrdinalIgnoreCase))
+            {
+                // No need to scan the body since they values should be found only in the header.
+                return SanitizeValue;
+            }
+
             return value;
         }
     }

--- a/sdk/search/Azure.Search.Documents/tests/Utilities/SearchTestEnvironment.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Utilities/SearchTestEnvironment.cs
@@ -5,15 +5,56 @@ using Azure.Core.TestFramework;
 
 namespace Azure.Search.Documents.Tests
 {
+    /// <summary>
+    /// Gets variables created from test-resources.json.
+    /// </summary>
     public class SearchTestEnvironment: TestEnvironment
     {
+        /// <summary>
+        /// The name of the variable for <see cref="SearchAdminKey"/>.
+        /// </summary>
+        public const string SearchAdminKeyVariableName = "SEARCH_ADMIN_API_KEY";
+
+        /// <summary>
+        /// The name of the variable for <see cref="SearchQueryKey"/>.
+        /// </summary>
+        public const string SearchQueryKeyVariableName = "SEARCH_QUERY_API_KEY";
+
+        /// <summary>
+        /// The name of the variable for <see cref="SearchStorageKey"/>.
+        /// </summary>
+        public const string StorageAccountKeyVariableName = "SEARCH_STORAGE_KEY";
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="SearchTestEnvironment"/> class.
+        /// </summary>
         public SearchTestEnvironment() : base("search")
         {
         }
 
-        public string SearchStorageName => GetRecordedVariable("SEARCH_STORAGE_NAME");
-        public string SearchStorageKey => GetRecordedVariable(StorageAccountKeyVariableName);
+        /// <summary>
+        /// Gets the service name.
+        /// </summary>
+        public string SearchServiceName => GetRecordedVariable("SEARCH_SERVICE_NAME");
 
-        public static string StorageAccountKeyVariableName = "SEARCH_STORAGE_KEY";
+        /// <summary>
+        /// Gets the admin key (read-write).
+        /// </summary>
+        public string SearchAdminKey => GetRecordedVariable(SearchAdminKeyVariableName);
+
+        /// <summary>
+        /// Gets the query key (read-only).
+        /// </summary>
+        public string SearchQueryKey => GetRecordedVariable(SearchQueryKeyVariableName);
+
+        /// <summary>
+        /// Gets the name of the storage account for external data sources.
+        /// </summary>
+        public string SearchStorageName => GetRecordedVariable("SEARCH_STORAGE_NAME");
+
+        /// <summary>
+        /// Gets the storage account key for external data sources.
+        /// </summary>
+        public string SearchStorageKey => GetRecordedVariable(StorageAccountKeyVariableName);
     }
 }

--- a/sdk/search/test-resources.json
+++ b/sdk/search/test-resources.json
@@ -40,13 +40,45 @@
             "metadata": {
                 "description": "The location of the resource. By default, this is the same as the resource group."
             }
+        },
+        "searchSku": {
+            "type": "string",
+            "defaultValue": "free",
+            "allowedValues": [
+                "free",
+                "basic",
+                "standard"
+            ],
+            "metadata": {
+                "description": "The Search service SKU to create."
+            }
         }
     },
     "variables": {
+        "searchServiceName": "[concat('azs-net-', parameters('baseName'))]",
+        "searchApiVersion": "2020-03-13",
         "storageAccountName": "[concat(parameters('baseName'), 'stg')]",
         "storageApiVersion": "2019-06-01"
     },
     "resources": [
+        {
+            "name": "[variables('searchServiceName')]",
+            "type": "Microsoft.Search/searchServices",
+            "apiVersion": "[variables('searchApiVersion')]",
+            "location": "[parameters('location')]",
+            "sku": {
+                "name": "[parameters('searchSku')]"
+            },
+            "properties": {
+                "replicaCount": 1,
+                "partitionCount": 1,
+                "hostingMode": "Default",
+                "publicNetworkAccess": "Enabled",
+                "networkRuleSet": {
+                    "ipRules": []
+                }
+            }
+        },
         {
             "name": "[variables('storageAccountName')]",
             "type": "Microsoft.Storage/storageAccounts",
@@ -63,6 +95,18 @@
         }
     ],
     "outputs": {
+        "SEARCH_SERVICE_NAME": {
+            "type": "string",
+            "value": "[variables('searchServiceName')]"
+        },
+        "SEARCH_ADMIN_API_KEY": {
+            "type": "string",
+            "value": "[listAdminKeys(variables('searchServiceName'), variables('searchApiVersion')).primaryKey]"
+        },
+        "SEARCH_QUERY_API_KEY": {
+            "type": "string",
+            "value": "[listQueryKeys(variables('searchServiceName'), variables('searchApiVersion')).value[0].key]"
+        },
         "SEARCH_STORAGE_NAME": {
             "type": "string",
             "value": "[variables('storageAccountName')]"


### PR DESCRIPTION
This prevents us from spamming Search with too many requests for free services, instead opting to create one free service per test platform, and creating and destroying indexes instead.

Also fixes #10604. The upstream bug was resolved a while ago, but the PlaybackTransport wasn't copying the ClientRequestId like the HttpTransport and RecordTransport do.