### PR TITLE
Fix timeout retries on .NET Framework

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.3.0-preview.1 (Unreleased)
 
+### Bugfix
+- Retry server timeouts on .NET Framework.
 
 ## 1.2.1  (2020-04-30)
 

--- a/sdk/core/Azure.Core/src/Pipeline/Internal/ReadTimeoutStream.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/ReadTimeoutStream.cs
@@ -38,9 +38,10 @@ namespace Azure.Core.Pipeline
                 return await _stream.ReadAsync(buffer, offset, count, source.Token).ConfigureAwait(false);
             }
             // We dispose stream on timeout so catch and check if cancellation token was cancelled
-            catch (ObjectDisposedException) when (source.IsCancellationRequested)
+            catch (ObjectDisposedException)
             {
-                throw new OperationCanceledException(source.Token);
+                source.Token.ThrowIfCancellationRequested();
+                throw;
             }
             finally
             {

--- a/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs
@@ -88,6 +88,7 @@ namespace Azure.Core.Pipeline
                     bufferedStream.Position = 0;
                     message.Response.ContentStream = bufferedStream;
                 }
+                // We dispose stream on timeout so catch and check if cancellation token was cancelled
                 catch (ObjectDisposedException)
                 {
                     cts.Token.ThrowIfCancellationRequested();


### PR DESCRIPTION
Also pull in a rogue commit that didn't get pushed.