### PR TITLE
generate sdk with data sync changes

### DIFF
--- a/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/src/Generated/Models/SyncGroup.cs
+++ b/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/src/Generated/Models/SyncGroup.cs
@@ -51,7 +51,9 @@ namespace Microsoft.Azure.Management.Sql.Models
         /// values include: 'NotReady', 'Error', 'Warning', 'Progressing',
         /// 'Good'</param>
         /// <param name="schema">Sync schema of the sync group.</param>
-        public SyncGroup(string id = default(string), string name = default(string), string type = default(string), int? interval = default(int?), System.DateTime? lastSyncTime = default(System.DateTime?), string conflictResolutionPolicy = default(string), string syncDatabaseId = default(string), string hubDatabaseUserName = default(string), string hubDatabasePassword = default(string), string syncState = default(string), SyncGroupSchema schema = default(SyncGroupSchema))
+        /// <param name="usePrivateLinkConnection">If use private link
+        /// connection is enabled.</param>
+        public SyncGroup(string id = default(string), string name = default(string), string type = default(string), int? interval = default(int?), System.DateTime? lastSyncTime = default(System.DateTime?), string conflictResolutionPolicy = default(string), string syncDatabaseId = default(string), string hubDatabaseUserName = default(string), string hubDatabasePassword = default(string), string syncState = default(string), SyncGroupSchema schema = default(SyncGroupSchema), bool? usePrivateLinkConnection = default(bool?))
             : base(id, name, type)
         {
             Interval = interval;
@@ -62,6 +64,7 @@ namespace Microsoft.Azure.Management.Sql.Models
             HubDatabasePassword = hubDatabasePassword;
             SyncState = syncState;
             Schema = schema;
+            UsePrivateLinkConnection = usePrivateLinkConnection;
             CustomInit();
         }
 
@@ -120,6 +123,12 @@ namespace Microsoft.Azure.Management.Sql.Models
         /// </summary>
         [JsonProperty(PropertyName = "properties.schema")]
         public SyncGroupSchema Schema { get; set; }
+
+        /// <summary>
+        /// Gets or sets if use private link connection is enabled.
+        /// </summary>
+        [JsonProperty(PropertyName = "properties.usePrivateLinkConnection")]
+        public bool? UsePrivateLinkConnection { get; set; }
 
     }
 }

--- a/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/src/Generated/Models/SyncMember.cs
+++ b/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/src/Generated/Models/SyncMember.cs
@@ -42,6 +42,11 @@ namespace Microsoft.Azure.Management.Sql.Models
         /// sync member.</param>
         /// <param name="sqlServerDatabaseId">SQL Server database id of the
         /// sync member.</param>
+        /// <param name="syncMemberAzureDatabaseResourceId">ARM resource id of
+        /// the sync member logical database, for sync members in
+        /// Azure.</param>
+        /// <param name="usePrivateLinkConnection">Whether to use private link
+        /// connection.</param>
         /// <param name="serverName">Server name of the member database in the
         /// sync member</param>
         /// <param name="databaseName">Database name of the member database in
@@ -60,12 +65,14 @@ namespace Microsoft.Azure.Management.Sql.Models
         /// 'UnProvisioned', 'Provisioning', 'Provisioned', 'ProvisionFailed',
         /// 'DeProvisioning', 'DeProvisioned', 'DeProvisionFailed',
         /// 'Reprovisioning', 'ReprovisionFailed', 'UnReprovisioned'</param>
-        public SyncMember(string id = default(string), string name = default(string), string type = default(string), string databaseType = default(string), string syncAgentId = default(string), System.Guid? sqlServerDatabaseId = default(System.Guid?), string serverName = default(string), string databaseName = default(string), string userName = default(string), string password = default(string), string syncDirection = default(string), string syncState = default(string))
+        public SyncMember(string id = default(string), string name = default(string), string type = default(string), string databaseType = default(string), string syncAgentId = default(string), System.Guid? sqlServerDatabaseId = default(System.Guid?), string syncMemberAzureDatabaseResourceId = default(string), bool? usePrivateLinkConnection = default(bool?), string serverName = default(string), string databaseName = default(string), string userName = default(string), string password = default(string), string syncDirection = default(string), string syncState = default(string))
             : base(id, name, type)
         {
             DatabaseType = databaseType;
             SyncAgentId = syncAgentId;
             SqlServerDatabaseId = sqlServerDatabaseId;
+            SyncMemberAzureDatabaseResourceId = syncMemberAzureDatabaseResourceId;
+            UsePrivateLinkConnection = usePrivateLinkConnection;
             ServerName = serverName;
             DatabaseName = databaseName;
             UserName = userName;
@@ -98,6 +105,19 @@ namespace Microsoft.Azure.Management.Sql.Models
         /// </summary>
         [JsonProperty(PropertyName = "properties.sqlServerDatabaseId")]
         public System.Guid? SqlServerDatabaseId { get; set; }
+
+        /// <summary>
+        /// Gets or sets ARM resource id of the sync member logical database,
+        /// for sync members in Azure.
+        /// </summary>
+        [JsonProperty(PropertyName = "properties.syncMemberAzureDatabaseResourceId")]
+        public string SyncMemberAzureDatabaseResourceId { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to use private link connection.
+        /// </summary>
+        [JsonProperty(PropertyName = "properties.usePrivateLinkConnection")]
+        public bool? UsePrivateLinkConnection { get; set; }
 
         /// <summary>
         /// Gets or sets server name of the member database in the sync member


### PR DESCRIPTION
This review is associated with the swagger changes at https://github.com/Azure/azure-rest-api-specs/pull/9454

SyncGroupCRUD and SyncMemberCRUD tests are passing with this change, Different values of the new parameters were tested manually (automated tests would not work as those parameters need manual setup to function correctly).