### PR TITLE
Need not compare headers for track 1 session files

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/RecordMatcher.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordMatcher.cs
@@ -91,12 +91,11 @@ namespace Azure.Core.TestFramework
                 }
 
                 //we only check Uri + RequestMethod for track1 record
-                if (entry.IsTrack1Recording)
+                if (!entry.IsTrack1Recording)
                 {
                     score += CompareHeaderDictionaries(request.Request.Headers, entry.Request.Headers, ExcludeHeaders);
+                    score += CompareBodies(request.Request.Body, entry.Request.Body);
                 }
-
-                score += CompareBodies(request.Request.Body, entry.Request.Body);
 
                 if (score == 0)
                 {

--- a/sdk/core/Azure.Core/tests/RecordSessionTests.cs
+++ b/sdk/core/Azure.Core/tests/RecordSessionTests.cs
@@ -283,7 +283,7 @@ namespace Azure.Core.Tests
 
             recordTransport.Process(message);
 
-            request.Content = RequestContent.Create(Encoding.UTF8.GetBytes("A bad and longer body."));
+            request.Content = RequestContent.Create(Encoding.UTF8.GetBytes("A bad and longer body"));
 
             var skipRequestBody = true;
             var playbackTransport = new PlaybackTransport(session, new RecordMatcher(), new RecordedTestSanitizer(), Mock.Of<Random>(), entry => skipRequestBody);

--- a/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableClientLiveTests/EntitiyCanBeUpserted.json
+++ b/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableClientLiveTests/EntitiyCanBeUpserted.json
@@ -51,7 +51,7 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "88",
-        "Content-Type": "application/json; odata=nometadata",
+        "Content-Type": "application/json",
         "DataServiceVersion": "3.0",
         "traceparent": "00-a9f9ca627310084fbf75deb8ae688396-961eaade0bb38443-00",
         "User-Agent": [
@@ -139,7 +139,7 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "539",
-        "Content-Type": "application/json; odata=nometadata",
+        "Content-Type": "application/json",
         "DataServiceVersion": "3.0",
         "traceparent": "00-654ddfb83eb8704f8aa3b641ba3b3043-7f1bc539b07a5a48-00",
         "User-Agent": [

--- a/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableClientLiveTests/EntitiyCanBeUpsertedAsync.json
+++ b/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableClientLiveTests/EntitiyCanBeUpsertedAsync.json
@@ -51,7 +51,7 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "88",
-        "Content-Type": "application/json; odata=nometadata",
+        "Content-Type": "application/json",
         "DataServiceVersion": "3.0",
         "traceparent": "00-226b46839e7d6a438538f304899a39fe-e665ea71c051f844-00",
         "User-Agent": [
@@ -139,7 +139,7 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "539",
-        "Content-Type": "application/json; odata=nometadata",
+        "Content-Type": "application/json",
         "DataServiceVersion": "3.0",
         "traceparent": "00-6a92bb35d5c1934f8a7a394636aa70a5-da54cb7c8900d149-00",
         "User-Agent": [

--- a/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableClientLiveTests/EntityDeleteRespectsEtag.json
+++ b/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableClientLiveTests/EntityDeleteRespectsEtag.json
@@ -51,7 +51,7 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "88",
-        "Content-Type": "application/json; odata=nometadata",
+        "Content-Type": "application/json",
         "DataServiceVersion": "3.0",
         "traceparent": "00-97b05deb6c18ad4ca9f53c56e431ef90-3d24d2a7571b8c48-00",
         "User-Agent": [
@@ -209,7 +209,7 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "88",
-        "Content-Type": "application/json; odata=nometadata",
+        "Content-Type": "application/json",
         "DataServiceVersion": "3.0",
         "traceparent": "00-63531bf1c82778459151b977950570b5-6918a67d3557a94a-00",
         "User-Agent": [

--- a/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableClientLiveTests/EntityDeleteRespectsEtagAsync.json
+++ b/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableClientLiveTests/EntityDeleteRespectsEtagAsync.json
@@ -51,7 +51,7 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "88",
-        "Content-Type": "application/json; odata=nometadata",
+        "Content-Type": "application/json",
         "DataServiceVersion": "3.0",
         "traceparent": "00-80b6904593261546b64117dd56cf0d7b-142dea19fa1a9648-00",
         "User-Agent": [
@@ -209,7 +209,7 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "88",
-        "Content-Type": "application/json; odata=nometadata",
+        "Content-Type": "application/json",
         "DataServiceVersion": "3.0",
         "traceparent": "00-7b03227d8f0fe34d8a3a3661b74cbd1f-247955b70603c84c-00",
         "User-Agent": [

--- a/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableClientLiveTests/EntityUpdateRespectsEtag.json
+++ b/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableClientLiveTests/EntityUpdateRespectsEtag.json
@@ -51,7 +51,7 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "88",
-        "Content-Type": "application/json; odata=nometadata",
+        "Content-Type": "application/json",
         "DataServiceVersion": "3.0",
         "traceparent": "00-0073539b1af21247b2ff5df3ee1375c4-a283d722405ce846-00",
         "User-Agent": [
@@ -139,7 +139,7 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "540",
-        "Content-Type": "application/json; odata=nometadata",
+        "Content-Type": "application/json",
         "DataServiceVersion": "3.0",
         "If-Match": "*",
         "traceparent": "00-89d498f3cc3f3d4f88b16156cafe5f2f-ed18ecb4c34e0141-00",
@@ -234,7 +234,7 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "550",
-        "Content-Type": "application/json; odata=nometadata",
+        "Content-Type": "application/json",
         "DataServiceVersion": "3.0",
         "If-Match": "W/\u0022datetime\u00272020-05-11T14%3A34%3A27.0315799Z\u0027\u0022",
         "traceparent": "00-e1921256f9c05842b87f12db390de0f1-cb79e7d672174e4b-00",
@@ -289,7 +289,7 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "550",
-        "Content-Type": "application/json; odata=nometadata",
+        "Content-Type": "application/json",
         "DataServiceVersion": "3.0",
         "If-Match": "W/\u0022datetime\u00272020-05-11T14%3A34%3A27.1156507Z\u0027\u0022",
         "traceparent": "00-19e6532fe8b61a4cb27db48cf62bf2aa-26b2c11322c7f34e-00",

--- a/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableClientLiveTests/EntityUpdateRespectsEtagAsync.json
+++ b/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableClientLiveTests/EntityUpdateRespectsEtagAsync.json
@@ -51,7 +51,7 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "88",
-        "Content-Type": "application/json; odata=nometadata",
+        "Content-Type": "application/json",
         "DataServiceVersion": "3.0",
         "traceparent": "00-6e08d740d6a68946ad5acd236c08f3da-c17fdd0d1026c94d-00",
         "User-Agent": [
@@ -139,7 +139,7 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "540",
-        "Content-Type": "application/json; odata=nometadata",
+        "Content-Type": "application/json",
         "DataServiceVersion": "3.0",
         "If-Match": "*",
         "traceparent": "00-8ab5c32f0943204b90bdbed73b1eefcb-0fc5919957995a40-00",
@@ -234,7 +234,7 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "550",
-        "Content-Type": "application/json; odata=nometadata",
+        "Content-Type": "application/json",
         "DataServiceVersion": "3.0",
         "If-Match": "W/\u0022datetime\u00272020-05-11T14%3A34%3A33.8702777Z\u0027\u0022",
         "traceparent": "00-b3a808c7c953504db513f0822e4a99a2-1f374d9712a18e42-00",
@@ -289,7 +289,7 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "550",
-        "Content-Type": "application/json; odata=nometadata",
+        "Content-Type": "application/json",
         "DataServiceVersion": "3.0",
         "If-Match": "W/\u0022datetime\u00272020-05-11T14%3A34%3A34.1455075Z\u0027\u0022",
         "traceparent": "00-257a24452378074aadeac049888b39d6-29aba4b15d079349-00",

--- a/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableClientLiveTests/QueryReturnsEntitiesWithoutOdataAnnoations.json
+++ b/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableClientLiveTests/QueryReturnsEntitiesWithoutOdataAnnoations.json
@@ -51,7 +51,7 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "624",
-        "Content-Type": "application/json; odata=nometadata",
+        "Content-Type": "application/json",
         "DataServiceVersion": "3.0",
         "traceparent": "00-1368a0812fb47c4caaa427fef3251546-ee0ecf078dfe5d40-00",
         "User-Agent": [

--- a/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableClientLiveTests/QueryReturnsEntitiesWithoutOdataAnnoationsAsync.json
+++ b/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableClientLiveTests/QueryReturnsEntitiesWithoutOdataAnnoationsAsync.json
@@ -51,7 +51,7 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "624",
-        "Content-Type": "application/json; odata=nometadata",
+        "Content-Type": "application/json",
         "DataServiceVersion": "3.0",
         "traceparent": "00-92c0761b63722947a527bd1095fe38b2-c0b4506acae61e43-00",
         "User-Agent": [

--- a/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableClientLiveTests/UpsertedEntitiesAreRoundtrippedWithProperOdataAnnoations.json
+++ b/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableClientLiveTests/UpsertedEntitiesAreRoundtrippedWithProperOdataAnnoations.json
@@ -51,7 +51,7 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "624",
-        "Content-Type": "application/json; odata=nometadata",
+        "Content-Type": "application/json",
         "DataServiceVersion": "3.0",
         "traceparent": "00-1c71a74e281cb84fbb579106957c8751-572e02c7397b8549-00",
         "User-Agent": [

--- a/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableClientLiveTests/UpsertedEntitiesAreRoundtrippedWithProperOdataAnnoationsAsync.json
+++ b/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableClientLiveTests/UpsertedEntitiesAreRoundtrippedWithProperOdataAnnoationsAsync.json
@@ -51,7 +51,7 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "Content-Length": "624",
-        "Content-Type": "application/json; odata=nometadata",
+        "Content-Type": "application/json",
         "DataServiceVersion": "3.0",
         "traceparent": "00-9e03a88ae56c7444819010f67c974654-fe174d468eaa4b4c-00",
         "User-Agent": [

--- a/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableClientLiveTests/ValidateSasCredentials.json
+++ b/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableClientLiveTests/ValidateSasCredentials.json
@@ -84,7 +84,7 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Content-Length": "621",
-        "Content-Type": "application/json; odata=nometadata",
+        "Content-Type": "application/json",
         "DataServiceVersion": "3.0",
         "traceparent": "00-a96c11816cc8554ea51ddd9299048728-e39ba114adf0a64a-00",
         "User-Agent": [

--- a/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableClientLiveTests/ValidateSasCredentialsAsync.json
+++ b/sdk/tables/Azure.Data.Tables/tests/SessionRecords/TableClientLiveTests/ValidateSasCredentialsAsync.json
@@ -84,7 +84,7 @@
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Content-Length": "621",
-        "Content-Type": "application/json; odata=nometadata",
+        "Content-Type": "application/json",
         "DataServiceVersion": "3.0",
         "traceparent": "00-1c764e393fbb9f409b90e62f0b168deb-e096bffb172bf240-00",
         "User-Agent": [


### PR DESCRIPTION
To reuse track 1 session files, we should not compare headers because their headers must not be same.

This code is only meaningful during migrating track 1 to track 2, we should clean up this logic after migration is done.