### PR TITLE
fix(swagger): Add readonly fields for direct method APIs

### DIFF
--- a/sdk/iot/Azure.Iot.Hub.Service/src/swagger/iothubservice_modified_readonlyfields.json
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/swagger/iothubservice_modified_readonlyfields.json
@@ -3039,11 +3039,13 @@
                 "status": {
                     "format": "int32",
                     "description": "Method invocation result status.",
-                    "type": "integer"
+                    "type": "integer",
+                    "readOnly": true
                 },
                 "payload": {
                     "description": "Method invocation result payload.",
-                    "type": "object"
+                    "type": "object",
+                    "readOnly": true
                 }
             }
         },


### PR DESCRIPTION
Mark `status` and `payload` as readonly in `CloudToDeviceMethodResult`.