### PR TITLE
[storage] Change generated code Uri.ToString to Uri.AbsoluteUri

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
@@ -7078,7 +7078,7 @@ namespace Azure.Storage.Blobs
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-copy-source", copySource.ToString());
+                _request.Headers.SetValue("x-ms-copy-source", copySource.AbsoluteUri);
                 _request.Headers.SetValue("x-ms-version", version);
                 if (metadata != null) {
                     foreach (System.Collections.Generic.KeyValuePair<string, string> _pair in metadata)
@@ -7324,7 +7324,7 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-requires-sync", "true");
-                _request.Headers.SetValue("x-ms-copy-source", copySource.ToString());
+                _request.Headers.SetValue("x-ms-copy-source", copySource.AbsoluteUri);
                 _request.Headers.SetValue("x-ms-version", version);
                 if (metadata != null) {
                     foreach (System.Collections.Generic.KeyValuePair<string, string> _pair in metadata)
@@ -8767,7 +8767,7 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-page-write", "update");
-                _request.Headers.SetValue("x-ms-copy-source", sourceUri.ToString());
+                _request.Headers.SetValue("x-ms-copy-source", sourceUri.AbsoluteUri);
                 _request.Headers.SetValue("x-ms-source-range", sourceRange);
                 _request.Headers.SetValue("Content-Length", contentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 _request.Headers.SetValue("x-ms-range", range);
@@ -9225,7 +9225,7 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", version);
-                if (prevSnapshotUrl != null) { _request.Headers.SetValue("x-ms-previous-snapshot-url", prevSnapshotUrl.ToString()); }
+                if (prevSnapshotUrl != null) { _request.Headers.SetValue("x-ms-previous-snapshot-url", prevSnapshotUrl.AbsoluteUri); }
                 if (range != null) { _request.Headers.SetValue("x-ms-range", range); }
                 if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
                 if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
@@ -9833,7 +9833,7 @@ namespace Azure.Storage.Blobs
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-copy-source", copySource.ToString());
+                _request.Headers.SetValue("x-ms-copy-source", copySource.AbsoluteUri);
                 _request.Headers.SetValue("x-ms-version", version);
                 if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
                 if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
@@ -10663,7 +10663,7 @@ namespace Azure.Storage.Blobs
                 if (timeout != null) { _request.Uri.AppendQuery("timeout", timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-copy-source", sourceUri.ToString());
+                _request.Headers.SetValue("x-ms-copy-source", sourceUri.AbsoluteUri);
                 _request.Headers.SetValue("Content-Length", contentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 _request.Headers.SetValue("x-ms-version", version);
                 if (sourceRange != null) { _request.Headers.SetValue("x-ms-source-range", sourceRange); }
@@ -11497,7 +11497,7 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("Content-Length", contentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
-                _request.Headers.SetValue("x-ms-copy-source", sourceUri.ToString());
+                _request.Headers.SetValue("x-ms-copy-source", sourceUri.AbsoluteUri);
                 _request.Headers.SetValue("x-ms-version", version);
                 if (sourceRange != null) { _request.Headers.SetValue("x-ms-source-range", sourceRange); }
                 if (sourceContentHash != null) { _request.Headers.SetValue("x-ms-source-content-md5", System.Convert.ToBase64String(sourceContentHash)); }
@@ -18048,7 +18048,7 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// The service error response object.
         /// </summary>
-        public Azure.Storage.Blobs.Models.Error Error { get; internal set; }
+        public Azure.Storage.Blobs.Models.DataLakeStorageErrorDetails DataLakeStorageErrorDetails { get; internal set; }
 
         /// <summary>
         /// Creates a new DataLakeStorageError instance
@@ -18066,7 +18066,7 @@ namespace Azure.Storage.Blobs.Models
         {
             if (!skipInitialization)
             {
-                Error = new Azure.Storage.Blobs.Models.Error();
+                DataLakeStorageErrorDetails = new Azure.Storage.Blobs.Models.DataLakeStorageErrorDetails();
             }
         }
 
@@ -18083,7 +18083,7 @@ namespace Azure.Storage.Blobs.Models
             _child = element.Element(System.Xml.Linq.XName.Get("error", ""));
             if (_child != null)
             {
-                _value.Error = Azure.Storage.Blobs.Models.Error.FromXml(_child);
+                _value.DataLakeStorageErrorDetails = Azure.Storage.Blobs.Models.DataLakeStorageErrorDetails.FromXml(_child);
             }
             CustomizeFromXml(element, _value);
             return _value;
@@ -18093,6 +18093,59 @@ namespace Azure.Storage.Blobs.Models
     }
 }
 #endregion class DataLakeStorageError
+
+#region class DataLakeStorageErrorDetails
+namespace Azure.Storage.Blobs.Models
+{
+    /// <summary>
+    /// The service error response object.
+    /// </summary>
+    internal partial class DataLakeStorageErrorDetails
+    {
+        /// <summary>
+        /// The service error code.
+        /// </summary>
+        public string Code { get; internal set; }
+
+        /// <summary>
+        /// The service error message.
+        /// </summary>
+        public string Message { get; internal set; }
+
+        /// <summary>
+        /// Prevent direct instantiation of DataLakeStorageErrorDetails instances.
+        /// You can use BlobsModelFactory.DataLakeStorageErrorDetails instead.
+        /// </summary>
+        internal DataLakeStorageErrorDetails() { }
+
+        /// <summary>
+        /// Deserializes XML into a new DataLakeStorageErrorDetails instance.
+        /// </summary>
+        /// <param name="element">The XML element to deserialize.</param>
+        /// <returns>A deserialized DataLakeStorageErrorDetails instance.</returns>
+        internal static Azure.Storage.Blobs.Models.DataLakeStorageErrorDetails FromXml(System.Xml.Linq.XElement element)
+        {
+            System.Diagnostics.Debug.Assert(element != null);
+            System.Xml.Linq.XElement _child;
+            Azure.Storage.Blobs.Models.DataLakeStorageErrorDetails _value = new Azure.Storage.Blobs.Models.DataLakeStorageErrorDetails();
+            _child = element.Element(System.Xml.Linq.XName.Get("Code", ""));
+            if (_child != null)
+            {
+                _value.Code = _child.Value;
+            }
+            _child = element.Element(System.Xml.Linq.XName.Get("Message", ""));
+            if (_child != null)
+            {
+                _value.Message = _child.Value;
+            }
+            CustomizeFromXml(element, _value);
+            return _value;
+        }
+
+        static partial void CustomizeFromXml(System.Xml.Linq.XElement element, Azure.Storage.Blobs.Models.DataLakeStorageErrorDetails value);
+    }
+}
+#endregion class DataLakeStorageErrorDetails
 
 #region enum DeleteSnapshotsOption
 namespace Azure.Storage.Blobs.Models
@@ -19849,58 +19902,5 @@ namespace Azure.Storage.Blobs.Models
     }
 }
 #endregion class UserDelegationKey
-
-#region class Error
-namespace Azure.Storage.Blobs.Models
-{
-    /// <summary>
-    /// The service error response object.
-    /// </summary>
-    internal partial class Error
-    {
-        /// <summary>
-        /// The service error code.
-        /// </summary>
-        public string Code { get; internal set; }
-
-        /// <summary>
-        /// The service error message.
-        /// </summary>
-        public string Message { get; internal set; }
-
-        /// <summary>
-        /// Prevent direct instantiation of Error instances.
-        /// You can use BlobsModelFactory.Error instead.
-        /// </summary>
-        internal Error() { }
-
-        /// <summary>
-        /// Deserializes XML into a new Error instance.
-        /// </summary>
-        /// <param name="element">The XML element to deserialize.</param>
-        /// <returns>A deserialized Error instance.</returns>
-        internal static Azure.Storage.Blobs.Models.Error FromXml(System.Xml.Linq.XElement element)
-        {
-            System.Diagnostics.Debug.Assert(element != null);
-            System.Xml.Linq.XElement _child;
-            Azure.Storage.Blobs.Models.Error _value = new Azure.Storage.Blobs.Models.Error();
-            _child = element.Element(System.Xml.Linq.XName.Get("Code", ""));
-            if (_child != null)
-            {
-                _value.Code = _child.Value;
-            }
-            _child = element.Element(System.Xml.Linq.XName.Get("Message", ""));
-            if (_child != null)
-            {
-                _value.Message = _child.Value;
-            }
-            CustomizeFromXml(element, _value);
-            return _value;
-        }
-
-        static partial void CustomizeFromXml(System.Xml.Linq.XElement element, Azure.Storage.Blobs.Models.Error value);
-    }
-}
-#endregion class Error
 #endregion Models
 

--- a/sdk/storage/Azure.Storage.Blobs/src/StorageRequestFailedException.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/StorageRequestFailedException.cs
@@ -78,6 +78,6 @@ namespace Azure.Storage.Blobs.Models
         /// <param name="response">The failed response.</param>
         /// <returns>A RequestFailedException.</returns>
         public Exception CreateException(ClientDiagnostics clientDiagnostics, Azure.Response response)
-            => clientDiagnostics.CreateRequestFailedExceptionWithContent(response, message: Error.Message, content: null, response.GetErrorCode(Error.Code));
+            => clientDiagnostics.CreateRequestFailedExceptionWithContent(response, message: DataLakeStorageErrorDetails.Message, content: null, response.GetErrorCode(DataLakeStorageErrorDetails.Code));
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/AppendBlobClientTests.cs
@@ -919,6 +919,30 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [Test]
+        public async Task AppendBlockFromUriAsync_NonAsciiSourceUri()
+        {
+            await using DisposingContainer test = await GetTestContainerAsync();
+
+            // Arrange
+            await test.Container.SetAccessPolicyAsync(PublicAccessType.BlobContainer);
+
+            var data = GetRandomBuffer(Constants.KB);
+
+            using (var stream = new MemoryStream(data))
+            {
+                AppendBlobClient sourceBlob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewNonAsciiBlobName()));
+                await sourceBlob.CreateAsync();
+                await sourceBlob.AppendBlockAsync(stream);
+
+                AppendBlobClient destBlob = InstrumentClient(test.Container.GetAppendBlobClient(GetNewBlobName()));
+                await destBlob.CreateAsync();
+
+                // Act
+                await destBlob.AppendBlockFromUriAsync(sourceBlob.Uri, new HttpRange(0, Constants.KB));
+            }
+        }
+
+        [Test]
         public async Task AppendBlockAsync_NullStream_Error()
         {
             await using DisposingContainer test = await GetTestContainerAsync();

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -46,6 +46,7 @@ namespace Azure.Storage.Test.Shared
         public string GetNewContainerName() => $"test-container-{Recording.Random.NewGuid()}";
         public string GetNewBlobName() => $"test-blob-{Recording.Random.NewGuid()}";
         public string GetNewBlockName() => $"test-block-{Recording.Random.NewGuid()}";
+        public string GetNewNonAsciiBlobName() => $"test-β£©þ‽-{Recording.Random.NewGuid()}";
 
         public BlobClientOptions GetOptions(bool parallelRange = false)
         {

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
@@ -687,6 +687,29 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [Test]
+        public async Task StageBlockFromUriAsync_NonAsciiSourceUri()
+        {
+            await using DisposingContainer test = await GetTestContainerAsync();
+
+            // Arrange
+            const int blobSize = Constants.KB;
+            var data = GetRandomBuffer(blobSize);
+
+            BlockBlobClient sourceBlob = InstrumentClient(test.Container.GetBlockBlobClient(GetNewNonAsciiBlobName()));
+            using (var stream = new MemoryStream(data))
+            {
+                await sourceBlob.UploadAsync(stream);
+            }
+
+            BlockBlobClient destBlob = InstrumentClient(test.Container.GetBlockBlobClient(GetNewBlobName()));
+
+            // Act
+            await RetryAsync(
+                async () => await destBlob.StageBlockFromUriAsync(sourceBlob.Uri, ToBase64(GetNewBlockName())),
+                _retryStageBlockFromUri);
+        }
+
+        [Test]
         public async Task CommitBlockListAsync()
         {
             await using DisposingContainer test = await GetTestContainerAsync();

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTests/AppendBlockFromUriAsync_NonAsciiSourceUri.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTests/AppendBlockFromUriAsync_NonAsciiSourceUri.json
@@ -1,0 +1,252 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-898ba10e-6fa5-c945-c757-eab311497a97?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-1f7d90d234477940b2649f4cd4b6c343-7c71977bf5a04d4a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "e8c3b6da-522b-add5-6486-9ab603dda849",
+        "x-ms-date": "Fri, 15 May 2020 23:29:37 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:37 GMT",
+        "ETag": "\u00220x8D7F927D5C78F6C\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e8c3b6da-522b-add5-6486-9ab603dda849",
+        "x-ms-request-id": "f79cb8c0-001e-0130-6410-2b8e64000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-898ba10e-6fa5-c945-c757-eab311497a97?restype=container\u0026comp=acl",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "21",
+        "Content-Type": "application/xml",
+        "traceparent": "00-da63d0be8b130a4ea8f09d6be8505cda-f8332e61f0251d4f-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "5ad8457d-9286-c96b-1a4d-f9e854165569",
+        "x-ms-date": "Fri, 15 May 2020 23:29:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": "\u003CSignedIdentifiers /\u003E",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:37 GMT",
+        "ETag": "\u00220x8D7F927D5D71147\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5ad8457d-9286-c96b-1a4d-f9e854165569",
+        "x-ms-request-id": "f79cb8f5-001e-0130-0c10-2b8e64000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-898ba10e-6fa5-c945-c757-eab311497a97/test-\u03B2\u00A3\u00A9\u00FE\u203D-3ebd17a8-2968-da4c-504e-be424a1e0d7d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-86dcb8440668b948b0891a2e23cd9e81-27ac5270a120794b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "1f44b19c-36a0-1a1d-0e38-0f6fdcd40331",
+        "x-ms-date": "Fri, 15 May 2020 23:29:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:38 GMT",
+        "ETag": "\u00220x8D7F927D5F6222B\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1f44b19c-36a0-1a1d-0e38-0f6fdcd40331",
+        "x-ms-request-id": "f79cb955-001e-0130-5f10-2b8e64000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-898ba10e-6fa5-c945-c757-eab311497a97/test-\u03B2\u00A3\u00A9\u00FE\u203D-3ebd17a8-2968-da4c-504e-be424a1e0d7d?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "traceparent": "00-41283e638ee6ca4aa5a6ae8dd5b6049a-d6c624a59064d343-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "99a65e27-edd9-ecdd-6fda-232fcd797daf",
+        "x-ms-date": "Fri, 15 May 2020 23:29:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": "gO3/l1IF3vvjoxL5D1hzEVQXOL0FTsNglCe5eOXpy7/c2fxMVJowd2fdduJ/cbrC2eiUPN2YZDEqngIrTGYV\u002BtdTHTZcJ7y55sFWJ9fg4SNt95/9VY/hRHTKIrWYBSsAyHwLK1SDZrEr2lUbQTxaSb3evVXHF6RIctnBkQUHIOGVVV9a1LbO6pHt0no5xgI4cNj4uUfWObDXw7l7wtSrI7l0hevc/3UHENPE2UQqD6vWiCEtDmeavxyvgxH8Uyi8Qq7AxUAXXHBi8al0EmBrrbMNpTmzfRVS2cbPLXxjCr2rB5aVaUlrvyywyh29Jq27Q9Vd763vCcSZbet6Ry7z/\u002BbsyArJ1kNqoeYMArP3lbMYFOqmBRoPvP3S\u002B/xe8Xf\u002BvMs20V2j8W2S807H4wcRotg3YjNETfnL3AwM99pGC7BuDUXowMNWdCJ8ExLMR9n2wVkjJ49EuW/RavRQlvqSS\u002BieWdXBKeEU4O0Qxznn/5QzFTaAI\u002BMgKVTVFlXOBt4o6sgpLu4DNJh3D0aiM/E16WtgHYDDEigEfS\u002BA6xKMRdoO6N1xvtCmL\u002BCeCBOdfvZioC3pbuhdZNefJbG\u002Bg0mF68lrk0sUxCubue2fJQkUZ/85HkvlotbxsYMF0pgf56yXGBxKMeqqTtsBTrX7vT/Oir2yhWT9oEnzeuLHDvKSfNFBCA3syjUUjtBw41Qh9vNEN0fabGJHmnfTV7cI4kDpb9HjubUy4b\u002BInfaUjb310YPug9aqtw9u\u002BW2VGXN\u002BC6yPhnSCPTw9EVaHUs5ssw263oUzGV5pP7fBdMBInMhMCZJKBAZJcpRGsXGAImRAAkVg2zrtSvFNJke8wMh89XWNO0k8Iq4GcGvx7Wjt6RxSgXJ658CNXr6g/d6/jLHLyrv88ucbBOCXWmrO/F2JYDwqaj9WAQ20ANyKmyXPRuS5JiKs8Pc0NnyS441WvmFgF52ilSFydMitR/ILkGi6xxOFFNY73G9F9TPCxB5/XkF6KoSILbHDR7Fa/qgEKaYU1xt60KqLJTotXJ/ur7CqLumxkGbjMpliws0k4N3GQMuNruwCBY2W7wRKWtAR1ZcBsNC\u002BU5k/MKWBFw3cZkRcZxzUYAHDpyhcGqFimdfJUe01IzAMB\u002BwyTX5Hge5/uoi/7fO0PXSWPgmoYjn33ZbNuMYgpkMTT18voROCeyU63GAYoqzkFBR5n\u002BQnZKWzOm/necgnXxNFq52UhZtgE8LjboXZ3zvp6aOxpwde7Ou6e2akmwFcEn1M0/YPT494GIshRPYf2ls0/ZAldbcL5r\u002Bx2Qk0vHjBhlsIjAtE2pkTOY57Paf0m6ELb51xN5zFQe03XXWGQ1sTYL6bFk5P7yP2ETwpjw==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:38 GMT",
+        "ETag": "\u00220x8D7F927D6016EDA\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "99a65e27-edd9-ecdd-6fda-232fcd797daf",
+        "x-ms-content-crc64": "BtUKF82b/EU=",
+        "x-ms-request-id": "f79cb96c-001e-0130-7210-2b8e64000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-898ba10e-6fa5-c945-c757-eab311497a97/test-blob-d49d8a4f-a3a7-a519-8a78-f03c7c08ac42",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-99e35063fe683149a4ad4c817352b825-324625a7ae60dd4a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "e3c60ae6-8b2e-842e-4500-0e61fda07067",
+        "x-ms-date": "Fri, 15 May 2020 23:29:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:38 GMT",
+        "ETag": "\u00220x8D7F927D6095F81\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e3c60ae6-8b2e-842e-4500-0e61fda07067",
+        "x-ms-request-id": "f79cb97f-001e-0130-0410-2b8e64000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-898ba10e-6fa5-c945-c757-eab311497a97/test-blob-d49d8a4f-a3a7-a519-8a78-f03c7c08ac42?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-2845750d042db54bbf10e2c860d261dc-c75d11c866602243-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "71563b79-c941-4c13-0bc2-392c5bf6f727",
+        "x-ms-copy-source": "http://amandadev2.blob.core.windows.net/test-container-898ba10e-6fa5-c945-c757-eab311497a97/test-\u03B2\u00A3\u00A9\u00FE\u203D-3ebd17a8-2968-da4c-504e-be424a1e0d7d",
+        "x-ms-date": "Fri, 15 May 2020 23:29:38 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-source-range": "bytes=0-1023",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "\u002Bn7/nXi05mdgxXHOfeeNPA==",
+        "Date": "Fri, 15 May 2020 23:29:38 GMT",
+        "ETag": "\u00220x8D7F927D6445033\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "71563b79-c941-4c13-0bc2-392c5bf6f727",
+        "x-ms-request-id": "f79cb9ab-001e-0130-2410-2b8e64000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-898ba10e-6fa5-c945-c757-eab311497a97?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-2bc40b2466cf3f458182727815e0d010-bf3b33b651358349-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "c1e77c2e-ff4a-6525-ce0b-886ec555893c",
+        "x-ms-date": "Fri, 15 May 2020 23:29:39 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:38 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c1e77c2e-ff4a-6525-ce0b-886ec555893c",
+        "x-ms-request-id": "f79cba68-001e-0130-4110-2b8e64000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1848144205",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTests/AppendBlockFromUriAsync_NonAsciiSourceUriAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientTests/AppendBlockFromUriAsync_NonAsciiSourceUriAsync.json
@@ -1,0 +1,252 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-2a359de6-0c5f-fa47-399d-db873eea99c0?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-5fcd11fdd5f04244bdb0b0f670d9e925-8e24d12de5a09a4b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "2a6483af-08eb-5ad5-89eb-d02227800d6b",
+        "x-ms-date": "Fri, 15 May 2020 23:29:39 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:38 GMT",
+        "ETag": "\u00220x8D7F927D673A7A8\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "2a6483af-08eb-5ad5-89eb-d02227800d6b",
+        "x-ms-request-id": "f79cbab2-001e-0130-0410-2b8e64000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-2a359de6-0c5f-fa47-399d-db873eea99c0?restype=container\u0026comp=acl",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "21",
+        "Content-Type": "application/xml",
+        "traceparent": "00-86880d38a5db1344b06022e85c70ab06-d86457dc09e8f742-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "bad70431-6f85-a8d5-d094-6adfea57685f",
+        "x-ms-date": "Fri, 15 May 2020 23:29:39 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": "\u003CSignedIdentifiers /\u003E",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:38 GMT",
+        "ETag": "\u00220x8D7F927D67DD187\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bad70431-6f85-a8d5-d094-6adfea57685f",
+        "x-ms-request-id": "f79cbac4-001e-0130-1310-2b8e64000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-2a359de6-0c5f-fa47-399d-db873eea99c0/test-\u03B2\u00A3\u00A9\u00FE\u203D-8ce92671-2776-2bbf-46a6-9829c330ba48",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-852f9a9526d1374b8ed359547ffbc963-589e5d72ef293d45-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "71032535-2466-456a-4b3b-e8be99e229fc",
+        "x-ms-date": "Fri, 15 May 2020 23:29:39 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:38 GMT",
+        "ETag": "\u00220x8D7F927D6869532\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "71032535-2466-456a-4b3b-e8be99e229fc",
+        "x-ms-request-id": "f79cbad5-001e-0130-2310-2b8e64000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-2a359de6-0c5f-fa47-399d-db873eea99c0/test-\u03B2\u00A3\u00A9\u00FE\u203D-8ce92671-2776-2bbf-46a6-9829c330ba48?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "traceparent": "00-28a49b77b8384b4cb44f28a0fc2daae9-f8e1e1889de65544-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "9df4fc82-482d-59e2-fbf2-2009cee545be",
+        "x-ms-date": "Fri, 15 May 2020 23:29:39 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": "YNbm6I5K5KtvOQZFvuOPjB4o8CKoUuX0cFpRXpo0Qcw86pH0FuMY5yAsSkxoj\u002BrsBd3AwWdGtw3w8ng0\u002BIUQO/c6CNRRmnY7EAgBeweYi\u002BBwZVm9c39k9jKEBCNq5O\u002BaHA9ULocWmmtmhbFfRDsFV2aXw5MsU8d41hKhzZVS0CwZZl/4RF1ZWsrtVu7NBbH2fq290iBcbchH3Fd0dM3VE7SFRt3cDRMIPmnIPvzZqtFgqk7olf4LvPmWsGcF5OX9GEM6SL7TGnGZtJS2ky7LbjKGFMl/7X62eYnkRVyrA1mDyya5n2ESjJDcTuBpVSjKykI1ftAbfirFg84179QU7rE6MsgIEs/QdIc5op\u002BdTCRgGnoadoSJZ0z89BuT3J27x2AvLiJgwrhzZAlI4tuLJzaq1dVa\u002Bncsscp8DB2zPZjqfto/bR4CAFjBpxJ6QIVxcMzk6QfIYM3oAnxX5LabvydxXmQBTLkYqNV8mFJksnFFCptQz1ORIh0MVmuhqhyiJufqCeEhbyQSy0ExS8h6hFALEtkaSvDT3ztG9PZOd/242nJqeqiPJJt2PQMSX9dVktIalZhDh9z3Fimm2nsuxFRDeXBVDwmoe\u002B49pAztwYBk8WIjNOFkdVOVc2N/6UkfR3mvzuZm/4LIchqqBeLPClWoQegZCo9y3gMcwJymKJKkHVySPfKa/vLgW8HHunBwxmkN1qhgBj3qPO/iST/mIkmHBeeGPMxjDkP2OK/NqiSTrPkymFLqQxYfqAACt7Sz\u002Bjl4QLSI6omdqsdlas2OHJLLT51Fs4n3ncHQZ5PLYFeOQz51VWpvCsFvle2KhNlJkYxuN2cWbUavgaLyuIL10Upw1ieOGMYnXEXb1R2bbBjoh9YHXCnwd9X4xtTIfFE/esOjGq6yunjFR9ohO5gpFBSKCjCs7nUgf15RllLyX9/znFtZ\u002BFFqNc1dQRVOzjw9zrK/PXEgkotOgppPYCMm0\u002Bf7LZ48zxvCINVjT61g0rEiFMefMiFt0gnQC3W3GtSqNm0tU6GdAP\u002BW/B2cvUPd7rDpLExbhqDGjVqUbMOmCwUAuRg/Mn4PhBTICTYE0BXG8h3Eze2ITq/NZ8VGCJM87/AYnAQrnbsx2ag4k31qwbxFznmm4T4XeGpocsu5yHuAjBlF6zQRm1Rhk/NFULsyY6UJAToalQ6yACSawivweBAstwdjJNaINDMkRE5K0SeuNg8lsMdBZvYLkusQdtkpcRriGZi0zz7PgM0H9VG/Zy7864sby8hJ6lEQV5HqeL1Z\u002BtMzZ7iP\u002BWfRVi/5OnCkTCu8E4tNDaVSmC5Go3es5AgQrfp9jP92bPIkSnWYULDgbAtmLmQxDOwt4M6JSFXvJA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:39 GMT",
+        "ETag": "\u00220x8D7F927D68EFB1B\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "9df4fc82-482d-59e2-fbf2-2009cee545be",
+        "x-ms-content-crc64": "fOT422XshIc=",
+        "x-ms-request-id": "f79cbae7-001e-0130-3310-2b8e64000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-2a359de6-0c5f-fa47-399d-db873eea99c0/test-blob-ab8553e3-40e1-b27e-4648-ee5c39016d37",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-014db780926c0c49aed7877e41edbc65-6c81da6602cdd14e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "AppendBlob",
+        "x-ms-client-request-id": "83852cc5-4e8e-4177-7d41-57e5598520f9",
+        "x-ms-date": "Fri, 15 May 2020 23:29:39 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:39 GMT",
+        "ETag": "\u00220x8D7F927D69712E2\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "83852cc5-4e8e-4177-7d41-57e5598520f9",
+        "x-ms-request-id": "f79cbaf6-001e-0130-4010-2b8e64000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-2a359de6-0c5f-fa47-399d-db873eea99c0/test-blob-ab8553e3-40e1-b27e-4648-ee5c39016d37?comp=appendblock",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-4a94f6e4ae0b2d4bbec586f012fe25b1-233e36569e68cc48-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "0d96515a-ea7c-f2a9-18f9-1eac34ea841d",
+        "x-ms-copy-source": "http://amandadev2.blob.core.windows.net/test-container-2a359de6-0c5f-fa47-399d-db873eea99c0/test-\u03B2\u00A3\u00A9\u00FE\u203D-8ce92671-2776-2bbf-46a6-9829c330ba48",
+        "x-ms-date": "Fri, 15 May 2020 23:29:39 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-source-range": "bytes=0-1023",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "FYBNS7tC6BOqRuliCdtdYQ==",
+        "Date": "Fri, 15 May 2020 23:29:39 GMT",
+        "ETag": "\u00220x8D7F927D69F9FEA\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-append-offset": "0",
+        "x-ms-blob-committed-block-count": "1",
+        "x-ms-client-request-id": "0d96515a-ea7c-f2a9-18f9-1eac34ea841d",
+        "x-ms-request-id": "f79cbb08-001e-0130-5010-2b8e64000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-2a359de6-0c5f-fa47-399d-db873eea99c0?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-fc3c6f8c6d8cad4da2ded56f33920e92-e0ff315b9a1d3d4c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "078ae5f0-13ef-9a7d-3fd5-26b08a232299",
+        "x-ms-date": "Fri, 15 May 2020 23:29:39 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "078ae5f0-13ef-9a7d-3fd5-26b08a232299",
+        "x-ms-request-id": "f79cbb21-001e-0130-6910-2b8e64000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "660698873",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTests/StageBlockFromUriAsync_NonAsciiSourceUri.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTests/StageBlockFromUriAsync_NonAsciiSourceUri.json
@@ -1,0 +1,143 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-86c03965-fadb-b601-d047-a03de4cbc04c?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-259e98ed118c7a4c8ad561f900df9e64-27cd2babfa4ff742-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "cb7b9eb7-8075-6b75-1e9f-09d0b08dd783",
+        "x-ms-date": "Fri, 15 May 2020 23:29:39 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:39 GMT",
+        "ETag": "\u00220x8D7F927D6B1A6D7\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "cb7b9eb7-8075-6b75-1e9f-09d0b08dd783",
+        "x-ms-request-id": "f79cbb3b-001e-0130-0110-2b8e64000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-86c03965-fadb-b601-d047-a03de4cbc04c/test-\u03B2\u00A3\u00A9\u00FE\u203D-beb23120-ae34-3397-00e7-727f8e893ceb",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "traceparent": "00-af63f8af61fbc44ab369f4df90b6b5a9-ffde6e20910c1a48-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "3b203075-6e17-f16e-0c27-69ed729d7115",
+        "x-ms-date": "Fri, 15 May 2020 23:29:39 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": "BsY/k7dmJGID1Zi93DIzmkyChUVP9dewhJP3yvhlOl9Gmsi79mhmUXoYx5/nuI/rbG6ELgiSNBDvjg8kblpqnps5d0Jpd6TjGzPKNi04ycsDDF2J4QtWs2W3zGdZQuIgrikErUBMgfTKoBLVyP3jtsVDIGL84L2P48Pdsao9idlQqYgDMxuKtopov0D5gepn1BahFiGAJM5sdMp9b9BKjBY5hB5134KquGnXkyB8lmLZdd2Um3O30IW5l79QDUe6HjIpwPzL8fST9163qJGt795no/rytvGjgbSZvEfDWaoiHXTtU9ZlDYPoAaMU/yfzC6jg6WpMx2hBhT5IMjWsz560lYscv5sIAZZ2CbVNjoKMprCf4nBA1VYMrM2XHdtNPDEFYGqc10sN2OfT1b2y8/e8u4yFDewtdL80DxPNcOS7Kc2DRy0X8M5kkgqJbACZWbjW22FPxy9F2OyqZ8c4P2cDF6zvL6zJpMu9IXripAe/m7Za95WCbGGePm9BbYgHK1OihlRTqSoMDTeWkaa0YjPl68wR3UfSgKtKUfE9hzZDtfUnPx6ya/KLTuld7Nq76ds7W4G79k4LzwWpCFc5z4UAU9uwjCIVMn/ahY5ddZTQj2cVASy1h7\u002BnHG8ZCWOaUn9kXZj\u002BC124JikC4XC/rVpw2HjvI81ZS8scCG\u002Bz\u002BykcPzMO\u002BRf70YQKXNoCsqZP528VqDDqqi6yCxHN4gLtBSr/5qE9sLNCdQf05cfzVpglzCAAnVP5MZQEXO4FLu6BHFevA8wEEje70jMp9cVnvrR5qBbh7WfXBrQMOFTFPEYYcslvQ1PLILrpRMsgzzvPnJ05jIXYoC7v2PwX99ni9pXsEYP893tgrYdb96mbtzZ4PZu2i7DBP9KagGpXtCngBk02M76406Qh2d7\u002BfKiFUyHFnro9LGvkK9GxYXcRCflee/FcZYN4wGn2lLLRwsIpFSxIkRVuotriUQjsB3ItEM/loAG3KO6eTd5RRpi5EmgOh0tKyHjj79gXeRN6i7n3yYPj7CLBcuw\u002BqkQ3HVtBKD\u002Bf3YAm4khWAbAon6/bI8ElWX0U1iZGTRRfDB00rNJ81VDU26040eY7jOpymNM9Y4eDEsPeLFIYWZBsxtYqIlTeq8peB0gT7IiX2Uk807RAIamWsJoOnqj\u002Bu4EdzAoPEGmWlOwI31w\u002BcCU7RlMJ3IXcK6QtlHG5zw0hX0vH9R9\u002Bh8nfpT/HN0JNWEB101dV9d/7QaFl4nz43MTf538Qd3oFvL6JKTZFFPNi4DwxRPu1y2pry7R\u002BGKVM58l76FDCPODGbxaYy8uotiytAgFAxpfIKRsUpKzFh6MZPEFsyiyin6RbatXlHACfwhSH0BakDA==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "/kAZ62gQ2W2WN7BTJAgisA==",
+        "Date": "Fri, 15 May 2020 23:29:39 GMT",
+        "ETag": "\u00220x8D7F927D6C55719\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "3b203075-6e17-f16e-0c27-69ed729d7115",
+        "x-ms-content-crc64": "KVEVv0M5cK8=",
+        "x-ms-request-id": "f79cbb74-001e-0130-3010-2b8e64000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-86c03965-fadb-b601-d047-a03de4cbc04c/test-blob-c6872986-46b2-c427-6fcf-b11938b59cc2?comp=block\u0026blockid=dGVzdC1ibG9jay01ZTBhZTUzMS0wMTY5LTkyZDMtOWM3MS01MGJkZjJkNDcxNmY%3D",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-5bf52bd642b1184e8202fe17458b059c-7f077f5cf8c1f141-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "8cbca68b-1392-85ac-55f4-2940f66ad19a",
+        "x-ms-copy-source": "http://amandadev2.blob.core.windows.net/test-container-86c03965-fadb-b601-d047-a03de4cbc04c/test-\u03B2\u00A3\u00A9\u00FE\u203D-beb23120-ae34-3397-00e7-727f8e893ceb",
+        "x-ms-date": "Fri, 15 May 2020 23:29:39 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-source-range": "bytes=0-",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "8cbca68b-1392-85ac-55f4-2940f66ad19a",
+        "x-ms-content-crc64": "KVEVv0M5cK8=",
+        "x-ms-request-id": "f79cbb93-001e-0130-4b10-2b8e64000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-86c03965-fadb-b601-d047-a03de4cbc04c?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-8af36f321f9b8144b23f746909e63458-633ef322012adb41-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "4b32f9b9-e418-97dc-b4d5-19c2c69a389e",
+        "x-ms-date": "Fri, 15 May 2020 23:29:39 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4b32f9b9-e418-97dc-b4d5-19c2c69a389e",
+        "x-ms-request-id": "f79cbbab-001e-0130-6210-2b8e64000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1376543424",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTests/StageBlockFromUriAsync_NonAsciiSourceUriAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlockBlobClientTests/StageBlockFromUriAsync_NonAsciiSourceUriAsync.json
@@ -1,0 +1,143 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-ef056c99-529d-7f70-cf3e-bdb9afd7b0f5?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-388340dda387ad449d8e8a88ed4b58fe-bfc0b50d92332846-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "f4ccba32-62ef-278b-a3f4-82066b9d3530",
+        "x-ms-date": "Fri, 15 May 2020 23:29:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:39 GMT",
+        "ETag": "\u00220x8D7F927D6E3E3F8\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "f4ccba32-62ef-278b-a3f4-82066b9d3530",
+        "x-ms-request-id": "f79cbbc5-001e-0130-7710-2b8e64000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-ef056c99-529d-7f70-cf3e-bdb9afd7b0f5/test-\u03B2\u00A3\u00A9\u00FE\u203D-b078a817-cb29-8be4-c443-ffe2ad92158d",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "traceparent": "00-5c7baa73e5975444945a9d4d781621db-7aa8ed03121b964f-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "52a65e0e-19db-716f-33be-9b888d483a65",
+        "x-ms-date": "Fri, 15 May 2020 23:29:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": "8Xo\u002B12p3kA3fVNktlJ/N5M/Eh/QLvAWxUAbbYAmFRXg6jd44rJePuiq\u002BFJuJXpMDJ542phZAJTV0jYdknDAEWg5g8wbAlTg4NczKTKdqKPJy1zhqT59i\u002BWipwx8QKh75urqMKGqMQpJm/nFJdtmNCWWV8cT3mQpv/vmeF9EYJwqu0JLt3v\u002BH5pSmBFAtGYOOHLm6ezlZAiCvHCpw7ivBTddnmqVHnytlDQswUZW6QuV2D/sXXqvQVM5xPsHVFvho5bd5xX7dR3yOVG0uKbGL9dpE\u002Bt4wqe4rlkbX1WBqkPcTx2zdQHxnmMh\u002BiQo9oioc5knnkBwZNzvITi43BXEbI8R2G2FFrbRd3WEVsiDk7fQbuu8XgwDa\u002BZAwFfJNL5JXYmVFx4fJ1ziVibK6BIUb42E6G0uBBKDDmyHRFJfCEK7OvlC6niZtUuO3gfpOIPUKFTGRExRH1V3Egitl98Kg03gE7EU1YEQ6zMhnyoOmdXssxv5mMP2ahujy9Rz7CFsgFq6BSTSv1bXsVkZL4AvaHgyvODDDOqJ7amVdQmooP8RtR7TUJStHffFJedq3TqbdGNcQTM8qXNsLBd/OUpJKxBeB3ZlXBfjgZ7s/esHIxBu\u002BfyqSGPP0Q\u002BrYyB9MeSte/7TCNXENhhLfL\u002BQU6\u002BIaQ0HED9JouKwjjZqufzzZlO6P4HoMBY\u002BqsfkXs\u002BgO31gHvYXeh2lZ9kYIn6jXXgfVBpv2hQpnDT2yGl7YUATEFK1BpsG3\u002BgyENuk0BGbm0lLyQa1NGFpNoK9HLG0LgKVCQ4r6lbdFHguPck4gMwnXy0cL5Q5Xd/xS9AYRcM6eeLVE8cDb7D2arSOivaYMLGymb2EmAJuW6syNp6CxM6088PmY3EFI\u002B98JcDjqtblWRsiaawBteHgarQbzTUSc6Xl2Zc2sc08qXXOBHI9iqzUTN2DYFsitz3iAfS87VK2abYe/dE/rqdN4cA2M61vpuAHQ4BbjxNOxyJZVLPYg7wnF568IozbmJ46NX6a6IOMcl8UtanSXt6i0Dqy5lnzdWIAExgSs4RTK6riHVWQs9qiyOJQw8oSULi8GVJWKLZERsAcltlnfb7awYn\u002B8D2FDhxcDBl3nrGX7b5jUpYx/QL0mdqVdBz9O08negJAF2B7Owsx9hiYzKQOhKUfACsopMCLClZm75oDYtTKUCSvV9pZ6BuLAAbmW80yhu933jcj\u002BtVBtQkOEEtxMpdHznyDYzDKxRgTnaS5pK6JMGSqi4CdplVTbaLNS9fMGc1znolMsye\u002BqRkfEF0whAxehN/iyqcSqignM/WN/XlAQ4fXRgohOIFA6\u002BJrfpX4HuWScsb37U8qYPBhKYMyMK\u002Bf3szZWUIGOUg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "yhkIOBpSog8MI\u002BLH4loskw==",
+        "Date": "Fri, 15 May 2020 23:29:39 GMT",
+        "ETag": "\u00220x8D7F927D6EC952B\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "52a65e0e-19db-716f-33be-9b888d483a65",
+        "x-ms-content-crc64": "fjJoEaeZ1fo=",
+        "x-ms-request-id": "f79cbbe3-001e-0130-0e10-2b8e64000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-ef056c99-529d-7f70-cf3e-bdb9afd7b0f5/test-blob-172ca89d-1d3b-574e-23ca-e376e3f34413?comp=block\u0026blockid=dGVzdC1ibG9jay00ZmQ0MWJkYS1jMmVjLTExYjItYzlkNC0zYzQ1MjRmYjIwODQ%3D",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-bd173d4c91310c44a09dae4c255f7440-446fdd3281b3a845-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "71ae887a-ea74-da79-f61a-4d66e1083328",
+        "x-ms-copy-source": "http://amandadev2.blob.core.windows.net/test-container-ef056c99-529d-7f70-cf3e-bdb9afd7b0f5/test-\u03B2\u00A3\u00A9\u00FE\u203D-b078a817-cb29-8be4-c443-ffe2ad92158d",
+        "x-ms-date": "Fri, 15 May 2020 23:29:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-source-range": "bytes=0-",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "71ae887a-ea74-da79-f61a-4d66e1083328",
+        "x-ms-content-crc64": "fjJoEaeZ1fo=",
+        "x-ms-request-id": "f79cbbef-001e-0130-1710-2b8e64000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-ef056c99-529d-7f70-cf3e-bdb9afd7b0f5?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-54c7d8ff259bdd4d88e843f20c45f160-5979001f0b7bee4e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "9bcbfc47-ae4d-8e10-0978-a76a04410e06",
+        "x-ms-date": "Fri, 15 May 2020 23:29:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:39 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9bcbfc47-ae4d-8e10-0978-a76a04410e06",
+        "x-ms-request-id": "f79cbc02-001e-0130-2810-2b8e64000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "170116699",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTests/UploadPagesFromUriAsync_NonAsciiSourceUri.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTests/UploadPagesFromUriAsync_NonAsciiSourceUri.json
@@ -1,0 +1,256 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-29466e42-28da-cbd2-2db7-fbec2a04b39d?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-e8bd6e7540cc1443b8d34e992c994f03-b95cc63f960dff43-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "7a572549-a167-4250-f748-6fde8bc28d50",
+        "x-ms-date": "Fri, 15 May 2020 23:29:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:39 GMT",
+        "ETag": "\u00220x8D7F927D70862DC\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7a572549-a167-4250-f748-6fde8bc28d50",
+        "x-ms-request-id": "f79cbc25-001e-0130-4710-2b8e64000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-29466e42-28da-cbd2-2db7-fbec2a04b39d?restype=container\u0026comp=acl",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "21",
+        "Content-Type": "application/xml",
+        "traceparent": "00-02fec6186b69d5408e51eb07604a530f-67f76f15b897704a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "76dc84ec-dcb3-25b6-3df4-b8206722d50c",
+        "x-ms-date": "Fri, 15 May 2020 23:29:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": "\u003CSignedIdentifiers /\u003E",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:39 GMT",
+        "ETag": "\u00220x8D7F927D70FCD2D\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "76dc84ec-dcb3-25b6-3df4-b8206722d50c",
+        "x-ms-request-id": "f79cbc3c-001e-0130-5a10-2b8e64000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-29466e42-28da-cbd2-2db7-fbec2a04b39d/test-\u03B2\u00A3\u00A9\u00FE\u203D-7789343c-6dc4-628a-2c47-c7dff770ab05",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-4f3deb45e5621f4bad90c97cca737e36-652ac56482730249-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "b64996ce-960b-7e46-fa7a-4a6c15d72dcc",
+        "x-ms-date": "Fri, 15 May 2020 23:29:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:40 GMT",
+        "ETag": "\u00220x8D7F927D726E97C\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b64996ce-960b-7e46-fa7a-4a6c15d72dcc",
+        "x-ms-request-id": "f79cbc91-001e-0130-2210-2b8e64000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-29466e42-28da-cbd2-2db7-fbec2a04b39d/test-\u03B2\u00A3\u00A9\u00FE\u203D-7789343c-6dc4-628a-2c47-c7dff770ab05?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "traceparent": "00-eeb24f626d65854f93f604883dbee166-a348ccc0a8df764d-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "60119fc2-f427-19fa-811e-266ef71a1921",
+        "x-ms-date": "Fri, 15 May 2020 23:29:40 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": "gKM\u002BMTWFd2ZHZsVjAEPI\u002BP4SowStODaE4o5zK2xIU6Hp1w1f94eyw63wMwDb7UK0f3bfeR\u002BIo0htuU6mEkv6/hIjeSg2aAF3X99WvQU1qfRMvqv1aNqCYDTF8j04C7Bi9TTtt3MZfhZ1Zxk/MeZCNxBZWVOgBJU4oRj0cHbDP1Mu9MfRSPGBM0CUfwHBQi9Og7os3rJdwvCetRZaJQ2gsijFET0ece8f2CYTC4WUd17ppe27lmCh0TLWMpLbJg4z9M3Y\u002BzHxLxHLDQWLSbZrCT63cH8f5BvHIz8KSD5cRLIX3xa3vHst\u002BHbb74laFod7aihUI7WOExCyENfx5ubSb8lTc2qgtE3CiXgJQ/SRbA24j94WCCD8icwGBaujPBGPCYDAB6Id27bbkZo8hc8cIKPJOFcIvGepVuqdma6iH01nejpz0WVrm7QoOneFwAP86uUH2QO5h0wZF7C3f0EHOHJM1AuUqE4\u002BXp2j4IHvI5bmoa/Im0VKrvLuWrq0sxtyIAIFOOv4Z0KWyHtlFqbKKfMa0d6RP50sAiYYpk2UiauBMMB/6uqq7jltMtLJ5JdMIzHGmeI94OFk2DbF4MD0Aj7Q4\u002BXmSz4JcOKkJA3LYx2OzIMczu/IRE/eGxK05Q14eS\u002BT\u002BQGyZdjyvCn/mbzTmHQYNhQ91zROB5\u002BVBy8rVYvVK6vdOGkc3GerKRHGyKqTCoKdm675O6H7RPFhHF2ox2eeKm0Q9mAL/Fqtka4jiD/0Avytjbrc2\u002B8K4vN4usAJA2KqJ508ghQhkp9TTKry2LuybRlg\u002BzmtwU99BhRtkkGao45LeWGht3/oi/oaiY5FFwo3xk2mqQcp/GVOv3wAtABduKkbp15aEbWZd3A\u002BkjjAOO8KNcz09PmGInz8UvgD6Nb6vdDlKXCr3bWYDDGX6mosjoeN9X8zacSwlYTiXb68lo\u002BZQ9Vn2w5\u002BXlcXXOfH7zcRz8RxdvJXx1MMNZTsyH/223ai/aeVxbJ5DpYnGwzc6KVM0I75Sx\u002BcQnyBW6Z5kpbYIIBxJPGQfAoR\u002BGhbMKtHL0zun/fw/JBWBbsrE2kM/3sATvuLa8O0u1SE6FK2QRLQOixZivOe5yTwGh82ZWigBfnsWuGwu8SJOuOjbBQ9n8SpWtk9snSIYWfWm1Ckflbr5OJZyuYwIH9n0FAP\u002B3sPsnpajAuPYlKEZPl52R9z5LyNt4cy5NXeeDpa1eIjeWbsx\u002BjWSfFLXIGP1WXttkdf9OuUgUPz3c6kfBTRNYxwYOuSjRE3nJrKQlsFog5w8cLz\u002BuH2j/ci\u002BOoZMc3deif1HnR5Wig1KFdRyT/o7Tq/NItR3jqretH0b5QnHWvM7cg0EIOa9paZvdKJpMW4Og==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:40 GMT",
+        "ETag": "\u00220x8D7F927D73395F1\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "60119fc2-f427-19fa-811e-266ef71a1921",
+        "x-ms-content-crc64": "ArqHnhhPzi8=",
+        "x-ms-request-id": "f79cbcb2-001e-0130-4310-2b8e64000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-29466e42-28da-cbd2-2db7-fbec2a04b39d/test-blob-1e04f306-e50b-18a2-734f-08b118b6d0be",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-99847742a44ea24488b19c3bad3f9735-42ab3594ea4fd543-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "ba895c3f-7037-dda4-fdf8-edd7eb4801cb",
+        "x-ms-date": "Fri, 15 May 2020 23:29:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:40 GMT",
+        "ETag": "\u00220x8D7F927D73B869C\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ba895c3f-7037-dda4-fdf8-edd7eb4801cb",
+        "x-ms-request-id": "f79cbcc9-001e-0130-5510-2b8e64000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-29466e42-28da-cbd2-2db7-fbec2a04b39d/test-blob-1e04f306-e50b-18a2-734f-08b118b6d0be?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-bc1dc6493aefc148aded83bf48c08689-c24e787c03d0cd4d-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "bb71764b-162d-7986-f4cc-78cddfcd6970",
+        "x-ms-copy-source": "http://amandadev2.blob.core.windows.net/test-container-29466e42-28da-cbd2-2db7-fbec2a04b39d/test-\u03B2\u00A3\u00A9\u00FE\u203D-7789343c-6dc4-628a-2c47-c7dff770ab05",
+        "x-ms-date": "Fri, 15 May 2020 23:29:40 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-source-range": "bytes=0-1023",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "gZvsSO4/SMIHEPj59c9Qmg==",
+        "Date": "Fri, 15 May 2020 23:29:40 GMT",
+        "ETag": "\u00220x8D7F927D760C887\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "bb71764b-162d-7986-f4cc-78cddfcd6970",
+        "x-ms-request-id": "f79cbcef-001e-0130-7710-2b8e64000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-29466e42-28da-cbd2-2db7-fbec2a04b39d?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-f18bb95f169a154f935b0789c4ed46b4-501b7ca06b384943-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "758c2f6e-46d7-379e-e109-68a52c8d5a7f",
+        "x-ms-date": "Fri, 15 May 2020 23:29:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "758c2f6e-46d7-379e-e109-68a52c8d5a7f",
+        "x-ms-request-id": "f79cbd50-001e-0130-4810-2b8e64000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1202686812",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTests/UploadPagesFromUriAsync_NonAsciiSourceUriAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/PageBlobClientTests/UploadPagesFromUriAsync_NonAsciiSourceUriAsync.json
@@ -1,0 +1,256 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fe303aab-7e01-0435-dff0-5e5b01eea4af?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-ec8a73265b2e5c4ba762444ddadcd3e4-c27c98f7de23874e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "19592718-1153-8d9b-ac50-f4aa94dca964",
+        "x-ms-date": "Fri, 15 May 2020 23:29:40 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:40 GMT",
+        "ETag": "\u00220x8D7F927D776F12B\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:41 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "19592718-1153-8d9b-ac50-f4aa94dca964",
+        "x-ms-request-id": "f79cbd70-001e-0130-6310-2b8e64000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fe303aab-7e01-0435-dff0-5e5b01eea4af?restype=container\u0026comp=acl",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "21",
+        "Content-Type": "application/xml",
+        "traceparent": "00-e3b40ce84c2c0e408a058550c15a6bd1-db07876007d69d46-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "4b0d6802-41b2-2110-2104-3a24a3330f11",
+        "x-ms-date": "Fri, 15 May 2020 23:29:41 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": "\u003CSignedIdentifiers /\u003E",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:40 GMT",
+        "ETag": "\u00220x8D7F927D77E5B8B\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:41 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "4b0d6802-41b2-2110-2104-3a24a3330f11",
+        "x-ms-request-id": "f79cbd92-001e-0130-8010-2b8e64000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fe303aab-7e01-0435-dff0-5e5b01eea4af/test-\u03B2\u00A3\u00A9\u00FE\u203D-6940b86a-e7a8-4049-b27e-bfc223d8b093",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-b3517afba102824c868e657437c830cd-01bd3a4d23767946-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "bf190cf6-3ec2-1aed-1fcd-9833824dfd49",
+        "x-ms-date": "Fri, 15 May 2020 23:29:41 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:40 GMT",
+        "ETag": "\u00220x8D7F927D786F4FD\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:41 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "bf190cf6-3ec2-1aed-1fcd-9833824dfd49",
+        "x-ms-request-id": "f79cbdbd-001e-0130-2610-2b8e64000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fe303aab-7e01-0435-dff0-5e5b01eea4af/test-\u03B2\u00A3\u00A9\u00FE\u203D-6940b86a-e7a8-4049-b27e-bfc223d8b093?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "traceparent": "00-1385ed84871bb34089768139397d4392-9d5dba949fe7e847-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "16cc08c3-f0bf-92d1-3654-189412f5a663",
+        "x-ms-date": "Fri, 15 May 2020 23:29:41 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": "zS\u002B\u002B7tC6BH9ZBtGRFONVLvoKQtmVi1tGyekhRDY2lU/HBYR\u002B8giDXSLZwE1ACnjI\u002BsawipnPz0LUeCTnmcBJI3GByQ5f1zzyh\u002BS3u8oNBb5wWElwhQq19zZBqXrjm8RhkJ3cvkBqaCKJvgO1GBN4x3Jmd0B22J1my9HXHi3BD\u002BsgVSosMUd9BfAm5scGAN8jyeIHfCOD6rj/dfJvk0r1yK8XlMLpS5Ur6HJQUPHWYMvytFRKupLInWpxLbtUDnKlMR4X72wdOX5N3JSxMprHKRUnfN/1qg0dT/dXdx7Z1tn/qh7SvnBe1HrW/d39FmrQqgOmLZGTsIcQ\u002Bp91xsFgcwa6sYh89GqkyahkHqwwHzmMh80aM6hIbPqXwcPR6A64dorXQ2TiU7aYAWTpLpHa4Ntl6D70RT9dckWO5DKn0uCZq6ghWdzVqjMWgTFEXj1ovOHoawDPxDBLedAeU2\u002BD8S6ET4PpuIf/kD4L3cQNGRMHJSdQv2ffyud31t8LtlbEkpADwA\u002B6fwRa6NrBxOZsPV\u002B8Fy5HMjLHpIWcceKn89rnR0o0ClkETaYj9taMHgUAC5iATp8ofF9eOxuJHQ4is/QA2n2bNzMGuMmIIzxbO4Z/m2VJJ6U7v8rq1s49ei\u002BYAUPhi0OIZNRkeZXVoFgjAgCVCoGo2ItPxRuysGFlyD2a7yL4ea9C9zeR5K0PZh5xx9POqHCt7yi3ksYo1bRz/7BYO7A2K4hQUhJKF/PeP178QOmNlyDM7AD5QOfoGiGDHuT9tyttO5tKfVZdYtc02VJnK5XK5WiQi06wPOqhaDfxx/kP4IgzjgROQhrKb4koxWaUge\u002BMuDh7bSzcvf\u002BwqBQebJreJfnKM5yQfKNOxRzEh3aEDeZIZQ/Bk3NcV9EFnZkFqwLuSZ9tyU1T\u002BzyULacPFzWILJsu1geLHZKFbtzKi94JSRkZ1j7XFkSZ9GnSLGXLTD\u002BbfHH\u002B1tX7YiwN51twiHBdi\u002BON9kH3sRVWlOGdufAsuiKcLw5tC3JEHnMRyS/pKGz4dKGCPVb9pMpbp0L0Xak84C0401lh8H9xSdfO5ufmbWx1pEVPqnzMn4pEEmMwUMDK1OkCsFQSl4QhEfN\u002BL73jdTnWfrlk7TawbDTOHd4bQPkXBBH\u002B5L0XYg3ALZmITW/NYZwqWtEHZeeyUUMgRHmlBdD6Zyus5JF7vxuro7\u002BdKB/FAbxB8eYoD54pTJN69x6TGifIjuZEIXwLrpq1W8IoFCgkWkK9ZBTp0VeMgpj\u002BAcf9GIiX1Jk4gOA/NkNLc7PbATdqVpzb1rYT37yOt57kDK3Tt0M6kUCO69pifS3QnV6ksYFhlKorIUHRg/TcqclBWymVeLtwoXD22w==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:40 GMT",
+        "ETag": "\u00220x8D7F927D78FA920\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:41 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "16cc08c3-f0bf-92d1-3654-189412f5a663",
+        "x-ms-content-crc64": "n5hijHPKiEA=",
+        "x-ms-request-id": "f79cbdd0-001e-0130-3510-2b8e64000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fe303aab-7e01-0435-dff0-5e5b01eea4af/test-blob-6031ef5a-3cc9-1ff1-5d5a-30aa869d6a5b",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-b914cf3afc20f946a3da0353fec06ba0-6764e78a0fb7a644-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-blob-content-length": "1024",
+        "x-ms-blob-type": "PageBlob",
+        "x-ms-client-request-id": "c0f55470-d793-86cc-17ad-b965c0260c99",
+        "x-ms-date": "Fri, 15 May 2020 23:29:41 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:40 GMT",
+        "ETag": "\u00220x8D7F927D797C0DA\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:41 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c0f55470-d793-86cc-17ad-b965c0260c99",
+        "x-ms-request-id": "f79cbde0-001e-0130-4210-2b8e64000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fe303aab-7e01-0435-dff0-5e5b01eea4af/test-blob-6031ef5a-3cc9-1ff1-5d5a-30aa869d6a5b?comp=page",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "0",
+        "traceparent": "00-45fbaef00e80fb4aa9aabb5ac321f19c-c206176f130af34a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "323a96ae-a9a7-bec7-36ea-63d42d24a1af",
+        "x-ms-copy-source": "http://amandadev2.blob.core.windows.net/test-container-fe303aab-7e01-0435-dff0-5e5b01eea4af/test-\u03B2\u00A3\u00A9\u00FE\u203D-6940b86a-e7a8-4049-b27e-bfc223d8b093",
+        "x-ms-date": "Fri, 15 May 2020 23:29:41 GMT",
+        "x-ms-page-write": "update",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-source-range": "bytes=0-1023",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "6rrcTL/ffUQuqK64/r/hlg==",
+        "Date": "Fri, 15 May 2020 23:29:40 GMT",
+        "ETag": "\u00220x8D7F927D7A074F9\u0022",
+        "Last-Modified": "Fri, 15 May 2020 23:29:41 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-blob-sequence-number": "0",
+        "x-ms-client-request-id": "323a96ae-a9a7-bec7-36ea-63d42d24a1af",
+        "x-ms-request-id": "f79cbdeb-001e-0130-4d10-2b8e64000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.blob.core.windows.net/test-container-fe303aab-7e01-0435-dff0-5e5b01eea4af?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d23e321ce4c097478726884415204022-e2d65b070cc58145-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Blobs/12.5.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "29b6754c-d9ec-40f1-f641-d99bc90d4640",
+        "x-ms-date": "Fri, 15 May 2020 23:29:41 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Fri, 15 May 2020 23:29:40 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "29b6754c-d9ec-40f1-f641-d99bc90d4640",
+        "x-ms-request-id": "f79cbe0c-001e-0130-6610-2b8e64000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "181380107",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Common/swagger/Generator/src/types.ts
+++ b/sdk/storage/Azure.Storage.Common/swagger/Generator/src/types.ts
@@ -129,6 +129,8 @@ export function convertToString(expr: string, model: IModelType, service: IServi
             return `${expr}.ToString(System.Globalization.CultureInfo.InvariantCulture).ToLowerInvariant()`;
         case 'byte':
             return `System.Convert.ToBase64String(${expr})`;
+        case 'url':
+            return `${expr}.AbsoluteUri`;
         case 'dictionary':
         case 'binary': // stream
             throw `Cannot convert ${model.type} to string`;

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Generated/FileRestClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Generated/FileRestClient.cs
@@ -6216,7 +6216,7 @@ namespace Azure.Storage.Files.Shares
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-range", range);
-                _request.Headers.SetValue("x-ms-copy-source", copySource.ToString());
+                _request.Headers.SetValue("x-ms-copy-source", copySource.AbsoluteUri);
                 _request.Headers.SetValue("x-ms-write", "update");
                 _request.Headers.SetValue("Content-Length", contentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 _request.Headers.SetValue("x-ms-version", version);
@@ -6613,7 +6613,7 @@ namespace Azure.Storage.Files.Shares
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", version);
-                _request.Headers.SetValue("x-ms-copy-source", copySource.ToString());
+                _request.Headers.SetValue("x-ms-copy-source", copySource.AbsoluteUri);
                 if (metadata != null) {
                     foreach (System.Collections.Generic.KeyValuePair<string, string> _pair in metadata)
                     {

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
@@ -1241,6 +1241,30 @@ namespace Azure.Storage.Files.Shares.Test
         }
 
         [Test]
+        public async Task StartCopyAsync_NonAsciiSourceUri()
+        {
+            // Arrange
+            await using DisposingFile testSource = await GetTestFileAsync(fileName: GetNewNonAsciiFileName());
+            ShareFileClient source = testSource.File;
+            await using DisposingFile testDest = await GetTestFileAsync();
+            ShareFileClient dest = testDest.File;
+
+            var data = GetRandomBuffer(Constants.KB);
+            using (var stream = new MemoryStream(data))
+            {
+                await source.UploadRangeAsync(
+                    range: new HttpRange(0, Constants.KB),
+                    content: stream);
+            }
+
+            // Act
+            Response<ShareFileCopyInfo> response = await dest.StartCopyAsync(source.Uri);
+
+            // Assert
+            Assert.IsNotNull(response.GetRawResponse().Headers.RequestId);
+        }
+
+        [Test]
         public async Task StartCopyAsync_Error()
         {
             await using DisposingFile test = await GetTestFileAsync();
@@ -2197,6 +2221,59 @@ namespace Azure.Storage.Files.Shares.Test
                     sourceRange: sourceRange,
                     conditions: conditions),
                 e => Assert.AreEqual("LeaseNotPresentWithFileOperation", e.ErrorCode));
+        }
+
+        [Test]
+        [LiveOnly]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/9085")]
+        // TODO: #7645
+        public async Task UploadRangeFromUriAsync_NonAsciiSourceUri()
+        {
+            await using DisposingShare test = await GetTestShareAsync();
+            ShareClient share = test.Share;
+
+            // Arrange
+            var directoryName = this.GetNewDirectoryName();
+            var directory = this.InstrumentClient(share.GetDirectoryClient(directoryName));
+            await directory.CreateAsync();
+
+            var fileName = this.GetNewNonAsciiFileName();
+            var data = this.GetRandomBuffer(Constants.KB);
+            var sourceFile = this.InstrumentClient(directory.GetFileClient(fileName));
+            await sourceFile.CreateAsync(maxSize: 1024);
+            using (var stream = new MemoryStream(data))
+            {
+                await sourceFile.UploadRangeAsync(new HttpRange(0, 1024), stream);
+            }
+
+            var destFile = directory.GetFileClient("destFile");
+            await destFile.CreateAsync(maxSize: 1024);
+            var destRange = new HttpRange(256, 256);
+            var sourceRange = new HttpRange(512, 256);
+
+            var sasFile = this.InstrumentClient(
+                this.GetServiceClient_FileServiceSasShare(test.Share.Name)
+                .GetShareClient(test.Share.Name)
+                .GetDirectoryClient(directoryName)
+                .GetFileClient(fileName));
+
+            // Act
+            await destFile.UploadRangeFromUriAsync(
+                sourceUri: sasFile.Uri,
+                range: destRange,
+                sourceRange: sourceRange);
+
+            // Assert
+            var sourceDownloadResponse = await sourceFile.DownloadAsync(range: sourceRange);
+            var destDownloadResponse = await destFile.DownloadAsync(range: destRange);
+
+            var sourceStream = new MemoryStream();
+            await sourceDownloadResponse.Value.Content.CopyToAsync(sourceStream);
+
+            var destStream = new MemoryStream();
+            await destDownloadResponse.Value.Content.CopyToAsync(destStream);
+
+            TestHelper.AssertSequenceEqual(sourceStream.ToArray(), destStream.ToArray());
         }
 
         [Test]

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
@@ -33,6 +33,7 @@ namespace Azure.Storage.Files.Shares.Tests
         public string GetNewShareName() => $"test-share-{Recording.Random.NewGuid()}";
         public string GetNewDirectoryName() => $"test-directory-{Recording.Random.NewGuid()}";
         public string GetNewFileName() => $"test-file-{Recording.Random.NewGuid()}";
+        public string GetNewNonAsciiFileName() => $"test-ƒ¡£€‽-{Recording.Random.NewGuid()}";
 
         public ShareClientOptions GetOptions()
         {

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/StartCopyAsync_NonAsciiSourceUri.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/StartCopyAsync_NonAsciiSourceUri.json
@@ -1,0 +1,386 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-c8c2e8af-367d-c1ac-78df-efc66ae9d22e?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-75d4f35c9ab9484fbcc83dffc2b1587a-7f192ef4f47b1544-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "0454ab5d-c7b5-d2de-6f07-30f74d1ae70a",
+        "x-ms-date": "Sat, 16 May 2020 00:26:17 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 16 May 2020 00:26:17 GMT",
+        "ETag": "\u00220x8D7F92FC03566AA\u0022",
+        "Last-Modified": "Sat, 16 May 2020 00:26:17 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0454ab5d-c7b5-d2de-6f07-30f74d1ae70a",
+        "x-ms-request-id": "dc179438-d01a-0036-4318-2b3f49000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-c8c2e8af-367d-c1ac-78df-efc66ae9d22e/test-directory-d7ac0a4a-4de5-96bd-93d0-e3ba6d82804c?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-31aed8ae06c8a041adef7a69f9ad8e6e-6d4046ae7dcd5b4d-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "36debedc-7980-0f2c-eebe-70e4e42364ec",
+        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 16 May 2020 00:26:18 GMT",
+        "ETag": "\u00220x8D7F92FC0473A7D\u0022",
+        "Last-Modified": "Sat, 16 May 2020 00:26:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "36debedc-7980-0f2c-eebe-70e4e42364ec",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2020-05-16T00:26:18.0887165Z",
+        "x-ms-file-creation-time": "2020-05-16T00:26:18.0887165Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2020-05-16T00:26:18.0887165Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "dc17943a-d01a-0036-4418-2b3f49000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-c8c2e8af-367d-c1ac-78df-efc66ae9d22e/test-directory-d7ac0a4a-4de5-96bd-93d0-e3ba6d82804c/test-\u0192\u00A1\u00A3\u20AC\u203D-a9c81b08-3cd6-51e0-f41c-395eb4514ac3",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-3c8e3aa9b722844598d745aab4f4ded6-b775186645175949-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "afde192b-4aa4-16cc-af59-d1d75d9405db",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 16 May 2020 00:26:18 GMT",
+        "ETag": "\u00220x8D7F92FC0571BD7\u0022",
+        "Last-Modified": "Sat, 16 May 2020 00:26:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "afde192b-4aa4-16cc-af59-d1d75d9405db",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2020-05-16T00:26:18.1927895Z",
+        "x-ms-file-creation-time": "2020-05-16T00:26:18.1927895Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2020-05-16T00:26:18.1927895Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "dc17943b-d01a-0036-4518-2b3f49000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-0476a135-34f5-b418-4962-a4bda0e1502e?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-ebd8773157a73447a9431b64da2c54a0-ac4f6da7e1bc1d4c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "1e15fcbc-a848-f741-0029-6541a60e75ce",
+        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 16 May 2020 00:26:18 GMT",
+        "ETag": "\u00220x8D7F92FC0629955\u0022",
+        "Last-Modified": "Sat, 16 May 2020 00:26:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "1e15fcbc-a848-f741-0029-6541a60e75ce",
+        "x-ms-request-id": "dc17943c-d01a-0036-4618-2b3f49000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-0476a135-34f5-b418-4962-a4bda0e1502e/test-directory-24c7a208-3bda-8095-5839-eca373c05dac?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-a8c9e4c5b4d6f04caf5d18acdf482b07-1ffa68b9785ddf4e-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "b44ff2dc-fad5-8023-6794-c50ebc9e843f",
+        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 16 May 2020 00:26:18 GMT",
+        "ETag": "\u00220x8D7F92FC06AA75F\u0022",
+        "Last-Modified": "Sat, 16 May 2020 00:26:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b44ff2dc-fad5-8023-6794-c50ebc9e843f",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2020-05-16T00:26:18.3208799Z",
+        "x-ms-file-creation-time": "2020-05-16T00:26:18.3208799Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2020-05-16T00:26:18.3208799Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "dc17943e-d01a-0036-4718-2b3f49000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-0476a135-34f5-b418-4962-a4bda0e1502e/test-directory-24c7a208-3bda-8095-5839-eca373c05dac/test-file-fffeb8cc-d10d-d701-bb5f-2c18707a3051",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-b4a25ae49301e142bccb61d15d603f27-4a9b5943fea85947-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "964f8a3d-9708-0bfb-f178-f876cd0a10ed",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 16 May 2020 00:26:18 GMT",
+        "ETag": "\u00220x8D7F92FC0735B86\u0022",
+        "Last-Modified": "Sat, 16 May 2020 00:26:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "964f8a3d-9708-0bfb-f178-f876cd0a10ed",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2020-05-16T00:26:18.3779206Z",
+        "x-ms-file-creation-time": "2020-05-16T00:26:18.3779206Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2020-05-16T00:26:18.3779206Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "dc17943f-d01a-0036-4818-2b3f49000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-c8c2e8af-367d-c1ac-78df-efc66ae9d22e/test-directory-d7ac0a4a-4de5-96bd-93d0-e3ba6d82804c/test-\u0192\u00A1\u00A3\u20AC\u203D-a9c81b08-3cd6-51e0-f41c-395eb4514ac3?comp=range",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "traceparent": "00-2094ca6aea24b94d9e3a5273ee3b97c6-e3aa86cd3195f148-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "c0ade32c-bafd-e683-1c84-17d16cf6694c",
+        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07",
+        "x-ms-write": "update"
+      },
+      "RequestBody": "Y3Rr2NYDziLhtHyMlMlr47PT2uYqmkkL6LyP\u002BbBgfHlwT9T3bdOCOrsttVMbb3YoDBXC\u002BS8qwskqX\u002B8adNVygDgCG0T1dHbgUKAq/eX18HhFZ\u002BybnoJJRowKzQ3jaMbmujQbGFMyMpif4qmO/8XkNG531Azo1\u002BK1udW36qZo/OfaQ0Kw2tgkEzRU\u002B7zYukbHJZifbJS5/eNSZV5\u002BekfxN\u002BXCtLuDM1qWUsDYlNsl3P6O8MUOyI9TIUZeXnR5ppnsY8TWFgaKQ/E9CBrT4GkILIhg74mC4m5VbpN1JNXmHKsn6zEWT8b4A6zT0L91gEDdVjLrGLYQaYBWgKhzFR8cV\u002Bxuq/Q38dzCaOzcrxGu4O5Sl86i\u002BwP1F4KwwM4ehe6NtnnTBtRMpWRVKLDKM7puqJ\u002B5IH1QeVvoeZRyhzEOpOL9TviX2toaBvJqTdJSK\u002BPHQhcuZGRwPTwe641A2R4yR4POzOTB1s7FnxqL5iyJlU2wqkQa30B9jRG7ee5M2i3UOAVOhF//BmtJaMVK5VYPlFY/jy7ZGGdDUD7SBVzfecXtt64nOhDusaTZ0Hd7M6i7rOSYDEr\u002B\u002Bh\u002BdCzQgLAAOau//XS6o6FpFUd2JAEfwyByWF1l4Rm167ryOiS/bzoWkymaHe9V5EsOKUrtsdPnXrUIXiRSmliOChW5xGl8raYJY5TbhaE1GHAWV7vSxDXnCttzsxERx/TNCBfZmCPhkXug4FI/D9kT10GwOEKgv0Hf1rmODPqU95\u002BcCn2NX4BQMMY8Lefnp/8CX9/PYYuyLEzV\u002BcVqV4SBD\u002BiyowVbhnvBYAt8ZJFZ9C6\u002Bi60exZYX6dowt2G65d1Bux37NQT1ptlkCf2ANce7eAWaq8vXZkZWnrUrKs8WCnoqOqlzYsMlxOTXur\u002BUl7QSdT9cHDoVblTbpJZTyngKTgOHVfseRBlCdObjA6\u002BKvgr9FLWTue48EMxUm7oo0fpoyWi4ET289C0iGatXMm6pTOqPVrXGdpAVR0UqxaxjGaLoejZCzqzNPByEbaBC5N5hr07PnX9EolbYps30ki6AwwAEbrg4Zn49whaVPgjz0l5myRpdk3gno9ffaivi1K3yB6qcPnomKUTMkd9os2BN5NRvjckQIzOH4M7gWPxWXuloozpeU5fkQJ/VkP2cuux3kYFXc0bg3eB7FFmrQdBEejbyAAwl85U8i0ktPpI16yXebMd\u002B/uumh8VZ4zs6OQLPjRbKqrrgTaHsFuf5t59ORS03zNUMyXtLT3hGzAxaBlJKXa17bzxu\u002BiMhjugDqMwmC54OBmgpwsOff18\u002BmX2VlgyVr1Xt0tnsxNKx6z6PR6KsIMBuSAPmHJ7t3\u002B/hLGChj/jbbfl6NDg==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "HQleALV7oUJA7Om88jQ6yQ==",
+        "Date": "Sat, 16 May 2020 00:26:18 GMT",
+        "ETag": "\u00220x8D7F92FC07E0BD4\u0022",
+        "Last-Modified": "Sat, 16 May 2020 00:26:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c0ade32c-bafd-e683-1c84-17d16cf6694c",
+        "x-ms-request-id": "dc179440-d01a-0036-4918-2b3f49000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-0476a135-34f5-b418-4962-a4bda0e1502e/test-directory-24c7a208-3bda-8095-5839-eca373c05dac/test-file-fffeb8cc-d10d-d701-bb5f-2c18707a3051",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-7490fea43c967b4885abc6b15d63403f-09a877d57b4d0d48-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "9aafb32b-cdb0-7610-8468-49dade10d617",
+        "x-ms-copy-source": "http://amandadev2.file.core.windows.net/test-share-c8c2e8af-367d-c1ac-78df-efc66ae9d22e/test-directory-d7ac0a4a-4de5-96bd-93d0-e3ba6d82804c/test-\u0192\u00A1\u00A3\u20AC\u203D-a9c81b08-3cd6-51e0-f41c-395eb4514ac3",
+        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 16 May 2020 00:26:18 GMT",
+        "ETag": "\u00220x8D7F92FC08BA2DD\u0022",
+        "Last-Modified": "Sat, 16 May 2020 00:26:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9aafb32b-cdb0-7610-8468-49dade10d617",
+        "x-ms-copy-id": "ad2a61ac-1aba-40eb-a684-4936631adb07",
+        "x-ms-copy-status": "success",
+        "x-ms-request-id": "dc179441-d01a-0036-4a18-2b3f49000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-0476a135-34f5-b418-4962-a4bda0e1502e?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-7a35bd50c3849f40b12ad6bdc38181fc-2c343419d6aac74c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "b9a5fe8a-cf47-ad9c-1173-06484a4f54c9",
+        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 16 May 2020 00:26:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "b9a5fe8a-cf47-ad9c-1173-06484a4f54c9",
+        "x-ms-request-id": "dc179442-d01a-0036-4b18-2b3f49000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-c8c2e8af-367d-c1ac-78df-efc66ae9d22e?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-d5b3fdcc2c1d6b4c90f3fca150be9fb4-d37ad42b70658b49-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "df4fa6a8-1d6b-b5d0-3b76-faec41884e6a",
+        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 16 May 2020 00:26:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "df4fa6a8-1d6b-b5d0-3b76-faec41884e6a",
+        "x-ms-request-id": "dc179443-d01a-0036-4c18-2b3f49000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "819694172",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/StartCopyAsync_NonAsciiSourceUriAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileClientTests/StartCopyAsync_NonAsciiSourceUriAsync.json
@@ -1,0 +1,386 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-d3a43671-e53f-c502-602e-f30387696a2a?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-48029d53fa2e8e43a7af40c0215f5ae2-bf4f5a80a4ce9f4f-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "fcc1238e-1939-f2ac-3e7c-b5d56d08bdfa",
+        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 16 May 2020 00:26:18 GMT",
+        "ETag": "\u00220x8D7F92FC0B29C8F\u0022",
+        "Last-Modified": "Sat, 16 May 2020 00:26:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "fcc1238e-1939-f2ac-3e7c-b5d56d08bdfa",
+        "x-ms-request-id": "dc179445-d01a-0036-4d18-2b3f49000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-d3a43671-e53f-c502-602e-f30387696a2a/test-directory-8927c7c3-d2fd-d89c-004c-8f25ed08f217?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-7a73b36c8f0db24eb1c6ba517ec02217-d5ea4add63112645-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "0a37fd5c-4620-bb59-87e8-fced89870536",
+        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 16 May 2020 00:26:18 GMT",
+        "ETag": "\u00220x8D7F92FC0BE068E\u0022",
+        "Last-Modified": "Sat, 16 May 2020 00:26:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "0a37fd5c-4620-bb59-87e8-fced89870536",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2020-05-16T00:26:18.8672654Z",
+        "x-ms-file-creation-time": "2020-05-16T00:26:18.8672654Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2020-05-16T00:26:18.8672654Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "dc179447-d01a-0036-4e18-2b3f49000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-d3a43671-e53f-c502-602e-f30387696a2a/test-directory-8927c7c3-d2fd-d89c-004c-8f25ed08f217/test-\u0192\u00A1\u00A3\u20AC\u203D-154241d7-6004-450b-632d-f294d9c262b1",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-0febb49fed6408409e4ddc09917c3bf0-4c2a540ac8da8c42-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "efc85361-e7d0-17f6-42b9-dcbf7103ca1c",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 16 May 2020 00:26:18 GMT",
+        "ETag": "\u00220x8D7F92FC0C6BAB0\u0022",
+        "Last-Modified": "Sat, 16 May 2020 00:26:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "efc85361-e7d0-17f6-42b9-dcbf7103ca1c",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2020-05-16T00:26:18.9243056Z",
+        "x-ms-file-creation-time": "2020-05-16T00:26:18.9243056Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2020-05-16T00:26:18.9243056Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "dc179448-d01a-0036-4f18-2b3f49000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-450e1acc-19e9-02a9-abe2-344d602d3a83?restype=share",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-af0baec3d7a2814489c064ad855b2fe9-bd46ee01a342454f-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "665eca09-aff6-48b5-aac5-43edb3a9b714",
+        "x-ms-date": "Sat, 16 May 2020 00:26:18 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 16 May 2020 00:26:18 GMT",
+        "ETag": "\u00220x8D7F92FC0CF5184\u0022",
+        "Last-Modified": "Sat, 16 May 2020 00:26:18 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "665eca09-aff6-48b5-aac5-43edb3a9b714",
+        "x-ms-request-id": "dc179449-d01a-0036-5018-2b3f49000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-450e1acc-19e9-02a9-abe2-344d602d3a83/test-directory-14cc597e-9478-b75d-b46c-9e8a8bcf8518?restype=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-e04546975323f64a9a610bacfb203eb2-519d7345357c1a45-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "245a79a8-cec6-745a-6ca7-b189102bbcdb",
+        "x-ms-date": "Sat, 16 May 2020 00:26:19 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 16 May 2020 00:26:18 GMT",
+        "ETag": "\u00220x8D7F92FC0D75F86\u0022",
+        "Last-Modified": "Sat, 16 May 2020 00:26:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "245a79a8-cec6-745a-6ca7-b189102bbcdb",
+        "x-ms-file-attributes": "Directory",
+        "x-ms-file-change-time": "2020-05-16T00:26:19.0333830Z",
+        "x-ms-file-creation-time": "2020-05-16T00:26:19.0333830Z",
+        "x-ms-file-id": "13835128424026341376",
+        "x-ms-file-last-write-time": "2020-05-16T00:26:19.0333830Z",
+        "x-ms-file-parent-id": "0",
+        "x-ms-file-permission-key": "8720823596597466685*1287379445297103284",
+        "x-ms-request-id": "dc17944b-d01a-0036-5118-2b3f49000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-450e1acc-19e9-02a9-abe2-344d602d3a83/test-directory-14cc597e-9478-b75d-b46c-9e8a8bcf8518/test-file-52ee2b40-2065-aa45-cb88-6d350964e53c",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-20aa479ebd495d4baf355403671cd593-b01bf79c1a8d9441-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "a6b8af86-9c8a-8797-33b0-583e61256b08",
+        "x-ms-content-length": "1048576",
+        "x-ms-date": "Sat, 16 May 2020 00:26:19 GMT",
+        "x-ms-file-attributes": "None",
+        "x-ms-file-creation-time": "Now",
+        "x-ms-file-last-write-time": "Now",
+        "x-ms-file-permission": "Inherit",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-type": "file",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 16 May 2020 00:26:19 GMT",
+        "ETag": "\u00220x8D7F92FC0DF7748\u0022",
+        "Last-Modified": "Sat, 16 May 2020 00:26:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a6b8af86-9c8a-8797-33b0-583e61256b08",
+        "x-ms-file-attributes": "Archive",
+        "x-ms-file-change-time": "2020-05-16T00:26:19.0864200Z",
+        "x-ms-file-creation-time": "2020-05-16T00:26:19.0864200Z",
+        "x-ms-file-id": "11529285414812647424",
+        "x-ms-file-last-write-time": "2020-05-16T00:26:19.0864200Z",
+        "x-ms-file-parent-id": "13835128424026341376",
+        "x-ms-file-permission-key": "13365936616355342650*1287379445297103284",
+        "x-ms-request-id": "dc17944c-d01a-0036-5218-2b3f49000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-d3a43671-e53f-c502-602e-f30387696a2a/test-directory-8927c7c3-d2fd-d89c-004c-8f25ed08f217/test-\u0192\u00A1\u00A3\u20AC\u203D-154241d7-6004-450b-632d-f294d9c262b1?comp=range",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "Content-Length": "1024",
+        "traceparent": "00-ee73358fe2295442b8235a54431cc84d-a17edf6fcb4f8648-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "5907d07b-a8a5-13f8-c938-fe7e08572dc5",
+        "x-ms-date": "Sat, 16 May 2020 00:26:19 GMT",
+        "x-ms-range": "bytes=0-1023",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07",
+        "x-ms-write": "update"
+      },
+      "RequestBody": "wnUMbkmrZuDZvkqW9h6HyFTyrlqrPrHhCVrdxAcTzuJjIWSt98Qx20jYzcxRAJAVKJDqb3YRXITDKmXvzaHYxu9oM9W52tCPwNMR03DlkAjJyJx3KV9rUsTf6cxfQQ6m/wfd6M27W02/Wq6j/4kU3ppcJgQFYZyP/eAR2fADMH/EatNpCKc7Dm1Ot86xyFM6ywsyAxsJoZ5qTevtqYFduykv3pS1q9XzIRiXtqnO3TWN1g3k0S1ju8g1/rq8TWTr8fukgum\u002BhSA1P\u002BECcuv0nHC1X9JzeOr8yyPMf6wbNtOzq8WtKVtLz1HtrpFLYUjdQGJKBu6ReHgRqLbF8gV0GggOTsYlRnMUaZCBhspYsWra7j9K0TDkITNNnICkht1LeJSJPBKCuPnuNZxeEPGtuPdM6gPGKknYKSyS2Kryb\u002BOyNg02z3RXWDVFW5uThhFCn\u002BOJV5vZhE5KsBLl7\u002BBP/MW5q9njd\u002BmC9JLOgc6uRKMbUDjGaBhI2bG\u002B6x5hcmhV9V7V2ts3Xif5B2IJCwOAnGxvyp\u002BniJStcNEoJIzLIIIpeItv2GrH4/ERzWG1P86tPk\u002By8ajJrm3KKGkKDzmbLubg35J4EMMBqOatlrsy\u002BDEDeuU9GS7aYModpbAAvdS4dZ961F87NS6LsEnBGxiyly84BpRTXhW3BX/IWmoTAesS9SAcuCPRyEW2sWjlGESyaw2AyLY/ZBeJw8/gctrEd69eryX4lt8MZj5OnKys0e07Fu9ckjg00pEIkvVU8VVr8jm4h2keudUudGJ48cdr3fHipVvqZ\u002BV2KdyU7wPqt3Tp46py80qDHFwaLh7WvOHJnbUEckz5gItUQV2MicrRQ7ztjg0d\u002BOmmXoj/0DjGoG37y1JO5kUo72IeHbHs9pKSSOph6S3Tq6TMXRPD\u002BrBSjaHwkb53gl13xZ\u002Br/ts3umf2bIdNZbZAJx\u002BugokyZPWyzI8Q/GTUGsWN6iSOKKzJlKOrzY0oBCjqsGqeyQDURGCp\u002BDJLJr0CIVLBwHuSsf5z5O3lhpZoicdnJUv6NVDFuKXD5C95fW7lqKw6ZkOtWP5rK\u002BQS7r7KQG5r5AFxCOsB/AjVz8zO\u002BWd/AN3qLiODus1Njwprssnm\u002BKPBDplsc6DAOGo714gxnDF9k\u002B7g4BJL5yk0JHnhlkk\u002B7tYpDerNEow9KfW4SOJEG/LY7R7bBhiQdSdvOE4n36Ig/eiyCI5HsIBho7Ydk59H7wmGCKgqYui\u002BmJjDXdo\u002BFkpTl0r5khNjkT2eemNhc\u002BGIKElFoNb59poA83D2g1KmI4xsyvtUTV31I3ZqjOiEXSS2OzWR\u002BHVzWaGw\u002BZ6jbQ7r91bW9anmM9vrT31gj2mye5ZLP0gdFQ==",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "zjv7FdxXuQ/lL\u002BFOqCHbXA==",
+        "Date": "Sat, 16 May 2020 00:26:19 GMT",
+        "ETag": "\u00220x8D7F92FC0E7B62A\u0022",
+        "Last-Modified": "Sat, 16 May 2020 00:26:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5907d07b-a8a5-13f8-c938-fe7e08572dc5",
+        "x-ms-request-id": "dc17944d-d01a-0036-5318-2b3f49000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-450e1acc-19e9-02a9-abe2-344d602d3a83/test-directory-14cc597e-9478-b75d-b46c-9e8a8bcf8518/test-file-52ee2b40-2065-aa45-cb88-6d350964e53c",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-2a8c6a52f47ff748aaf053af9e75658b-77e536386865ab47-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "6ecf2ecd-c341-8270-1fe5-a722a5d5b5fa",
+        "x-ms-copy-source": "http://amandadev2.file.core.windows.net/test-share-d3a43671-e53f-c502-602e-f30387696a2a/test-directory-8927c7c3-d2fd-d89c-004c-8f25ed08f217/test-\u0192\u00A1\u00A3\u20AC\u203D-154241d7-6004-450b-632d-f294d9c262b1",
+        "x-ms-date": "Sat, 16 May 2020 00:26:19 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 16 May 2020 00:26:19 GMT",
+        "ETag": "\u00220x8D7F92FC0F3ED5F\u0022",
+        "Last-Modified": "Sat, 16 May 2020 00:26:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6ecf2ecd-c341-8270-1fe5-a722a5d5b5fa",
+        "x-ms-copy-id": "412c6de7-3f2c-4b49-ac9f-d995b8b94f1c",
+        "x-ms-copy-status": "success",
+        "x-ms-request-id": "dc17944e-d01a-0036-5418-2b3f49000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-450e1acc-19e9-02a9-abe2-344d602d3a83?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-336596c3ce42d64a88edf4dd10f2ae71-2f9e0656bca0a149-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "d9b1dd64-be88-0984-71a9-a0179069e9b2",
+        "x-ms-date": "Sat, 16 May 2020 00:26:19 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 16 May 2020 00:26:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d9b1dd64-be88-0984-71a9-a0179069e9b2",
+        "x-ms-request-id": "dc17944f-d01a-0036-5518-2b3f49000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "http://amandadev2.file.core.windows.net/test-share-d3a43671-e53f-c502-602e-f30387696a2a?restype=share",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-2fe7c770fc3f2d41a03d6248bbd69ab7-9fbc1004c5e0af4a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.Shares/12.3.0-dev.20200515.1",
+          "(.NET Core 4.6.28619.01; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "c8beedc9-dc24-c972-1ea8-41bc4e53b3db",
+        "x-ms-date": "Sat, 16 May 2020 00:26:19 GMT",
+        "x-ms-delete-snapshots": "include",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2019-07-07"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Sat, 16 May 2020 00:26:19 GMT",
+        "Server": [
+          "Windows-Azure-File/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c8beedc9-dc24-c972-1ea8-41bc4e53b3db",
+        "x-ms-request-id": "dc179450-d01a-0036-5618-2b3f49000000",
+        "x-ms-version": "2019-07-07"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "597615400",
+    "Storage_TestConfigDefault": "ProductionTenant\namandadev2\nU2FuaXRpemVk\nhttp://amandadev2.blob.core.windows.net\nhttp://amandadev2.file.core.windows.net\nhttp://amandadev2.queue.core.windows.net\nhttp://amandadev2.table.core.windows.net\n\n\n\n\nhttp://amandadev2-secondary.blob.core.windows.net\nhttp://amandadev2-secondary.file.core.windows.net\nhttp://amandadev2-secondary.queue.core.windows.net\nhttp://amandadev2-secondary.table.core.windows.net\n\nSanitized\n\n\nCloud\nBlobEndpoint=http://amandadev2.blob.core.windows.net/;QueueEndpoint=http://amandadev2.queue.core.windows.net/;FileEndpoint=http://amandadev2.file.core.windows.net/;BlobSecondaryEndpoint=http://amandadev2-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandadev2-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandadev2-secondary.file.core.windows.net/;AccountName=amandadev2;AccountKey=Sanitized\n"
+  }
+}


### PR DESCRIPTION
Resolves #11368

Uri.ToString() unencodes the Uri before sending the request to storage. When using a source Uri that has non ascii characters, we will encode the Uri by putting it in the Uri object but unencode it when setting the header.

Switching to using Uri.AbsoluteUri fixes this problem. This fix applies to AppendBlobClient.AppendBlockFromUri. BlockBlobClient.StageBlockFromUri, PageBlobClient.UploadPagesFromUri, FileClient.StartCopy, FileClient.UploadRangeFromUri

This PR also has updates to DataLakeErrorDetails because of the regenerated code.

- Updated generator to convert Uri.ToString to Uri.AbsoluteUri
- Regenerated adding in Error to DataLakeErrorDetails
- Added tests and recordings for non Ascii source blob/file names