### PR TITLE
fix(swagger): Update required fields for Twin APIs

### DIFF
--- a/sdk/iot/Azure.Iot.Hub.Service/src/swagger/iothubservice_modified_requiredparameters.json
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/swagger/iothubservice_modified_requiredparameters.json
@@ -2545,7 +2545,8 @@
                         "type": "string"
                     }
                 }
-            }
+            },
+            "required": ["deviceId"]
         },
         "TwinProperties": {
             "description": "Represents Twin properties",


### PR DESCRIPTION
Marking "deviceId" as the only required field for a Twin. We need an update from service, if there are other fields that are also required. 
The MSDN doc doesn't say much about this: https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-device-twins