### PR TITLE
Attach all Search test output to test results

### DIFF
--- a/sdk/search/Azure.Search.Documents/tests/SearchServiceClientTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/SearchServiceClientTests.cs
@@ -331,9 +331,7 @@ namespace Azure.Search.Documents.Tests
             long count = await client.GetDocumentCountAsync(
                 GetOptions());
 
-            // While there should only be 10 documents and this data source uses a random name and should not be shared,
-            // occasionally we get back 20 documents. Since this still proves the indexer worked, do not fail the tests.
-            Assert.That(count, Is.GreaterThanOrEqualTo(SearchResources.TestDocuments.Length));
+            Assert.AreEqual(SearchResources.TestDocuments.Length, count);
         }
 
         [Test]

--- a/sdk/search/tests.yml
+++ b/sdk/search/tests.yml
@@ -14,3 +14,4 @@ jobs:
     MaxParallel: 2
     EnvVars:
       AZURE_SEARCH_TEST_MODE: Live
+      AZURE_SEARCH_TEST_VERBOSE: 1


### PR DESCRIPTION
Fixes #11969 until we figure out why the count is 20 sometimes instead of 10.