### PR TITLE
Use dotnet core sdk 3.1.4 for mgmt

### DIFF
--- a/eng/pipelines/mgmt.yml
+++ b/eng/pipelines/mgmt.yml
@@ -143,7 +143,7 @@ resources:
     name: Azure/azure-sdk-tools
     endpoint: azure
 variables:
-  DotNetCoreSDKVersion: '3.1.202'
+  DotNetCoreSDKVersion: '2.1.806'
   skipComponentGovernanceDetection: true
   msBuildLogDir: msbuildlogs
   loggingArgs: '/clp:ShowtimeStamp /flp:LogFile=$(msBuildLogDir)/msbuild.normal.log;Verbosity=normal /flp1:Summary;Verbosity=minimal;LogFile=$(msBuildLogDir)/msbuild.sum.log /flp2:warningsonly;logfile=$(msBuildLogDir)/msbuild.wrn.log /flp3:errorsonly;logfile=$(msBuildLogDir)/msbuild.err.log'

--- a/eng/pipelines/mgmt.yml
+++ b/eng/pipelines/mgmt.yml
@@ -143,7 +143,7 @@ resources:
     name: Azure/azure-sdk-tools
     endpoint: azure
 variables:
-  DotNetCoreSDKVersion: '2.2.202'
+  DotNetCoreSDKVersion: '3.1.202'
   skipComponentGovernanceDetection: true
   msBuildLogDir: msbuildlogs
   loggingArgs: '/clp:ShowtimeStamp /flp:LogFile=$(msBuildLogDir)/msbuild.normal.log;Verbosity=normal /flp1:Summary;Verbosity=minimal;LogFile=$(msBuildLogDir)/msbuild.sum.log /flp2:warningsonly;logfile=$(msBuildLogDir)/msbuild.wrn.log /flp3:errorsonly;logfile=$(msBuildLogDir)/msbuild.err.log'

--- a/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/TransientFaultHandling/MemoryTest/CRMemoryTests.cs
+++ b/sdk/mgmtcommon/ClientRuntime/Tests/ClientRuntime.NetCore.Tests/TransientFaultHandling/MemoryTest/CRMemoryTests.cs
@@ -10,7 +10,7 @@ namespace CR.Azure.NetCore.Tests.MemoryTest
 
     public class CRMemoryTests
     {
-        [Fact(Skip="It fails on MacOS. Possibly due to ADO env. Skip to unblock PRs.")]
+        [Fact]
         public void MeasureSvcClientMem()
         {
             AddHeaderResponseDelegatingHandler addHeader = new AddHeaderResponseDelegatingHandler("Hello", "World");


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
