### PR TITLE
Update CODEOWNERS with smoke test owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,7 +47,7 @@
 /sdk/formrecognizer/                            @annelo-msft @kinelski @maririos
 
 # Smoke tests
-/common/SmokeTests/                             @schaabs @heaths @tg-msft @jsquire
+/common/SmokeTests/                             @AlexGhiondea @schaabs @heaths @tg-msft @jsquire
 
 # Management Plane
 /**/*Management*/                               @isra-fel @erich-wang

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,6 +46,9 @@
 
 /sdk/formrecognizer/                            @annelo-msft @kinelski @maririos
 
+# Smoke tests
+/common/SmokeTests/                             @schaabs @heaths @tg-msft @jsquire
+
 # Management Plane
 /**/*Management*/                               @isra-fel @erich-wang
 


### PR DESCRIPTION
This change (arbitrarily) selects code owners for the Smoke Tests pipelines. You will receive email notifications from Azure DevOps when the smoke tests fail. If someone else should be in your place please comment here. 

What are smoke tests? 
https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/198/Smoke-Testing

Who is being subscribed? 
@AlexGhiondea @schaabs @heaths @tg-msft @jsquire