### PR TITLE
Retry on timeouts on .NET Framework

### DIFF
--- a/sdk/core/Azure.Core/src/Pipeline/Internal/ReadTimeoutStream.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/ReadTimeoutStream.cs
@@ -80,7 +80,6 @@ namespace Azure.Core.Pipeline
 
         private void DisposeStream()
         {
-            Console.WriteLine("Disposing stream");
             _stream.Dispose();
         }
 

--- a/sdk/core/Azure.Core/src/Pipeline/Internal/ReadTimeoutStream.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/ReadTimeoutStream.cs
@@ -15,14 +15,14 @@ namespace Azure.Core.Pipeline
     {
         private readonly Stream _stream;
         private TimeSpan _readTimeout;
-        private CancellationTokenSource _cancellationTokenSource;
+        private CancellationTokenSource _cancellationTokenSource = null!;
 
         public ReadTimeoutStream(Stream stream, TimeSpan readTimeout)
         {
             _stream = stream;
             _readTimeout = readTimeout;
             UpdateReadTimeout();
-            _cancellationTokenSource = new CancellationTokenSource();
+            InitializeTokenSource();
         }
 
         public override int Read(byte[] buffer, int offset, int count)
@@ -37,6 +37,11 @@ namespace Azure.Core.Pipeline
             {
                 return await _stream.ReadAsync(buffer, offset, count, source.Token).ConfigureAwait(false);
             }
+            // We dispose stream on timeout so catch and check if cancellation token was cancelled
+            catch (ObjectDisposedException) when (source.IsCancellationRequested)
+            {
+                throw new OperationCanceledException(source.Token);
+            }
             finally
             {
                 StopTimeout(source, dispose);
@@ -47,7 +52,7 @@ namespace Azure.Core.Pipeline
         {
             if (_cancellationTokenSource.IsCancellationRequested)
             {
-                _cancellationTokenSource = new CancellationTokenSource();
+                InitializeTokenSource();
             }
 
             CancellationTokenSource source;
@@ -65,6 +70,18 @@ namespace Azure.Core.Pipeline
             _cancellationTokenSource.CancelAfter(_readTimeout);
 
             return source;
+        }
+
+        private void InitializeTokenSource()
+        {
+            _cancellationTokenSource = new CancellationTokenSource();
+            _cancellationTokenSource.Token.Register(() => DisposeStream());
+        }
+
+        private void DisposeStream()
+        {
+            Console.WriteLine("Disposing stream");
+            _stream.Dispose();
         }
 
         private void StopTimeout(CancellationTokenSource source, bool dispose)

--- a/sdk/core/Azure.Core/tests/HttpPipelineFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpPipelineFunctionalTests.cs
@@ -183,7 +183,6 @@ namespace Azure.Core.Tests
             testDoneTcs.Cancel();
         }
 
-#if NETCOREAPP
         [Test]
         public async Task RetriesBufferedBodyTimeout()
         {
@@ -267,7 +266,6 @@ namespace Azure.Core.Tests
 
              testDoneTcs.Cancel();
         }
-#endif
 
         private class TestOptions : ClientOptions
         {

--- a/sdk/core/Azure.Core/tests/RetriableStreamTests.cs
+++ b/sdk/core/Azure.Core/tests/RetriableStreamTests.cs
@@ -55,6 +55,37 @@ namespace Azure.Core.Tests
         }
 
         [Test]
+        public async Task DisposesStreams()
+        {
+            var stream1 = new MockReadStream(100, throwAfter: 50);
+            var stream2 = new MockReadStream(50, offset: 50);
+
+            MockTransport mockTransport = CreateMockTransport(
+                new MockResponse(200) { ContentStream = stream1 },
+                new MockResponse(200) { ContentStream = stream2 }
+            );
+            var pipeline = new HttpPipeline(mockTransport);
+
+            Stream reliableStream = await CreateAsync(
+                offset => SendTestRequest(pipeline, offset),
+                offset => SendTestRequestAsync(pipeline, offset),
+                new ResponseClassifier(), maxRetries: 5);
+
+            Assert.AreEqual(25, await ReadAsync(reliableStream, _buffer, 0, 25));
+            Assert.AreEqual(25, await ReadAsync(reliableStream, _buffer, 25, 25));
+            Assert.AreEqual(50, await ReadAsync(reliableStream, _buffer, 50, 50));
+            Assert.True(stream1.IsDisposed);
+
+            Assert.AreEqual(0, await ReadAsync(reliableStream, _buffer, 0, 50));
+            Assert.False(stream2.IsDisposed);
+
+            reliableStream.Dispose();
+            Assert.True(stream2.IsDisposed);
+
+            AssertReads(_buffer, 100);
+        }
+
+        [Test]
         public async Task DoesntRetryNonRetryableExceptions()
         {
             var stream1 = new MockReadStream(100, throwAfter: 50);
@@ -405,6 +436,14 @@ namespace Azure.Core.Tests
             public override bool CanSeek { get; } = false;
             public override long Length { get; }
             public override long Position { get; set; }
+            public bool IsDisposed { get; set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                base.Dispose(disposing);
+                IsDisposed = true;
+            }
+
         }
     }
 }


### PR DESCRIPTION
And don't leak streams from RetriableStream.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/11125