### PR TITLE
[FormRecognizer] API changes: return collections instead of interface in Response<T>

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.0.0-preview.3 (Unreleased)
 
+### Breaking changes
+
+- `RecognizeContentOperation` now returns a `FormPageCollection`.
+- `RecognizeReceiptsOperation` now returns a `RecognizedReceiptCollection`.
+- `RecognizeCustomFormsOperation` now returns a `RecognizedFormCollection`.
 
 ## 1.0.0-preview.2 (05-06-2020)
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
@@ -116,8 +116,8 @@ Recognize data from US sales receipts using a prebuilt model.
 ```C# Snippet:FormRecognizerSampleRecognizeReceiptFileStream
 using (FileStream stream = new FileStream(receiptPath, FileMode.Open))
 {
-    Response<RecognizedReceiptCollection> receipts = await client.StartRecognizeReceipts(stream).WaitForCompletionAsync();
-    foreach (var receipt in receipts.Value)
+    RecognizedReceiptCollection receipts = await client.StartRecognizeReceipts(stream).WaitForCompletionAsync();
+    foreach (var receipt in receipts)
     {
         USReceipt usReceipt = receipt.AsUSReceipt();
 
@@ -152,8 +152,8 @@ using (FileStream stream = new FileStream(receiptPath, FileMode.Open))
 Recognize text and table data, along with their bounding box coordinates, from documents.
 
 ```C# Snippet:FormRecognizerSampleRecognizeContentFromUri
