### PR TITLE
Increasing Search test retry delays considerably for throttling

### DIFF
--- a/sdk/search/Azure.Search.Documents/tests/Utilities/SearchTestBase.cs
+++ b/sdk/search/Azure.Search.Documents/tests/Utilities/SearchTestBase.cs
@@ -22,11 +22,6 @@ namespace Azure.Search.Documents.Tests
     public abstract partial class SearchTestBase : RecordedTestBase<SearchTestEnvironment>
     {
         /// <summary>
-        /// The maximum number of retries for service requests.
-        /// </summary>
-        private const int MaxRetries = 5;
-
-        /// <summary>
         /// Shared HTTP client instance with a longer timeout.  It's
         /// gratuitously long for the sake of live tests in a hammered
         /// environment.
@@ -73,9 +68,9 @@ namespace Azure.Search.Documents.Tests
             options ??= new SearchClientOptions(ServiceVersion);
             options.Diagnostics.IsLoggingEnabled = true;
             options.Retry.Mode = RetryMode.Exponential;
-            options.Retry.MaxRetries = MaxRetries;
-            options.Retry.Delay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.01 : 0.5);
-            options.Retry.MaxDelay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.1 : 10);
+            options.Retry.MaxRetries = 10;
+            options.Retry.Delay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.01 : 1);
+            options.Retry.MaxDelay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.1 : 600);
             options.Transport = new HttpClientTransport(s_httpClient);
             return Recording.InstrumentClientOptions(options);
         }


### PR DESCRIPTION
Creating indexes on a free account gets throttled and the ends of our test passes are failing.  I'm increasing the timeouts a lot while we explore what works for our tests.  The default exponential retry policy will randomly jitter any individual retry between 80% and 120% of the following targets:

```
  1:  0:01
  2:  0:02
  3:  0:04
  4:  0:08
  5:  0:16
  6:  0:32
  7:  1:04
  8:  2:08
  9:  4:16
 10:  8:32
Max: 10:00
```

We cap any single request at 10 minutes.  If that's not enough to get around index throttling, we'll need to change the type of resources we're using.