### PR TITLE
fix(swagger): Add required fields for direct method calls

### DIFF
--- a/sdk/iot/Azure.Iot.Hub.Service/src/swagger/iothubservice_modified_requiredparameters.json
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/swagger/iothubservice_modified_requiredparameters.json
@@ -2839,7 +2839,8 @@
                     "format": "int32",
                     "type": "integer"
                 }
-            }
+            },
+            "required": ["methodName"]
         },
         "JobResponse": {
             "type": "object",


### PR DESCRIPTION
Only change is add `methodName` as required for `CloudToDeviceMethod` input type. 