### PR TITLE
Update ASAL managed identity API version to 2020-05-01.

### DIFF
--- a/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/MsiAccessTokenProvider.cs
+++ b/sdk/mgmtcommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/MsiAccessTokenProvider.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
 
                 // Craft request as per the MSI protocol
                 var requestUrl = isAppServicesMsiAvailable
-                    ? $"{msiEndpoint}?resource={resource}{clientIdParameter}&api-version=2017-09-01"
+                    ? $"{msiEndpoint}?resource={resource}{clientIdParameter}&api-version=2020-05-01"
                     : $"{AzureVmImdsEndpoint}?resource={resource}{clientIdParameter}&api-version=2018-02-01";
 
                 Func<HttpRequestMessage> getRequestMessage = () =>


### PR DESCRIPTION
The ServiceFabric Managed Identity service no longer supports the API version in use here (2017-09-01). See their supported API versions [here](https://msazure.visualstudio.com/One/_git/WindowsFabric?path=%2Fsrc%2Fprod%2Fsrc%2Fmanaged%2FManagedIdentity%2FTokenService%2FConsts.cs&_a=contents&version=GBdevelop).

For our (internal) team, this has caused us to be unable to use the ASAL library with a ServiceFabric cluster. Upgrading the API version in this file and deploying the modified assembly resulted in successful authentication, and all tests appear to be passing.