### PR TITLE
Smoke Tests use new subscription configuration template

### DIFF
--- a/common/SmokeTests/smoke-tests.yml
+++ b/common/SmokeTests/smoke-tests.yml
@@ -97,3 +97,4 @@ jobs:
       - template: /eng/common/TestResources/remove-test-resources.yml
         parameters:
           ServiceDirectory: '$(Build.SourcesDirectory)/common/SmokeTests/'
+          SubscriptionConfiguration: $(SubscriptionConfiguration)

--- a/common/SmokeTests/smoke-tests.yml
+++ b/common/SmokeTests/smoke-tests.yml
@@ -29,22 +29,22 @@ jobs:
         Windows_NetCoreApp (AzureUSGovernment):
           OSVmImage: "windows-2019"
           TestTargetFramework: netcoreapp2.1
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-gov)
+          SubscriptionConfiguration: $(sub-config-gov-test-resources)
           ArmTemplateParameters: $(azureUSGovernmentArmParameters)
         Windows_NetFramework (AzureUSGovernment):
           OSVmImage: "windows-2019"
           TestTargetFramework: net461
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-gov)
+          SubscriptionConfiguration: $(sub-config-gov-test-resources)
           ArmTemplateParameters: $(azureUSGovernmentArmParameters)
         Windows_NetCoreApp (AzureChinaCloud):
           OSVmImage: "windows-2019"
           TestTargetFramework: netcoreapp2.1
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-cn)
+          SubscriptionConfiguration: $(sub-config-cn-test-resources)
           ArmTemplateParameters: $(azureChinaCloudArmParameters)
         Windows_NetFramework (AzureChinaCloud):
           OSVmImage: "windows-2019"
           TestTargetFramework: net461
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-cn)
+          SubscriptionConfiguration: $(sub-config-cn-test-resources)
           ArmTemplateParameters: $(azureChinaCloudArmParameters)
 
     pool:

--- a/common/SmokeTests/smoke-tests.yml
+++ b/common/SmokeTests/smoke-tests.yml
@@ -9,42 +9,42 @@ jobs:
         Linux (AzureCloud):
           OSVmImage: "ubuntu-18.04"
           TestTargetFramework: netcoreapp2.1
-          CloudType: AzureCloud
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
         Windows_NetCoreApp (AzureCloud):
           OSVmImage: "windows-2019"
           TestTargetFramework: netcoreapp2.1
-          CloudType: AzureCloud
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
         Windows_NetFramework (AzureCloud):
           OSVmImage: "windows-2019"
           TestTargetFramework: net461
-          CloudType: AzureCloud
-          ArmTemplateParameters: $(azureCloudArmParameters)
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+          ArmTemplateParameters: $(azureCloudArmParameters)exp
         MacOs (AzureCloud):
           OSVmImage: "macOS-10.15"
           TestTargetFramework: netcoreapp2.1
-          CloudType: AzureCloud
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
         Windows_NetCoreApp (AzureUSGovernment):
           OSVmImage: "windows-2019"
           TestTargetFramework: netcoreapp2.1
-          CloudType: AzureUSGovernment
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-gov)
           ArmTemplateParameters: $(azureUSGovernmentArmParameters)
         Windows_NetFramework (AzureUSGovernment):
           OSVmImage: "windows-2019"
           TestTargetFramework: net461
-          CloudType: AzureUSGovernment
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-gov)
           ArmTemplateParameters: $(azureUSGovernmentArmParameters)
         Windows_NetCoreApp (AzureChinaCloud):
           OSVmImage: "windows-2019"
           TestTargetFramework: netcoreapp2.1
-          CloudType: AzureChinaCloud
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-cn)
           ArmTemplateParameters: $(azureChinaCloudArmParameters)
         Windows_NetFramework (AzureChinaCloud):
           OSVmImage: "windows-2019"
           TestTargetFramework: net461
-          CloudType: AzureChinaCloud
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-cn)
           ArmTemplateParameters: $(azureChinaCloudArmParameters)
 
     pool:
@@ -88,7 +88,7 @@ jobs:
       - template: /eng/common/TestResources/deploy-test-resources.yml
         parameters:
           ServiceDirectory: '$(Build.SourcesDirectory)/common/SmokeTests/'
-          CloudType: $(CloudType)
+          SubscriptionConfiguration: $(SubscriptionConfiguration)
           ArmTemplateParameters: $(ArmTemplateParameters)
 
       - pwsh: dotnet run -p .\common\SmokeTests\SmokeTest\SmokeTest.csproj --framework $(TestTargetFramework)

--- a/common/SmokeTests/smoke-tests.yml
+++ b/common/SmokeTests/smoke-tests.yml
@@ -20,7 +20,7 @@ jobs:
           OSVmImage: "windows-2019"
           TestTargetFramework: net461
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
-          ArmTemplateParameters: $(azureCloudArmParameters)exp
+          ArmTemplateParameters: $(azureCloudArmParameters)
         MacOs (AzureCloud):
           OSVmImage: "macOS-10.15"
           TestTargetFramework: netcoreapp2.1

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -19,24 +19,24 @@ jobs:
         Linux:
           OSVmImage: "ubuntu-18.04"
           TestTargetFramework: netcoreapp2.1
-          CloudType: AzureCloud
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         Windows_NetCoreApp:
           OSVmImage: "windows-2019"
           TestTargetFramework: netcoreapp2.1
-          CloudType: AzureCloud
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         Windows_NetCoreApp_ProjectReferences:
           OSVmImage: "windows-2019"
           TestTargetFramework: netcoreapp2.1
-          CloudType: AzureCloud
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ConvertToProjectReferenceOption: /p:UseProjectReferenceToAzureClients=true
         Windows_NetFramework:
           OSVmImage: "windows-2019"
           TestTargetFramework: net461
-          CloudType: AzureCloud
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         MacOs:
           OSVmImage: "macOS-10.15"
           TestTargetFramework: netcoreapp2.1
-          CloudType: AzureCloud
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
     pool:
       vmImage: "$(OSVmImage)"
 
@@ -62,6 +62,7 @@ jobs:
       - template: /eng/common/TestResources/deploy-test-resources.yml
         parameters:
           ServiceDirectory: '${{ parameters.ServiceDirectory }}'
+          SubscriptionConfiguration: $(SubscriptionConfiguration)
 
       - script: >
           dotnet test eng/service.proj
@@ -84,6 +85,7 @@ jobs:
       - template: /eng/common/TestResources/remove-test-resources.yml
         parameters:
           ServiceDirectory: '${{ parameters.ServiceDirectory }}'
+          SubscriptionConfiguration: $(SubscriptionConfiguration)
 
       - task: PublishTestResults@2
         condition: always()


### PR DESCRIPTION
Note about changes in `eng/common` folder: These changes will be superseded by a sync from eng/common in tools. 