-Response<FormPageCollection> formPages = await client.StartRecognizeContentFromUri(new Uri(invoiceUri)).WaitForCompletionAsync();
-foreach (FormPage page in formPages.Value)
+FormPageCollection formPages = await client.StartRecognizeContentFromUri(new Uri(invoiceUri)).WaitForCompletionAsync();
+foreach (FormPage page in formPages)
 {
     Console.WriteLine($"Form Page {page.PageNumber} has {page.Lines.Count} lines.");
 
@@ -181,8 +181,8 @@ Recognize and extract form fields and other content from your custom forms, usin
 ```C# Snippet:FormRecognizerSample3RecognizeCustomFormsFromUri
 string modelId = "<modelId>";
 
-Response<RecognizedFormCollection> forms = await client.StartRecognizeCustomFormsFromUri(modelId, new Uri(formUri)).WaitForCompletionAsync();
-foreach (RecognizedForm form in forms.Value)
+RecognizedFormCollection forms = await client.StartRecognizeCustomFormsFromUri(modelId, new Uri(formUri)).WaitForCompletionAsync();
+foreach (RecognizedForm form in forms)
 {
     Console.WriteLine($"Form of type: {form.FormType}");
     foreach (FormField field in form.Fields.Values)
@@ -290,7 +290,7 @@ For example, if you submit a receipt image with an invalid `Uri`, a `400` error 
 ```C# Snippet:FormRecognizerBadRequest
 try
 {
-    Response<RecognizedReceiptCollection> receipts = await client.StartRecognizeReceiptsFromUri(new Uri("http://invalid.uri")).WaitForCompletionAsync();
+    RecognizedReceiptCollection receipts = await client.StartRecognizeReceiptsFromUri(new Uri("http://invalid.uri")).WaitForCompletionAsync();
 }
 catch (RequestFailedException e)
 {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/README.md
@@ -116,7 +116,7 @@ Recognize data from US sales receipts using a prebuilt model.
 ```C# Snippet:FormRecognizerSampleRecognizeReceiptFileStream
 using (FileStream stream = new FileStream(receiptPath, FileMode.Open))
 {
-    Response<IReadOnlyList<RecognizedReceipt>> receipts = await client.StartRecognizeReceipts(stream).WaitForCompletionAsync();
+    Response<RecognizedReceiptCollection> receipts = await client.StartRecognizeReceipts(stream).WaitForCompletionAsync();
     foreach (var receipt in receipts.Value)
     {
         USReceipt usReceipt = receipt.AsUSReceipt();
@@ -152,7 +152,7 @@ using (FileStream stream = new FileStream(receiptPath, FileMode.Open))
 Recognize text and table data, along with their bounding box coordinates, from documents.
 
 ```C# Snippet:FormRecognizerSampleRecognizeContentFromUri
-Response<IReadOnlyList<FormPage>> formPages = await client.StartRecognizeContentFromUri(new Uri(invoiceUri)).WaitForCompletionAsync();
+Response<FormPageCollection> formPages = await client.StartRecognizeContentFromUri(new Uri(invoiceUri)).WaitForCompletionAsync();
 foreach (FormPage page in formPages.Value)
 {
     Console.WriteLine($"Form Page {page.PageNumber} has {page.Lines.Count} lines.");
@@ -181,7 +181,7 @@ Recognize and extract form fields and other content from your custom forms, usin
 ```C# Snippet:FormRecognizerSample3RecognizeCustomFormsFromUri
 string modelId = "<modelId>";
 
-Response<IReadOnlyList<RecognizedForm>> forms = await client.StartRecognizeCustomFormsFromUri(modelId, new Uri(formUri)).WaitForCompletionAsync();
+Response<RecognizedFormCollection> forms = await client.StartRecognizeCustomFormsFromUri(modelId, new Uri(formUri)).WaitForCompletionAsync();
 foreach (RecognizedForm form in forms.Value)
 {
     Console.WriteLine($"Form of type: {form.FormType}");
@@ -290,7 +290,7 @@ For example, if you submit a receipt image with an invalid `Uri`, a `400` error 
 ```C# Snippet:FormRecognizerBadRequest
 try
 {
-    Response<IReadOnlyList<RecognizedReceipt>> receipts = await client.StartRecognizeReceiptsFromUri(new Uri("http://invalid.uri")).WaitForCompletionAsync();
+    Response<RecognizedReceiptCollection> receipts = await client.StartRecognizeReceiptsFromUri(new Uri("http://invalid.uri")).WaitForCompletionAsync();
 }
 catch (RequestFailedException e)
 {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample1_RecognizeFormContent.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample1_RecognizeFormContent.md
@@ -22,8 +22,8 @@ var client = new FormRecognizerClient(new Uri(endpoint), credential);
 To recognize the content from a given file at a URI, use the `StartRecognizeContentFromUri` method. The returned value is a collection of `FormPage` objects -- one for each page in the submitted document.
 
 ```C# Snippet:FormRecognizerSampleRecognizeContentFromUri
-Response<FormPageCollection> formPages = await client.StartRecognizeContentFromUri(new Uri(invoiceUri)).WaitForCompletionAsync();
-foreach (FormPage page in formPages.Value)
+FormPageCollection formPages = await client.StartRecognizeContentFromUri(new Uri(invoiceUri)).WaitForCompletionAsync();
+foreach (FormPage page in formPages)
 {
     Console.WriteLine($"Form Page {page.PageNumber} has {page.Lines.Count} lines.");
 
@@ -52,7 +52,7 @@ To recognize the content from a file stream, use the `StartRecognizeContent` met
 ```C# Snippet:FormRecognizerRecognizeFormContentFromFile
 using (FileStream stream = new FileStream(invoiceFilePath, FileMode.Open))
 {
-    Response<FormPageCollection> formPages = await client.StartRecognizeContent(stream).WaitForCompletionAsync();
+    FormPageCollection formPages = await client.StartRecognizeContent(stream).WaitForCompletionAsync();
     /*
      *
      */

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample1_RecognizeFormContent.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample1_RecognizeFormContent.md
@@ -22,7 +22,7 @@ var client = new FormRecognizerClient(new Uri(endpoint), credential);
 To recognize the content from a given file at a URI, use the `StartRecognizeContentFromUri` method. The returned value is a collection of `FormPage` objects -- one for each page in the submitted document.
 
 ```C# Snippet:FormRecognizerSampleRecognizeContentFromUri
-Response<IReadOnlyList<FormPage>> formPages = await client.StartRecognizeContentFromUri(new Uri(invoiceUri)).WaitForCompletionAsync();
+Response<FormPageCollection> formPages = await client.StartRecognizeContentFromUri(new Uri(invoiceUri)).WaitForCompletionAsync();
 foreach (FormPage page in formPages.Value)
 {
     Console.WriteLine($"Form Page {page.PageNumber} has {page.Lines.Count} lines.");
@@ -52,7 +52,7 @@ To recognize the content from a file stream, use the `StartRecognizeContent` met
 ```C# Snippet:FormRecognizerRecognizeFormContentFromFile
 using (FileStream stream = new FileStream(invoiceFilePath, FileMode.Open))
 {
-    Response<IReadOnlyList<FormPage>> formPages = await client.StartRecognizeContent(stream).WaitForCompletionAsync();
+    Response<FormPageCollection> formPages = await client.StartRecognizeContent(stream).WaitForCompletionAsync();
     /*
      *
      */

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample2_RecognizeReceipts.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample2_RecognizeReceipts.md
@@ -22,7 +22,7 @@ var client = new FormRecognizerClient(new Uri(endpoint), credential);
 To recognize receipts from a URI, use the `StartRecognizeReceiptsFromUri` method. The returned value is a collection of `RecognizedReceipt` objects -- one for each page in the submitted document.
 
 ```C# Snippet:FormRecognizerSampleRecognizeReceiptFileFromUri
-Response<IReadOnlyList<RecognizedReceipt>> receipts = await client.StartRecognizeReceiptsFromUri(new Uri(receiptUri)).WaitForCompletionAsync();
+Response<RecognizedReceiptCollection> receipts = await client.StartRecognizeReceiptsFromUri(new Uri(receiptUri)).WaitForCompletionAsync();
 foreach (var receipt in receipts.Value)
 {
     USReceipt usReceipt = receipt.AsUSReceipt();
@@ -60,7 +60,7 @@ To recognize receipts from a given file, use the `StartRecognizeReceipts` method
 ```C# Snippet:FormRecognizerRecognizeReceiptFromFile
 using (FileStream stream = new FileStream(receiptPath, FileMode.Open))
 {
-    Response<IReadOnlyList<RecognizedReceipt>> receipts = await client.StartRecognizeReceipts(stream).WaitForCompletionAsync();
+    Response<RecognizedReceiptCollection> receipts = await client.StartRecognizeReceipts(stream).WaitForCompletionAsync();
     /*
      *
      */

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample2_RecognizeReceipts.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample2_RecognizeReceipts.md
@@ -22,8 +22,8 @@ var client = new FormRecognizerClient(new Uri(endpoint), credential);
 To recognize receipts from a URI, use the `StartRecognizeReceiptsFromUri` method. The returned value is a collection of `RecognizedReceipt` objects -- one for each page in the submitted document.
 
 ```C# Snippet:FormRecognizerSampleRecognizeReceiptFileFromUri
-Response<RecognizedReceiptCollection> receipts = await client.StartRecognizeReceiptsFromUri(new Uri(receiptUri)).WaitForCompletionAsync();
-foreach (var receipt in receipts.Value)
+RecognizedReceiptCollection receipts = await client.StartRecognizeReceiptsFromUri(new Uri(receiptUri)).WaitForCompletionAsync();
+foreach (var receipt in receipts)
 {
     USReceipt usReceipt = receipt.AsUSReceipt();
 
@@ -60,7 +60,7 @@ To recognize receipts from a given file, use the `StartRecognizeReceipts` method
 ```C# Snippet:FormRecognizerRecognizeReceiptFromFile
 using (FileStream stream = new FileStream(receiptPath, FileMode.Open))
 {
-    Response<RecognizedReceiptCollection> receipts = await client.StartRecognizeReceipts(stream).WaitForCompletionAsync();
+    RecognizedReceiptCollection receipts = await client.StartRecognizeReceipts(stream).WaitForCompletionAsync();
     /*
      *
      */

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample3_RecognizeCustomForms.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample3_RecognizeCustomForms.md
@@ -24,7 +24,7 @@ To recognize form fields and other content from your custom forms from a given f
 ```C# Snippet:FormRecognizerSample3RecognizeCustomFormsFromUri
 string modelId = "<modelId>";
 
-Response<IReadOnlyList<RecognizedForm>> forms = await client.StartRecognizeCustomFormsFromUri(modelId, new Uri(formUri)).WaitForCompletionAsync();
+Response<RecognizedFormCollection> forms = await client.StartRecognizeCustomFormsFromUri(modelId, new Uri(formUri)).WaitForCompletionAsync();
 foreach (RecognizedForm form in forms.Value)
 {
     Console.WriteLine($"Form of type: {form.FormType}");
@@ -52,7 +52,7 @@ using (FileStream stream = new FileStream(formFilePath, FileMode.Open))
 {
     string modelId = "<modelId>";
 
-    Response<IReadOnlyList<RecognizedForm>> forms = await client.StartRecognizeCustomForms(modelId, stream).WaitForCompletionAsync();
+    Response<RecognizedFormCollection> forms = await client.StartRecognizeCustomForms(modelId, stream).WaitForCompletionAsync();
     /*
      *
      */

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample3_RecognizeCustomForms.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/samples/Sample3_RecognizeCustomForms.md
@@ -24,8 +24,8 @@ To recognize form fields and other content from your custom forms from a given f
 ```C# Snippet:FormRecognizerSample3RecognizeCustomFormsFromUri
 string modelId = "<modelId>";
 
-Response<RecognizedFormCollection> forms = await client.StartRecognizeCustomFormsFromUri(modelId, new Uri(formUri)).WaitForCompletionAsync();
-foreach (RecognizedForm form in forms.Value)
+RecognizedFormCollection forms = await client.StartRecognizeCustomFormsFromUri(modelId, new Uri(formUri)).WaitForCompletionAsync();
+foreach (RecognizedForm form in forms)
 {
     Console.WriteLine($"Form of type: {form.FormType}");
     foreach (FormField field in form.Fields.Values)
@@ -52,7 +52,7 @@ using (FileStream stream = new FileStream(formFilePath, FileMode.Open))
 {
     string modelId = "<modelId>";
 
-    Response<RecognizedFormCollection> forms = await client.StartRecognizeCustomForms(modelId, stream).WaitForCompletionAsync();
+    RecognizedFormCollection forms = await client.StartRecognizeCustomForms(modelId, stream).WaitForCompletionAsync();
     /*
      *
      */

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormPageCollection.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormPageCollection.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Azure.AI.FormRecognizer.Models
+{
+    /// <summary>
+    /// A read-only collection of <see cref="FormPage"/> objects.
+    /// </summary>
+    public class FormPageCollection : ReadOnlyCollection<FormPage>
+    {
+        /// <inheritdoc/>
+        internal FormPageCollection(IList<FormPage> list) : base(list)
+        {
+        }
+    }
+}

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/OperationExtensions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/OperationExtensions.cs
@@ -21,7 +21,7 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="Response{T}"/> representing the result of the operation. It can be cast to a <see cref="IReadOnlyList{T}"/>
         /// containing the recognized receipts.</returns>
-        public static async Task<Response<IReadOnlyList<RecognizedReceipt>>> WaitForCompletionAsync(this Task<RecognizeReceiptsOperation> operation, CancellationToken cancellationToken = default)
+        public static async Task<Response<RecognizedReceiptCollection>> WaitForCompletionAsync(this Task<RecognizeReceiptsOperation> operation, CancellationToken cancellationToken = default)
         {
             var o = await operation.ConfigureAwait(false);
             return await o.WaitForCompletionAsync(cancellationToken).ConfigureAwait(false);
@@ -34,7 +34,7 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="Response{T}"/> representing the result of the operation. It can be cast to a <see cref="IReadOnlyList{T}"/>
         /// containing the recognized forms.</returns>
-        public static async Task<Response<IReadOnlyList<RecognizedForm>>> WaitForCompletionAsync(this Task<RecognizeCustomFormsOperation> operation, CancellationToken cancellationToken = default)
+        public static async Task<Response<RecognizedFormCollection>> WaitForCompletionAsync(this Task<RecognizeCustomFormsOperation> operation, CancellationToken cancellationToken = default)
         {
             var o = await operation.ConfigureAwait(false);
             return await o.WaitForCompletionAsync(cancellationToken).ConfigureAwait(false);
@@ -47,7 +47,7 @@ namespace Azure.AI.FormRecognizer
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>A <see cref="Response{T}"/> representing the result of the operation. It can be cast to a <see cref="IReadOnlyList{T}"/>
         /// containing the recognized pages.</returns>
-        public static async Task<Response<IReadOnlyList<FormPage>>> WaitForCompletionAsync(this Task<RecognizeContentOperation> operation, CancellationToken cancellationToken = default)
+        public static async Task<Response<FormPageCollection>> WaitForCompletionAsync(this Task<RecognizeContentOperation> operation, CancellationToken cancellationToken = default)
         {
             var o = await operation.ConfigureAwait(false);
             return await o.WaitForCompletionAsync(cancellationToken).ConfigureAwait(false);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeContentOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeContentOperation.cs
@@ -15,7 +15,7 @@ namespace Azure.AI.FormRecognizer.Models
     /// <summary>
     /// Tracks the status of a long-running operation for recognizing layout elements from forms.
     /// </summary>
-    public class RecognizeContentOperation : Operation<IReadOnlyList<FormPage>>
+    public class RecognizeContentOperation : Operation<FormPageCollection>
     {
         /// <summary>Provides communication with the Form Recognizer Azure Cognitive Service through its REST API.</summary>
         private readonly ServiceClient _serviceClient;
@@ -24,7 +24,7 @@ namespace Azure.AI.FormRecognizer.Models
         private Response _response;
 
         /// <summary>The result of the long-running operation. <c>null</c> until result is received on status update.</summary>
-        private IReadOnlyList<FormPage> _value;
+        private FormPageCollection _value;
 
         /// <summary><c>true</c> if the long-running operation has completed. Otherwise, <c>false</c>.</summary>
         private bool _hasCompleted;
@@ -33,7 +33,7 @@ namespace Azure.AI.FormRecognizer.Models
         public override string Id { get; }
 
         /// <inheritdoc/>
-        public override IReadOnlyList<FormPage> Value => OperationHelpers.GetValue(ref _value);
+        public override FormPageCollection Value => OperationHelpers.GetValue(ref _value);
 
         /// <inheritdoc/>
         public override bool HasCompleted => _hasCompleted;
@@ -79,11 +79,11 @@ namespace Azure.AI.FormRecognizer.Models
         public override Response GetRawResponse() => _response;
 
         /// <inheritdoc/>
-        public override ValueTask<Response<IReadOnlyList<FormPage>>> WaitForCompletionAsync(CancellationToken cancellationToken = default) =>
+        public override ValueTask<Response<FormPageCollection>> WaitForCompletionAsync(CancellationToken cancellationToken = default) =>
             this.DefaultWaitForCompletionAsync(cancellationToken);
 
         /// <inheritdoc/>
-        public override ValueTask<Response<IReadOnlyList<FormPage>>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) =>
+        public override ValueTask<Response<FormPageCollection>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) =>
             this.DefaultWaitForCompletionAsync(pollingInterval, cancellationToken);
 
         /// <inheritdoc/>
@@ -121,7 +121,7 @@ namespace Azure.AI.FormRecognizer.Models
             return GetRawResponse();
         }
 
-        private static IReadOnlyList<FormPage> ConvertValue(IReadOnlyList<PageResult_internal> pageResults, IReadOnlyList<ReadResult_internal> readResults)
+        private static FormPageCollection ConvertValue(IReadOnlyList<PageResult_internal> pageResults, IReadOnlyList<ReadResult_internal> readResults)
         {
             Debug.Assert(pageResults.Count == readResults.Count);
 
@@ -133,7 +133,7 @@ namespace Azure.AI.FormRecognizer.Models
                 pages.Add(new FormPage(pageResults[pageIndex], rawPages, pageIndex));
             }
 
-            return pages;
+            return new FormPageCollection(pages);
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeCustomFormsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeCustomFormsOperation.cs
@@ -15,7 +15,7 @@ namespace Azure.AI.FormRecognizer.Models
     /// Tracks the status of a long-running operation for recognizing fields and other content from forms by using custom
     /// trained models.
     /// </summary>
-    public class RecognizeCustomFormsOperation : Operation<IReadOnlyList<RecognizedForm>>
+    public class RecognizeCustomFormsOperation : Operation<RecognizedFormCollection>
     {
         /// <summary>Provides communication with the Form Recognizer Azure Cognitive Service through its REST API.</summary>
         private readonly ServiceClient _serviceClient;
@@ -27,7 +27,7 @@ namespace Azure.AI.FormRecognizer.Models
         private Response _response;
 
         /// <summary>The result of the long-running operation. <c>null</c> until result is received on status update.</summary>
-        private IReadOnlyList<RecognizedForm> _value;
+        private RecognizedFormCollection _value;
 
         /// <summary><c>true</c> if the long-running operation has completed. Otherwise, <c>false</c>.</summary>
         private bool _hasCompleted;
@@ -42,7 +42,7 @@ namespace Azure.AI.FormRecognizer.Models
         public override string Id { get; }
 
         /// <inheritdoc/>
-        public override IReadOnlyList<RecognizedForm> Value => OperationHelpers.GetValue(ref _value);
+        public override RecognizedFormCollection Value => OperationHelpers.GetValue(ref _value);
 
         /// <inheritdoc/>
         public override bool HasCompleted => _hasCompleted;
@@ -54,11 +54,11 @@ namespace Azure.AI.FormRecognizer.Models
         public override Response GetRawResponse() => _response;
 
         /// <inheritdoc/>
-        public override ValueTask<Response<IReadOnlyList<RecognizedForm>>> WaitForCompletionAsync(CancellationToken cancellationToken = default) =>
+        public override ValueTask<Response<RecognizedFormCollection>> WaitForCompletionAsync(CancellationToken cancellationToken = default) =>
             this.DefaultWaitForCompletionAsync(cancellationToken);
 
         /// <inheritdoc/>
-        public override ValueTask<Response<IReadOnlyList<RecognizedForm>>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) =>
+        public override ValueTask<Response<RecognizedFormCollection>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) =>
             this.DefaultWaitForCompletionAsync(pollingInterval, cancellationToken);
 
         /// <summary>
@@ -155,7 +155,7 @@ namespace Azure.AI.FormRecognizer.Models
                 else if (update.Value.Status == OperationStatus.Failed)
                 {
                     _hasCompleted = true;
-                    _value = new List<RecognizedForm>();
+                    _value = new RecognizedFormCollection(new List<RecognizedForm>());
 
                     throw await CreateExceptionForFailedOperationAsync(async, update.Value.AnalyzeResult.Errors).ConfigureAwait(false);
                 }
@@ -164,31 +164,31 @@ namespace Azure.AI.FormRecognizer.Models
             return GetRawResponse();
         }
 
-        private static IReadOnlyList<RecognizedForm> ConvertToRecognizedForms(AnalyzeResult_internal analyzeResult)
+        private static RecognizedFormCollection ConvertToRecognizedForms(AnalyzeResult_internal analyzeResult)
         {
             return analyzeResult.DocumentResults?.Count == 0 ?
                 ConvertUnsupervisedResult(analyzeResult) :
                 ConvertSupervisedResult(analyzeResult);
         }
 
-        private static IReadOnlyList<RecognizedForm> ConvertUnsupervisedResult(AnalyzeResult_internal analyzeResult)
+        private static RecognizedFormCollection ConvertUnsupervisedResult(AnalyzeResult_internal analyzeResult)
         {
             List<RecognizedForm> forms = new List<RecognizedForm>();
             foreach (var pageResult in analyzeResult.PageResults)
             {
                 forms.Add(new RecognizedForm(pageResult, analyzeResult.ReadResults));
             }
-            return forms;
+            return new RecognizedFormCollection(forms);
         }
 
-        private static IReadOnlyList<RecognizedForm> ConvertSupervisedResult(AnalyzeResult_internal analyzeResult)
+        private static RecognizedFormCollection ConvertSupervisedResult(AnalyzeResult_internal analyzeResult)
         {
             List<RecognizedForm> forms = new List<RecognizedForm>();
             foreach (var documentResult in analyzeResult.DocumentResults)
             {
                 forms.Add(new RecognizedForm(documentResult, analyzeResult.PageResults, analyzeResult.ReadResults));
             }
-            return forms;
+            return new RecognizedFormCollection(forms);
         }
 
         private async ValueTask<RequestFailedException> CreateExceptionForFailedOperationAsync(bool async, IReadOnlyList<FormRecognizerError> errors)

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeReceiptsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeReceiptsOperation.cs
@@ -14,7 +14,7 @@ namespace Azure.AI.FormRecognizer.Models
     /// <summary>
     /// Tracks the status of a long-running operation for recognizing values from receipts.
     /// </summary>
-    public class RecognizeReceiptsOperation : Operation<IReadOnlyList<RecognizedReceipt>>
+    public class RecognizeReceiptsOperation : Operation<RecognizedReceiptCollection>
     {
         /// <summary>Provides communication with the Form Recognizer Azure Cognitive Service through its REST API.</summary>
         private readonly ServiceClient _serviceClient;
@@ -23,7 +23,7 @@ namespace Azure.AI.FormRecognizer.Models
         private Response _response;
 
         /// <summary>The result of the long-running operation. <c>null</c> until result is received on status update.</summary>
-        private IReadOnlyList<RecognizedReceipt> _value;
+        private RecognizedReceiptCollection _value;
 
         /// <summary><c>true</c> if the long-running operation has completed. Otherwise, <c>false</c>.</summary>
         private bool _hasCompleted;
@@ -32,7 +32,7 @@ namespace Azure.AI.FormRecognizer.Models
         public override string Id { get; }
 
         /// <inheritdoc/>
-        public override IReadOnlyList<RecognizedReceipt> Value => OperationHelpers.GetValue(ref _value);
+        public override RecognizedReceiptCollection Value => OperationHelpers.GetValue(ref _value);
 
         /// <inheritdoc/>
         public override bool HasCompleted => _hasCompleted;
@@ -78,11 +78,11 @@ namespace Azure.AI.FormRecognizer.Models
         }
 
         /// <inheritdoc/>
-        public override ValueTask<Response<IReadOnlyList<RecognizedReceipt>>> WaitForCompletionAsync(CancellationToken cancellationToken = default) =>
+        public override ValueTask<Response<RecognizedReceiptCollection>> WaitForCompletionAsync(CancellationToken cancellationToken = default) =>
             this.DefaultWaitForCompletionAsync(cancellationToken);
 
         /// <inheritdoc/>
-        public override ValueTask<Response<IReadOnlyList<RecognizedReceipt>>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) =>
+        public override ValueTask<Response<RecognizedReceiptCollection>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken = default) =>
             this.DefaultWaitForCompletionAsync(pollingInterval, cancellationToken);
 
         /// <inheritdoc/>
@@ -124,14 +124,14 @@ namespace Azure.AI.FormRecognizer.Models
             return GetRawResponse();
         }
 
-        private static IReadOnlyList<RecognizedReceipt> ConvertToRecognizedReceipts(AnalyzeResult_internal analyzeResult)
+        private static RecognizedReceiptCollection ConvertToRecognizedReceipts(AnalyzeResult_internal analyzeResult)
         {
             List<RecognizedReceipt> receipts = new List<RecognizedReceipt>();
             for (int i = 0; i < analyzeResult.DocumentResults.Count; i++)
             {
                 receipts.Add(new RecognizedReceipt(analyzeResult.DocumentResults[i], analyzeResult.PageResults, analyzeResult.ReadResults));
             }
-            return receipts;
+            return new RecognizedReceiptCollection(receipts);
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizedFormCollection.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizedFormCollection.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Azure.AI.FormRecognizer.Models
+{
+    /// <summary>
+    /// A read-only collection of <see cref="RecognizedForm"/> objects.
+    /// </summary>
+    public class RecognizedFormCollection : ReadOnlyCollection<RecognizedForm>
+    {
+        /// <inheritdoc/>
+        internal RecognizedFormCollection(IList<RecognizedForm> list) : base(list)
+        {
+        }
+    }
+}

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizedReceiptCollection.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizedReceiptCollection.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Azure.AI.FormRecognizer.Models
+{
+    /// <summary>
+    /// A read-only collection of <see cref="RecognizedReceipt"/> objects.
+    /// </summary>
+    public class RecognizedReceiptCollection : ReadOnlyCollection<RecognizedReceipt>
+    {
+        /// <inheritdoc/>
+        internal RecognizedReceiptCollection(IList<RecognizedReceipt> list) : base(list)
+        {
+        }
+    }
+}

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
@@ -55,7 +55,7 @@ namespace Azure.AI.FormRecognizer.Tests
         public async Task StartRecognizeContentPopulatesFormPage(bool useStream)
         {
             var client = CreateInstrumentedFormRecognizerClient();
-            Operation<IReadOnlyList<FormPage>> operation;
+            RecognizeContentOperation operation;
 
             if (useStream)
             {
@@ -165,7 +165,7 @@ namespace Azure.AI.FormRecognizer.Tests
         public async Task StartRecognizeReceiptsPopulatesExtractedReceipt(bool useStream)
         {
             var client = CreateInstrumentedFormRecognizerClient();
-            Operation<IReadOnlyList<RecognizedReceipt>> operation;
+            RecognizeReceiptsOperation operation;
 
             if (useStream)
             {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample1_RecognizeContentFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample1_RecognizeContentFromFile.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Models;
@@ -26,7 +25,7 @@ namespace Azure.AI.FormRecognizer.Samples
 
             using (FileStream stream = new FileStream(invoiceFilePath, FileMode.Open))
             {
-                Response<IReadOnlyList<FormPage>> formPages = await client.StartRecognizeContent(stream).WaitForCompletionAsync();
+                Response<FormPageCollection> formPages = await client.StartRecognizeContent(stream).WaitForCompletionAsync();
                 foreach (FormPage page in formPages.Value)
                 {
                     Console.WriteLine($"Form Page {page.PageNumber} has {page.Lines.Count} lines.");

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample1_RecognizeContentFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample1_RecognizeContentFromFile.cs
@@ -25,8 +25,8 @@ namespace Azure.AI.FormRecognizer.Samples
 
             using (FileStream stream = new FileStream(invoiceFilePath, FileMode.Open))
             {
-                Response<FormPageCollection> formPages = await client.StartRecognizeContent(stream).WaitForCompletionAsync();
-                foreach (FormPage page in formPages.Value)
+                FormPageCollection formPages = await client.StartRecognizeContent(stream).WaitForCompletionAsync();
+                foreach (FormPage page in formPages)
                 {
                     Console.WriteLine($"Form Page {page.PageNumber} has {page.Lines.Count} lines.");
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample1_RecognizeContentFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample1_RecognizeContentFromUri.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Models;
 using Azure.AI.FormRecognizer.Tests;
@@ -25,7 +24,7 @@ namespace Azure.AI.FormRecognizer.Samples
 
             #region Snippet:FormRecognizerSampleRecognizeContentFromUri
 
-            Response<IReadOnlyList<FormPage>> formPages = await client.StartRecognizeContentFromUri(new Uri(invoiceUri)).WaitForCompletionAsync();
+            Response<FormPageCollection> formPages = await client.StartRecognizeContentFromUri(new Uri(invoiceUri)).WaitForCompletionAsync();
             foreach (FormPage page in formPages.Value)
             {
                 Console.WriteLine($"Form Page {page.PageNumber} has {page.Lines.Count} lines.");

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample1_RecognizeContentFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample1_RecognizeContentFromUri.cs
@@ -24,8 +24,8 @@ namespace Azure.AI.FormRecognizer.Samples
 
             #region Snippet:FormRecognizerSampleRecognizeContentFromUri
 
-            Response<FormPageCollection> formPages = await client.StartRecognizeContentFromUri(new Uri(invoiceUri)).WaitForCompletionAsync();
-            foreach (FormPage page in formPages.Value)
+            FormPageCollection formPages = await client.StartRecognizeContentFromUri(new Uri(invoiceUri)).WaitForCompletionAsync();
+            foreach (FormPage page in formPages)
             {
                 Console.WriteLine($"Form Page {page.PageNumber} has {page.Lines.Count} lines.");
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample2_RecognizeReceiptsFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample2_RecognizeReceiptsFromFile.cs
@@ -29,7 +29,7 @@ namespace Azure.AI.FormRecognizer.Samples
             #region Snippet:FormRecognizerSampleRecognizeReceiptFileStream
             using (FileStream stream = new FileStream(receiptPath, FileMode.Open))
             {
-                Response<IReadOnlyList<RecognizedReceipt>> receipts = await client.StartRecognizeReceipts(stream).WaitForCompletionAsync();
+                Response<RecognizedReceiptCollection> receipts = await client.StartRecognizeReceipts(stream).WaitForCompletionAsync();
                 foreach (var receipt in receipts.Value)
                 {
                     USReceipt usReceipt = receipt.AsUSReceipt();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample2_RecognizeReceiptsFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample2_RecognizeReceiptsFromFile.cs
@@ -29,8 +29,8 @@ namespace Azure.AI.FormRecognizer.Samples
             #region Snippet:FormRecognizerSampleRecognizeReceiptFileStream
             using (FileStream stream = new FileStream(receiptPath, FileMode.Open))
             {
-                Response<RecognizedReceiptCollection> receipts = await client.StartRecognizeReceipts(stream).WaitForCompletionAsync();
-                foreach (var receipt in receipts.Value)
+                RecognizedReceiptCollection receipts = await client.StartRecognizeReceipts(stream).WaitForCompletionAsync();
+                foreach (var receipt in receipts)
                 {
                     USReceipt usReceipt = receipt.AsUSReceipt();
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample2_RecognizeReceiptsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample2_RecognizeReceiptsFromUri.cs
@@ -24,8 +24,8 @@ namespace Azure.AI.FormRecognizer.Samples
             string receiptUri = FormRecognizerTestEnvironment.JpgReceiptUri;
 
             #region Snippet:FormRecognizerSampleRecognizeReceiptFileFromUri
-            Response<RecognizedReceiptCollection> receipts = await client.StartRecognizeReceiptsFromUri(new Uri(receiptUri)).WaitForCompletionAsync();
-            foreach (var receipt in receipts.Value)
+            RecognizedReceiptCollection receipts = await client.StartRecognizeReceiptsFromUri(new Uri(receiptUri)).WaitForCompletionAsync();
+            foreach (var receipt in receipts)
             {
                 USReceipt usReceipt = receipt.AsUSReceipt();
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample2_RecognizeReceiptsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample2_RecognizeReceiptsFromUri.cs
@@ -24,7 +24,7 @@ namespace Azure.AI.FormRecognizer.Samples
             string receiptUri = FormRecognizerTestEnvironment.JpgReceiptUri;
 
             #region Snippet:FormRecognizerSampleRecognizeReceiptFileFromUri
-            Response<IReadOnlyList<RecognizedReceipt>> receipts = await client.StartRecognizeReceiptsFromUri(new Uri(receiptUri)).WaitForCompletionAsync();
+            Response<RecognizedReceiptCollection> receipts = await client.StartRecognizeReceiptsFromUri(new Uri(receiptUri)).WaitForCompletionAsync();
             foreach (var receipt in receipts.Value)
             {
                 USReceipt usReceipt = receipt.AsUSReceipt();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample3_RecognizeCustomFormsFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample3_RecognizeCustomFormsFromFile.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Models;
@@ -39,7 +38,7 @@ namespace Azure.AI.FormRecognizer.Samples
 
             using (FileStream stream = new FileStream(formFilePath, FileMode.Open))
             {
-                Response<IReadOnlyList<RecognizedForm>> forms = await client.StartRecognizeCustomForms(modelId, stream).WaitForCompletionAsync();
+                Response<RecognizedFormCollection> forms = await client.StartRecognizeCustomForms(modelId, stream).WaitForCompletionAsync();
                 foreach (RecognizedForm form in forms.Value)
                 {
                     Console.WriteLine($"Form of type: {form.FormType}");

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample3_RecognizeCustomFormsFromFile.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample3_RecognizeCustomFormsFromFile.cs
@@ -38,8 +38,8 @@ namespace Azure.AI.FormRecognizer.Samples
 
             using (FileStream stream = new FileStream(formFilePath, FileMode.Open))
             {
-                Response<RecognizedFormCollection> forms = await client.StartRecognizeCustomForms(modelId, stream).WaitForCompletionAsync();
-                foreach (RecognizedForm form in forms.Value)
+                RecognizedFormCollection forms = await client.StartRecognizeCustomForms(modelId, stream).WaitForCompletionAsync();
+                foreach (RecognizedForm form in forms)
                 {
                     Console.WriteLine($"Form of type: {form.FormType}");
                     foreach (FormField field in form.Fields.Values)

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample3_RecognizeCustomFormsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample3_RecognizeCustomFormsFromUri.cs
@@ -38,8 +38,8 @@ namespace Azure.AI.FormRecognizer.Samples
             #region Snippet:FormRecognizerSample3RecognizeCustomFormsFromUri
             //@@ string modelId = "<modelId>";
 
-            Response<RecognizedFormCollection> forms = await client.StartRecognizeCustomFormsFromUri(modelId, new Uri(formUri)).WaitForCompletionAsync();
-            foreach (RecognizedForm form in forms.Value)
+            RecognizedFormCollection forms = await client.StartRecognizeCustomFormsFromUri(modelId, new Uri(formUri)).WaitForCompletionAsync();
+            foreach (RecognizedForm form in forms)
             {
                 Console.WriteLine($"Form of type: {form.FormType}");
                 foreach (FormField field in form.Fields.Values)

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample3_RecognizeCustomFormsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample3_RecognizeCustomFormsFromUri.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Models;
 using Azure.AI.FormRecognizer.Tests;
@@ -39,7 +38,7 @@ namespace Azure.AI.FormRecognizer.Samples
             #region Snippet:FormRecognizerSample3RecognizeCustomFormsFromUri
             //@@ string modelId = "<modelId>";
 
-            Response<IReadOnlyList<RecognizedForm>> forms = await client.StartRecognizeCustomFormsFromUri(modelId, new Uri(formUri)).WaitForCompletionAsync();
+            Response<RecognizedFormCollection> forms = await client.StartRecognizeCustomFormsFromUri(modelId, new Uri(formUri)).WaitForCompletionAsync();
             foreach (RecognizedForm form in forms.Value)
             {
                 Console.WriteLine($"Form of type: {form.FormType}");

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/SampleSnippets.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/SampleSnippets.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Models;
@@ -58,7 +57,7 @@ namespace Azure.AI.FormRecognizer.Samples
             #region Snippet:FormRecognizerBadRequest
             try
             {
-                Response<IReadOnlyList<RecognizedReceipt>> receipts = await client.StartRecognizeReceiptsFromUri(new Uri("http://invalid.uri")).WaitForCompletionAsync();
+                Response<RecognizedReceiptCollection> receipts = await client.StartRecognizeReceiptsFromUri(new Uri("http://invalid.uri")).WaitForCompletionAsync();
             }
             catch (RequestFailedException e)
             {
@@ -81,7 +80,7 @@ namespace Azure.AI.FormRecognizer.Samples
             #region Snippet:FormRecognizerRecognizeFormContentFromFile
             using (FileStream stream = new FileStream(invoiceFilePath, FileMode.Open))
             {
-                Response<IReadOnlyList<FormPage>> formPages = await client.StartRecognizeContent(stream).WaitForCompletionAsync();
+                Response<FormPageCollection> formPages = await client.StartRecognizeContent(stream).WaitForCompletionAsync();
                 /*
                  *
                  */
@@ -103,7 +102,7 @@ namespace Azure.AI.FormRecognizer.Samples
             #region Snippet:FormRecognizerRecognizeReceiptFromFile
             using (FileStream stream = new FileStream(receiptPath, FileMode.Open))
             {
-                Response<IReadOnlyList<RecognizedReceipt>> receipts = await client.StartRecognizeReceipts(stream).WaitForCompletionAsync();
+                Response<RecognizedReceiptCollection> receipts = await client.StartRecognizeReceipts(stream).WaitForCompletionAsync();
                 /*
                  *
                  */
@@ -136,7 +135,7 @@ namespace Azure.AI.FormRecognizer.Samples
             {
                 //@@ string modelId = "<modelId>";
 
-                Response<IReadOnlyList<RecognizedForm>> forms = await client.StartRecognizeCustomForms(modelId, stream).WaitForCompletionAsync();
+                Response<RecognizedFormCollection> forms = await client.StartRecognizeCustomForms(modelId, stream).WaitForCompletionAsync();
                 /*
                  *
                  */

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/SampleSnippets.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/SampleSnippets.cs
@@ -57,7 +57,7 @@ namespace Azure.AI.FormRecognizer.Samples
             #region Snippet:FormRecognizerBadRequest
             try
             {
-                Response<RecognizedReceiptCollection> receipts = await client.StartRecognizeReceiptsFromUri(new Uri("http://invalid.uri")).WaitForCompletionAsync();
+                RecognizedReceiptCollection receipts = await client.StartRecognizeReceiptsFromUri(new Uri("http://invalid.uri")).WaitForCompletionAsync();
             }
             catch (RequestFailedException e)
             {
@@ -80,7 +80,7 @@ namespace Azure.AI.FormRecognizer.Samples
             #region Snippet:FormRecognizerRecognizeFormContentFromFile
             using (FileStream stream = new FileStream(invoiceFilePath, FileMode.Open))
             {
-                Response<FormPageCollection> formPages = await client.StartRecognizeContent(stream).WaitForCompletionAsync();
+                FormPageCollection formPages = await client.StartRecognizeContent(stream).WaitForCompletionAsync();
                 /*
                  *
                  */
@@ -102,7 +102,7 @@ namespace Azure.AI.FormRecognizer.Samples
             #region Snippet:FormRecognizerRecognizeReceiptFromFile
             using (FileStream stream = new FileStream(receiptPath, FileMode.Open))
             {
-                Response<RecognizedReceiptCollection> receipts = await client.StartRecognizeReceipts(stream).WaitForCompletionAsync();
+                RecognizedReceiptCollection receipts = await client.StartRecognizeReceipts(stream).WaitForCompletionAsync();
                 /*
                  *
                  */
@@ -135,7 +135,7 @@ namespace Azure.AI.FormRecognizer.Samples
             {
                 //@@ string modelId = "<modelId>";
 
-                Response<RecognizedFormCollection> forms = await client.StartRecognizeCustomForms(modelId, stream).WaitForCompletionAsync();
+                RecognizedFormCollection forms = await client.StartRecognizeCustomForms(modelId, stream).WaitForCompletionAsync();
                 /*
                  *
                  */


### PR DESCRIPTION
Changes:
- Created classes `RecognizedReceiptCollection`, `RecognizedFormCollection` and `FormPageCollection` to be used as generic types in `Response<T>`.
- Updated the client and tests accordingly.

Fixes #11772.