### PR TITLE
Live tests allow passing of location from top level tests.yml

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -21,24 +21,19 @@ jobs:
         Linux:
           OSVmImage: "ubuntu-18.04"
           TestTargetFramework: netcoreapp2.1
-          SubscriptionConfiguration: ${{ parameters.SubscriptionConfiguration }}
         Windows_NetCoreApp:
           OSVmImage: "windows-2019"
           TestTargetFramework: netcoreapp2.1
-          SubscriptionConfiguration: ${{ parameters.SubscriptionConfiguration }}
         Windows_NetCoreApp_ProjectReferences:
           OSVmImage: "windows-2019"
           TestTargetFramework: netcoreapp2.1
-          SubscriptionConfiguration: ${{ parameters.SubscriptionConfiguration }}
           ConvertToProjectReferenceOption: /p:UseProjectReferenceToAzureClients=true
         Windows_NetFramework:
           OSVmImage: "windows-2019"
           TestTargetFramework: net461
-          SubscriptionConfiguration: ${{ parameters.SubscriptionConfiguration }}
         MacOs:
           OSVmImage: "macOS-10.15"
           TestTargetFramework: netcoreapp2.1
-          SubscriptionConfiguration: ${{ parameters.SubscriptionConfiguration }}
     pool:
       vmImage: "$(OSVmImage)"
 
@@ -65,7 +60,7 @@ jobs:
         parameters:
           Location: ${{ parameters.Location }}
           ServiceDirectory: '${{ parameters.ServiceDirectory }}'
-          SubscriptionConfiguration: $(SubscriptionConfiguration)
+          SubscriptionConfiguration: ${{ parameters.SubscriptionConfiguration }}
 
       - script: >
           dotnet test eng/service.proj

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -12,6 +12,8 @@ jobs:
   - job: "Test"
     variables:
       - template: ../variables/globals.yml
+      - name: SubscriptionConfiguration
+        value: ${{ parameters.SubscriptionConfiguration }}
 
     timeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
 
@@ -60,7 +62,7 @@ jobs:
         parameters:
           Location: ${{ parameters.Location }}
           ServiceDirectory: '${{ parameters.ServiceDirectory }}'
-          SubscriptionConfiguration: ${{ parameters.SubscriptionConfiguration }}
+          SubscriptionConfiguration: $(SubscriptionConfiguration)
 
       - script: >
           dotnet test eng/service.proj

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -5,6 +5,7 @@ parameters:
   MaxParallel: 0
   BuildInParallel: true
   TimeoutInMinutes: 60
+  Location: ''
 
 jobs:
   - job: "Test"
@@ -61,6 +62,7 @@ jobs:
 
       - template: /eng/common/TestResources/deploy-test-resources.yml
         parameters:
+          Location: ${{ parameters.Location }}
           ServiceDirectory: '${{ parameters.ServiceDirectory }}'
           SubscriptionConfiguration: $(SubscriptionConfiguration)
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -14,6 +14,8 @@ jobs:
       - template: ../variables/globals.yml
       - name: SubscriptionConfiguration
         value: ${{ parameters.SubscriptionConfiguration }}
+      - name: Location
+        value: ${{ parameters.Location }}
 
     timeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
 
@@ -60,7 +62,7 @@ jobs:
 
       - template: /eng/common/TestResources/deploy-test-resources.yml
         parameters:
-          Location: ${{ parameters.Location }}
+          Location: $(Location)
           ServiceDirectory: '${{ parameters.ServiceDirectory }}'
           SubscriptionConfiguration: $(SubscriptionConfiguration)
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -6,6 +6,7 @@ parameters:
   BuildInParallel: true
   TimeoutInMinutes: 60
   Location: ''
+  SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
 
 jobs:
   - job: "Test"
@@ -20,24 +21,24 @@ jobs:
         Linux:
           OSVmImage: "ubuntu-18.04"
           TestTargetFramework: netcoreapp2.1
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+          SubscriptionConfiguration: ${{ parameters.SubscriptionConfiguration }}
         Windows_NetCoreApp:
           OSVmImage: "windows-2019"
           TestTargetFramework: netcoreapp2.1
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+          SubscriptionConfiguration: ${{ parameters.SubscriptionConfiguration }}
         Windows_NetCoreApp_ProjectReferences:
           OSVmImage: "windows-2019"
           TestTargetFramework: netcoreapp2.1
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+          SubscriptionConfiguration: ${{ parameters.SubscriptionConfiguration }}
           ConvertToProjectReferenceOption: /p:UseProjectReferenceToAzureClients=true
         Windows_NetFramework:
           OSVmImage: "windows-2019"
           TestTargetFramework: net461
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+          SubscriptionConfiguration: ${{ parameters.SubscriptionConfiguration }}
         MacOs:
           OSVmImage: "macOS-10.15"
           TestTargetFramework: netcoreapp2.1
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+          SubscriptionConfiguration: ${{ parameters.SubscriptionConfiguration }}
     pool:
       vmImage: "$(OSVmImage)"
 


### PR DESCRIPTION
We have a situation where a particular service wants to test packages in a specific region. This service's changes are in the `net-pr` repo. This updates the main repo to support that scenario. 