### PR TITLE
Swagger changes for Iot Hub

### DIFF
--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/ConfigurationRestClient.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/ConfigurationRestClient.cs
@@ -58,8 +58,8 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Get a configuration on IoT Hub for automatic device/module management. </summary>
-        /// <param name="id"> The unique identifier of the configuration. </param>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<TwinConfiguration>> GetAsync(string id, CancellationToken cancellationToken = default)
         {
@@ -91,8 +91,8 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Get a configuration on IoT Hub for automatic device/module management. </summary>
-        /// <param name="id"> The unique identifier of the configuration. </param>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<TwinConfiguration> Get(string id, CancellationToken cancellationToken = default)
         {
@@ -146,10 +146,10 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Create or update a configuration on IoT Hub for automatic device/module management. Configuration Id and Content cannot be updated. </summary>
-        /// <param name="id"> The unique identifier of the configuration. </param>
-        /// <param name="configuration"> The configuration to be created or updated. </param>
-        /// <param name="ifMatch"> A string representing a weak ETag for configuration, as per RFC7232. Should not be set when creating a configuration, but may be set when updating a configuration. </param>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> The String to use. </param>
+        /// <param name="configuration"> The Configuration to use. </param>
+        /// <param name="ifMatch"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<TwinConfiguration>> CreateOrUpdateAsync(string id, TwinConfiguration configuration, string ifMatch = null, CancellationToken cancellationToken = default)
         {
@@ -186,10 +186,10 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Create or update a configuration on IoT Hub for automatic device/module management. Configuration Id and Content cannot be updated. </summary>
-        /// <param name="id"> The unique identifier of the configuration. </param>
-        /// <param name="configuration"> The configuration to be created or updated. </param>
-        /// <param name="ifMatch"> A string representing a weak ETag for configuration, as per RFC7232. Should not be set when creating a configuration, but may be set when updating a configuration. </param>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> The String to use. </param>
+        /// <param name="configuration"> The Configuration to use. </param>
+        /// <param name="ifMatch"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<TwinConfiguration> CreateOrUpdate(string id, TwinConfiguration configuration, string ifMatch = null, CancellationToken cancellationToken = default)
         {
@@ -244,9 +244,9 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Delete a configuration on IoT Hub for automatic device/module management. </summary>
-        /// <param name="id"> The unique identifier of the configuration. </param>
-        /// <param name="ifMatch"> A string representing a weak ETag for configuration, as per RFC7232. The delete operation is performed only if this ETag matches the value maintained by the server, indicating that the configuration has not been modified since it was last retrieved. To force an unconditional delete, set If-Match to the wildcard character (*). </param>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> The String to use. </param>
+        /// <param name="ifMatch"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> DeleteAsync(string id, string ifMatch = null, CancellationToken cancellationToken = default)
         {
@@ -266,9 +266,9 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Delete a configuration on IoT Hub for automatic device/module management. </summary>
-        /// <param name="id"> The unique identifier of the configuration. </param>
-        /// <param name="ifMatch"> A string representing a weak ETag for configuration, as per RFC7232. The delete operation is performed only if this ETag matches the value maintained by the server, indicating that the configuration has not been modified since it was last retrieved. To force an unconditional delete, set If-Match to the wildcard character (*). </param>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> The String to use. </param>
+        /// <param name="ifMatch"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response Delete(string id, string ifMatch = null, CancellationToken cancellationToken = default)
         {
@@ -305,8 +305,8 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Get multiple configurations on IoT Hub for automatic device/module management. </summary>
-        /// <param name="top"> Number of configurations to retrieve. TODO: Ask service team if this value can be overriden if too large. </param>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="top"> The Integer to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IReadOnlyList<TwinConfiguration>>> GetConfigurationsAsync(int? top = null, CancellationToken cancellationToken = default)
         {
@@ -345,8 +345,8 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Get multiple configurations on IoT Hub for automatic device/module management. </summary>
-        /// <param name="top"> Number of configurations to retrieve. TODO: Ask service team if this value can be overriden if too large. </param>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="top"> The Integer to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IReadOnlyList<TwinConfiguration>> GetConfigurations(int? top = null, CancellationToken cancellationToken = default)
         {
@@ -402,8 +402,8 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Validate the target condition and custom metric queries for a configuration on IoT Hub. </summary>
-        /// <param name="input"> Configuration query for target condition or custom metrics. </param>
+        /// <summary> Validates the target condition query and custom metric queries for a configuration. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="input"> The ConfigurationQueriesTestInput to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ConfigurationQueriesTestResponse>> TestQueriesAsync(ConfigurationQueriesTestInput input, CancellationToken cancellationToken = default)
         {
@@ -435,8 +435,8 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Validate the target condition and custom metric queries for a configuration on IoT Hub. </summary>
-        /// <param name="input"> Configuration query for target condition or custom metrics. </param>
+        /// <summary> Validates the target condition query and custom metric queries for a configuration. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="input"> The ConfigurationQueriesTestInput to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ConfigurationQueriesTestResponse> TestQueries(ConfigurationQueriesTestInput input, CancellationToken cancellationToken = default)
         {
@@ -487,8 +487,8 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Apply the provided configuration content to the specified edge device. </summary>
-        /// <param name="id"> The unique identifier of the device. </param>
+        /// <summary> Applies the provided configuration content to the specified edge device. Configuration content must have modules content For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
         /// <param name="content"> Configuration Content. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<object>> ApplyOnEdgeDeviceAsync(string id, ConfigurationContent content, CancellationToken cancellationToken = default)
@@ -527,8 +527,8 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Apply the provided configuration content to the specified edge device. </summary>
-        /// <param name="id"> The unique identifier of the device. </param>
+        /// <summary> Applies the provided configuration content to the specified edge device. Configuration content must have modules content For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
         /// <param name="content"> Configuration Content. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<object> ApplyOnEdgeDevice(string id, ConfigurationContent content, CancellationToken cancellationToken = default)

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/DeviceMethodRestClient.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/DeviceMethodRestClient.cs
@@ -63,8 +63,8 @@ namespace Azure.Iot.Hub.Service
         }
 
         /// <summary> Invoke a direct method on a device. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-direct-methods for more information. </summary>
-        /// <param name="deviceId"> The unique identifier of the device. </param>
-        /// <param name="directMethodRequest"> Parameters to execute a direct method on the device. </param>
+        /// <param name="deviceId"> The String to use. </param>
+        /// <param name="directMethodRequest"> The CloudToDeviceMethod to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<CloudToDeviceMethodResult>> InvokeDeviceMethodAsync(string deviceId, CloudToDeviceMethod directMethodRequest, CancellationToken cancellationToken = default)
         {
@@ -101,8 +101,8 @@ namespace Azure.Iot.Hub.Service
         }
 
         /// <summary> Invoke a direct method on a device. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-direct-methods for more information. </summary>
-        /// <param name="deviceId"> The unique identifier of the device. </param>
-        /// <param name="directMethodRequest"> Parameters to execute a direct method on the device. </param>
+        /// <param name="deviceId"> The String to use. </param>
+        /// <param name="directMethodRequest"> The CloudToDeviceMethod to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<CloudToDeviceMethodResult> InvokeDeviceMethod(string deviceId, CloudToDeviceMethod directMethodRequest, CancellationToken cancellationToken = default)
         {
@@ -160,9 +160,9 @@ namespace Azure.Iot.Hub.Service
         }
 
         /// <summary> Invoke a direct method on a module of a device. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-direct-methods for more information. </summary>
-        /// <param name="deviceId"> The unique identifier of the device. </param>
-        /// <param name="moduleId"> The unique identifier of the module. </param>
-        /// <param name="directMethodRequest"> Parameters to execute a direct method on the module. </param>
+        /// <param name="deviceId"> The String to use. </param>
+        /// <param name="moduleId"> The String to use. </param>
+        /// <param name="directMethodRequest"> The CloudToDeviceMethod to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<CloudToDeviceMethodResult>> InvokeModuleMethodAsync(string deviceId, string moduleId, CloudToDeviceMethod directMethodRequest, CancellationToken cancellationToken = default)
         {
@@ -203,9 +203,9 @@ namespace Azure.Iot.Hub.Service
         }
 
         /// <summary> Invoke a direct method on a module of a device. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-direct-methods for more information. </summary>
-        /// <param name="deviceId"> The unique identifier of the device. </param>
-        /// <param name="moduleId"> The unique identifier of the module. </param>
-        /// <param name="directMethodRequest"> Parameters to execute a direct method on the module. </param>
+        /// <param name="deviceId"> The String to use. </param>
+        /// <param name="moduleId"> The String to use. </param>
+        /// <param name="directMethodRequest"> The CloudToDeviceMethod to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<CloudToDeviceMethodResult> InvokeModuleMethod(string deviceId, string moduleId, CloudToDeviceMethod directMethodRequest, CancellationToken cancellationToken = default)
         {

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/DigitalTwinRestClient.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/DigitalTwinRestClient.cs
@@ -58,8 +58,8 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Get the list of interfaces. </summary>
-        /// <param name="digitalTwinId"> The unique identifier of the digital twin. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional. </param>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="digitalTwinId"> Digital Twin ID. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DigitalTwinInterfaces>> GetComponentsAsync(string digitalTwinId, CancellationToken cancellationToken = default)
         {
@@ -91,8 +91,8 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Get the list of interfaces. </summary>
-        /// <param name="digitalTwinId"> The unique identifier of the digital twin. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional. </param>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="digitalTwinId"> Digital Twin ID. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DigitalTwinInterfaces> GetComponents(string digitalTwinId, CancellationToken cancellationToken = default)
         {
@@ -147,10 +147,10 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Updates desired properties of multiple interfaces. </summary>
-        /// <param name="digitalTwinId"> The unique identifier of the digital twin. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional. </param>
-        /// <param name="interfacesPatchInfo"> The JSON representation of the update patch. </param>
-        /// <param name="ifMatch"> A string representing a weak ETag for digital twin, as per RFC7232. </param>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="digitalTwinId"> Digital Twin ID. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional. </param>
+        /// <param name="interfacesPatchInfo"> Multiple interfaces desired properties to update. </param>
+        /// <param name="ifMatch"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DigitalTwinInterfaces>> UpdateComponentAsync(string digitalTwinId, DigitalTwinInterfacesPatch interfacesPatchInfo, string ifMatch = null, CancellationToken cancellationToken = default)
         {
@@ -186,10 +186,10 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Updates desired properties of multiple interfaces. </summary>
-        /// <param name="digitalTwinId"> The unique identifier of the digital twin. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional. </param>
-        /// <param name="interfacesPatchInfo"> The JSON representation of the update patch. </param>
-        /// <param name="ifMatch"> A string representing a weak ETag for digital twin, as per RFC7232. </param>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="digitalTwinId"> Digital Twin ID. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional. </param>
+        /// <param name="interfacesPatchInfo"> Multiple interfaces desired properties to update. </param>
+        /// <param name="ifMatch"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DigitalTwinInterfaces> UpdateComponent(string digitalTwinId, DigitalTwinInterfacesPatch interfacesPatchInfo, string ifMatch = null, CancellationToken cancellationToken = default)
         {
@@ -241,8 +241,8 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Get the interface. </summary>
-        /// <param name="digitalTwinId"> The unique identifier of the digital twin. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional. </param>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="digitalTwinId"> Digital Twin ID. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional. </param>
         /// <param name="interfaceName"> The interface name. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DigitalTwinInterfaces>> GetComponentAsync(string digitalTwinId, string interfaceName, CancellationToken cancellationToken = default)
@@ -279,8 +279,8 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Get the interface. </summary>
-        /// <param name="digitalTwinId"> The unique identifier of the digital twin. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional. </param>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="digitalTwinId"> Digital Twin ID. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional. </param>
         /// <param name="interfaceName"> The interface name. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DigitalTwinInterfaces> GetComponent(string digitalTwinId, string interfaceName, CancellationToken cancellationToken = default)
@@ -335,13 +335,7 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary>
-        /// Returns a DigitalTwin model definition for the given id.
-        /// 
-        /// If &quot;expand&quot; is present in the query parameters and id is for a device capability model then it returns
-        /// 
-        /// the capability metamodel with expanded interface definitions.
-        /// </summary>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
         /// <param name="modelId"> Model id Ex: &lt;example&gt;urn:contoso:TemperatureSensor:1&lt;/example&gt;. </param>
         /// <param name="expand">
         /// Indicates whether to expand the device capability model&apos;s interface definitions inline or not.
@@ -382,13 +376,7 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary>
-        /// Returns a DigitalTwin model definition for the given id.
-        /// 
-        /// If &quot;expand&quot; is present in the query parameters and id is for a device capability model then it returns
-        /// 
-        /// the capability metamodel with expanded interface definitions.
-        /// </summary>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
         /// <param name="modelId"> Model id Ex: &lt;example&gt;urn:contoso:TemperatureSensor:1&lt;/example&gt;. </param>
         /// <param name="expand">
         /// Indicates whether to expand the device capability model&apos;s interface definitions inline or not.

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/FaultInjectionRestClient.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/FaultInjectionRestClient.cs
@@ -56,7 +56,7 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Get FaultInjection entity. </summary>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<FaultInjectionProperties>> GetAsync(CancellationToken cancellationToken = default)
         {
@@ -83,7 +83,7 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Get FaultInjection entity. </summary>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<FaultInjectionProperties> Get(CancellationToken cancellationToken = default)
         {
@@ -127,7 +127,7 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Create or update FaultInjection entity. </summary>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
         /// <param name="value"> The FaultInjectionProperties to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> SetAsync(FaultInjectionProperties value, CancellationToken cancellationToken = default)
@@ -148,7 +148,7 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Create or update FaultInjection entity. </summary>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
         /// <param name="value"> The FaultInjectionProperties to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response Set(FaultInjectionProperties value, CancellationToken cancellationToken = default)

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/HttpRuntimeRestClient.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/HttpRuntimeRestClient.cs
@@ -54,7 +54,7 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> This method is used to retrieve feedback for cloud-to-device messages. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information. This capability is only available in the standard tier IoT Hub. For more information, see [Choose the right IoT Hub tier](https://aka.ms/scaleyouriotsolution). </summary>
+        /// <summary> This method is used to retrieve feedback of a cloud-to-device message See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information. This capability is only available in the standard tier IoT Hub. For more information, see [Choose the right IoT Hub tier](https://aka.ms/scaleyouriotsolution). For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> ReceiveFeedbackNotificationAsync(CancellationToken cancellationToken = default)
         {
@@ -70,7 +70,7 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> This method is used to retrieve feedback for cloud-to-device messages. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information. This capability is only available in the standard tier IoT Hub. For more information, see [Choose the right IoT Hub tier](https://aka.ms/scaleyouriotsolution). </summary>
+        /// <summary> This method is used to retrieve feedback of a cloud-to-device message See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information. This capability is only available in the standard tier IoT Hub. For more information, see [Choose the right IoT Hub tier](https://aka.ms/scaleyouriotsolution). For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response ReceiveFeedbackNotification(CancellationToken cancellationToken = default)
         {
@@ -100,8 +100,8 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> This method completes a cloud-to-device feedback message. A completed message is deleted from the service&apos;s feedback queue. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information. </summary>
-        /// <param name="lockToken"> The lock token obtained when the C2D message was received, and provided to resolve race conditions when completing a feedback message. </param>
+        /// <summary> This method completes a feedback message. The lockToken obtained when the message was received must be provided to resolve race conditions when completing, a feedback message. A completed message is deleted from the feedback queue. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="lockToken"> Lock token. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> CompleteFeedbackNotificationAsync(string lockToken, CancellationToken cancellationToken = default)
         {
@@ -121,8 +121,8 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> This method completes a cloud-to-device feedback message. A completed message is deleted from the service&apos;s feedback queue. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information. </summary>
-        /// <param name="lockToken"> The lock token obtained when the C2D message was received, and provided to resolve race conditions when completing a feedback message. </param>
+        /// <summary> This method completes a feedback message. The lockToken obtained when the message was received must be provided to resolve race conditions when completing, a feedback message. A completed message is deleted from the feedback queue. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="lockToken"> Lock token. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response CompleteFeedbackNotification(string lockToken, CancellationToken cancellationToken = default)
         {
@@ -157,8 +157,8 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> This method abandons a cloud-to-device feedback message. An abandoned message is deleted from the service&apos;s feedback queue. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information. </summary>
-        /// <param name="lockToken"> The lock token obtained when the C2D message was received, and provided to resolve race conditions when abandoning a feedback message. </param>
+        /// <summary> This method abandons a feedback message. The lockToken obtained when the message was received must be provided to resolve race conditions when abandoning, a feedback message. A abandoned message is deleted from the feedback queue. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="lockToken"> Lock Token. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> AbandonFeedbackNotificationAsync(string lockToken, CancellationToken cancellationToken = default)
         {
@@ -178,8 +178,8 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> This method abandons a cloud-to-device feedback message. An abandoned message is deleted from the service&apos;s feedback queue. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information. </summary>
-        /// <param name="lockToken"> The lock token obtained when the C2D message was received, and provided to resolve race conditions when abandoning a feedback message. </param>
+        /// <summary> This method abandons a feedback message. The lockToken obtained when the message was received must be provided to resolve race conditions when abandoning, a feedback message. A abandoned message is deleted from the feedback queue. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="lockToken"> Lock Token. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response AbandonFeedbackNotification(string lockToken, CancellationToken cancellationToken = default)
         {

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/JobRestClient.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/JobRestClient.cs
@@ -61,7 +61,7 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Create a new import or export job on IoT Hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. </summary>
+        /// <summary> Create a new import/export job on an IoT hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
         /// <param name="jobProperties"> Specifies the job specification. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<JobProperties>> CreateImportExportJobAsync(JobProperties jobProperties, CancellationToken cancellationToken = default)
@@ -94,7 +94,7 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Create a new import or export job on IoT Hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. </summary>
+        /// <summary> Create a new import/export job on an IoT hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
         /// <param name="jobProperties"> Specifies the job specification. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<JobProperties> CreateImportExportJob(JobProperties jobProperties, CancellationToken cancellationToken = default)
@@ -140,7 +140,7 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Get the status of all import and export jobs in IoT Hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. </summary>
+        /// <summary> Gets the status of all import/export jobs in an iot hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IReadOnlyList<JobProperties>>> GetImportExportJobsAsync(CancellationToken cancellationToken = default)
         {
@@ -179,7 +179,7 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Get the status of all import and export jobs in IoT Hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. </summary>
+        /// <summary> Gets the status of all import/export jobs in an iot hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IReadOnlyList<JobProperties>> GetImportExportJobs(CancellationToken cancellationToken = default)
         {
@@ -232,8 +232,8 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Get the status of an import or export job in IoT Hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. </summary>
-        /// <param name="id"> The unique identifier of the job. </param>
+        /// <summary> Gets the status of an import or export job in an iot hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Job ID. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<JobProperties>> GetImportExportJobAsync(string id, CancellationToken cancellationToken = default)
         {
@@ -265,8 +265,8 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Get the status of an import or export job in IoT Hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. </summary>
-        /// <param name="id"> The unique identifier of the job. </param>
+        /// <summary> Gets the status of an import or export job in an iot hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Job ID. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<JobProperties> GetImportExportJob(string id, CancellationToken cancellationToken = default)
         {
@@ -312,8 +312,8 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Cancels an import or export job in IoT Hub. </summary>
-        /// <param name="id"> The unique identifier of the job. </param>
+        /// <summary> Cancels an import or export job in an IoT hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Job ID. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<object>> CancelImportExportJobAsync(string id, CancellationToken cancellationToken = default)
         {
@@ -347,8 +347,8 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Cancels an import or export job in IoT Hub. </summary>
-        /// <param name="id"> The unique identifier of the job. </param>
+        /// <summary> Cancels an import or export job in an IoT hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Job ID. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<object> CancelImportExportJob(string id, CancellationToken cancellationToken = default)
         {
@@ -396,8 +396,8 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Retrieves details of a scheduled job from IoT hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information. </summary>
-        /// <param name="id"> The unique identifier of the job. </param>
+        /// <summary> Retrieves details of a scheduled job from an IoT hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Job ID. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<JobResponse>> GetJobAsync(string id, CancellationToken cancellationToken = default)
         {
@@ -429,8 +429,8 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Retrieves details of a scheduled job from IoT hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information. </summary>
-        /// <param name="id"> The unique identifier of the job. </param>
+        /// <summary> Retrieves details of a scheduled job from an IoT hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Job ID. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<JobResponse> GetJob(string id, CancellationToken cancellationToken = default)
         {
@@ -480,9 +480,9 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Creates a new job to schedule twin updates or direct methods on IoT Hub at a scheduled time. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information. </summary>
-        /// <param name="id"> The unique identifier of the job. </param>
-        /// <param name="jobRequest"> The job to be created. </param>
+        /// <summary> Creates a new job to schedule update twins or device direct methods on an IoT hub at a scheduled time. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Job ID. </param>
+        /// <param name="jobRequest"> The JobRequest to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<JobResponse>> CreateJobAsync(string id, JobRequest jobRequest, CancellationToken cancellationToken = default)
         {
@@ -518,9 +518,9 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Creates a new job to schedule twin updates or direct methods on IoT Hub at a scheduled time. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information. </summary>
-        /// <param name="id"> The unique identifier of the job. </param>
-        /// <param name="jobRequest"> The job to be created. </param>
+        /// <summary> Creates a new job to schedule update twins or device direct methods on an IoT hub at a scheduled time. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Job ID. </param>
+        /// <param name="jobRequest"> The JobRequest to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<JobResponse> CreateJob(string id, JobRequest jobRequest, CancellationToken cancellationToken = default)
         {
@@ -571,8 +571,8 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Cancels a scheduled job on IoT Hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information. </summary>
-        /// <param name="id"> The unique identifier of the job. </param>
+        /// <summary> Cancels a scheduled job on an IoT hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Job ID. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<JobResponse>> CancelJobAsync(string id, CancellationToken cancellationToken = default)
         {
@@ -604,8 +604,8 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Cancels a scheduled job on IoT Hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information. </summary>
-        /// <param name="id"> The unique identifier of the job. </param>
+        /// <summary> Cancels a scheduled job on an IoT hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Job ID. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<JobResponse> CancelJob(string id, CancellationToken cancellationToken = default)
         {
@@ -658,9 +658,9 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Query IoT hub to retrieve information regarding jobs using the IoT Hub query language. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language for more information. </summary>
-        /// <param name="jobType"> The job type. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs#querying-for-progress-on-jobs for a list of possible job types. </param>
-        /// <param name="jobStatus"> The job status. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs#querying-for-progress-on-jobs for a list of possible statuses. </param>
+        /// <summary> Query an IoT hub to retrieve information regarding jobs using the IoT Hub query language. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language for more information. Pagination of results is supported. This returns information about jobs only. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="jobType"> Job Type. </param>
+        /// <param name="jobStatus"> Job Status. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<QueryResult>> QueryJobsAsync(string jobType = null, string jobStatus = null, CancellationToken cancellationToken = default)
         {
@@ -687,9 +687,9 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Query IoT hub to retrieve information regarding jobs using the IoT Hub query language. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language for more information. </summary>
-        /// <param name="jobType"> The job type. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs#querying-for-progress-on-jobs for a list of possible job types. </param>
-        /// <param name="jobStatus"> The job status. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs#querying-for-progress-on-jobs for a list of possible statuses. </param>
+        /// <summary> Query an IoT hub to retrieve information regarding jobs using the IoT Hub query language. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language for more information. Pagination of results is supported. This returns information about jobs only. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="jobType"> Job Type. </param>
+        /// <param name="jobStatus"> Job Status. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<QueryResult> QueryJobs(string jobType = null, string jobStatus = null, CancellationToken cancellationToken = default)
         {

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/AuthenticationMechanism.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/AuthenticationMechanism.cs
@@ -16,9 +16,9 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of AuthenticationMechanism. </summary>
-        /// <param name="symmetricKey"> The primary and secondary keys used for SAS based authentication. </param>
-        /// <param name="x509Thumbprint"> The primary and secondary x509 thumbprints used for x509 based authentication. </param>
-        /// <param name="type"> The type of authentication used when connecting to the service. </param>
+        /// <param name="symmetricKey"> . </param>
+        /// <param name="x509Thumbprint"> . </param>
+        /// <param name="type"> . </param>
         internal AuthenticationMechanism(SymmetricKey symmetricKey, X509Thumbprint x509Thumbprint, AuthenticationMechanismType? type)
         {
             SymmetricKey = symmetricKey;
@@ -26,11 +26,8 @@ namespace Azure.Iot.Hub.Service.Models
             Type = type;
         }
 
-        /// <summary> The primary and secondary keys used for SAS based authentication. </summary>
         public SymmetricKey SymmetricKey { get; set; }
-        /// <summary> The primary and secondary x509 thumbprints used for x509 based authentication. </summary>
         public X509Thumbprint X509Thumbprint { get; set; }
-        /// <summary> The type of authentication used when connecting to the service. </summary>
         public AuthenticationMechanismType? Type { get; set; }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/AuthenticationMechanismType.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/AuthenticationMechanismType.cs
@@ -10,7 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.Iot.Hub.Service.Models
 {
-    /// <summary> The type of authentication used when connecting to the service. </summary>
+    /// <summary> The AuthenticationMechanismType. </summary>
     public readonly partial struct AuthenticationMechanismType : IEquatable<AuthenticationMechanismType>
     {
         private readonly string _value;

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/CloudToDeviceMethod.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/CloudToDeviceMethod.cs
@@ -16,10 +16,10 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of CloudToDeviceMethod. </summary>
-        /// <param name="methodName"> Name of the method to be executed. </param>
-        /// <param name="payload"> The JSON-formatted direct method payload, up to 128kb in size. </param>
-        /// <param name="responseTimeoutInSeconds"> Time (in seconds) that the service waits for the method invocation to return a response. It defaults to 30 seconds. Minimum allowed value is 5 seconds, maximum allowed value is 300 seconds. </param>
-        /// <param name="connectTimeoutInSeconds"> Time (in seconds) that the service waits for the device to come online. It defaults to 0, meaning the device must already be online. Maximum allowed value is 300 seconds. </param>
+        /// <param name="methodName"> Method to run. </param>
+        /// <param name="payload"> Payload. </param>
+        /// <param name="responseTimeoutInSeconds"> . </param>
+        /// <param name="connectTimeoutInSeconds"> . </param>
         internal CloudToDeviceMethod(string methodName, object payload, int? responseTimeoutInSeconds, int? connectTimeoutInSeconds)
         {
             MethodName = methodName;
@@ -28,13 +28,11 @@ namespace Azure.Iot.Hub.Service.Models
             ConnectTimeoutInSeconds = connectTimeoutInSeconds;
         }
 
-        /// <summary> Name of the method to be executed. </summary>
+        /// <summary> Method to run. </summary>
         public string MethodName { get; set; }
-        /// <summary> The JSON-formatted direct method payload, up to 128kb in size. </summary>
+        /// <summary> Payload. </summary>
         public object Payload { get; set; }
-        /// <summary> Time (in seconds) that the service waits for the method invocation to return a response. It defaults to 30 seconds. Minimum allowed value is 5 seconds, maximum allowed value is 300 seconds. </summary>
         public int? ResponseTimeoutInSeconds { get; set; }
-        /// <summary> Time (in seconds) that the service waits for the device to come online. It defaults to 0, meaning the device must already be online. Maximum allowed value is 300 seconds. </summary>
         public int? ConnectTimeoutInSeconds { get; set; }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/CloudToDeviceMethodResult.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/CloudToDeviceMethodResult.cs
@@ -16,17 +16,17 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of CloudToDeviceMethodResult. </summary>
-        /// <param name="status"> Method invocation result status, provided by the device. </param>
-        /// <param name="payload"> The JSON-formatted direct method result payload, up to 128kb in size; provided by the device. </param>
+        /// <param name="status"> Method invocation result status. </param>
+        /// <param name="payload"> Method invocation result payload. </param>
         internal CloudToDeviceMethodResult(int? status, object payload)
         {
             Status = status;
             Payload = payload;
         }
 
-        /// <summary> Method invocation result status, provided by the device. </summary>
+        /// <summary> Method invocation result status. </summary>
         public int? Status { get; }
-        /// <summary> The JSON-formatted direct method result payload, up to 128kb in size; provided by the device. </summary>
+        /// <summary> Method invocation result payload. </summary>
         public object Payload { get; }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/Components17Cpi2FSchemasDigitaltwininterfacespatchPropertiesInterfacesAdditionalpropertiesPropertiesAdditionalproperties.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/Components17Cpi2FSchemasDigitaltwininterfacespatchPropertiesInterfacesAdditionalpropertiesPropertiesAdditionalproperties.cs
@@ -16,13 +16,12 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of Components17Cpi2FSchemasDigitaltwininterfacespatchPropertiesInterfacesAdditionalpropertiesPropertiesAdditionalproperties. </summary>
-        /// <param name="desired"> The desired property of the interface. </param>
+        /// <param name="desired"> . </param>
         internal Components17Cpi2FSchemasDigitaltwininterfacespatchPropertiesInterfacesAdditionalpropertiesPropertiesAdditionalproperties(DigitalTwinInterfacesPatchInterfacesPropertiesAdditionalPropertiesDesired desired)
         {
             Desired = desired;
         }
 
-        /// <summary> The desired property of the interface. </summary>
         public DigitalTwinInterfacesPatchInterfacesPropertiesAdditionalPropertiesDesired Desired { get; set; }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/ConfigurationContent.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/ConfigurationContent.cs
@@ -18,9 +18,9 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of ConfigurationContent. </summary>
-        /// <param name="deviceContent"> Device Configurations. </param>
-        /// <param name="modulesContent"> Modules configuration content. </param>
-        /// <param name="moduleContent"> Module configuration content. </param>
+        /// <param name="deviceContent"> Gets or sets device Configurations. </param>
+        /// <param name="modulesContent"> Gets or sets Modules Configurations. </param>
+        /// <param name="moduleContent"> Gets or sets Module Configurations. </param>
         internal ConfigurationContent(IDictionary<string, object> deviceContent, IDictionary<string, object> modulesContent, IDictionary<string, object> moduleContent)
         {
             DeviceContent = deviceContent;
@@ -28,11 +28,11 @@ namespace Azure.Iot.Hub.Service.Models
             ModuleContent = moduleContent;
         }
 
-        /// <summary> Device Configurations. </summary>
+        /// <summary> Gets or sets device Configurations. </summary>
         public IDictionary<string, object> DeviceContent { get; set; }
-        /// <summary> Modules configuration content. </summary>
+        /// <summary> Gets or sets Modules Configurations. </summary>
         public IDictionary<string, object> ModulesContent { get; set; }
-        /// <summary> Module configuration content. </summary>
+        /// <summary> Gets or sets Module Configurations. </summary>
         public IDictionary<string, object> ModuleContent { get; set; }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/ConfigurationMetrics.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/ConfigurationMetrics.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 
 namespace Azure.Iot.Hub.Service.Models
 {
-    /// <summary> Configuration Metrics for IotHub devices and modules. </summary>
+    /// <summary> Configuration Metrics. </summary>
     public partial class ConfigurationMetrics
     {
         /// <summary> Initializes a new instance of ConfigurationMetrics. </summary>
@@ -18,17 +18,17 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of ConfigurationMetrics. </summary>
-        /// <param name="results"> TODO: Service to fill in. </param>
-        /// <param name="queries"> TODO: Service to fill in. </param>
+        /// <param name="results"> Dictionary of &lt;integer&gt;. </param>
+        /// <param name="queries"> Dictionary of &lt;string&gt;. </param>
         internal ConfigurationMetrics(IDictionary<string, long> results, IDictionary<string, string> queries)
         {
             Results = results;
             Queries = queries;
         }
 
-        /// <summary> TODO: Service to fill in. </summary>
+        /// <summary> Dictionary of &lt;integer&gt;. </summary>
         public IDictionary<string, long> Results { get; set; }
-        /// <summary> TODO: Service to fill in. </summary>
+        /// <summary> Dictionary of &lt;string&gt;. </summary>
         public IDictionary<string, string> Queries { get; set; }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/ConfigurationQueriesTestInput.Serialization.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/ConfigurationQueriesTestInput.Serialization.cs
@@ -23,7 +23,13 @@ namespace Azure.Iot.Hub.Service.Models
             if (CustomMetricQueries != null)
             {
                 writer.WritePropertyName("customMetricQueries");
-                writer.WriteStringValue(CustomMetricQueries);
+                writer.WriteStartObject();
+                foreach (var item in CustomMetricQueries)
+                {
+                    writer.WritePropertyName(item.Key);
+                    writer.WriteStringValue(item.Value);
+                }
+                writer.WriteEndObject();
             }
             writer.WriteEndObject();
         }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/ConfigurationQueriesTestInput.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/ConfigurationQueriesTestInput.cs
@@ -5,6 +5,8 @@
 
 #nullable disable
 
+using System.Collections.Generic;
+
 namespace Azure.Iot.Hub.Service.Models
 {
     /// <summary> The ConfigurationQueriesTestInput. </summary>
@@ -16,17 +18,16 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of ConfigurationQueriesTestInput. </summary>
-        /// <param name="targetCondition"> The query used to define targeted devices or modules. The query is based on twin tags and/or reported properties. </param>
-        /// <param name="customMetricQueries"> Queries on twin reported properties. </param>
-        internal ConfigurationQueriesTestInput(string targetCondition, string customMetricQueries)
+        /// <param name="targetCondition"> . </param>
+        /// <param name="customMetricQueries"> Dictionary of &lt;string&gt;. </param>
+        internal ConfigurationQueriesTestInput(string targetCondition, IDictionary<string, string> customMetricQueries)
         {
             TargetCondition = targetCondition;
             CustomMetricQueries = customMetricQueries;
         }
 
-        /// <summary> The query used to define targeted devices or modules. The query is based on twin tags and/or reported properties. </summary>
         public string TargetCondition { get; set; }
-        /// <summary> Queries on twin reported properties. </summary>
-        public string CustomMetricQueries { get; set; }
+        /// <summary> Dictionary of &lt;string&gt;. </summary>
+        public IDictionary<string, string> CustomMetricQueries { get; set; }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/ConfigurationQueriesTestResponse.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/ConfigurationQueriesTestResponse.cs
@@ -18,7 +18,7 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of ConfigurationQueriesTestResponse. </summary>
-        /// <param name="targetConditionError"> Errors running the target condition query. </param>
+        /// <param name="targetConditionError"> . </param>
         /// <param name="customMetricQueryErrors"> Dictionary of &lt;string&gt;. </param>
         internal ConfigurationQueriesTestResponse(string targetConditionError, IReadOnlyDictionary<string, string> customMetricQueryErrors)
         {
@@ -26,7 +26,6 @@ namespace Azure.Iot.Hub.Service.Models
             CustomMetricQueryErrors = customMetricQueryErrors;
         }
 
-        /// <summary> Errors running the target condition query. </summary>
         public string TargetConditionError { get; }
         /// <summary> Dictionary of &lt;string&gt;. </summary>
         public IReadOnlyDictionary<string, string> CustomMetricQueryErrors { get; }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/DeviceCapabilities.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/DeviceCapabilities.cs
@@ -16,13 +16,12 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of DeviceCapabilities. </summary>
-        /// <param name="iotEdge"> Whether or not this device is an edge device. </param>
+        /// <param name="iotEdge"> . </param>
         internal DeviceCapabilities(bool? iotEdge)
         {
             IotEdge = iotEdge;
         }
 
-        /// <summary> Whether or not this device is an edge device. </summary>
         public bool? IotEdge { get; set; }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/DeviceConnectionState.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/DeviceConnectionState.cs
@@ -10,7 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.Iot.Hub.Service.Models
 {
-    /// <summary> Tells whether the device is connected or not. </summary>
+    /// <summary> The DeviceConnectionState. </summary>
     public readonly partial struct DeviceConnectionState : IEquatable<DeviceConnectionState>
     {
         private readonly string _value;

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/DeviceIdentity.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/DeviceIdentity.cs
@@ -19,20 +19,20 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of DeviceIdentity. </summary>
-        /// <param name="deviceId"> The unique identifier of this device. </param>
-        /// <param name="generationId"> An IoT hub-generated, case-sensitive string up to 128 characters long. This value is used to distinguish devices with the same deviceId, when they have been deleted and re-created. </param>
-        /// <param name="etag"> A string representing a weak ETag for the device identity, as per RFC7232. </param>
-        /// <param name="connectionState"> Tells whether the device is connected or not. </param>
-        /// <param name="status"> Flags whether a device is enabled or not. If disabled, a device cannot connect to the service. </param>
-        /// <param name="statusReason"> A 128 character-long string that stores the reason for the device identity status. All UTF-8 characters are allowed. </param>
-        /// <param name="connectionStateUpdatedTime"> A temporal indicator, showing the date and last time the connection state was updated. </param>
-        /// <param name="statusUpdatedTime"> The last timestamp of when the status field was updated. </param>
-        /// <param name="lastActivityTime"> A temporal indicator, showing the date and last time the device connected, received, or sent a message. </param>
-        /// <param name="cloudToDeviceMessageCount"> The number of cloud to device messages currently queued to be sent to the device. </param>
-        /// <param name="authentication"> The details on what authentication mechanisms are used by this device. </param>
-        /// <param name="capabilities"> The set of capabilities that this device has. For example, if this device is an edge device or not. </param>
-        /// <param name="deviceScope"> The scope that this device belongs to. </param>
-        /// <param name="parentScopes"> TODO: service team needs to explain this. </param>
+        /// <param name="deviceId"> . </param>
+        /// <param name="generationId"> . </param>
+        /// <param name="etag"> . </param>
+        /// <param name="connectionState"> . </param>
+        /// <param name="status"> . </param>
+        /// <param name="statusReason"> . </param>
+        /// <param name="connectionStateUpdatedTime"> . </param>
+        /// <param name="statusUpdatedTime"> . </param>
+        /// <param name="lastActivityTime"> . </param>
+        /// <param name="cloudToDeviceMessageCount"> . </param>
+        /// <param name="authentication"> . </param>
+        /// <param name="capabilities"> Status of Capabilities enabled on the device. </param>
+        /// <param name="deviceScope"> . </param>
+        /// <param name="parentScopes"> . </param>
         internal DeviceIdentity(string deviceId, string generationId, string etag, DeviceConnectionState? connectionState, DeviceStatus? status, string statusReason, DateTimeOffset? connectionStateUpdatedTime, DateTimeOffset? statusUpdatedTime, DateTimeOffset? lastActivityTime, int? cloudToDeviceMessageCount, AuthenticationMechanism authentication, DeviceCapabilities capabilities, string deviceScope, IList<string> parentScopes)
         {
             DeviceId = deviceId;
@@ -51,33 +51,20 @@ namespace Azure.Iot.Hub.Service.Models
             ParentScopes = parentScopes;
         }
 
-        /// <summary> The unique identifier of this device. </summary>
         public string DeviceId { get; set; }
-        /// <summary> An IoT hub-generated, case-sensitive string up to 128 characters long. This value is used to distinguish devices with the same deviceId, when they have been deleted and re-created. </summary>
         public string GenerationId { get; set; }
-        /// <summary> A string representing a weak ETag for the device identity, as per RFC7232. </summary>
         public string Etag { get; set; }
-        /// <summary> Tells whether the device is connected or not. </summary>
         public DeviceConnectionState? ConnectionState { get; set; }
-        /// <summary> Flags whether a device is enabled or not. If disabled, a device cannot connect to the service. </summary>
         public DeviceStatus? Status { get; set; }
-        /// <summary> A 128 character-long string that stores the reason for the device identity status. All UTF-8 characters are allowed. </summary>
         public string StatusReason { get; set; }
-        /// <summary> A temporal indicator, showing the date and last time the connection state was updated. </summary>
         public DateTimeOffset? ConnectionStateUpdatedTime { get; set; }
-        /// <summary> The last timestamp of when the status field was updated. </summary>
         public DateTimeOffset? StatusUpdatedTime { get; set; }
-        /// <summary> A temporal indicator, showing the date and last time the device connected, received, or sent a message. </summary>
         public DateTimeOffset? LastActivityTime { get; set; }
-        /// <summary> The number of cloud to device messages currently queued to be sent to the device. </summary>
         public int? CloudToDeviceMessageCount { get; set; }
-        /// <summary> The details on what authentication mechanisms are used by this device. </summary>
         public AuthenticationMechanism Authentication { get; set; }
-        /// <summary> The set of capabilities that this device has. For example, if this device is an edge device or not. </summary>
+        /// <summary> Status of Capabilities enabled on the device. </summary>
         public DeviceCapabilities Capabilities { get; set; }
-        /// <summary> The scope that this device belongs to. </summary>
         public string DeviceScope { get; set; }
-        /// <summary> TODO: service team needs to explain this. </summary>
         public IList<string> ParentScopes { get; set; }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/DeviceRegistryOperationError.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/DeviceRegistryOperationError.cs
@@ -16,11 +16,11 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of DeviceRegistryOperationError. </summary>
-        /// <param name="deviceId"> Identifier of the device that indicated the error. </param>
+        /// <param name="deviceId"> The ID of the device that indicated the error. </param>
         /// <param name="errorCode"> ErrorCode associated with the error. </param>
         /// <param name="errorStatus"> Additional details associated with the error. </param>
-        /// <param name="moduleId"> Identifier of the module associated with the error, if applicable. </param>
-        /// <param name="operation"> The type of the operation that failed. </param>
+        /// <param name="moduleId"> . </param>
+        /// <param name="operation"> . </param>
         internal DeviceRegistryOperationError(string deviceId, DeviceRegistryOperationErrorCode? errorCode, string errorStatus, string moduleId, string operation)
         {
             DeviceId = deviceId;
@@ -30,15 +30,13 @@ namespace Azure.Iot.Hub.Service.Models
             Operation = operation;
         }
 
-        /// <summary> Identifier of the device that indicated the error. </summary>
+        /// <summary> The ID of the device that indicated the error. </summary>
         public string DeviceId { get; }
         /// <summary> ErrorCode associated with the error. </summary>
         public DeviceRegistryOperationErrorCode? ErrorCode { get; }
         /// <summary> Additional details associated with the error. </summary>
         public string ErrorStatus { get; }
-        /// <summary> Identifier of the module associated with the error, if applicable. </summary>
         public string ModuleId { get; }
-        /// <summary> The type of the operation that failed. </summary>
         public string Operation { get; }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/DeviceRegistryOperationWarning.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/DeviceRegistryOperationWarning.cs
@@ -17,8 +17,8 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of DeviceRegistryOperationWarning. </summary>
-        /// <param name="deviceId"> Identifier of the device that indicated the warning. </param>
-        /// <param name="warningCode"> The code associated with the warning. </param>
+        /// <param name="deviceId"> The ID of the device that indicated the warning. </param>
+        /// <param name="warningCode"> . </param>
         /// <param name="warningStatus"> Additional details associated with the warning. </param>
         internal DeviceRegistryOperationWarning(string deviceId, string warningCode, string warningStatus)
         {
@@ -27,9 +27,8 @@ namespace Azure.Iot.Hub.Service.Models
             WarningStatus = warningStatus;
         }
 
-        /// <summary> Identifier of the device that indicated the warning. </summary>
+        /// <summary> The ID of the device that indicated the warning. </summary>
         public string DeviceId { get; }
-        /// <summary> The code associated with the warning. </summary>
         public string WarningCode { get; }
         /// <summary> Additional details associated with the warning. </summary>
         public string WarningStatus { get; }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/DeviceStatus.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/DeviceStatus.cs
@@ -10,7 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.Iot.Hub.Service.Models
 {
-    /// <summary> Flags whether a device is enabled or not. If disabled, a device cannot connect to the service. </summary>
+    /// <summary> The DeviceStatus. </summary>
     public readonly partial struct DeviceStatus : IEquatable<DeviceStatus>
     {
         private readonly string _value;

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/DigitalTwinInterfacesPatchInterfacesPropertiesAdditionalPropertiesDesired.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/DigitalTwinInterfacesPatchInterfacesPropertiesAdditionalPropertiesDesired.cs
@@ -7,7 +7,7 @@
 
 namespace Azure.Iot.Hub.Service.Models
 {
-    /// <summary> The desired property of the interface. </summary>
+    /// <summary> The DigitalTwinInterfacesPatchInterfacesPropertiesAdditionalPropertiesDesired. </summary>
     public partial class DigitalTwinInterfacesPatchInterfacesPropertiesAdditionalPropertiesDesired
     {
         /// <summary> Initializes a new instance of DigitalTwinInterfacesPatchInterfacesPropertiesAdditionalPropertiesDesired. </summary>

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/ExportImportDevice.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/ExportImportDevice.cs
@@ -18,19 +18,19 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of ExportImportDevice. </summary>
-        /// <param name="id"> Identifier of the device to perform this operation on. </param>
-        /// <param name="moduleId"> Identifier of the module to perform this operation on, if applicable. </param>
+        /// <param name="id"> Device Id is always required. </param>
+        /// <param name="moduleId"> ModuleId is applicable to modules only. </param>
         /// <param name="eTag"> ETag parameter is only used for pre-conditioning the update when importMode is updateIfMatchETag. </param>
-        /// <param name="importMode"> The type of registry operation and if ETag should be ignored or not. </param>
-        /// <param name="status"> Flags whether a module is enabled or not. If disabled, a module cannot connect to the service. </param>
-        /// <param name="statusReason"> A 128 character-long string that stores the reason for the device identity status. All UTF-8 characters are allowed. </param>
+        /// <param name="importMode"> . </param>
+        /// <param name="status"> Status is optional and defaults to enabled. </param>
+        /// <param name="statusReason"> . </param>
         /// <param name="authentication"> Authentication parameter is optional and defaults to SAS if not provided. In that case, we auto-generate primary/secondary access keys. </param>
         /// <param name="twinETag"> twinETag parameter is only used for pre-conditioning the update when importMode is updateTwinIfMatchETag. </param>
         /// <param name="tags"> Dictionary of &lt;any&gt;. </param>
-        /// <param name="properties"> TODO need service folks to explain this. </param>
-        /// <param name="capabilities"> Status of capabilities enabled on the device. </param>
-        /// <param name="deviceScope"> The scope that this identity belongs to. </param>
-        /// <param name="parentScopes"> TODO: service team needs to explain this. </param>
+        /// <param name="properties"> Properties are optional and defaults to empty object. </param>
+        /// <param name="capabilities"> Capabilities param is optional and defaults to no capability. </param>
+        /// <param name="deviceScope"> . </param>
+        /// <param name="parentScopes"> . </param>
         internal ExportImportDevice(string id, string moduleId, string eTag, ExportImportDeviceImportMode? importMode, ExportImportDeviceStatus? status, string statusReason, AuthenticationMechanism authentication, string twinETag, IDictionary<string, object> tags, PropertyContainer properties, DeviceCapabilities capabilities, string deviceScope, IList<string> parentScopes)
         {
             Id = id;
@@ -48,17 +48,15 @@ namespace Azure.Iot.Hub.Service.Models
             ParentScopes = parentScopes;
         }
 
-        /// <summary> Identifier of the device to perform this operation on. </summary>
+        /// <summary> Device Id is always required. </summary>
         public string Id { get; set; }
-        /// <summary> Identifier of the module to perform this operation on, if applicable. </summary>
+        /// <summary> ModuleId is applicable to modules only. </summary>
         public string ModuleId { get; set; }
         /// <summary> ETag parameter is only used for pre-conditioning the update when importMode is updateIfMatchETag. </summary>
         public string ETag { get; set; }
-        /// <summary> The type of registry operation and if ETag should be ignored or not. </summary>
         public ExportImportDeviceImportMode? ImportMode { get; set; }
-        /// <summary> Flags whether a module is enabled or not. If disabled, a module cannot connect to the service. </summary>
+        /// <summary> Status is optional and defaults to enabled. </summary>
         public ExportImportDeviceStatus? Status { get; set; }
-        /// <summary> A 128 character-long string that stores the reason for the device identity status. All UTF-8 characters are allowed. </summary>
         public string StatusReason { get; set; }
         /// <summary> Authentication parameter is optional and defaults to SAS if not provided. In that case, we auto-generate primary/secondary access keys. </summary>
         public AuthenticationMechanism Authentication { get; set; }
@@ -66,13 +64,11 @@ namespace Azure.Iot.Hub.Service.Models
         public string TwinETag { get; set; }
         /// <summary> Dictionary of &lt;any&gt;. </summary>
         public IDictionary<string, object> Tags { get; set; }
-        /// <summary> TODO need service folks to explain this. </summary>
+        /// <summary> Properties are optional and defaults to empty object. </summary>
         public PropertyContainer Properties { get; set; }
-        /// <summary> Status of capabilities enabled on the device. </summary>
+        /// <summary> Capabilities param is optional and defaults to no capability. </summary>
         public DeviceCapabilities Capabilities { get; set; }
-        /// <summary> The scope that this identity belongs to. </summary>
         public string DeviceScope { get; set; }
-        /// <summary> TODO: service team needs to explain this. </summary>
         public IList<string> ParentScopes { get; set; }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/ExportImportDeviceImportMode.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/ExportImportDeviceImportMode.cs
@@ -10,7 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.Iot.Hub.Service.Models
 {
-    /// <summary> The type of registry operation and if ETag should be ignored or not. </summary>
+    /// <summary> The ExportImportDeviceImportMode. </summary>
     public readonly partial struct ExportImportDeviceImportMode : IEquatable<ExportImportDeviceImportMode>
     {
         private readonly string _value;

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/ExportImportDeviceStatus.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/ExportImportDeviceStatus.cs
@@ -10,7 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.Iot.Hub.Service.Models
 {
-    /// <summary> Flags whether a module is enabled or not. If disabled, a module cannot connect to the service. </summary>
+    /// <summary> Status is optional and defaults to enabled. </summary>
     public readonly partial struct ExportImportDeviceStatus : IEquatable<ExportImportDeviceStatus>
     {
         private readonly string _value;

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/FaultInjectionConnectionProperties.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/FaultInjectionConnectionProperties.cs
@@ -16,17 +16,15 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of FaultInjectionConnectionProperties. </summary>
-        /// <param name="action"> Action to perform. </param>
-        /// <param name="blockDurationInMinutes"> TODO: to be filled by the service team. </param>
+        /// <param name="action"> . </param>
+        /// <param name="blockDurationInMinutes"> . </param>
         internal FaultInjectionConnectionProperties(FaultInjectionConnectionPropertiesAction? action, int? blockDurationInMinutes)
         {
             Action = action;
             BlockDurationInMinutes = blockDurationInMinutes;
         }
 
-        /// <summary> Action to perform. </summary>
         public FaultInjectionConnectionPropertiesAction? Action { get; set; }
-        /// <summary> TODO: to be filled by the service team. </summary>
         public int? BlockDurationInMinutes { get; set; }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/FaultInjectionConnectionPropertiesAction.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/FaultInjectionConnectionPropertiesAction.cs
@@ -10,7 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.Iot.Hub.Service.Models
 {
-    /// <summary> Action to perform. </summary>
+    /// <summary> The FaultInjectionConnectionPropertiesAction. </summary>
     public readonly partial struct FaultInjectionConnectionPropertiesAction : IEquatable<FaultInjectionConnectionPropertiesAction>
     {
         private readonly string _value;

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/FaultInjectionProperties.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/FaultInjectionProperties.cs
@@ -18,8 +18,8 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of FaultInjectionProperties. </summary>
-        /// <param name="iotHubName"> Name of the IotHub. </param>
-        /// <param name="connection"> TODO: to be filled by the service team. </param>
+        /// <param name="iotHubName"> . </param>
+        /// <param name="connection"> . </param>
         /// <param name="lastUpdatedTimeUtc"> Service generated. </param>
         internal FaultInjectionProperties(string iotHubName, FaultInjectionConnectionProperties connection, DateTimeOffset? lastUpdatedTimeUtc)
         {
@@ -28,9 +28,7 @@ namespace Azure.Iot.Hub.Service.Models
             LastUpdatedTimeUtc = lastUpdatedTimeUtc;
         }
 
-        /// <summary> Name of the IotHub. </summary>
         public string IotHubName { get; set; }
-        /// <summary> TODO: to be filled by the service team. </summary>
         public FaultInjectionConnectionProperties Connection { get; set; }
         /// <summary> Service generated. </summary>
         public DateTimeOffset? LastUpdatedTimeUtc { get; set; }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/JobProperties.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/JobProperties.cs
@@ -18,19 +18,43 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of JobProperties. </summary>
-        /// <param name="jobId"> The unique identifier of the job. </param>
-        /// <param name="startTimeUtc"> The start time of the job in UTC. </param>
-        /// <param name="endTimeUtc"> The time the job stopped. </param>
-        /// <param name="type"> The type of job to execute. </param>
-        /// <param name="status"> The status of the job. </param>
-        /// <param name="progress"> Represents the percentage of completion. </param>
+        /// <param name="jobId"> System generated.  Ignored at creation. </param>
+        /// <param name="startTimeUtc"> System generated.  Ignored at creation. </param>
+        /// <param name="endTimeUtc">
+        /// System generated.  Ignored at creation.
+        /// 
+        /// Represents the time the job stopped processing.
+        /// </param>
+        /// <param name="type">
+        /// Required.
+        /// 
+        /// The type of job to execute.
+        /// </param>
+        /// <param name="status"> System generated.  Ignored at creation. </param>
+        /// <param name="progress">
+        /// System generated.  Ignored at creation.
+        /// 
+        /// Represents the percentage of completion.
+        /// </param>
         /// <param name="inputBlobContainerUri"> URI containing SAS token to a blob container that contains registry data to sync. </param>
         /// <param name="inputBlobName"> The blob name to be used when importing from the provided input blob container. </param>
-        /// <param name="outputBlobContainerUri"> SAS token to access a blob container. This is used to output the status of the job and the results. </param>
-        /// <param name="outputBlobName"> The name of the blob that will be created in the provided output blob container. This blob will contain the exported device registry information for the IoT Hub. </param>
-        /// <param name="excludeKeysInExport"> Optional for export jobs; ignored for other jobs. If not specified, the service defaults to false. If false, authorization keys are included in export output. Keys are exported as null otherwise. </param>
+        /// <param name="outputBlobContainerUri"> URI containing SAS token to a blob container.  This is used to output the status of the job and the results. </param>
+        /// <param name="outputBlobName">
+        /// The name of the blob that will be created in the provided output blob container.  This blob will contain
+        /// 
+        /// the exported device registry information for the IoT Hub.
+        /// </param>
+        /// <param name="excludeKeysInExport">
+        /// Optional for export jobs; ignored for other jobs.  Default: false.  If false, authorization keys are included
+        /// 
+        /// in export output.  Keys are exported as null otherwise.
+        /// </param>
         /// <param name="storageAuthenticationType"> Specifies authentication type being used for connecting to storage account. </param>
-        /// <param name="failureReason"> Contains the reason for the failure, if a failure occurred. </param>
+        /// <param name="failureReason">
+        /// System genereated.  Ignored at creation.
+        /// 
+        /// If status == failure, this represents a string containing the reason.
+        /// </param>
         internal JobProperties(string jobId, DateTimeOffset? startTimeUtc, DateTimeOffset? endTimeUtc, JobPropertiesType? type, JobPropertiesStatus? status, int? progress, string inputBlobContainerUri, string inputBlobName, string outputBlobContainerUri, string outputBlobName, bool? excludeKeysInExport, JobPropertiesStorageAuthenticationType? storageAuthenticationType, string failureReason)
         {
             JobId = jobId;
@@ -48,31 +72,55 @@ namespace Azure.Iot.Hub.Service.Models
             FailureReason = failureReason;
         }
 
-        /// <summary> The unique identifier of the job. </summary>
+        /// <summary> System generated.  Ignored at creation. </summary>
         public string JobId { get; set; }
-        /// <summary> The start time of the job in UTC. </summary>
+        /// <summary> System generated.  Ignored at creation. </summary>
         public DateTimeOffset? StartTimeUtc { get; set; }
-        /// <summary> The time the job stopped. </summary>
+        /// <summary>
+        /// System generated.  Ignored at creation.
+        /// 
+        /// Represents the time the job stopped processing.
+        /// </summary>
         public DateTimeOffset? EndTimeUtc { get; set; }
-        /// <summary> The type of job to execute. </summary>
+        /// <summary>
+        /// Required.
+        /// 
+        /// The type of job to execute.
+        /// </summary>
         public JobPropertiesType? Type { get; set; }
-        /// <summary> The status of the job. </summary>
+        /// <summary> System generated.  Ignored at creation. </summary>
         public JobPropertiesStatus? Status { get; set; }
-        /// <summary> Represents the percentage of completion. </summary>
+        /// <summary>
+        /// System generated.  Ignored at creation.
+        /// 
+        /// Represents the percentage of completion.
+        /// </summary>
         public int? Progress { get; set; }
         /// <summary> URI containing SAS token to a blob container that contains registry data to sync. </summary>
         public string InputBlobContainerUri { get; set; }
         /// <summary> The blob name to be used when importing from the provided input blob container. </summary>
         public string InputBlobName { get; set; }
-        /// <summary> SAS token to access a blob container. This is used to output the status of the job and the results. </summary>
+        /// <summary> URI containing SAS token to a blob container.  This is used to output the status of the job and the results. </summary>
         public string OutputBlobContainerUri { get; set; }
-        /// <summary> The name of the blob that will be created in the provided output blob container. This blob will contain the exported device registry information for the IoT Hub. </summary>
+        /// <summary>
+        /// The name of the blob that will be created in the provided output blob container.  This blob will contain
+        /// 
+        /// the exported device registry information for the IoT Hub.
+        /// </summary>
         public string OutputBlobName { get; set; }
-        /// <summary> Optional for export jobs; ignored for other jobs. If not specified, the service defaults to false. If false, authorization keys are included in export output. Keys are exported as null otherwise. </summary>
+        /// <summary>
+        /// Optional for export jobs; ignored for other jobs.  Default: false.  If false, authorization keys are included
+        /// 
+        /// in export output.  Keys are exported as null otherwise.
+        /// </summary>
         public bool? ExcludeKeysInExport { get; set; }
         /// <summary> Specifies authentication type being used for connecting to storage account. </summary>
         public JobPropertiesStorageAuthenticationType? StorageAuthenticationType { get; set; }
-        /// <summary> Contains the reason for the failure, if a failure occurred. </summary>
+        /// <summary>
+        /// System genereated.  Ignored at creation.
+        /// 
+        /// If status == failure, this represents a string containing the reason.
+        /// </summary>
         public string FailureReason { get; set; }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/JobPropertiesStatus.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/JobPropertiesStatus.cs
@@ -10,7 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.Iot.Hub.Service.Models
 {
-    /// <summary> The status of the job. </summary>
+    /// <summary> System generated.  Ignored at creation. </summary>
     public readonly partial struct JobPropertiesStatus : IEquatable<JobPropertiesStatus>
     {
         private readonly string _value;

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/JobPropertiesType.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/JobPropertiesType.cs
@@ -10,7 +10,11 @@ using System.ComponentModel;
 
 namespace Azure.Iot.Hub.Service.Models
 {
-    /// <summary> The type of job to execute. </summary>
+    /// <summary>
+    /// Required.
+    /// 
+    /// The type of job to execute.
+    /// </summary>
     public readonly partial struct JobPropertiesType : IEquatable<JobPropertiesType>
     {
         private readonly string _value;

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/JobRequest.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/JobRequest.cs
@@ -19,10 +19,22 @@ namespace Azure.Iot.Hub.Service.Models
 
         /// <summary> Initializes a new instance of JobRequest. </summary>
         /// <param name="jobId"> Job identifier. </param>
-        /// <param name="type"> The type of job to execute. </param>
-        /// <param name="cloudToDeviceMethod"> Required if jobType is cloudToDeviceMethod. The method type and parameters. </param>
-        /// <param name="updateTwin"> The state information for a device or module. Implicitly created and deleted when the corresponding device/ module identity is created or deleted in IoT Hub. </param>
-        /// <param name="queryCondition"> Required if jobType is updateTwin or cloudToDeviceMethod. Condition for device query to get devices to execute the job on. </param>
+        /// <param name="type">
+        /// Required.
+        /// 
+        /// The type of job to execute.
+        /// </param>
+        /// <param name="cloudToDeviceMethod">
+        /// Required if jobType is cloudToDeviceMethod.
+        /// 
+        /// The method type and parameters.
+        /// </param>
+        /// <param name="updateTwin"> Twin Representation. </param>
+        /// <param name="queryCondition">
+        /// Required if jobType is updateTwin or cloudToDeviceMethod.
+        /// 
+        /// Condition for device query to get devices to execute the job on.
+        /// </param>
         /// <param name="startTime"> ISO 8601 date time to start the job. </param>
         /// <param name="maxExecutionTimeInSeconds"> Max execution time in secounds (ttl duration). </param>
         internal JobRequest(string jobId, JobRequestType? type, CloudToDeviceMethod cloudToDeviceMethod, TwinData updateTwin, string queryCondition, DateTimeOffset? startTime, long? maxExecutionTimeInSeconds)
@@ -38,13 +50,25 @@ namespace Azure.Iot.Hub.Service.Models
 
         /// <summary> Job identifier. </summary>
         public string JobId { get; set; }
-        /// <summary> The type of job to execute. </summary>
+        /// <summary>
+        /// Required.
+        /// 
+        /// The type of job to execute.
+        /// </summary>
         public JobRequestType? Type { get; set; }
-        /// <summary> Required if jobType is cloudToDeviceMethod. The method type and parameters. </summary>
+        /// <summary>
+        /// Required if jobType is cloudToDeviceMethod.
+        /// 
+        /// The method type and parameters.
+        /// </summary>
         public CloudToDeviceMethod CloudToDeviceMethod { get; set; }
-        /// <summary> The state information for a device or module. Implicitly created and deleted when the corresponding device/ module identity is created or deleted in IoT Hub. </summary>
+        /// <summary> Twin Representation. </summary>
         public TwinData UpdateTwin { get; set; }
-        /// <summary> Required if jobType is updateTwin or cloudToDeviceMethod. Condition for device query to get devices to execute the job on. </summary>
+        /// <summary>
+        /// Required if jobType is updateTwin or cloudToDeviceMethod.
+        /// 
+        /// Condition for device query to get devices to execute the job on.
+        /// </summary>
         public string QueryCondition { get; set; }
         /// <summary> ISO 8601 date time to start the job. </summary>
         public DateTimeOffset? StartTime { get; set; }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/JobRequestType.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/JobRequestType.cs
@@ -10,7 +10,11 @@ using System.ComponentModel;
 
 namespace Azure.Iot.Hub.Service.Models
 {
-    /// <summary> The type of job to execute. </summary>
+    /// <summary>
+    /// Required.
+    /// 
+    /// The type of job to execute.
+    /// </summary>
     public readonly partial struct JobRequestType : IEquatable<JobRequestType>
     {
         private readonly string _value;

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/JobResponse.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/JobResponse.cs
@@ -18,17 +18,33 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of JobResponse. </summary>
-        /// <param name="jobId"> The unique identifier of the job. </param>
+        /// <param name="jobId"> System generated.  Ignored at creation. </param>
         /// <param name="queryCondition"> Device query condition. </param>
-        /// <param name="createdTime"> The creation time of the job. </param>
+        /// <param name="createdTime"> System generated.  Ignored at creation. </param>
         /// <param name="startTime"> Scheduled job start time in UTC. </param>
-        /// <param name="endTime"> The time the job stopped. </param>
+        /// <param name="endTime">
+        /// System generated.  Ignored at creation.
+        /// 
+        /// Represents the time the job stopped processing.
+        /// </param>
         /// <param name="maxExecutionTimeInSeconds"> Max execution time in secounds (ttl duration). </param>
-        /// <param name="type"> The type of job to execute. </param>
-        /// <param name="cloudToDeviceMethod"> Required if jobType is cloudToDeviceMethod. The method type and parameters. </param>
-        /// <param name="updateTwin"> The state information for a device or module. Implicitly created and deleted when the corresponding device/ module identity is created or deleted in IoT Hub. </param>
-        /// <param name="status"> The status of the job. </param>
-        /// <param name="failureReason"> Contains the reason for the failure, if a failure occurred. </param>
+        /// <param name="type">
+        /// Required.
+        /// 
+        /// The type of job to execute.
+        /// </param>
+        /// <param name="cloudToDeviceMethod">
+        /// Required if jobType is cloudToDeviceMethod.
+        /// 
+        /// The method type and parameters.
+        /// </param>
+        /// <param name="updateTwin"> Twin Representation. </param>
+        /// <param name="status"> System generated.  Ignored at creation. </param>
+        /// <param name="failureReason">
+        /// System generated.  Ignored at creation.
+        /// 
+        /// If status == failure, this represents a string containing the reason.
+        /// </param>
         /// <param name="statusMessage"> Status message for the job. </param>
         /// <param name="deviceJobStatistics"> Job details. </param>
         internal JobResponse(string jobId, string queryCondition, DateTimeOffset? createdTime, DateTimeOffset? startTime, DateTimeOffset? endTime, long? maxExecutionTimeInSeconds, JobResponseType? type, CloudToDeviceMethod cloudToDeviceMethod, TwinData updateTwin, JobResponseStatus? status, string failureReason, string statusMessage, DeviceJobStatistics deviceJobStatistics)
@@ -48,27 +64,43 @@ namespace Azure.Iot.Hub.Service.Models
             DeviceJobStatistics = deviceJobStatistics;
         }
 
-        /// <summary> The unique identifier of the job. </summary>
+        /// <summary> System generated.  Ignored at creation. </summary>
         public string JobId { get; }
         /// <summary> Device query condition. </summary>
         public string QueryCondition { get; }
-        /// <summary> The creation time of the job. </summary>
+        /// <summary> System generated.  Ignored at creation. </summary>
         public DateTimeOffset? CreatedTime { get; }
         /// <summary> Scheduled job start time in UTC. </summary>
         public DateTimeOffset? StartTime { get; }
-        /// <summary> The time the job stopped. </summary>
+        /// <summary>
+        /// System generated.  Ignored at creation.
+        /// 
+        /// Represents the time the job stopped processing.
+        /// </summary>
         public DateTimeOffset? EndTime { get; }
         /// <summary> Max execution time in secounds (ttl duration). </summary>
         public long? MaxExecutionTimeInSeconds { get; }
-        /// <summary> The type of job to execute. </summary>
+        /// <summary>
+        /// Required.
+        /// 
+        /// The type of job to execute.
+        /// </summary>
         public JobResponseType? Type { get; }
-        /// <summary> Required if jobType is cloudToDeviceMethod. The method type and parameters. </summary>
+        /// <summary>
+        /// Required if jobType is cloudToDeviceMethod.
+        /// 
+        /// The method type and parameters.
+        /// </summary>
         public CloudToDeviceMethod CloudToDeviceMethod { get; }
-        /// <summary> The state information for a device or module. Implicitly created and deleted when the corresponding device/ module identity is created or deleted in IoT Hub. </summary>
+        /// <summary> Twin Representation. </summary>
         public TwinData UpdateTwin { get; }
-        /// <summary> The status of the job. </summary>
+        /// <summary> System generated.  Ignored at creation. </summary>
         public JobResponseStatus? Status { get; }
-        /// <summary> Contains the reason for the failure, if a failure occurred. </summary>
+        /// <summary>
+        /// System generated.  Ignored at creation.
+        /// 
+        /// If status == failure, this represents a string containing the reason.
+        /// </summary>
         public string FailureReason { get; }
         /// <summary> Status message for the job. </summary>
         public string StatusMessage { get; }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/JobResponseStatus.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/JobResponseStatus.cs
@@ -10,7 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.Iot.Hub.Service.Models
 {
-    /// <summary> The status of the job. </summary>
+    /// <summary> System generated.  Ignored at creation. </summary>
     public readonly partial struct JobResponseStatus : IEquatable<JobResponseStatus>
     {
         private readonly string _value;

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/JobResponseType.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/JobResponseType.cs
@@ -10,7 +10,11 @@ using System.ComponentModel;
 
 namespace Azure.Iot.Hub.Service.Models
 {
-    /// <summary> The type of job to execute. </summary>
+    /// <summary>
+    /// Required.
+    /// 
+    /// The type of job to execute.
+    /// </summary>
     public readonly partial struct JobResponseType : IEquatable<JobResponseType>
     {
         private readonly string _value;

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/ModuleConnectionState.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/ModuleConnectionState.cs
@@ -10,7 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.Iot.Hub.Service.Models
 {
-    /// <summary> Tells whether the module is connected or not. </summary>
+    /// <summary> The ModuleConnectionState. </summary>
     public readonly partial struct ModuleConnectionState : IEquatable<ModuleConnectionState>
     {
         private readonly string _value;

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/ModuleIdentity.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/ModuleIdentity.cs
@@ -18,16 +18,16 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of ModuleIdentity. </summary>
-        /// <param name="moduleId"> The unique identifier of this module. </param>
-        /// <param name="managedBy"> Identifies who manages this module. For instance, this value is &quot;IotEdge&quot; if the edge runtime owns this module. </param>
-        /// <param name="deviceId"> The unique identifier of the device that has this module. </param>
-        /// <param name="generationId"> An IoT hub-generated, case-sensitive string up to 128 characters long. This value is used to distinguish modules with the same moduleId, when they have been deleted and re-created. </param>
-        /// <param name="etag"> A string representing a weak ETag for the module identity, as per RFC7232. </param>
-        /// <param name="connectionState"> Tells whether the module is connected or not. </param>
-        /// <param name="connectionStateUpdatedTime"> A temporal indicator, showing the date and last time the connection state was updated. </param>
-        /// <param name="lastActivityTime"> A temporal indicator, showing the date and last time the device connected, received, or sent a message. </param>
-        /// <param name="cloudToDeviceMessageCount"> The number of cloud to module messages currently queued to be sent to the module. </param>
-        /// <param name="authentication"> The details on what authentication mechanisms are used by this module when connecting to the service and edgehub. </param>
+        /// <param name="moduleId"> . </param>
+        /// <param name="managedBy"> . </param>
+        /// <param name="deviceId"> . </param>
+        /// <param name="generationId"> . </param>
+        /// <param name="etag"> . </param>
+        /// <param name="connectionState"> . </param>
+        /// <param name="connectionStateUpdatedTime"> . </param>
+        /// <param name="lastActivityTime"> . </param>
+        /// <param name="cloudToDeviceMessageCount"> . </param>
+        /// <param name="authentication"> . </param>
         internal ModuleIdentity(string moduleId, string managedBy, string deviceId, string generationId, string etag, ModuleConnectionState? connectionState, DateTimeOffset? connectionStateUpdatedTime, DateTimeOffset? lastActivityTime, int? cloudToDeviceMessageCount, AuthenticationMechanism authentication)
         {
             ModuleId = moduleId;
@@ -42,25 +42,15 @@ namespace Azure.Iot.Hub.Service.Models
             Authentication = authentication;
         }
 
-        /// <summary> The unique identifier of this module. </summary>
         public string ModuleId { get; set; }
-        /// <summary> Identifies who manages this module. For instance, this value is &quot;IotEdge&quot; if the edge runtime owns this module. </summary>
         public string ManagedBy { get; set; }
-        /// <summary> The unique identifier of the device that has this module. </summary>
         public string DeviceId { get; set; }
-        /// <summary> An IoT hub-generated, case-sensitive string up to 128 characters long. This value is used to distinguish modules with the same moduleId, when they have been deleted and re-created. </summary>
         public string GenerationId { get; set; }
-        /// <summary> A string representing a weak ETag for the module identity, as per RFC7232. </summary>
         public string Etag { get; set; }
-        /// <summary> Tells whether the module is connected or not. </summary>
         public ModuleConnectionState? ConnectionState { get; set; }
-        /// <summary> A temporal indicator, showing the date and last time the connection state was updated. </summary>
         public DateTimeOffset? ConnectionStateUpdatedTime { get; set; }
-        /// <summary> A temporal indicator, showing the date and last time the device connected, received, or sent a message. </summary>
         public DateTimeOffset? LastActivityTime { get; set; }
-        /// <summary> The number of cloud to module messages currently queued to be sent to the module. </summary>
         public int? CloudToDeviceMessageCount { get; set; }
-        /// <summary> The details on what authentication mechanisms are used by this module when connecting to the service and edgehub. </summary>
         public AuthenticationMechanism Authentication { get; set; }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/PurgeMessageQueueResult.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/PurgeMessageQueueResult.cs
@@ -16,7 +16,7 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of PurgeMessageQueueResult. </summary>
-        /// <param name="totalMessagesPurged"> The total number of messages purged. </param>
+        /// <param name="totalMessagesPurged"> . </param>
         /// <param name="deviceId"> The ID of the device whose messages are being purged. </param>
         /// <param name="moduleId"> The ID of the device whose messages are being purged. </param>
         internal PurgeMessageQueueResult(int? totalMessagesPurged, string deviceId, string moduleId)
@@ -26,7 +26,6 @@ namespace Azure.Iot.Hub.Service.Models
             ModuleId = moduleId;
         }
 
-        /// <summary> The total number of messages purged. </summary>
         public int? TotalMessagesPurged { get; }
         /// <summary> The ID of the device whose messages are being purged. </summary>
         public string DeviceId { get; }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/RegistryStatistics.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/RegistryStatistics.cs
@@ -16,9 +16,9 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of RegistryStatistics. </summary>
-        /// <param name="totalDeviceCount"> The total number of devices registered for this hub. </param>
-        /// <param name="enabledDeviceCount"> The number of currently enabled devices. </param>
-        /// <param name="disabledDeviceCount"> The number of currently disabled devices. </param>
+        /// <param name="totalDeviceCount"> . </param>
+        /// <param name="enabledDeviceCount"> . </param>
+        /// <param name="disabledDeviceCount"> . </param>
         internal RegistryStatistics(long? totalDeviceCount, long? enabledDeviceCount, long? disabledDeviceCount)
         {
             TotalDeviceCount = totalDeviceCount;
@@ -26,11 +26,8 @@ namespace Azure.Iot.Hub.Service.Models
             DisabledDeviceCount = disabledDeviceCount;
         }
 
-        /// <summary> The total number of devices registered for this hub. </summary>
         public long? TotalDeviceCount { get; }
-        /// <summary> The number of currently enabled devices. </summary>
         public long? EnabledDeviceCount { get; }
-        /// <summary> The number of currently disabled devices. </summary>
         public long? DisabledDeviceCount { get; }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/ServiceStatistics.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/ServiceStatistics.cs
@@ -16,13 +16,12 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of ServiceStatistics. </summary>
-        /// <param name="connectedDeviceCount"> The number of currently connected devices. </param>
+        /// <param name="connectedDeviceCount"> . </param>
         internal ServiceStatistics(long? connectedDeviceCount)
         {
             ConnectedDeviceCount = connectedDeviceCount;
         }
 
-        /// <summary> The number of currently connected devices. </summary>
         public long? ConnectedDeviceCount { get; }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/SymmetricKey.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/SymmetricKey.cs
@@ -16,17 +16,15 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of SymmetricKey. </summary>
-        /// <param name="primaryKey"> The base 64 encoded primary key of your device. </param>
-        /// <param name="secondaryKey"> The base 64 encoded secondary key of your device. </param>
+        /// <param name="primaryKey"> . </param>
+        /// <param name="secondaryKey"> . </param>
         internal SymmetricKey(string primaryKey, string secondaryKey)
         {
             PrimaryKey = primaryKey;
             SecondaryKey = secondaryKey;
         }
 
-        /// <summary> The base 64 encoded primary key of your device. </summary>
         public string PrimaryKey { get; set; }
-        /// <summary> The base 64 encoded secondary key of your device. </summary>
         public string SecondaryKey { get; set; }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/TwinConfiguration.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/TwinConfiguration.cs
@@ -19,17 +19,17 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of TwinConfiguration. </summary>
-        /// <param name="id"> The unique identifier of the configuration. </param>
-        /// <param name="schemaVersion"> Schema version of the configuration. </param>
-        /// <param name="labels"> Key-value pairs used to describe a configuration. </param>
-        /// <param name="content"> Content of the configuration. </param>
-        /// <param name="targetCondition"> The query used to define targeted devices or modules. The query is based on twin tags and/or reported properties. </param>
-        /// <param name="createdTimeUtc"> Creation time of the configuration. </param>
-        /// <param name="lastUpdatedTimeUtc"> Update time of the configuration. </param>
-        /// <param name="priority"> The priority number assigned to the configuration. </param>
-        /// <param name="systemMetrics"> Metrics calculated by IoT Hub that cannot be customized. </param>
-        /// <param name="metrics"> Custom metrics specified by developer as queries against twin reported properties. </param>
-        /// <param name="etag"> ETag of the configuration. </param>
+        /// <param name="id"> Gets Identifier for the configuration. </param>
+        /// <param name="schemaVersion"> Gets Schema version for the configuration. </param>
+        /// <param name="labels"> Gets or sets labels for the configuration. </param>
+        /// <param name="content"> Gets or sets Content for the configuration. </param>
+        /// <param name="targetCondition"> Gets or sets Target Condition for the configuration. </param>
+        /// <param name="createdTimeUtc"> Gets creation time for the configuration. </param>
+        /// <param name="lastUpdatedTimeUtc"> Gets last update time for the configuration. </param>
+        /// <param name="priority"> Gets or sets Priority for the configuration. </param>
+        /// <param name="systemMetrics"> System Configuration Metrics. </param>
+        /// <param name="metrics"> Custom Configuration Metrics. </param>
+        /// <param name="etag"> Gets or sets configuration&apos;s ETag. </param>
         internal TwinConfiguration(string id, string schemaVersion, IDictionary<string, string> labels, ConfigurationContent content, string targetCondition, DateTimeOffset? createdTimeUtc, DateTimeOffset? lastUpdatedTimeUtc, int? priority, ConfigurationMetrics systemMetrics, ConfigurationMetrics metrics, string etag)
         {
             Id = id;
@@ -45,27 +45,27 @@ namespace Azure.Iot.Hub.Service.Models
             Etag = etag;
         }
 
-        /// <summary> The unique identifier of the configuration. </summary>
+        /// <summary> Gets Identifier for the configuration. </summary>
         public string Id { get; set; }
-        /// <summary> Schema version of the configuration. </summary>
+        /// <summary> Gets Schema version for the configuration. </summary>
         public string SchemaVersion { get; set; }
-        /// <summary> Key-value pairs used to describe a configuration. </summary>
+        /// <summary> Gets or sets labels for the configuration. </summary>
         public IDictionary<string, string> Labels { get; set; }
-        /// <summary> Content of the configuration. </summary>
+        /// <summary> Gets or sets Content for the configuration. </summary>
         public ConfigurationContent Content { get; set; }
-        /// <summary> The query used to define targeted devices or modules. The query is based on twin tags and/or reported properties. </summary>
+        /// <summary> Gets or sets Target Condition for the configuration. </summary>
         public string TargetCondition { get; set; }
-        /// <summary> Creation time of the configuration. </summary>
+        /// <summary> Gets creation time for the configuration. </summary>
         public DateTimeOffset? CreatedTimeUtc { get; set; }
-        /// <summary> Update time of the configuration. </summary>
+        /// <summary> Gets last update time for the configuration. </summary>
         public DateTimeOffset? LastUpdatedTimeUtc { get; set; }
-        /// <summary> The priority number assigned to the configuration. </summary>
+        /// <summary> Gets or sets Priority for the configuration. </summary>
         public int? Priority { get; set; }
-        /// <summary> Metrics calculated by IoT Hub that cannot be customized. </summary>
+        /// <summary> System Configuration Metrics. </summary>
         public ConfigurationMetrics SystemMetrics { get; set; }
-        /// <summary> Custom metrics specified by developer as queries against twin reported properties. </summary>
+        /// <summary> Custom Configuration Metrics. </summary>
         public ConfigurationMetrics Metrics { get; set; }
-        /// <summary> ETag of the configuration. </summary>
+        /// <summary> Gets or sets configuration&apos;s ETag. </summary>
         public string Etag { get; set; }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/TwinConnectionState.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/TwinConnectionState.cs
@@ -10,7 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.Iot.Hub.Service.Models
 {
-    /// <summary> The device&apos;s connection state. </summary>
+    /// <summary> Corresponding Device&apos;s ConnectionState. </summary>
     public readonly partial struct TwinConnectionState : IEquatable<TwinConnectionState>
     {
         private readonly string _value;

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/TwinData.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/TwinData.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.Iot.Hub.Service.Models
 {
-    /// <summary> The state information for a device or module. Implicitly created and deleted when the corresponding device/ module identity is created or deleted in IoT Hub. </summary>
+    /// <summary> Twin Representation. </summary>
     public partial class TwinData
     {
         /// <summary> Initializes a new instance of TwinData. </summary>
@@ -19,24 +19,24 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of TwinData. </summary>
-        /// <param name="deviceId"> The unique identifier of the device in the IoT hub&apos;s identity registry. It is a case-sensitive string (up to 128 char long) of ASCII 7-bit alphanumeric chars, and the following special characters {&apos;-&apos;, &apos;:&apos;, &apos;.&apos;, &apos;+&apos;, &apos;%&apos;, &apos;_&apos;, &apos;#&apos;, &apos;*&apos;, &apos;?&apos;, &apos;!&apos;, &apos;(&apos;, &apos;)&apos;, &apos;,&apos;, &apos;=&apos;, &apos;@&apos;, &apos;;&apos;, &apos;$&apos;, &apos;&apos;&apos;}. </param>
-        /// <param name="moduleId"> The unique identifier of the module in the IoT hub&apos;s identity registry. It is a case-sensitive string (up to 128 char long) of ASCII 7-bit alphanumeric chars, and the following special characters {&apos;-&apos;, &apos;:&apos;, &apos;.&apos;, &apos;+&apos;, &apos;%&apos;, &apos;_&apos;, &apos;#&apos;, &apos;*&apos;, &apos;?&apos;, &apos;!&apos;, &apos;(&apos;, &apos;)&apos;, &apos;,&apos;, &apos;=&apos;, &apos;@&apos;, &apos;;&apos;, &apos;$&apos;, &apos;&apos;&apos;}. </param>
-        /// <param name="tags"> A collection of key-value pairs read and written by the solution back end. They are not visible to device apps. </param>
-        /// <param name="properties"> The twin&apos;s desired and reported properties. </param>
-        /// <param name="etag"> TODO - which operation does this affect - update tags/ properties etc?. </param>
+        /// <param name="deviceId"> The deviceId uniquely identifies the device in the IoT hub&apos;s identity registry. A case-sensitive string (up to 128 char long) of ASCII 7-bit alphanumeric chars + {&apos;-&apos;, &apos;:&apos;, &apos;.&apos;, &apos;+&apos;, &apos;%&apos;, &apos;_&apos;, &apos;#&apos;, &apos;*&apos;, &apos;?&apos;, &apos;!&apos;, &apos;(&apos;, &apos;)&apos;, &apos;,&apos;, &apos;=&apos;, &apos;@&apos;, &apos;;&apos;, &apos;$&apos;, &apos;&apos;&apos;}. </param>
+        /// <param name="moduleId"> Gets and sets the Module Id. </param>
+        /// <param name="tags"> A JSON document read and written by the solution back end. Tags are not visible to device apps. </param>
+        /// <param name="properties"> Gets and sets the Twin properties. </param>
+        /// <param name="etag"> Twin&apos;s ETag. </param>
         /// <param name="version"> Version for device twin, including tags and desired properties. </param>
-        /// <param name="deviceEtag"> TODO - which operation does this affect?. </param>
-        /// <param name="status"> Flags whether a device is enabled or not. If disabled, a device cannot connect to the service. </param>
-        /// <param name="statusReason"> Reason, if any, for the device&apos;s current status. </param>
-        /// <param name="statusUpdateTime"> Time when the corresponding device&apos;s status was last updated. </param>
-        /// <param name="connectionState"> The device&apos;s connection state. </param>
+        /// <param name="deviceEtag"> Device&apos;s ETag. </param>
+        /// <param name="status"> Gets the corresponding Device&apos;s Status. </param>
+        /// <param name="statusReason"> Reason, if any, for the corresponding Device to be in specified Status. </param>
+        /// <param name="statusUpdateTime"> Time when the corresponding Device&apos;s Status was last updated. </param>
+        /// <param name="connectionState"> Corresponding Device&apos;s ConnectionState. </param>
         /// <param name="lastActivityTime"> The last time the device connected, received or sent a message. In ISO8601 datetime format in UTC, for example, 2015-01-28T16:24:48.789Z. This does not update if the device uses the HTTP/1 protocol to perform messaging operations. </param>
         /// <param name="cloudToDeviceMessageCount"> Number of messages sent to the corresponding Device from the Cloud. </param>
         /// <param name="authenticationType"> Corresponding Device&apos;s authentication type. </param>
         /// <param name="x509Thumbprint"> Corresponding Device&apos;s X509 thumbprint. </param>
         /// <param name="capabilities"> Status of Capabilities enabled on the device. </param>
-        /// <param name="deviceScope"> Scope to which this device instance belongs to. </param>
-        /// <param name="parentScopes"> TODO: new property added - need explanation. </param>
+        /// <param name="deviceScope"> . </param>
+        /// <param name="parentScopes"> . </param>
         internal TwinData(string deviceId, string moduleId, IDictionary<string, object> tags, TwinProperties properties, string etag, long? version, string deviceEtag, TwinStatus? status, string statusReason, DateTimeOffset? statusUpdateTime, TwinConnectionState? connectionState, DateTimeOffset? lastActivityTime, int? cloudToDeviceMessageCount, TwinAuthenticationType? authenticationType, X509Thumbprint x509Thumbprint, DeviceCapabilities capabilities, string deviceScope, IList<string> parentScopes)
         {
             DeviceId = deviceId;
@@ -59,27 +59,27 @@ namespace Azure.Iot.Hub.Service.Models
             ParentScopes = parentScopes;
         }
 
-        /// <summary> The unique identifier of the device in the IoT hub&apos;s identity registry. It is a case-sensitive string (up to 128 char long) of ASCII 7-bit alphanumeric chars, and the following special characters {&apos;-&apos;, &apos;:&apos;, &apos;.&apos;, &apos;+&apos;, &apos;%&apos;, &apos;_&apos;, &apos;#&apos;, &apos;*&apos;, &apos;?&apos;, &apos;!&apos;, &apos;(&apos;, &apos;)&apos;, &apos;,&apos;, &apos;=&apos;, &apos;@&apos;, &apos;;&apos;, &apos;$&apos;, &apos;&apos;&apos;}. </summary>
+        /// <summary> The deviceId uniquely identifies the device in the IoT hub&apos;s identity registry. A case-sensitive string (up to 128 char long) of ASCII 7-bit alphanumeric chars + {&apos;-&apos;, &apos;:&apos;, &apos;.&apos;, &apos;+&apos;, &apos;%&apos;, &apos;_&apos;, &apos;#&apos;, &apos;*&apos;, &apos;?&apos;, &apos;!&apos;, &apos;(&apos;, &apos;)&apos;, &apos;,&apos;, &apos;=&apos;, &apos;@&apos;, &apos;;&apos;, &apos;$&apos;, &apos;&apos;&apos;}. </summary>
         public string DeviceId { get; set; }
-        /// <summary> The unique identifier of the module in the IoT hub&apos;s identity registry. It is a case-sensitive string (up to 128 char long) of ASCII 7-bit alphanumeric chars, and the following special characters {&apos;-&apos;, &apos;:&apos;, &apos;.&apos;, &apos;+&apos;, &apos;%&apos;, &apos;_&apos;, &apos;#&apos;, &apos;*&apos;, &apos;?&apos;, &apos;!&apos;, &apos;(&apos;, &apos;)&apos;, &apos;,&apos;, &apos;=&apos;, &apos;@&apos;, &apos;;&apos;, &apos;$&apos;, &apos;&apos;&apos;}. </summary>
+        /// <summary> Gets and sets the Module Id. </summary>
         public string ModuleId { get; set; }
-        /// <summary> A collection of key-value pairs read and written by the solution back end. They are not visible to device apps. </summary>
+        /// <summary> A JSON document read and written by the solution back end. Tags are not visible to device apps. </summary>
         public IDictionary<string, object> Tags { get; set; }
-        /// <summary> The twin&apos;s desired and reported properties. </summary>
+        /// <summary> Gets and sets the Twin properties. </summary>
         public TwinProperties Properties { get; set; }
-        /// <summary> TODO - which operation does this affect - update tags/ properties etc?. </summary>
+        /// <summary> Twin&apos;s ETag. </summary>
         public string Etag { get; set; }
         /// <summary> Version for device twin, including tags and desired properties. </summary>
         public long? Version { get; set; }
-        /// <summary> TODO - which operation does this affect?. </summary>
+        /// <summary> Device&apos;s ETag. </summary>
         public string DeviceEtag { get; set; }
-        /// <summary> Flags whether a device is enabled or not. If disabled, a device cannot connect to the service. </summary>
+        /// <summary> Gets the corresponding Device&apos;s Status. </summary>
         public TwinStatus? Status { get; set; }
-        /// <summary> Reason, if any, for the device&apos;s current status. </summary>
+        /// <summary> Reason, if any, for the corresponding Device to be in specified Status. </summary>
         public string StatusReason { get; set; }
-        /// <summary> Time when the corresponding device&apos;s status was last updated. </summary>
+        /// <summary> Time when the corresponding Device&apos;s Status was last updated. </summary>
         public DateTimeOffset? StatusUpdateTime { get; set; }
-        /// <summary> The device&apos;s connection state. </summary>
+        /// <summary> Corresponding Device&apos;s ConnectionState. </summary>
         public TwinConnectionState? ConnectionState { get; set; }
         /// <summary> The last time the device connected, received or sent a message. In ISO8601 datetime format in UTC, for example, 2015-01-28T16:24:48.789Z. This does not update if the device uses the HTTP/1 protocol to perform messaging operations. </summary>
         public DateTimeOffset? LastActivityTime { get; set; }
@@ -91,9 +91,7 @@ namespace Azure.Iot.Hub.Service.Models
         public X509Thumbprint X509Thumbprint { get; set; }
         /// <summary> Status of Capabilities enabled on the device. </summary>
         public DeviceCapabilities Capabilities { get; set; }
-        /// <summary> Scope to which this device instance belongs to. </summary>
         public string DeviceScope { get; set; }
-        /// <summary> TODO: new property added - need explanation. </summary>
         public IList<string> ParentScopes { get; set; }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/TwinProperties.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/TwinProperties.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 
 namespace Azure.Iot.Hub.Service.Models
 {
-    /// <summary> The twin&apos;s desired and reported properties. The maximum depth of twin property objects is 10. </summary>
+    /// <summary> Represents Twin properties. </summary>
     public partial class TwinProperties
     {
         /// <summary> Initializes a new instance of TwinProperties. </summary>
@@ -18,17 +18,17 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of TwinProperties. </summary>
-        /// <param name="desired"> Properties that are set by the solution back end and read by the device. </param>
-        /// <param name="reported"> Properties that are set by the device, and read and queried by the solution back end. </param>
+        /// <param name="desired"> Used in conjunction with reported properties to synchronize device configuration or condition. Desired properties can only be set by the solution back end and can be read by the device app. The device app can also be notified in real time of changes on the desired properties. </param>
+        /// <param name="reported"> Used in conjunction with desired properties to synchronize device configuration or condition. Reported properties can only be set by the device app and can be read and queried by the solution back end. </param>
         internal TwinProperties(IDictionary<string, object> desired, IDictionary<string, object> reported)
         {
             Desired = desired;
             Reported = reported;
         }
 
-        /// <summary> Properties that are set by the solution back end and read by the device. </summary>
+        /// <summary> Used in conjunction with reported properties to synchronize device configuration or condition. Desired properties can only be set by the solution back end and can be read by the device app. The device app can also be notified in real time of changes on the desired properties. </summary>
         public IDictionary<string, object> Desired { get; set; }
-        /// <summary> Properties that are set by the device, and read and queried by the solution back end. </summary>
+        /// <summary> Used in conjunction with desired properties to synchronize device configuration or condition. Reported properties can only be set by the device app and can be read and queried by the solution back end. </summary>
         public IDictionary<string, object> Reported { get; set; }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/TwinStatus.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/TwinStatus.cs
@@ -10,7 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.Iot.Hub.Service.Models
 {
-    /// <summary> Flags whether a device is enabled or not. If disabled, a device cannot connect to the service. </summary>
+    /// <summary> Gets the corresponding Device&apos;s Status. </summary>
     public readonly partial struct TwinStatus : IEquatable<TwinStatus>
     {
         private readonly string _value;

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/X509Thumbprint.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/Models/X509Thumbprint.cs
@@ -16,17 +16,15 @@ namespace Azure.Iot.Hub.Service.Models
         }
 
         /// <summary> Initializes a new instance of X509Thumbprint. </summary>
-        /// <param name="primaryThumbprint"> Gets and sets the X509 client certificate primary thumbprint. </param>
-        /// <param name="secondaryThumbprint"> Gets and sets the X509 client certificate secondary thumbprint. </param>
+        /// <param name="primaryThumbprint"> . </param>
+        /// <param name="secondaryThumbprint"> . </param>
         internal X509Thumbprint(string primaryThumbprint, string secondaryThumbprint)
         {
             PrimaryThumbprint = primaryThumbprint;
             SecondaryThumbprint = secondaryThumbprint;
         }
 
-        /// <summary> Gets and sets the X509 client certificate primary thumbprint. </summary>
         public string PrimaryThumbprint { get; set; }
-        /// <summary> Gets and sets the X509 client certificate secondary thumbprint. </summary>
         public string SecondaryThumbprint { get; set; }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/RegistryManagerRestClient.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/RegistryManagerRestClient.cs
@@ -57,7 +57,7 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Get statistics about device identities in the IoT hub’s identity registry, such as total device count. </summary>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<RegistryStatistics>> GetDeviceStatisticsAsync(CancellationToken cancellationToken = default)
         {
@@ -84,7 +84,7 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Get statistics about device identities in the IoT hub’s identity registry, such as total device count. </summary>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<RegistryStatistics> GetDeviceStatistics(CancellationToken cancellationToken = default)
         {
@@ -124,7 +124,7 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Retrieves device statistics for this IoT hub, such as connected device count. </summary>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ServiceStatistics>> GetServiceStatisticsAsync(CancellationToken cancellationToken = default)
         {
@@ -151,7 +151,7 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Retrieves device statistics for this IoT hub, such as connected device count. </summary>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ServiceStatistics> GetServiceStatistics(CancellationToken cancellationToken = default)
         {
@@ -195,7 +195,7 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Get the identities of multiple devices from the IoT hub identity registry. Not recommended. Use the IoT Hub query API to retrieve device twin and device identity information. See https://docs.microsoft.com/en-us/rest/api/iothub/service/queryiothub and https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-query-language for more information. </summary>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
         /// <param name="top"> This parameter when specified, defines the maximum number of device identities that are returned. Any value outside the range of 1-1000 is considered to be 1000. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IReadOnlyList<DeviceIdentity>>> GetDevicesAsync(int? top = null, CancellationToken cancellationToken = default)
@@ -235,7 +235,7 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Get the identities of multiple devices from the IoT hub identity registry. Not recommended. Use the IoT Hub query API to retrieve device twin and device identity information. See https://docs.microsoft.com/en-us/rest/api/iothub/service/queryiothub and https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-query-language for more information. </summary>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
         /// <param name="top"> This parameter when specified, defines the maximum number of device identities that are returned. Any value outside the range of 1-1000 is considered to be 1000. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IReadOnlyList<DeviceIdentity>> GetDevices(int? top = null, CancellationToken cancellationToken = default)
@@ -297,7 +297,7 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Create, update, or delete the identiies of multiple devices from the IoT hub identity registry. A device identity can be specified only once in the list. Different operations (create, update, delete) on different devices are allowed. A maximum of 100 devices can be specified per invocation. For large scale operations, consider using the import feature using blob storage(https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities). </summary>
+        /// <summary> Create, update, or delete the identiies of multiple devices from the IoT hub identity registry. A device identity can be specified only once in the list. Different operations (create, update, delete) on different devices are allowed. A maximum of 100 devices can be specified per invocation. For large scale operations, consider using the import feature using blob storage(https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities). For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
         /// <param name="devices"> The ArrayOfExportImportDevice to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<BulkRegistryOperationResult>> BulkDeviceCrudAsync(IEnumerable<ExportImportDevice> devices, CancellationToken cancellationToken = default)
@@ -331,7 +331,7 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Create, update, or delete the identiies of multiple devices from the IoT hub identity registry. A device identity can be specified only once in the list. Different operations (create, update, delete) on different devices are allowed. A maximum of 100 devices can be specified per invocation. For large scale operations, consider using the import feature using blob storage(https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities). </summary>
+        /// <summary> Create, update, or delete the identiies of multiple devices from the IoT hub identity registry. A device identity can be specified only once in the list. Different operations (create, update, delete) on different devices are allowed. A maximum of 100 devices can be specified per invocation. For large scale operations, consider using the import feature using blob storage(https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities). For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
         /// <param name="devices"> The ArrayOfExportImportDevice to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<BulkRegistryOperationResult> BulkDeviceCrud(IEnumerable<ExportImportDevice> devices, CancellationToken cancellationToken = default)
@@ -390,10 +390,10 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Query an IoT hub to retrieve information regarding device twins using a SQL-like language. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language for more information. Pagination is supported. This returns information about device twins only. </summary>
-        /// <param name="querySpecification"> The query string to run. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language for more information. </param>
-        /// <param name="xMsContinuation"> The continuation token to get the next page of results. </param>
-        /// <param name="xMsMaxItemCount"> The maximum number of items to return per page. The service may use a different value if the value specified is not acceptable. </param>
+        /// <summary> Query an IoT hub to retrieve information regarding device twins using a SQL-like language. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language for more information. Pagination of results is supported. This returns information about device twins only. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="querySpecification"> The QuerySpecification to use. </param>
+        /// <param name="xMsContinuation"> The String to use. </param>
+        /// <param name="xMsMaxItemCount"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<ResponseWithHeaders<IReadOnlyList<TwinData>, RegistryManagerQueryIotHubHeaders>> QueryIotHubAsync(QuerySpecification querySpecification, string xMsContinuation = null, string xMsMaxItemCount = null, CancellationToken cancellationToken = default)
         {
@@ -438,10 +438,10 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Query an IoT hub to retrieve information regarding device twins using a SQL-like language. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language for more information. Pagination is supported. This returns information about device twins only. </summary>
-        /// <param name="querySpecification"> The query string to run. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language for more information. </param>
-        /// <param name="xMsContinuation"> The continuation token to get the next page of results. </param>
-        /// <param name="xMsMaxItemCount"> The maximum number of items to return per page. The service may use a different value if the value specified is not acceptable. </param>
+        /// <summary> Query an IoT hub to retrieve information regarding device twins using a SQL-like language. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language for more information. Pagination of results is supported. This returns information about device twins only. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="querySpecification"> The QuerySpecification to use. </param>
+        /// <param name="xMsContinuation"> The String to use. </param>
+        /// <param name="xMsMaxItemCount"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public ResponseWithHeaders<IReadOnlyList<TwinData>, RegistryManagerQueryIotHubHeaders> QueryIotHub(QuerySpecification querySpecification, string xMsContinuation = null, string xMsMaxItemCount = null, CancellationToken cancellationToken = default)
         {
@@ -500,8 +500,8 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Get a device from the identity registry of an IoT hub. </summary>
-        /// <param name="id"> The unique identifier of the device to retrieve. </param>
+        /// <summary> Retrieve a device from the identity registry of an IoT hub. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DeviceIdentity>> GetDeviceAsync(string id, CancellationToken cancellationToken = default)
         {
@@ -533,8 +533,8 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Get a device from the identity registry of an IoT hub. </summary>
-        /// <param name="id"> The unique identifier of the device to retrieve. </param>
+        /// <summary> Retrieve a device from the identity registry of an IoT hub. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DeviceIdentity> GetDevice(string id, CancellationToken cancellationToken = default)
         {
@@ -588,10 +588,10 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Create or update the identity of a device in the identity registry of an IoT hub. </summary>
-        /// <param name="id"> The unique identifier of the device to create. </param>
-        /// <param name="device"> The contents of the device to create. </param>
-        /// <param name="ifMatch"> A string representing a weak ETag for the device identity, as per RFC7232. Should not be set when creating a device, but may be set when updating a device. </param>
+        /// <summary> Create or update the identity of a device in the identity registry of an IoT hub. An ETag must not be specified for the create operation. An ETag must be specified for the update operation. Note that generationId and deviceId cannot be updated by the user. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
+        /// <param name="device"> The Device to use. </param>
+        /// <param name="ifMatch"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<DeviceIdentity>> CreateOrUpdateDeviceAsync(string id, DeviceIdentity device, string ifMatch = null, CancellationToken cancellationToken = default)
         {
@@ -627,10 +627,10 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Create or update the identity of a device in the identity registry of an IoT hub. </summary>
-        /// <param name="id"> The unique identifier of the device to create. </param>
-        /// <param name="device"> The contents of the device to create. </param>
-        /// <param name="ifMatch"> A string representing a weak ETag for the device identity, as per RFC7232. Should not be set when creating a device, but may be set when updating a device. </param>
+        /// <summary> Create or update the identity of a device in the identity registry of an IoT hub. An ETag must not be specified for the create operation. An ETag must be specified for the update operation. Note that generationId and deviceId cannot be updated by the user. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
+        /// <param name="device"> The Device to use. </param>
+        /// <param name="ifMatch"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<DeviceIdentity> CreateOrUpdateDevice(string id, DeviceIdentity device, string ifMatch = null, CancellationToken cancellationToken = default)
         {
@@ -684,9 +684,9 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Delete the identity of a device from the identity registry of an IoT hub. </summary>
-        /// <param name="id"> The unique identifier of the device to delete. </param>
-        /// <param name="ifMatch"> A string representing a weak ETag for the device identity, as per RFC7232. The delete operation is performed only if this ETag matches the value maintained by the server, indicating that the device identity has not been modified since it was last retrieved. To force an unconditional delete, set If-Match to the wildcard character (*). </param>
+        /// <summary> Delete the identity of a device from the identity registry of an IoT hub. This request requires the If-Match header. The client may specify the ETag for the device identity on the request in order to compare to the ETag maintained by the service for the purpose of optimistic concurrency. The delete operation is performed only if the ETag sent by the client matches the value maintained by the server, indicating that the device identity has not been modified since it was retrieved by the client. To force an unconditional delete, set If-Match to the wildcard character (*). For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
+        /// <param name="ifMatch"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> DeleteDeviceAsync(string id, string ifMatch = null, CancellationToken cancellationToken = default)
         {
@@ -706,9 +706,9 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Delete the identity of a device from the identity registry of an IoT hub. </summary>
-        /// <param name="id"> The unique identifier of the device to delete. </param>
-        /// <param name="ifMatch"> A string representing a weak ETag for the device identity, as per RFC7232. The delete operation is performed only if this ETag matches the value maintained by the server, indicating that the device identity has not been modified since it was last retrieved. To force an unconditional delete, set If-Match to the wildcard character (*). </param>
+        /// <summary> Delete the identity of a device from the identity registry of an IoT hub. This request requires the If-Match header. The client may specify the ETag for the device identity on the request in order to compare to the ETag maintained by the service for the purpose of optimistic concurrency. The delete operation is performed only if the ETag sent by the client matches the value maintained by the server, indicating that the device identity has not been modified since it was retrieved by the client. To force an unconditional delete, set If-Match to the wildcard character (*). For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
+        /// <param name="ifMatch"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response DeleteDevice(string id, string ifMatch = null, CancellationToken cancellationToken = default)
         {
@@ -743,8 +743,8 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Deletes all the pending commands for this device from the IoT hub. </summary>
-        /// <param name="id"> The unique identifier of the device. </param>
+        /// <summary> Deletes all the pending commands for this device from the IoT hub For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<PurgeMessageQueueResult>> PurgeCommandQueueAsync(string id, CancellationToken cancellationToken = default)
         {
@@ -776,8 +776,8 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Deletes all the pending commands for this device from the IoT hub. </summary>
-        /// <param name="id"> The unique identifier of the device. </param>
+        /// <summary> Deletes all the pending commands for this device from the IoT hub For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<PurgeMessageQueueResult> PurgeCommandQueue(string id, CancellationToken cancellationToken = default)
         {
@@ -824,8 +824,8 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Get all the module identities of the device. </summary>
-        /// <param name="id"> The unique identifier of the device. </param>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<IReadOnlyList<ModuleIdentity>>> GetModulesOnDeviceAsync(string id, CancellationToken cancellationToken = default)
         {
@@ -869,8 +869,8 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Get all the module identities of the device. </summary>
-        /// <param name="id"> The unique identifier of the device. </param>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<IReadOnlyList<ModuleIdentity>> GetModulesOnDevice(string id, CancellationToken cancellationToken = default)
         {
@@ -930,9 +930,9 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Get the specified module identity of the device. </summary>
-        /// <param name="id"> The unique identifier of the device. </param>
-        /// <param name="mid"> The unique identifier of the module. </param>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
+        /// <param name="mid"> Module ID. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ModuleIdentity>> GetModuleAsync(string id, string mid, CancellationToken cancellationToken = default)
         {
@@ -968,9 +968,9 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Get the specified module identity of the device. </summary>
-        /// <param name="id"> The unique identifier of the device. </param>
-        /// <param name="mid"> The unique identifier of the module. </param>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
+        /// <param name="mid"> Module ID. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ModuleIdentity> GetModule(string id, string mid, CancellationToken cancellationToken = default)
         {
@@ -1030,11 +1030,11 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Create or update the module identity for device in IoT hub. The moduleId and generation cannot be updated by the user. </summary>
-        /// <param name="id"> The unique identifier of the device. </param>
-        /// <param name="mid"> The unique identifier of the module. </param>
-        /// <param name="module"> The module identity. </param>
-        /// <param name="ifMatch"> A string representing a weak ETag for the module, as per RFC7232. Should not be set when creating module, but may be set when updating a module. </param>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
+        /// <param name="mid"> Module ID. </param>
+        /// <param name="module"> The Module to use. </param>
+        /// <param name="ifMatch"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<ModuleIdentity>> CreateOrUpdateModuleAsync(string id, string mid, ModuleIdentity module, string ifMatch = null, CancellationToken cancellationToken = default)
         {
@@ -1075,11 +1075,11 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Create or update the module identity for device in IoT hub. The moduleId and generation cannot be updated by the user. </summary>
-        /// <param name="id"> The unique identifier of the device. </param>
-        /// <param name="mid"> The unique identifier of the module. </param>
-        /// <param name="module"> The module identity. </param>
-        /// <param name="ifMatch"> A string representing a weak ETag for the module, as per RFC7232. Should not be set when creating module, but may be set when updating a module. </param>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
+        /// <param name="mid"> Module ID. </param>
+        /// <param name="module"> The Module to use. </param>
+        /// <param name="ifMatch"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<ModuleIdentity> CreateOrUpdateModule(string id, string mid, ModuleIdentity module, string ifMatch = null, CancellationToken cancellationToken = default)
         {
@@ -1140,10 +1140,10 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Delete the module identity for device of an IoT hub. </summary>
-        /// <param name="id"> The unique identifier of the deivce. </param>
-        /// <param name="mid"> The unique identifier of the module. </param>
-        /// <param name="ifMatch">  A string representing a weak ETag for the module, as per RFC7232. The delete operation is performed only if this ETag matches the value maintained by the server, indicating that the module has not been modified since it was last retrieved. To force an unconditional delete, set If-Match to the wildcard character (*). </param>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
+        /// <param name="mid"> Module ID. </param>
+        /// <param name="ifMatch"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response> DeleteModuleAsync(string id, string mid, string ifMatch = null, CancellationToken cancellationToken = default)
         {
@@ -1167,10 +1167,10 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Delete the module identity for device of an IoT hub. </summary>
-        /// <param name="id"> The unique identifier of the deivce. </param>
-        /// <param name="mid"> The unique identifier of the module. </param>
-        /// <param name="ifMatch">  A string representing a weak ETag for the module, as per RFC7232. The delete operation is performed only if this ETag matches the value maintained by the server, indicating that the module has not been modified since it was last retrieved. To force an unconditional delete, set If-Match to the wildcard character (*). </param>
+        /// <summary>  For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
+        /// <param name="mid"> Module ID. </param>
+        /// <param name="ifMatch"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response DeleteModule(string id, string mid, string ifMatch = null, CancellationToken cancellationToken = default)
         {

--- a/sdk/iot/Azure.Iot.Hub.Service/src/Generated/TwinRestClient.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/Generated/TwinRestClient.cs
@@ -57,8 +57,8 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Gets the device twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. </summary>
-        /// <param name="id"> The unique identifier of the device. </param>
+        /// <summary> Gets a device twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<TwinData>> GetDeviceTwinAsync(string id, CancellationToken cancellationToken = default)
         {
@@ -90,8 +90,8 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Gets the device twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. </summary>
-        /// <param name="id"> The unique identifier of the device. </param>
+        /// <summary> Gets a device twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<TwinData> GetDeviceTwin(string id, CancellationToken cancellationToken = default)
         {
@@ -145,10 +145,10 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Replaces the tags and desired properties of a device. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. </summary>
-        /// <param name="id"> The unique identifier of the device. </param>
-        /// <param name="deviceTwinInfo"> The twin object that will replace the current device twin. </param>
-        /// <param name="ifMatch"> A string representing a weak ETag for the device twin, as per RFC7232. It determines if the replace operation should be carried out. </param>
+        /// <summary> Replaces a device twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
+        /// <param name="deviceTwinInfo"> Device twin info. </param>
+        /// <param name="ifMatch"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<TwinData>> ReplaceDeviceTwinAsync(string id, TwinData deviceTwinInfo, string ifMatch = null, CancellationToken cancellationToken = default)
         {
@@ -184,10 +184,10 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Replaces the tags and desired properties of a device. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. </summary>
-        /// <param name="id"> The unique identifier of the device. </param>
-        /// <param name="deviceTwinInfo"> The twin object that will replace the current device twin. </param>
-        /// <param name="ifMatch"> A string representing a weak ETag for the device twin, as per RFC7232. It determines if the replace operation should be carried out. </param>
+        /// <summary> Replaces a device twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
+        /// <param name="deviceTwinInfo"> Device twin info. </param>
+        /// <param name="ifMatch"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<TwinData> ReplaceDeviceTwin(string id, TwinData deviceTwinInfo, string ifMatch = null, CancellationToken cancellationToken = default)
         {
@@ -245,10 +245,10 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Updates the tags and desired properties of a device. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. </summary>
-        /// <param name="id"> The unique identifier of the device. </param>
-        /// <param name="deviceTwinInfo"> The twin object containing the tags and desired properties to be updated. </param>
-        /// <param name="ifMatch"> A string representing a weak ETag for the device twin, as per RFC7232. It determines if the update operation should be carried out. </param>
+        /// <summary> Updates a device twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
+        /// <param name="deviceTwinInfo"> Device twin info. </param>
+        /// <param name="ifMatch"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<TwinData>> UpdateDeviceTwinAsync(string id, TwinData deviceTwinInfo, string ifMatch = null, CancellationToken cancellationToken = default)
         {
@@ -284,10 +284,10 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Updates the tags and desired properties of a device. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. </summary>
-        /// <param name="id"> The unique identifier of the device. </param>
-        /// <param name="deviceTwinInfo"> The twin object containing the tags and desired properties to be updated. </param>
-        /// <param name="ifMatch"> A string representing a weak ETag for the device twin, as per RFC7232. It determines if the update operation should be carried out. </param>
+        /// <summary> Updates a device twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
+        /// <param name="deviceTwinInfo"> Device twin info. </param>
+        /// <param name="ifMatch"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<TwinData> UpdateDeviceTwin(string id, TwinData deviceTwinInfo, string ifMatch = null, CancellationToken cancellationToken = default)
         {
@@ -339,9 +339,9 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Gets the module twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. </summary>
-        /// <param name="id"> The unique identifier of the device. </param>
-        /// <param name="mid"> The unique identifier of the module. </param>
+        /// <summary> Gets a module twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
+        /// <param name="mid"> Module ID. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<TwinData>> GetModuleTwinAsync(string id, string mid, CancellationToken cancellationToken = default)
         {
@@ -377,9 +377,9 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Gets the module twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. </summary>
-        /// <param name="id"> The unique identifier of the device. </param>
-        /// <param name="mid"> The unique identifier of the module. </param>
+        /// <summary> Gets a module twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
+        /// <param name="mid"> Module ID. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<TwinData> GetModuleTwin(string id, string mid, CancellationToken cancellationToken = default)
         {
@@ -439,11 +439,11 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Replaces the tags and desired properties of a module. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. </summary>
-        /// <param name="id"> The unique identifier of the device. </param>
-        /// <param name="mid"> The unique identifier of the module. </param>
-        /// <param name="deviceTwinInfo"> The twin object that will replace the current module twin. </param>
-        /// <param name="ifMatch"> A string representing a weak ETag for the device twin, as per RFC7232. It determines if the replace operation should be carried out. </param>
+        /// <summary> Replaces a module twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
+        /// <param name="mid"> Module ID. </param>
+        /// <param name="deviceTwinInfo"> Device twin info. </param>
+        /// <param name="ifMatch"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<TwinData>> ReplaceModuleTwinAsync(string id, string mid, TwinData deviceTwinInfo, string ifMatch = null, CancellationToken cancellationToken = default)
         {
@@ -483,11 +483,11 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Replaces the tags and desired properties of a module. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. </summary>
-        /// <param name="id"> The unique identifier of the device. </param>
-        /// <param name="mid"> The unique identifier of the module. </param>
-        /// <param name="deviceTwinInfo"> The twin object that will replace the current module twin. </param>
-        /// <param name="ifMatch"> A string representing a weak ETag for the device twin, as per RFC7232. It determines if the replace operation should be carried out. </param>
+        /// <summary> Replaces a module twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
+        /// <param name="mid"> Module ID. </param>
+        /// <param name="deviceTwinInfo"> Device twin info. </param>
+        /// <param name="ifMatch"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<TwinData> ReplaceModuleTwin(string id, string mid, TwinData deviceTwinInfo, string ifMatch = null, CancellationToken cancellationToken = default)
         {
@@ -551,11 +551,11 @@ namespace Azure.Iot.Hub.Service
             return message;
         }
 
-        /// <summary> Updates the tags and desired properties of a module. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. </summary>
-        /// <param name="id"> The unique identifier of the device. </param>
-        /// <param name="mid"> The unique identifier of the module. </param>
-        /// <param name="deviceTwinInfo"> The twin object containing the tags and desired properties to be updated. </param>
-        /// <param name="ifMatch"> A string representing a weak ETag for the device twin, as per RFC7232. It determines if the update operation should be carried out. </param>
+        /// <summary> Updates a module twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
+        /// <param name="mid"> Module ID. </param>
+        /// <param name="deviceTwinInfo"> Device twin information. </param>
+        /// <param name="ifMatch"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public async ValueTask<Response<TwinData>> UpdateModuleTwinAsync(string id, string mid, TwinData deviceTwinInfo, string ifMatch = null, CancellationToken cancellationToken = default)
         {
@@ -595,11 +595,11 @@ namespace Azure.Iot.Hub.Service
             }
         }
 
-        /// <summary> Updates the tags and desired properties of a module. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. </summary>
-        /// <param name="id"> The unique identifier of the device. </param>
-        /// <param name="mid"> The unique identifier of the module. </param>
-        /// <param name="deviceTwinInfo"> The twin object containing the tags and desired properties to be updated. </param>
-        /// <param name="ifMatch"> A string representing a weak ETag for the device twin, as per RFC7232. It determines if the update operation should be carried out. </param>
+        /// <summary> Updates a module twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version &apos;2020-03-13&apos;.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version &apos;2019-10-01&apos;. </summary>
+        /// <param name="id"> Device ID. </param>
+        /// <param name="mid"> Module ID. </param>
+        /// <param name="deviceTwinInfo"> Device twin information. </param>
+        /// <param name="ifMatch"> The String to use. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         public Response<TwinData> UpdateModuleTwin(string id, string mid, TwinData deviceTwinInfo, string ifMatch = null, CancellationToken cancellationToken = default)
         {

--- a/sdk/iot/Azure.Iot.Hub.Service/src/swagger/iothubservice.json
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/swagger/iothubservice.json
@@ -11,7 +11,8 @@
   "paths": {
     "/configurations/{id}": {
       "get": {
-        "description": "Get a configuration on IoT Hub for automatic device/module management.",
+        "summary": "Retrieve a configuration for Iot Hub devices and modules by it identifier.",
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "Configuration_Get",
         "consumes": [],
         "produces": [
@@ -20,7 +21,6 @@
         "parameters": [
           {
             "name": "id",
-            "description": "The unique identifier of the configuration.",
             "in": "path",
             "required": true,
             "type": "string"
@@ -31,83 +31,80 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the Configuration.",
+            "description": "Returns the Configuration object",
             "schema": {
               "$ref": "#/definitions/Configuration"
             }
           }
         }
       },
-        "put": {
-            "description": "Create or update a configuration on IoT Hub for automatic device/module management. Configuration Id and Content cannot be updated.",
-            "operationId": "Configuration_CreateOrUpdate",
-            "consumes": [
-                "application/json"
-            ],
-            "produces": [
-                "application/json"
-            ],
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The unique identifier of the configuration.",
-                    "in": "path",
-                    "required": true,
-                    "type": "string"
-                },
-                {
-                    "name": "configuration",
-                    "description": "The configuration to be created or updated.",
-                    "in": "body",
-                    "required": true,
-                    "schema": {
-                        "$ref": "#/definitions/Configuration"
-                    }
-                },
-                {
-                    "name": "If-Match",
-                    "description": "A string representing a weak ETag for configuration, as per RFC7232. Should not be set when creating a configuration, but may be set when updating a configuration.",
-                    "in": "header",
-                    "required": false,
-                    "type": "string"
-                },
-                {
-                    "$ref": "#/parameters/api-version"
-                }
-            ],
-            "responses": {
-                "200": {
-                    "description": "Returns the updated configuration",
-                    "schema": {
-                        "$ref": "#/definitions/Configuration"
-                    }
-                },
-                "201": {
-                    "description": "Returns the created configuration",
-                    "schema": {
-                        "$ref": "#/definitions/Configuration"
-                    }
-                }
+      "put": {
+        "summary": "Create or update the configuration for devices or modules of an IoT hub. An ETag must not be specified for the create operation. An ETag must be specified for the update operation. Note that configuration Id and Content cannot be updated by the user.",
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "Configuration_CreateOrUpdate",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "configuration",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Configuration"
             }
-        },
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the updated Configuration object",
+            "schema": {
+              "$ref": "#/definitions/Configuration"
+            }
+          },
+          "201": {
+            "description": "Returns the created Configuration object",
+            "schema": {
+              "$ref": "#/definitions/Configuration"
+            }
+          }
+        }
+      },
       "delete": {
-        "description": "Delete a configuration on IoT Hub for automatic device/module management",
+        "summary": "Delete the configuration for devices or modules of an IoT hub. This request requires the If-Match header. The client may specify the ETag for the device identity on the request in order to compare to the ETag maintained by the service for the purpose of optimistic concurrency. The delete operation is performed only if the ETag sent by the client matches the value maintained by the server, indicating that the device identity has not been modified since it was retrieved by the client. To force an unconditional delete, set If-Match to the wildcard character (*).",
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "Configuration_Delete",
         "consumes": [],
         "produces": [
           "application/json"
         ],
         "parameters": [
-            {
-                "name": "id",
-                "description": "The unique identifier of the configuration.",
-                "in": "path",
-                "required": true,
-                "type": "string"
-            },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
           {
             "name": "If-Match",
-            "description": "A string representing a weak ETag for configuration, as per RFC7232. The delete operation is performed only if this ETag matches the value maintained by the server, indicating that the configuration has not been modified since it was last retrieved. To force an unconditional delete, set If-Match to the wildcard character (*).",
             "in": "header",
             "required": false,
             "type": "string"
@@ -125,28 +122,28 @@
     },
     "/configurations": {
       "get": {
-        "description": "Get multiple configurations on IoT Hub for automatic device/module management",
+        "summary": "Get multiple configurations for devices or modules of an IoT Hub. Returns the specified number of configurations for Iot Hub. Pagination is not supported.",
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "Configuration_GetConfigurations",
         "consumes": [],
         "produces": [
           "application/json"
         ],
         "parameters": [
-            {
-                "name": "top",
-                "description": "Number of configurations to retrieve. TODO: Ask service team if this value can be overriden if too large",
-                "in": "query",
-                "required": false,
-                "type": "integer",
-                "format": "int32"
-            },
+          {
+            "name": "top",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
           {
             "$ref": "#/parameters/api-version"
           }
         ],
         "responses": {
           "200": {
-            "description": "Returns a list of configurations. Pagination is not supported.",
+            "description": "Returns the list of Configuration objects",
             "schema": {
               "type": "array",
               "items": {
@@ -159,7 +156,8 @@
     },
     "/configurations/testQueries": {
       "post": {
-        "description": "Validate the target condition and custom metric queries for a configuration on IoT Hub.",
+        "summary": "Validates the target condition query and custom metric queries for a configuration.",
+        "description": "Validates the target condition query and custom metric queries for a configuration. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "Configuration_TestQueries",
         "consumes": [
           "application/json"
@@ -170,7 +168,6 @@
         "parameters": [
           {
             "name": "input",
-            "description": "Configuration query for target condition or custom metrics.",
             "in": "body",
             "required": true,
             "schema": {
@@ -183,7 +180,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the configuration queries test response.",
+            "description": "Returns the ConfigurationQueriesTestResponse object.",
             "schema": {
               "$ref": "#/definitions/ConfigurationQueriesTestResponse"
             }
@@ -193,7 +190,8 @@
     },
     "/statistics/devices": {
       "get": {
-        "description": "Get statistics about device identities in the IoT hub’s identity registry, such as total device count.",
+        "summary": "Retrieves statistics about device identities in the IoT hub’s identity registry.",
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "RegistryManager_GetDeviceStatistics",
         "consumes": [],
         "produces": [
@@ -216,7 +214,8 @@
     },
     "/statistics/service": {
       "get": {
-        "description": "Retrieves device statistics for this IoT hub, such as connected device count.",
+        "summary": "Retrieves service statistics for this IoT hub’s identity registry.",
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "RegistryManager_GetServiceStatistics",
         "consumes": [],
         "produces": [
@@ -239,7 +238,8 @@
     },
     "/devices": {
       "get": {
-        "description": "Get the identities of multiple devices from the IoT hub identity registry. Not recommended. Use the IoT Hub query API to retrieve device twin and device identity information. See https://docs.microsoft.com/en-us/rest/api/iothub/service/queryiothub and https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-query-language for more information.",
+        "summary": "Get the identities of multiple devices from the IoT hub identity registry. Not recommended. Use the IoT Hub query language to retrieve device twin and device identity information. See https://docs.microsoft.com/en-us/rest/api/iothub/service/queryiothub and https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-query-language for more information.",
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "RegistryManager_GetDevices",
         "consumes": [],
         "produces": [
@@ -271,7 +271,8 @@
         }
       },
       "post": {
-        "description": "Create, update, or delete the identiies of multiple devices from the IoT hub identity registry. A device identity can be specified only once in the list. Different operations (create, update, delete) on different devices are allowed. A maximum of 100 devices can be specified per invocation. For large scale operations, consider using the import feature using blob storage(https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities).",
+        "summary": "Create, update, or delete the identities of multiple devices from the IoT hub identity registry.",
+        "description": "Create, update, or delete the identiies of multiple devices from the IoT hub identity registry. A device identity can be specified only once in the list. Different operations (create, update, delete) on different devices are allowed. A maximum of 100 devices can be specified per invocation. For large scale operations, consider using the import feature using blob storage(https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities). For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "RegistryManager_BulkDeviceCRUD",
         "consumes": [
           "application/json"
@@ -288,8 +289,7 @@
               "type": "array",
               "items": {
                 "$ref": "#/definitions/ExportImportDevice"
-              },
-              "description": "The set of registry operations to perform."
+              }
             }
           },
           {
@@ -314,7 +314,8 @@
     },
     "/devices/query": {
       "post": {
-        "description": "Query an IoT hub to retrieve information regarding device twins using a SQL-like language. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language for more information. Pagination is supported. This returns information about device twins only.",
+        "summary": "Query an IoT hub to retrieve information regarding device twins using a SQL-like language.",
+        "description": "Query an IoT hub to retrieve information regarding device twins using a SQL-like language. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language for more information. Pagination of results is supported. This returns information about device twins only. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "RegistryManager_QueryIotHub",
         "consumes": [
           "application/json"
@@ -329,8 +330,7 @@
             "required": true,
             "schema": {
               "$ref": "#/definitions/QuerySpecification"
-            },
-            "description": "The query string to run. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language for more information."
+            }
           },
           {
             "$ref": "#/parameters/api-version"
@@ -339,15 +339,13 @@
             "name": "x-ms-continuation",
             "in": "header",
             "required": false,
-            "type": "string",
-            "description": "The continuation token to get the next page of results."
+            "type": "string"
           },
           {
             "name": "x-ms-max-item-count",
             "in": "header",
             "required": false,
-            "type": "string",
-            "description": "The maximum number of items to return per page. The service may use a different value if the value specified is not acceptable."
+            "type": "string"
           }
         ],
         "responses": {
@@ -375,7 +373,8 @@
     },
     "/devices/{id}": {
       "get": {
-        "description": "Get a device from the identity registry of an IoT hub.",
+        "summary": "Retrieve a device from the identity registry of an IoT hub.",
+        "description": "Retrieve a device from the identity registry of an IoT hub. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "RegistryManager_GetDevice",
         "consumes": [],
         "produces": [
@@ -385,7 +384,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "The unique identifier of the device to retrieve.",
+            "description": "Device ID.",
             "required": true,
             "type": "string"
           },
@@ -395,7 +394,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the Device.",
+            "description": "Returns the Device object",
             "schema": {
               "$ref": "#/definitions/Device"
             }
@@ -403,7 +402,8 @@
         }
       },
       "put": {
-        "description": "Create or update the identity of a device in the identity registry of an IoT hub.",
+        "summary": "Create or update the identity of a device in the identity registry of an IoT hub.",
+        "description": "Create or update the identity of a device in the identity registry of an IoT hub. An ETag must not be specified for the create operation. An ETag must be specified for the update operation. Note that generationId and deviceId cannot be updated by the user. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "RegistryManager_CreateOrUpdateDevice",
         "consumes": [
           "application/json"
@@ -415,7 +415,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "The unique identifier of the device to create",
+            "description": "Device ID.",
             "required": true,
             "type": "string"
           },
@@ -425,15 +425,13 @@
             "required": true,
             "schema": {
               "$ref": "#/definitions/Device"
-            },
-            "description": "The contents of the device to create."
+            }
           },
           {
             "name": "If-Match",
             "in": "header",
             "required": false,
-            "type": "string",
-            "description": "A string representing a weak ETag for the device identity, as per RFC7232. Should not be set when creating a device, but may be set when updating a device."
+            "type": "string"
           },
           {
             "$ref": "#/parameters/api-version"
@@ -441,7 +439,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the Device",
+            "description": "Returns the Device object",
             "schema": {
               "$ref": "#/definitions/Device"
             }
@@ -449,7 +447,8 @@
         }
       },
       "delete": {
-        "description": "Delete the identity of a device from the identity registry of an IoT hub.",
+        "summary": "Delete the identity of a device from the identity registry of an IoT hub.",
+        "description": "Delete the identity of a device from the identity registry of an IoT hub. This request requires the If-Match header. The client may specify the ETag for the device identity on the request in order to compare to the ETag maintained by the service for the purpose of optimistic concurrency. The delete operation is performed only if the ETag sent by the client matches the value maintained by the server, indicating that the device identity has not been modified since it was retrieved by the client. To force an unconditional delete, set If-Match to the wildcard character (*). For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "RegistryManager_DeleteDevice",
         "consumes": [],
         "produces": [
@@ -459,7 +458,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "The unique identifier of the device to delete.",
+            "description": "Device ID.",
             "required": true,
             "type": "string"
           },
@@ -467,8 +466,7 @@
             "name": "If-Match",
             "in": "header",
             "required": false,
-            "type": "string",
-            "description": "A string representing a weak ETag for the device identity, as per RFC7232. The delete operation is performed only if this ETag matches the value maintained by the server, indicating that the device identity has not been modified since it was last retrieved. To force an unconditional delete, set If-Match to the wildcard character (*)."
+            "type": "string"
           },
           {
             "$ref": "#/parameters/api-version"
@@ -483,7 +481,8 @@
     },
     "/devices/{id}/applyConfigurationContent": {
       "post": {
-        "description": "Apply the provided configuration content to the specified edge device.",
+        "summary": "Applies the provided configuration content to the specified edge device.",
+        "description": "Applies the provided configuration content to the specified edge device. Configuration content must have modules content For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "Configuration_ApplyOnEdgeDevice",
         "consumes": [
           "application/json"
@@ -494,8 +493,8 @@
         "parameters": [
           {
             "name": "id",
-            "description": "The unique identifier of the device.",
             "in": "path",
+            "description": "Device ID.",
             "required": true,
             "type": "string"
           },
@@ -527,7 +526,8 @@
     },
     "/jobs/create": {
       "post": {
-        "description": "Create a new import or export job on IoT Hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information.",
+        "summary": "Create a new import/export job on an IoT hub.",
+        "description": "Create a new import/export job on an IoT hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "JobClient_CreateImportExportJob",
         "consumes": [
           "application/json"
@@ -551,7 +551,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the JobProperties",
+            "description": "Returns the JobProperties object",
             "schema": {
               "$ref": "#/definitions/JobProperties"
             }
@@ -561,7 +561,8 @@
     },
     "/jobs": {
       "get": {
-        "description": "Get the status of all import and export jobs in IoT Hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information.",
+        "summary": "Gets the status of all import/export jobs in an iot hub",
+        "description": "Gets the status of all import/export jobs in an iot hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "JobClient_GetImportExportJobs",
         "consumes": [],
         "produces": [
@@ -574,7 +575,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns an array of JobProperties",
+            "description": "Returns the array of JobProperties object",
             "schema": {
               "type": "array",
               "items": {
@@ -587,7 +588,8 @@
     },
     "/jobs/{id}": {
       "get": {
-        "description": "Get the status of an import or export job in IoT Hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information.",
+        "summary": "Gets the status of an import or export job in an iot hub",
+        "description": "Gets the status of an import or export job in an iot hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "JobClient_GetImportExportJob",
         "consumes": [],
         "produces": [
@@ -597,7 +599,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "The unique identifier of the job.",
+            "description": "Job ID.",
             "required": true,
             "type": "string"
           },
@@ -607,7 +609,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the JobProperties",
+            "description": "Returns the JobProperties object",
             "schema": {
               "$ref": "#/definitions/JobProperties"
             }
@@ -615,7 +617,8 @@
         }
       },
       "delete": {
-        "description": "Cancels an import or export job in IoT Hub.",
+        "summary": "Cancels an import or export job in an IoT hub.",
+        "description": "Cancels an import or export job in an IoT hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "JobClient_CancelImportExportJob",
         "consumes": [],
         "produces": [
@@ -625,7 +628,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "The unique identifier of the job.",
+            "description": "Job ID.",
             "required": true,
             "type": "string"
           },
@@ -648,20 +651,21 @@
     },
     "/devices/{id}/commands": {
       "delete": {
-        "description": "Deletes all the pending commands for this device from the IoT hub.",
+        "summary": "Deletes all the pending commands for this device from the IoT hub.",
+        "description": "Deletes all the pending commands for this device from the IoT hub For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "RegistryManager_PurgeCommandQueue",
         "consumes": [],
         "produces": [
           "application/json"
         ],
         "parameters": [
-        {
-          "name": "id",
-          "in": "path",
-          "description": "The unique identifier of the device.",
-          "required": true,
-          "type": "string"
-        },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Device ID.",
+            "required": true,
+            "type": "string"
+          },
           {
             "$ref": "#/parameters/api-version"
           }
@@ -677,59 +681,62 @@
       }
     },
     "/faultInjection": {
-        "get": {
-            "description": "Get FaultInjection entity.",
-            "operationId": "FaultInjection_Get",
-            "consumes": [],
-            "produces": [
-                "application/json"
-            ],
-            "parameters": [
-                {
-                    "$ref": "#/parameters/api-version"
-                }
-            ],
-            "responses": {
-                "200": {
-                    "description": "OK",
-                    "schema": {
-                        "$ref": "#/definitions/FaultInjectionProperties"
-                    }
-                }
+      "get": {
+        "summary": "Get FaultInjection entity",
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "FaultInjection_Get",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "typeof faultInjectionProperty",
+            "schema": {
+              "$ref": "#/definitions/FaultInjectionProperties"
             }
-        },
-        "put": {
-            "description": "Create or update FaultInjection entity.",
-            "operationId": "FaultInjection_Set",
-            "consumes": [
-                "application/json"
-            ],
-            "produces": [
-                "application/json"
-            ],
-            "parameters": [
-                {
-                    "name": "value",
-                    "in": "body",
-                    "required": true,
-                    "schema": {
-                        "$ref": "#/definitions/FaultInjectionProperties"
-                    }
-                },
-                {
-                    "$ref": "#/parameters/api-version"
-                }
-            ],
-            "responses": {
-                "200": {
-                    "description": "OK"
-                }
-            }
+          }
         }
+      },
+      "put": {
+        "summary": "Create or update FaultInjection entity",
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "FaultInjection_Set",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "value",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FaultInjectionProperties"
+            }
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
     },
     "/twins/{id}": {
       "get": {
-        "description": "Gets the device twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information.",
+        "summary": "Gets a device twin.",
+        "description": "Gets a device twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "Twin_GetDeviceTwin",
         "consumes": [],
         "produces": [
@@ -739,7 +746,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "The unique identifier of the device.",
+            "description": "Device ID.",
             "required": true,
             "type": "string"
           },
@@ -749,7 +756,7 @@
         ],
         "responses": {
           "200": {
-            "description": "OK.",
+            "description": "Returns the device twin object",
             "schema": {
               "$ref": "#/definitions/Twin"
             }
@@ -757,7 +764,8 @@
         }
       },
       "put": {
-        "description": "Replaces the tags and desired properties of a device. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information.",
+        "summary": "Replaces tags and desired properties of a device twin.",
+        "description": "Replaces a device twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "Twin_ReplaceDeviceTwin",
         "consumes": [
           "application/json"
@@ -769,14 +777,14 @@
           {
             "name": "id",
             "in": "path",
-            "description": "The unique identifier of the device.",
+            "description": "Device ID.",
             "required": true,
             "type": "string"
           },
           {
             "name": "deviceTwinInfo",
             "in": "body",
-            "description": "The twin object that will replace the current device twin.",
+            "description": "Device twin info",
             "required": true,
             "schema": {
               "$ref": "#/definitions/Twin"
@@ -785,7 +793,6 @@
           {
             "name": "If-Match",
             "in": "header",
-            "description": "A string representing a weak ETag for the device twin, as per RFC7232. It determines if the replace operation should be carried out.",
             "required": false,
             "type": "string"
           },
@@ -795,7 +802,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The updated device twin.",
+            "description": "Returns the device twin object",
             "schema": {
               "$ref": "#/definitions/Twin"
             }
@@ -803,7 +810,8 @@
         }
       },
       "patch": {
-        "description": "Updates the tags and desired properties of a device. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information.",
+        "summary": "Updates tags and desired properties of a device twin.",
+        "description": "Updates a device twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "Twin_UpdateDeviceTwin",
         "consumes": [
           "application/json"
@@ -815,14 +823,14 @@
           {
             "name": "id",
             "in": "path",
-            "description": "The unique identifier of the device.",
+            "description": "Device ID.",
             "required": true,
             "type": "string"
           },
           {
             "name": "deviceTwinInfo",
             "in": "body",
-            "description": "The twin object containing the tags and desired properties to be updated.",
+            "description": "Device twin info",
             "required": true,
             "schema": {
               "$ref": "#/definitions/Twin"
@@ -831,7 +839,6 @@
           {
             "name": "If-Match",
             "in": "header",
-            "description": "A string representing a weak ETag for the device twin, as per RFC7232. It determines if the update operation should be carried out.",
             "required": false,
             "type": "string"
           },
@@ -841,7 +848,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The updated device twin.",
+            "description": "Returns the device twin object",
             "schema": {
               "$ref": "#/definitions/Twin"
             }
@@ -851,7 +858,8 @@
     },
     "/twins/{id}/modules/{mid}": {
       "get": {
-        "description": "Gets the module twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information.",
+        "summary": "Gets a module twin.",
+        "description": "Gets a module twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "Twin_GetModuleTwin",
         "consumes": [],
         "produces": [
@@ -861,14 +869,14 @@
           {
             "name": "id",
             "in": "path",
-            "description": "The unique identifier of the device",
+            "description": "Device ID.",
             "required": true,
             "type": "string"
           },
           {
             "name": "mid",
             "in": "path",
-            "description": "The unique identifier of the module",
+            "description": "Module ID.",
             "required": true,
             "type": "string"
           },
@@ -878,7 +886,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The module state information.",
+            "description": "Returns the device twin object",
             "schema": {
               "$ref": "#/definitions/Twin"
             }
@@ -886,7 +894,8 @@
         }
       },
       "put": {
-        "description": "Replaces the tags and desired properties of a module. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information.",
+        "summary": "Replaces tags and desired properties of a module twin.",
+        "description": "Replaces a module twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "Twin_ReplaceModuleTwin",
         "consumes": [
           "application/json"
@@ -898,21 +907,21 @@
           {
             "name": "id",
             "in": "path",
-            "description": "The unique identifier of the device.",
+            "description": "Device ID.",
             "required": true,
             "type": "string"
           },
           {
             "name": "mid",
             "in": "path",
-            "description": "The unique identifier of the module.",
+            "description": "Module ID.",
             "required": true,
             "type": "string"
           },
           {
             "name": "deviceTwinInfo",
             "in": "body",
-            "description": "The twin object that will replace the current module twin.",
+            "description": "Device twin info",
             "required": true,
             "schema": {
               "$ref": "#/definitions/Twin"
@@ -921,7 +930,6 @@
           {
             "name": "If-Match",
             "in": "header",
-            "description": "A string representing a weak ETag for the device twin, as per RFC7232. It determines if the replace operation should be carried out.",
             "required": false,
             "type": "string"
           },
@@ -931,7 +939,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The updated module twin.",
+            "description": "Returns the device twin object",
             "schema": {
               "$ref": "#/definitions/Twin"
             }
@@ -939,7 +947,8 @@
         }
       },
       "patch": {
-        "description": "Updates the tags and desired properties of a module. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information.",
+        "summary": "Updates tags and desired properties of a module twin.",
+        "description": "Updates a module twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "Twin_UpdateModuleTwin",
         "consumes": [
           "application/json"
@@ -951,21 +960,21 @@
           {
             "name": "id",
             "in": "path",
-            "description": "The unique identifier of the device.",
+            "description": "Device ID.",
             "required": true,
             "type": "string"
           },
           {
             "name": "mid",
             "in": "path",
-            "description": "The unique identifier of the module.",
+            "description": "Module ID.",
             "required": true,
             "type": "string"
           },
           {
             "name": "deviceTwinInfo",
             "in": "body",
-            "description": "The twin object containing the tags and desired properties to be updated.",
+            "description": "Device twin information",
             "required": true,
             "schema": {
               "$ref": "#/definitions/Twin"
@@ -974,7 +983,6 @@
           {
             "name": "If-Match",
             "in": "header",
-            "description": "A string representing a weak ETag for the device twin, as per RFC7232. It determines if the update operation should be carried out.",
             "required": false,
             "type": "string"
           },
@@ -984,7 +992,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The updated module twin.",
+            "description": "Returns the device twin object",
             "schema": {
               "$ref": "#/definitions/Twin"
             }
@@ -994,7 +1002,8 @@
     },
     "/digitalTwins/{digitalTwinId}/interfaces": {
       "get": {
-        "description": "Get the list of interfaces.",
+        "summary": "Gets the list of interfaces.",
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "DigitalTwin_GetComponents",
         "consumes": [],
         "produces": [
@@ -1004,7 +1013,7 @@
           {
             "name": "digitalTwinId",
             "in": "path",
-            "description": "The unique identifier of the digital twin. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional.",
+            "description": "Digital Twin ID. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional.",
             "required": true,
             "type": "string"
           },
@@ -1014,7 +1023,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns a collection of interfaces",
+            "description": "Returns a collection of interface objects",
             "schema": {
               "$ref": "#/definitions/DigitalTwinInterfaces"
             },
@@ -1028,7 +1037,8 @@
         }
       },
       "patch": {
-        "description": "Updates desired properties of multiple interfaces.",
+        "summary": "Updates desired properties of multiple interfaces.\r\n            Example URI: \"digitalTwins/{digitalTwinId}/interfaces\"",
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "DigitalTwin_UpdateComponent",
         "consumes": [
           "application/json"
@@ -1040,14 +1050,14 @@
           {
             "name": "digitalTwinId",
             "in": "path",
-            "description": "The unique identifier of the digital twin. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional.",
+            "description": "Digital Twin ID. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional.",
             "required": true,
             "type": "string"
           },
           {
             "name": "interfacesPatchInfo",
             "in": "body",
-            "description": "The JSON representation of the update patch",
+            "description": "Multiple interfaces desired properties to update.",
             "required": true,
             "schema": {
               "$ref": "#/definitions/DigitalTwinInterfacesPatch"
@@ -1055,7 +1065,6 @@
           },
           {
             "name": "If-Match",
-            "description": "A string representing a weak ETag for digital twin, as per RFC7232",
             "in": "header",
             "required": false,
             "type": "string"
@@ -1082,7 +1091,8 @@
     },
     "/digitalTwins/{digitalTwinId}/interfaces/{interfaceName}": {
       "get": {
-        "description": "Get the interface.",
+        "summary": "Gets the interface of given interfaceId.\r\n            Example URI: \"digitalTwins/{digitalTwinId}/interfaces/{interfaceName}\"",
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "DigitalTwin_GetComponent",
         "consumes": [],
         "produces": [
@@ -1092,7 +1102,7 @@
           {
             "name": "digitalTwinId",
             "in": "path",
-            "description": "The unique identifier of the digital twin. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional.",
+            "description": "Digital Twin ID. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional.",
             "required": true,
             "type": "string"
           },
@@ -1109,7 +1119,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the interface",
+            "description": "Returns interface object of given id",
             "schema": {
               "$ref": "#/definitions/DigitalTwinInterfaces"
             },
@@ -1125,7 +1135,8 @@
     },
     "/messages/serviceBound/feedback": {
       "get": {
-        "description": "This method is used to retrieve feedback for cloud-to-device messages. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information. This capability is only available in the standard tier IoT Hub. For more information, see [Choose the right IoT Hub tier](https://aka.ms/scaleyouriotsolution).",
+        "summary": "This method is used to retrieve feedback of a cloud-to-device message.",
+        "description": "This method is used to retrieve feedback of a cloud-to-device message See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information. This capability is only available in the standard tier IoT Hub. For more information, see [Choose the right IoT Hub tier](https://aka.ms/scaleyouriotsolution). For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "HttpRuntime_ReceiveFeedbackNotification",
         "consumes": [],
         "produces": [
@@ -1138,7 +1149,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The feedback response of a cloud-to-device message"
+            "description": "The feedback response object"
           },
           "204": {
             "description": "No Content Sent if feedback queue is empty"
@@ -1148,7 +1159,8 @@
     },
     "/messages/serviceBound/feedback/{lockToken}": {
       "delete": {
-        "description": "This method completes a cloud-to-device feedback message. A completed message is deleted from the service's feedback queue. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information.",
+        "summary": "This method completes a feedback message.",
+        "description": "This method completes a feedback message. The lockToken obtained when the message was received must be provided to resolve race conditions when completing, a feedback message. A completed message is deleted from the feedback queue. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "HttpRuntime_CompleteFeedbackNotification",
         "consumes": [],
         "produces": [
@@ -1158,7 +1170,7 @@
           {
             "name": "lockToken",
             "in": "path",
-            "description": "The lock token obtained when the C2D message was received, and provided to resolve race conditions when completing a feedback message.",
+            "description": "Lock token.",
             "required": true,
             "type": "string"
           },
@@ -1175,7 +1187,8 @@
     },
     "/messages/serviceBound/feedback/{lockToken}/abandon": {
       "post": {
-        "description": "This method abandons a cloud-to-device feedback message. An abandoned message is deleted from the service's feedback queue. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information.",
+        "summary": "This method abandons a feedback message.",
+        "description": "This method abandons a feedback message. The lockToken obtained when the message was received must be provided to resolve race conditions when abandoning, a feedback message. A abandoned message is deleted from the feedback queue. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "HttpRuntime_AbandonFeedbackNotification",
         "consumes": [],
         "produces": [
@@ -1185,7 +1198,7 @@
           {
             "name": "lockToken",
             "in": "path",
-            "description": "The lock token obtained when the C2D message was received, and provided to resolve race conditions when abandoning a feedback message.",
+            "description": "Lock Token.",
             "required": true,
             "type": "string"
           },
@@ -1202,7 +1215,8 @@
     },
     "/jobs/v2/{id}": {
       "get": {
-        "description": "Retrieves details of a scheduled job from IoT hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information.",
+        "summary": "Retrieves details of a scheduled job from an IoT hub.",
+        "description": "Retrieves details of a scheduled job from an IoT hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "JobClient_GetJob",
         "consumes": [],
         "produces": [
@@ -1212,7 +1226,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "The unique identifier of the job.",
+            "description": "Job ID.",
             "required": true,
             "type": "string"
           },
@@ -1222,7 +1236,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the job details.",
+            "description": "Returns the Job response object",
             "schema": {
               "$ref": "#/definitions/JobResponse"
             }
@@ -1230,7 +1244,8 @@
         }
       },
       "put": {
-        "description": "Creates a new job to schedule twin updates or direct methods on IoT Hub at a scheduled time. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information.",
+        "summary": "Creates a new job to schedule update twins or device direct methods on an IoT hub at a scheduled time.",
+        "description": "Creates a new job to schedule update twins or device direct methods on an IoT hub at a scheduled time. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "JobClient_CreateJob",
         "consumes": [
           "application/json"
@@ -1242,14 +1257,13 @@
           {
             "name": "id",
             "in": "path",
-            "description": "The unique identifier of the job.",
+            "description": "Job ID.",
             "required": true,
             "type": "string"
           },
           {
             "name": "jobRequest",
             "in": "body",
-            "description": "The job to be created.",
             "required": true,
             "schema": {
               "$ref": "#/definitions/JobRequest"
@@ -1261,7 +1275,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the job response.",
+            "description": "Returns the Job response object",
             "schema": {
               "$ref": "#/definitions/JobResponse"
             }
@@ -1271,7 +1285,8 @@
     },
     "/jobs/v2/{id}/cancel": {
       "post": {
-        "description": "Cancels a scheduled job on IoT Hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information.",
+        "summary": "Cancels a scheduled job on an IoT hub.",
+        "description": "Cancels a scheduled job on an IoT hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "JobClient_CancelJob",
         "consumes": [],
         "produces": [
@@ -1281,7 +1296,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "The unique identifier of the job.",
+            "description": "Job ID.",
             "required": true,
             "type": "string"
           },
@@ -1291,7 +1306,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the job response",
+            "description": "Returns the Job response object",
             "schema": {
               "$ref": "#/definitions/JobResponse"
             }
@@ -1301,7 +1316,8 @@
     },
     "/jobs/v2/query": {
       "get": {
-        "description": "Query IoT hub to retrieve information regarding jobs using the IoT Hub query language. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language for more information.",
+        "summary": "Query an IoT hub to retrieve information regarding jobs using the IoT Hub query language",
+        "description": "Query an IoT hub to retrieve information regarding jobs using the IoT Hub query language. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language for more information. Pagination of results is supported. This returns information about jobs only. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "JobClient_QueryJobs",
         "consumes": [],
         "produces": [
@@ -1311,14 +1327,14 @@
           {
             "name": "jobType",
             "in": "query",
-            "description": "The job type. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs#querying-for-progress-on-jobs for a list of possible job types.",
+            "description": "Job Type.",
             "required": false,
             "type": "string"
           },
           {
             "name": "jobStatus",
             "in": "query",
-            "description": "The job status. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs#querying-for-progress-on-jobs for a list of possible statuses.",
+            "description": "Job Status.",
             "required": false,
             "type": "string"
           },
@@ -1328,7 +1344,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the Query Result.",
+            "description": "Returns the Query Result object",
             "schema": {
               "$ref": "#/definitions/QueryResult"
             }
@@ -1338,7 +1354,8 @@
     },
     "/devices/{id}/modules": {
       "get": {
-        "description": "Get all the module identities of the device.",
+        "summary": "Retrieve all the module identities on the device.",
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "RegistryManager_GetModulesOnDevice",
         "consumes": [],
         "produces": [
@@ -1348,7 +1365,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "The unique identifier of the device.",
+            "description": "Device ID.",
             "required": true,
             "type": "string"
           },
@@ -1358,7 +1375,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns all the modules of the device.",
+            "description": "Returns the Device object",
             "schema": {
               "type": "array",
               "items": {
@@ -1371,7 +1388,8 @@
     },
     "/devices/{id}/modules/{mid}": {
       "get": {
-        "description": "Get the specified module identity of the device.",
+        "summary": "Retrieve the specified module identity on the device.",
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "RegistryManager_GetModule",
         "consumes": [],
         "produces": [
@@ -1381,14 +1399,14 @@
           {
             "name": "id",
             "in": "path",
-            "description": "The unique identifier of the device.",
+            "description": "Device ID.",
             "required": true,
             "type": "string"
           },
           {
             "name": "mid",
             "in": "path",
-            "description": "The unique identifier of the module.",
+            "description": "Module ID.",
             "required": true,
             "type": "string"
           },
@@ -1398,7 +1416,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the module.",
+            "description": "Returns the DeviceModule object",
             "schema": {
               "$ref": "#/definitions/Module"
             }
@@ -1406,7 +1424,8 @@
         }
       },
       "put": {
-        "description": "Create or update the module identity for device in IoT hub. The moduleId and generation cannot be updated by the user.",
+        "summary": "Create or update the module identity for device in IoT hub. An ETag must not be specified for the create operation. An ETag must be specified for the update operation. Note that moduleId and generation cannot be updated by the user.",
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "RegistryManager_CreateOrUpdateModule",
         "consumes": [
           "application/json"
@@ -1418,20 +1437,19 @@
           {
             "name": "id",
             "in": "path",
-            "description": "The unique identifier of the device.",
+            "description": "Device ID.",
             "required": true,
             "type": "string"
           },
           {
             "name": "mid",
             "in": "path",
-            "description": "The unique identifier of the module.",
+            "description": "Module ID.",
             "required": true,
             "type": "string"
           },
           {
             "name": "module",
-            "description": "The module identity.",
             "in": "body",
             "required": true,
             "schema": {
@@ -1440,7 +1458,6 @@
           },
           {
             "name": "If-Match",
-            "description": "A string representing a weak ETag for the module, as per RFC7232. Should not be set when creating module, but may be set when updating a module",
             "in": "header",
             "required": false,
             "type": "string"
@@ -1451,21 +1468,22 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the updated module.",
+            "description": "Returns the updated DeviceModule object",
             "schema": {
               "$ref": "#/definitions/Module"
             }
           },
           "201": {
-            "description": "Returns the created module.",
+            "description": "Returns the created DeviceModule object",
             "schema": {
               "$ref": "#/definitions/Module"
             }
           }
         }
       },
-      "delete": {        
-        "description": "Delete the module identity for device of an IoT hub.",
+      "delete": {
+        "summary": "Delete the module identity for device of an IoT hub. This request requires the If-Match header. The client may specify the ETag for the device identity on the request in order to compare to the ETag maintained by the service for the purpose of optimistic concurrency. The delete operation is performed only if the ETag sent by the client matches the value maintained by the server, indicating that the device identity has not been modified since it was retrieved by the client. To force an unconditional delete, set If-Match to the wildcard character (*).",
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "RegistryManager_DeleteModule",
         "consumes": [],
         "produces": [
@@ -1475,20 +1493,19 @@
           {
             "name": "id",
             "in": "path",
-            "description": "The unique identifier of the deivce.",
+            "description": "Device ID.",
             "required": true,
             "type": "string"
           },
           {
             "name": "mid",
             "in": "path",
-            "description": "The unique identifier of the module.",
+            "description": "Module ID.",
             "required": true,
             "type": "string"
           },
           {
             "name": "If-Match",
-            "description": " A string representing a weak ETag for the module, as per RFC7232. The delete operation is performed only if this ETag matches the value maintained by the server, indicating that the module has not been modified since it was last retrieved. To force an unconditional delete, set If-Match to the wildcard character (*).",
             "in": "header",
             "required": false,
             "type": "string"
@@ -1506,7 +1523,8 @@
     },
     "/digitalTwins/models/{modelId}": {
       "get": {
-        "description": "Returns a DigitalTwin model definition for the given id.\r\nIf \"expand\" is present in the query parameters and id is for a device capability model then it returns\r\nthe capability metamodel with expanded interface definitions.",
+        "summary": "Returns a DigitalTwin model definition for the given id.\r\nIf \"expand\" is present in the query parameters and id is for a device capability model then it returns\r\nthe capability metamodel with expanded interface definitions.",
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
         "operationId": "DigitalTwin_GetDigitalTwinModel",
         "consumes": [],
         "produces": [
@@ -1582,6 +1600,7 @@
     },
     "/twins/{deviceId}/methods": {
       "post": {
+        "summary": "Invoke a direct method on a device.",
         "description": "Invoke a direct method on a device. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-direct-methods for more information.",
         "operationId": "DeviceMethod_InvokeDeviceMethod",
         "consumes": [
@@ -1594,14 +1613,12 @@
           {
             "name": "deviceId",
             "in": "path",
-            "description": "The unique identifier of the device.",
             "required": true,
             "type": "string"
           },
           {
             "name": "directMethodRequest",
             "in": "body",
-            "description": "Parameters to execute a direct method on the device.",
             "required": true,
             "schema": {
               "$ref": "#/definitions/CloudToDeviceMethod"
@@ -1613,7 +1630,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The direct method response payload.",
+            "description": "Returns the method response payload",
             "schema": {
               "$ref": "#/definitions/CloudToDeviceMethodResult"
             }
@@ -1623,7 +1640,8 @@
     },
     "/twins/{deviceId}/modules/{moduleId}/methods": {
       "post": {
-        "description": "Invoke a direct method on a module of a device. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-direct-methods for more information.",
+        "summary": "Invoke a direct method on a module of a device.",
+        "description": "Invoke a direct method on a module of a device. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-direct-methods for more information",
         "operationId": "DeviceMethod_InvokeModuleMethod",
         "consumes": [
           "application/json"
@@ -1635,21 +1653,18 @@
           {
             "name": "deviceId",
             "in": "path",
-            "description": "The unique identifier of the device.",
             "required": true,
             "type": "string"
           },
           {
             "name": "moduleId",
             "in": "path",
-            "description": "The unique identifier of the module.",
             "required": true,
             "type": "string"
           },
           {
             "name": "directMethodRequest",
             "in": "body",
-            "description": "Parameters to execute a direct method on the module.",
             "required": true,
             "schema": {
               "$ref": "#/definitions/CloudToDeviceMethod"
@@ -1661,7 +1676,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The direct method response payload.",
+            "description": "Returns the method response payload",
             "schema": {
               "$ref": "#/definitions/CloudToDeviceMethodResult"
             }
@@ -1753,20 +1768,18 @@
   },
   "definitions": {
     "ConfigurationMetrics": {
-      "description": "Configuration Metrics for IotHub devices and modules.",
+      "description": "Configuration Metrics",
       "type": "object",
       "properties": {
         "results": {
           "type": "object",
-          "description": "TODO: Service to fill in",
-          "additionalProperties": {            
+          "additionalProperties": {
             "format": "int64",
             "type": "integer"
           }
         },
         "queries": {
           "type": "object",
-          "description": "TODO: Service to fill in",
           "additionalProperties": {
             "type": "string"
           }
@@ -1778,15 +1791,15 @@
       "type": "object",
       "properties": {
         "id": {
-          "description": "The unique identifier of the configuration.",
+          "description": "Gets Identifier for the configuration",
           "type": "string"
         },
         "schemaVersion": {
-          "description": "Schema version of the configuration",
+          "description": "Gets Schema version for the configuration",
           "type": "string"
         },
         "labels": {
-          "description": "Key-value pairs used to describe a configuration",
+          "description": "Gets or sets labels for the configuration",
           "type": "object",
           "additionalProperties": {
             "type": "string"
@@ -1794,37 +1807,37 @@
         },
         "content": {
           "$ref": "#/definitions/ConfigurationContent",
-          "description": "Content of the configuration."
+          "description": "Gets or sets Content for the configuration"
         },
         "targetCondition": {
-          "description": "The query used to define targeted devices or modules. The query is based on twin tags and/or reported properties",
+          "description": "Gets or sets Target Condition for the configuration",
           "type": "string"
         },
         "createdTimeUtc": {
           "format": "date-time",
-          "description": "Creation time of the configuration.",
+          "description": "Gets creation time for the configuration",
           "type": "string"
         },
         "lastUpdatedTimeUtc": {
           "format": "date-time",
-          "description": "Update time of the configuration.",
+          "description": "Gets last update time for the configuration",
           "type": "string"
         },
         "priority": {
           "format": "int32",
-          "description": "The priority number assigned to the configuration.",
+          "description": "Gets or sets Priority for the configuration",
           "type": "integer"
         },
         "systemMetrics": {
           "$ref": "#/definitions/ConfigurationMetrics",
-          "description": "Metrics calculated by IoT Hub that cannot be customized."
+          "description": "System Configuration Metrics"
         },
         "metrics": {
           "$ref": "#/definitions/ConfigurationMetrics",
-          "description": "Custom metrics specified by developer as queries against twin reported properties"
+          "description": "Custom Configuration Metrics"
         },
         "etag": {
-          "description": "ETag of the configuration",
+          "description": "Gets or sets configuration's ETag",
           "type": "string"
         }
       }
@@ -1834,14 +1847,14 @@
       "type": "object",
       "properties": {
         "deviceContent": {
-          "description": "Device Configurations",
+          "description": "Gets or sets device Configurations",
           "type": "object",
           "additionalProperties": {
             "type": "object"
           }
         },
         "modulesContent": {
-          "description": "Modules configuration content",
+          "description": "Gets or sets Modules Configurations",
           "type": "object",
           "additionalProperties": {
             "type": "object",
@@ -1851,7 +1864,7 @@
           }
         },
         "moduleContent": {
-          "description": "Module configuration content",
+          "description": "Gets or sets Module Configurations",
           "type": "object",
           "additionalProperties": {
             "type": "object"
@@ -1863,12 +1876,10 @@
       "type": "object",
       "properties": {
         "targetCondition": {
-          "type": "string",
-          "description": "The query used to define targeted devices or modules. The query is based on twin tags and/or reported properties"
+          "type": "string"
         },
         "customMetricQueries": {
-          "type": "string",
-          "description": "Queries on twin reported properties",
+          "type": "object",
           "additionalProperties": {
             "type": "string"
           }
@@ -1879,14 +1890,12 @@
       "type": "object",
       "properties": {
         "targetConditionError": {
-          "type": "string",
-          "description": "Errors running the target condition query."
+          "type": "string"
         },
         "customMetricQueryErrors": {
           "type": "object",
           "additionalProperties": {
-            "type": "string",
-            "description": "Errors running the custom metric query."
+            "type": "string"
           }
         }
       }
@@ -1896,18 +1905,15 @@
       "properties": {
         "totalDeviceCount": {
           "format": "int64",
-          "type": "integer",
-          "description": "The total number of devices registered for this hub."
+          "type": "integer"
         },
         "enabledDeviceCount": {
           "format": "int64",
-          "type": "integer",
-          "description": "The number of currently enabled devices."
+          "type": "integer"
         },
         "disabledDeviceCount": {
           "format": "int64",
-          "type": "integer",
-          "description": "The number of currently disabled devices."
+          "type": "integer"
         }
       }
     },
@@ -1916,8 +1922,7 @@
       "properties": {
         "connectedDeviceCount": {
           "format": "int64",
-          "type": "integer",
-          "description": "The number of currently connected devices."
+          "type": "integer"
         }
       }
     },
@@ -1925,72 +1930,58 @@
       "type": "object",
       "properties": {
         "deviceId": {
-          "type": "string",
-          "description": "The unique identifier of this device."
+          "type": "string"
         },
         "generationId": {
-          "type": "string",
-          "description": "An IoT hub-generated, case-sensitive string up to 128 characters long. This value is used to distinguish devices with the same deviceId, when they have been deleted and re-created."
+          "type": "string"
         },
         "etag": {
-          "type": "string",
-          "description": "A string representing a weak ETag for the device identity, as per RFC7232."
+          "type": "string"
         },
         "connectionState": {
           "enum": [
             "Disconnected",
             "Connected"
           ],
-          "type": "string",
-          "description": "Tells whether the device is connected or not."
+          "type": "string"
         },
         "status": {
           "enum": [
             "enabled",
             "disabled"
           ],
-          "type": "string",
-          "description": "Flags whether a device is enabled or not. If disabled, a device cannot connect to the service."
+          "type": "string"
         },
         "statusReason": {
-          "type": "string",
-          "description": "A 128 character-long string that stores the reason for the device identity status. All UTF-8 characters are allowed."
+          "type": "string"
         },
         "connectionStateUpdatedTime": {
           "format": "date-time",
-          "type": "string",
-          "description": "A temporal indicator, showing the date and last time the connection state was updated."
+          "type": "string"
         },
         "statusUpdatedTime": {
           "format": "date-time",
-          "type": "string",
-          "description": "The last timestamp of when the status field was updated."
+          "type": "string"
         },
         "lastActivityTime": {
           "format": "date-time",
-          "type": "string",
-          "description": "A temporal indicator, showing the date and last time the device connected, received, or sent a message."
+          "type": "string"
         },
         "cloudToDeviceMessageCount": {
           "format": "int32",
-          "type": "integer",
-          "description": "The number of cloud to device messages currently queued to be sent to the device."
+          "type": "integer"
         },
         "authentication": {
-          "$ref": "#/definitions/AuthenticationMechanism",
-          "description": "The details on what authentication mechanisms are used by this device."
+          "$ref": "#/definitions/AuthenticationMechanism"
         },
         "capabilities": {
-          "$ref": "#/definitions/DeviceCapabilities",
-          "description": "The set of capabilities that this device has. For example, if this device is an edge device or not."
+          "$ref": "#/definitions/DeviceCapabilities"
         },
         "deviceScope": {
-          "type": "string",
-          "description": "The scope that this device belongs to."
+          "type": "string"
         },
         "parentScopes": {
           "type": "array",
-          "description": "TODO: service team needs to explain this",
           "items": {
             "type": "string"
           }
@@ -2001,12 +1992,10 @@
       "type": "object",
       "properties": {
         "symmetricKey": {
-          "$ref": "#/definitions/SymmetricKey",
-          "description": "The primary and secondary keys used for SAS based authentication."
+          "$ref": "#/definitions/SymmetricKey"
         },
         "x509Thumbprint": {
-          "$ref": "#/definitions/X509Thumbprint",
-          "description": "The primary and secondary x509 thumbprints used for x509 based authentication."
+          "$ref": "#/definitions/X509Thumbprint"
         },
         "type": {
           "enum": [
@@ -2015,8 +2004,7 @@
             "certificateAuthority",
             "none"
           ],
-          "type": "string",
-          "description": "The type of authentication used when connecting to the service."
+          "type": "string"
         }
       }
     },
@@ -2025,7 +2013,6 @@
       "type": "object",
       "properties": {
         "iotEdge": {
-          "description": "Whether or not this device is an edge device.",
           "type": "boolean"
         }
       }
@@ -2034,12 +2021,10 @@
       "type": "object",
       "properties": {
         "primaryKey": {
-          "type": "string",
-          "description": "The base 64 encoded primary key of your device."
+          "type": "string"
         },
         "secondaryKey": {
-          "type": "string",
-          "description": "The base 64 encoded secondary key of your device."
+          "type": "string"
         }
       }
     },
@@ -2047,11 +2032,9 @@
       "type": "object",
       "properties": {
         "primaryThumbprint": {
-          "description": "Gets and sets the X509 client certificate primary thumbprint.",
           "type": "string"
         },
         "secondaryThumbprint": {
-          "description": "Gets and sets the X509 client certificate secondary thumbprint.",
           "type": "string"
         }
       }
@@ -2060,11 +2043,11 @@
       "type": "object",
       "properties": {
         "id": {
-          "description": "Identifier of the device to perform this operation on.",
+          "description": "Device Id is always required",
           "type": "string"
         },
         "moduleId": {
-          "description": "Identifier of the module to perform this operation on, if applicable.",
+          "description": "ModuleId is applicable to modules only",
           "type": "string"
         },
         "eTag": {
@@ -2081,11 +2064,10 @@
             "updateTwin",
             "updateTwinIfMatchETag"
           ],
-          "type": "string",
-          "description": "The type of registry operation and if ETag should be ignored or not."
+          "type": "string"
         },
         "status": {
-          "description": "Flags whether a module is enabled or not. If disabled, a module cannot connect to the service.",
+          "description": "Status is optional and defaults to enabled",
           "enum": [
             "enabled",
             "disabled"
@@ -2093,42 +2075,37 @@
           "type": "string"
         },
         "statusReason": {
-          "type": "string",
-          "description": "A 128 character-long string that stores the reason for the device identity status. All UTF-8 characters are allowed."
+          "type": "string"
         },
         "authentication": {
           "$ref": "#/definitions/AuthenticationMechanism",
-          "description": "Authentication parameter is optional and defaults to SAS if not provided. In that case, we auto-generate primary/secondary access keys."
+          "description": "Authentication parameter is optional and defaults to SAS if not provided. In that case, we auto-generate primary/secondary access keys"
         },
         "twinETag": {
-          "description": "twinETag parameter is only used for pre-conditioning the update when importMode is updateTwinIfMatchETag.",
+          "description": "twinETag parameter is only used for pre-conditioning the update when importMode is updateTwinIfMatchETag",
           "type": "string"
         },
         "tags": {
           "type": "object",
           "additionalProperties": {
-            "type": "object",
-            "description": "A JSON document read and written by the solution back end. Tags are not visible to device apps."
+            "type": "object"
           }
         },
         "properties": {
           "$ref": "#/definitions/PropertyContainer",
-          "description": "TODO need service folks to explain this."
+          "description": "Properties are optional and defaults to empty object"
         },
         "capabilities": {
           "$ref": "#/definitions/DeviceCapabilities",
-          "description": "Status of capabilities enabled on the device."
+          "description": "Capabilities param is optional and defaults to no capability"
         },
         "deviceScope": {
-          "type": "string",
-          "description": "The scope that this identity belongs to."
+          "type": "string"
         },
         "parentScopes": {
           "type": "array",
-          "description": "TODO: service team needs to explain this",
           "items": {
-            "type": "string",
-            "description": "TODO service folks need to explain this."
+            "type": "string"
           }
         }
       }
@@ -2182,7 +2159,7 @@
       "type": "object",
       "properties": {
         "deviceId": {
-          "description": "Identifier of the device that indicated the error.",
+          "description": "The ID of the device that indicated the error.",
           "type": "string"
         },
         "errorCode": {
@@ -2411,12 +2388,10 @@
           "type": "string"
         },
         "moduleId": {
-          "type": "string",
-          "description": "Identifier of the module associated with the error, if applicable."
+          "type": "string"
         },
         "operation": {
-          "type": "string",
-          "description": "The type of the operation that failed."
+          "type": "string"
         }
       }
     },
@@ -2425,15 +2400,14 @@
       "type": "object",
       "properties": {
         "deviceId": {
-          "description": "Identifier of the device that indicated the warning.",
+          "description": "The ID of the device that indicated the warning.",
           "type": "string"
         },
         "warningCode": {
           "enum": [
             "DeviceRegisteredWithoutTwin"
           ],
-          "type": "string",
-          "description": "The code associated with the warning."
+          "type": "string"
         },
         "warningStatus": {
           "description": "Additional details associated with the warning.",
@@ -2452,31 +2426,30 @@
       }
     },
     "Twin": {
-      "description": "The state information for a device or module. Implicitly created and deleted when the corresponding device/ module identity is created or deleted in IoT Hub.",
+      "description": "Twin Representation",
       "type": "object",
       "properties": {
         "deviceId": {
-          "description": "The unique identifier of the device in the IoT hub's identity registry. It is a case-sensitive string (up to 128 char long) of ASCII 7-bit alphanumeric chars, and the following special characters {'-', ':', '.', '+', '%', '_', '#', '*', '?', '!', '(', ')', ',', '=', '@', ';', '$', '''}.",
+          "description": "The deviceId uniquely identifies the device in the IoT hub's identity registry. A case-sensitive string (up to 128 char long) of ASCII 7-bit alphanumeric chars + {'-', ':', '.', '+', '%', '_', '#', '*', '?', '!', '(', ')', ',', '=', '@', ';', '$', '''}.",
           "type": "string"
         },
         "moduleId": {
-          "description": "The unique identifier of the module in the IoT hub's identity registry. It is a case-sensitive string (up to 128 char long) of ASCII 7-bit alphanumeric chars, and the following special characters {'-', ':', '.', '+', '%', '_', '#', '*', '?', '!', '(', ')', ',', '=', '@', ';', '$', '''}.",
+          "description": "Gets and sets the Module Id.",
           "type": "string"
         },
         "tags": {
-          "description": "A collection of key-value pairs read and written by the solution back end. They are not visible to device apps.",
+          "description": "A JSON document read and written by the solution back end. Tags are not visible to device apps.",
           "type": "object",
           "additionalProperties": {
-            "description": "The collection of the twin's tags as key-value pairs. They keys are UTF-8 encoded, case-sensitive and up-to 1KB in length. Allowed characters exclude UNICODE control characters (segments C0 and C1), '.', '$' and space. The values are JSON objects, up-to 4KB in length.",
             "type": "object"
           }
         },
         "properties": {
           "$ref": "#/definitions/TwinProperties",
-          "description": "The twin's desired and reported properties."
+          "description": "Gets and sets the Twin properties."
         },
         "etag": {
-          "description": "TODO - which operation does this affect - update tags/ properties etc?",
+          "description": "Twin's ETag",
           "type": "string"
         },
         "version": {
@@ -2485,11 +2458,11 @@
           "type": "integer"
         },
         "deviceEtag": {
-          "description": "TODO - which operation does this affect?",
+          "description": "Device's ETag",
           "type": "string"
         },
         "status": {
-          "description": "Flags whether a device is enabled or not. If disabled, a device cannot connect to the service.",
+          "description": "Gets the corresponding Device's Status.",
           "enum": [
             "enabled",
             "disabled"
@@ -2497,16 +2470,16 @@
           "type": "string"
         },
         "statusReason": {
-          "description": "Reason, if any, for the device's current status.",
+          "description": "Reason, if any, for the corresponding Device to be in specified Status",
           "type": "string"
         },
         "statusUpdateTime": {
           "format": "date-time",
-          "description": "Time when the corresponding device's status was last updated.",
+          "description": "Time when the corresponding Device's Status was last updated",
           "type": "string"
         },
         "connectionState": {
-          "description": "The device's connection state.",
+          "description": "Corresponding Device's ConnectionState",
           "enum": [
             "Disconnected",
             "Connected"
@@ -2541,11 +2514,9 @@
           "$ref": "#/definitions/DeviceCapabilities"
         },
         "deviceScope": {
-          "description": "Scope to which this device instance belongs to",
           "type": "string"
         },
         "parentScopes": {
-          "description": "TODO: new property added - need explanation",
           "type": "array",
           "items": {
             "type": "string"
@@ -2554,22 +2525,20 @@
       }
     },
     "TwinProperties": {
-      "description": "The twin's desired and reported properties. The maximum depth of twin property objects is 10.",
+      "description": "Represents Twin properties",
       "type": "object",
       "properties": {
         "desired": {
-          "description": "Properties that are set by the solution back end and read by the device.",
+          "description": "Used in conjunction with reported properties to synchronize device configuration or condition. Desired properties can only be set by the solution back end and can be read by the device app. The device app can also be notified in real time of changes on the desired properties.",
           "type": "object",
           "additionalProperties": {
-            "description": "The collection of desired property key-value pairs. The keys are UTF-8 encoded, case-sensitive and up-to 1KB in length. Allowed characters exclude UNICODE control characters (segments C0 and C1), '.', '$' and space. The desired porperty values are JSON objects, up-to 4KB in length.",
             "type": "object"
           }
         },
         "reported": {
-          "description": "Properties that are set by the device, and read and queried by the solution back end.",
+          "description": "Used in conjunction with desired properties to synchronize device configuration or condition. Reported properties can only be set by the device app and can be read and queried by the solution back end.",
           "type": "object",
           "additionalProperties": {
-            "description": "The collection of reported property key-value pairs. The keys are UTF-8 encoded, case-sensitive and up-to 1KB in length. Allowed characters exclude UNICODE control characters (segments C0 and C1), '.', '$' and space. The reported property values are JSON objects, up-to 4KB in length.",
             "type": "object"
           }
         }
@@ -2579,21 +2548,21 @@
       "type": "object",
       "properties": {
         "jobId": {
-          "description": "The unique identifier of the job.",
+          "description": "System generated.  Ignored at creation.",
           "type": "string"
         },
         "startTimeUtc": {
           "format": "date-time",
-          "description": "The start time of the job in UTC.",
+          "description": "System generated.  Ignored at creation.",
           "type": "string"
         },
         "endTimeUtc": {
           "format": "date-time",
-          "description": "The time the job stopped.",
+          "description": "System generated.  Ignored at creation.\r\nRepresents the time the job stopped processing.",
           "type": "string"
         },
         "type": {
-          "description": "The type of job to execute.",
+          "description": "Required.\r\nThe type of job to execute.",
           "enum": [
             "unknown",
             "export",
@@ -2613,7 +2582,7 @@
           "type": "string"
         },
         "status": {
-          "description": "The status of the job.",
+          "description": "System generated.  Ignored at creation.",
           "enum": [
             "unknown",
             "enqueued",
@@ -2628,7 +2597,7 @@
         },
         "progress": {
           "format": "int32",
-          "description": "Represents the percentage of completion.",
+          "description": "System generated.  Ignored at creation.\r\nRepresents the percentage of completion.",
           "type": "integer"
         },
         "inputBlobContainerUri": {
@@ -2640,15 +2609,15 @@
           "type": "string"
         },
         "outputBlobContainerUri": {
-          "description": "SAS token to access a blob container. This is used to output the status of the job and the results.",
+          "description": "URI containing SAS token to a blob container.  This is used to output the status of the job and the results.",
           "type": "string"
         },
         "outputBlobName": {
-          "description": "The name of the blob that will be created in the provided output blob container. This blob will contain the exported device registry information for the IoT Hub.",
+          "description": "The name of the blob that will be created in the provided output blob container.  This blob will contain\r\nthe exported device registry information for the IoT Hub.",
           "type": "string"
         },
         "excludeKeysInExport": {
-          "description": "Optional for export jobs; ignored for other jobs. If not specified, the service defaults to false. If false, authorization keys are included in export output. Keys are exported as null otherwise.",
+          "description": "Optional for export jobs; ignored for other jobs.  Default: false.  If false, authorization keys are included\r\nin export output.  Keys are exported as null otherwise.",
           "type": "boolean"
         },
         "storageAuthenticationType": {
@@ -2660,7 +2629,7 @@
           "type": "string"
         },
         "failureReason": {
-          "description": "Contains the reason for the failure, if a failure occurred.",
+          "description": "System genereated.  Ignored at creation.\r\nIf status == failure, this represents a string containing the reason.",
           "type": "string"
         }
       }
@@ -2670,7 +2639,6 @@
       "type": "object",
       "properties": {
         "totalMessagesPurged": {
-          "description":  "The total number of messages purged.",
           "format": "int32",
           "type": "integer"
         },
@@ -2688,11 +2656,9 @@
       "type": "object",
       "properties": {
         "IotHubName": {
-          "type": "string",
-          "description":  "Name of the IotHub."
+          "type": "string"
         },
         "connection": {
-          "description": "TODO: to be filled by the service team.",
           "$ref": "#/definitions/FaultInjectionConnectionProperties"
         },
         "lastUpdatedTimeUtc": {
@@ -2706,7 +2672,6 @@
       "type": "object",
       "properties": {
         "action": {
-          "description":  "Action to perform",
           "enum": [
             "None",
             "CloseAll",
@@ -2715,7 +2680,6 @@
           "type": "string"
         },
         "blockDurationInMinutes": {
-          "description":  "TODO: to be filled by the service team",
           "format": "int32",
           "type": "integer"
         }
@@ -2813,7 +2777,7 @@
           "type": "string"
         },
         "type": {
-          "description": "The type of job to execute.",
+          "description": "Required.\r\nThe type of job to execute.",
           "enum": [
             "unknown",
             "export",
@@ -2834,13 +2798,13 @@
         },
         "cloudToDeviceMethod": {
           "$ref": "#/definitions/CloudToDeviceMethod",
-          "description": "Required if jobType is cloudToDeviceMethod. The method type and parameters."
+          "description": "Required if jobType is cloudToDeviceMethod.\r\nThe method type and parameters."
         },
         "updateTwin": {
           "$ref": "#/definitions/Twin"
         },
         "queryCondition": {
-          "description": "Required if jobType is updateTwin or cloudToDeviceMethod. Condition for device query to get devices to execute the job on.",
+          "description": "Required if jobType is updateTwin or cloudToDeviceMethod.\r\nCondition for device query to get devices to execute the job on",
           "type": "string"
         },
         "startTime": {
@@ -2856,24 +2820,22 @@
       }
     },
     "CloudToDeviceMethod": {
-      "description": "Parameters to execute a direct method on the device.",
+      "description": "Parameters to execute a direct method on the device",
       "type": "object",
       "properties": {
         "methodName": {
-          "description": "Name of the method to be executed.",
+          "description": "Method to run",
           "type": "string"
         },
         "payload": {
-          "description": "The JSON-formatted direct method payload, up to 128kb in size.",
+          "description": "Payload",
           "type": "object"
         },
         "responseTimeoutInSeconds": {
-          "description": "Time (in seconds) that the service waits for the method invocation to return a response. It defaults to 30 seconds. Minimum allowed value is 5 seconds, maximum allowed value is 300 seconds.",
           "format": "int32",
           "type": "integer"
         },
         "connectTimeoutInSeconds": {
-          "description": "Time (in seconds) that the service waits for the device to come online. It defaults to 0, meaning the device must already be online. Maximum allowed value is 300 seconds.",
           "format": "int32",
           "type": "integer"
         }
@@ -2883,7 +2845,7 @@
       "type": "object",
       "properties": {
         "jobId": {
-          "description": "The unique identifier of the job.",
+          "description": "System generated.  Ignored at creation.",
           "type": "string"
         },
         "queryCondition": {
@@ -2892,7 +2854,7 @@
         },
         "createdTime": {
           "format": "date-time",
-          "description": "The creation time of the job.",
+          "description": "System generated.  Ignored at creation.",
           "type": "string"
         },
         "startTime": {
@@ -2902,7 +2864,7 @@
         },
         "endTime": {
           "format": "date-time",
-          "description": "The time the job stopped.",
+          "description": "System generated.  Ignored at creation.\r\nRepresents the time the job stopped processing.",
           "type": "string"
         },
         "maxExecutionTimeInSeconds": {
@@ -2911,7 +2873,7 @@
           "type": "integer"
         },
         "type": {
-          "description": "The type of job to execute.",
+          "description": "Required.\r\nThe type of job to execute.",
           "enum": [
             "unknown",
             "export",
@@ -2932,13 +2894,13 @@
         },
         "cloudToDeviceMethod": {
           "$ref": "#/definitions/CloudToDeviceMethod",
-          "description": "Required if jobType is cloudToDeviceMethod. The method type and parameters."
+          "description": "Required if jobType is cloudToDeviceMethod.\r\nThe method type and parameters."
         },
         "updateTwin": {
           "$ref": "#/definitions/Twin"
         },
         "status": {
-          "description": "The status of the job.",
+          "description": "System generated.  Ignored at creation.",
           "enum": [
             "unknown",
             "enqueued",
@@ -2952,7 +2914,7 @@
           "type": "string"
         },
         "failureReason": {
-          "description": "Contains the reason for the failure, if a failure occurred.",
+          "description": "System generated.  Ignored at creation.\r\nIf status == failure, this represents a string containing the reason.",
           "type": "string"
         },
         "statusMessage": {
@@ -3028,31 +2990,25 @@
       }
     },
     "Module": {
-      "description": "Module identity on a device.",
+      "description": "Module identity on a device",
       "type": "object",
       "properties": {
         "moduleId": {
-          "type": "string",
-          "description": "The unique identifier of this module."
+          "type": "string"
         },
         "managedBy": {
-          "type": "string",
-          "description": "Identifies who manages this module. For instance, this value is \"IotEdge\" if the edge runtime owns this module."
+          "type": "string"
         },
         "deviceId": {
-          "type": "string",
-          "description": "The unique identifier of the device that has this module."
+          "type": "string"
         },
         "generationId": {
-          "type": "string",
-          "description": "An IoT hub-generated, case-sensitive string up to 128 characters long. This value is used to distinguish modules with the same moduleId, when they have been deleted and re-created."
+          "type": "string"
         },
         "etag": {
-          "type": "string",
-          "description": "A string representing a weak ETag for the module identity, as per RFC7232."
+          "type": "string"
         },
         "connectionState": {
-          "description": "Tells whether the module is connected or not.",
           "enum": [
             "Disconnected",
             "Connected"
@@ -3061,22 +3017,18 @@
         },
         "connectionStateUpdatedTime": {
           "format": "date-time",
-          "type": "string",
-          "description": "A temporal indicator, showing the date and last time the connection state was updated."
+          "type": "string"
         },
         "lastActivityTime": {
           "format": "date-time",
-          "type": "string",
-          "description": "A temporal indicator, showing the date and last time the device connected, received, or sent a message."
+          "type": "string"
         },
         "cloudToDeviceMessageCount": {
           "format": "int32",
-          "type": "integer",
-          "description": "The number of cloud to module messages currently queued to be sent to the module."
+          "type": "integer"
         },
         "authentication": {
-          "$ref": "#/definitions/AuthenticationMechanism",
-          "description": "The details on what authentication mechanisms are used by this module when connecting to the service and edgehub."
+          "$ref": "#/definitions/AuthenticationMechanism"
         }
       }
     },
@@ -3086,11 +3038,11 @@
       "properties": {
         "status": {
           "format": "int32",
-          "description": "Method invocation result status, provided by the device.",
+          "description": "Method invocation result status.",
           "type": "integer"
         },
         "payload": {
-          "description": "The JSON-formatted direct method result payload, up to 128kb in size; provided by the device.",
+          "description": "Method invocation result payload.",
           "type": "object"
         }
       }
@@ -3112,9 +3064,8 @@
                   "properties": {
                     "desired": {
                       "type": "object",
-                      "description": "The desired property of the interface",
                       "properties": {
-                      "value": {
+                        "value": {
                           "description": "The desired value of the interface property to set in a digitalTwin.",
                           "type": "object"
                         }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/swagger/iothubservice_modified.json
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/swagger/iothubservice_modified.json
@@ -11,7 +11,8 @@
   "paths": {
     "/configurations/{id}": {
       "get": {
-        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Retrieve a configuration for Iot Hub devices and modules by it identifier.",
+        "description": "Get a configuration on IoT Hub for automatic device/module management.",
         "operationId": "Configuration_Get",
         "consumes": [],
         "produces": [
@@ -20,10 +21,10 @@
         "parameters": [
           {
             "name": "id",
-            "description": "The unique identifier of the configuration.",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "description": "The unique identifier of the configuration."
           },
           {
             "$ref": "#/parameters/api-version"
@@ -31,16 +32,16 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the Configuration object",
+            "description": "Returns the Configuration.",
             "schema": {
               "$ref": "#/definitions/Configuration"
             }
           }
-        },
-        "summary": "Retrieve a configuration for Iot Hub devices and modules by it identifier."
+        }
       },
       "put": {
-        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Create or update the configuration for devices or modules of an IoT hub. An ETag must not be specified for the create operation. An ETag must be specified for the update operation. Note that configuration Id and Content cannot be updated by the user.",
+        "description": "Create or update a configuration on IoT Hub for automatic device/module management. Configuration Id and Content cannot be updated.",
         "operationId": "Configuration_CreateOrUpdate",
         "consumes": [
           "application/json"
@@ -51,26 +52,26 @@
         "parameters": [
           {
             "name": "id",
-            "description": "The unique identifier of the configuration.",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "description": "The unique identifier of the configuration."
           },
           {
             "name": "configuration",
-            "description": "The configuration to be created or updated.",
             "in": "body",
             "required": true,
             "schema": {
               "$ref": "#/definitions/Configuration"
-            }
+            },
+            "description": "The configuration to be created or updated."
           },
           {
             "name": "If-Match",
-            "description": "A string representing a weak ETag for configuration, as per RFC7232. Should not be set when creating a configuration, but may be set when updating a configuration.",
             "in": "header",
             "required": false,
-            "type": "string"
+            "type": "string",
+            "description": "A string representing a weak ETag for configuration, as per RFC7232. Should not be set when creating a configuration, but may be set when updating a configuration."
           },
           {
             "$ref": "#/parameters/api-version"
@@ -78,22 +79,22 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the updated Configuration object",
+            "description": "Returns the updated configuration",
             "schema": {
               "$ref": "#/definitions/Configuration"
             }
           },
           "201": {
-            "description": "Returns the created Configuration object",
+            "description": "Returns the created configuration",
             "schema": {
               "$ref": "#/definitions/Configuration"
             }
           }
-        },
-        "summary": "Create or update the configuration for devices or modules of an IoT hub. An ETag must not be specified for the create operation. An ETag must be specified for the update operation. Note that configuration Id and Content cannot be updated by the user."
+        }
       },
       "delete": {
-        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Delete the configuration for devices or modules of an IoT hub. This request requires the If-Match header. The client may specify the ETag for the device identity on the request in order to compare to the ETag maintained by the service for the purpose of optimistic concurrency. The delete operation is performed only if the ETag sent by the client matches the value maintained by the server, indicating that the device identity has not been modified since it was retrieved by the client. To force an unconditional delete, set If-Match to the wildcard character (*).",
+        "description": "Delete a configuration on IoT Hub for automatic device/module management",
         "operationId": "Configuration_Delete",
         "consumes": [],
         "produces": [
@@ -102,17 +103,17 @@
         "parameters": [
           {
             "name": "id",
-            "description": "The unique identifier of the configuration.",
             "in": "path",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "description": "The unique identifier of the configuration."
           },
           {
             "name": "If-Match",
-            "description": "A string representing a weak ETag for configuration, as per RFC7232. The delete operation is performed only if this ETag matches the value maintained by the server, indicating that the configuration has not been modified since it was last retrieved. To force an unconditional delete, set If-Match to the wildcard character (*).",
             "in": "header",
             "required": false,
-            "type": "string"
+            "type": "string",
+            "description": "A string representing a weak ETag for configuration, as per RFC7232. The delete operation is performed only if this ETag matches the value maintained by the server, indicating that the configuration has not been modified since it was last retrieved. To force an unconditional delete, set If-Match to the wildcard character (*)."
           },
           {
             "$ref": "#/parameters/api-version"
@@ -122,13 +123,13 @@
           "204": {
             "description": "No Content"
           }
-        },
-        "summary": "Delete the configuration for devices or modules of an IoT hub. This request requires the If-Match header. The client may specify the ETag for the device identity on the request in order to compare to the ETag maintained by the service for the purpose of optimistic concurrency. The delete operation is performed only if the ETag sent by the client matches the value maintained by the server, indicating that the device identity has not been modified since it was retrieved by the client. To force an unconditional delete, set If-Match to the wildcard character (*)."
+        }
       }
     },
     "/configurations": {
       "get": {
-        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Get multiple configurations for devices or modules of an IoT Hub. Returns the specified number of configurations for Iot Hub. Pagination is not supported.",
+        "description": "Get multiple configurations on IoT Hub for automatic device/module management",
         "operationId": "Configuration_GetConfigurations",
         "consumes": [],
         "produces": [
@@ -137,11 +138,11 @@
         "parameters": [
           {
             "name": "top",
-            "description": "Number of configurations to retrieve. TODO: Ask service team if this value can be overriden if too large",
             "in": "query",
             "required": false,
             "type": "integer",
-            "format": "int32"
+            "format": "int32",
+            "description": "Number of configurations to retrieve. TODO: Ask service team if this value can be overriden if too large"
           },
           {
             "$ref": "#/parameters/api-version"
@@ -149,7 +150,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the list of Configuration objects",
+            "description": "Returns a list of configurations. Pagination is not supported.",
             "schema": {
               "type": "array",
               "items": {
@@ -157,13 +158,13 @@
               }
             }
           }
-        },
-        "summary": "Get multiple configurations for devices or modules of an IoT Hub. Returns the specified number of configurations for Iot Hub. Pagination is not supported."
+        }
       }
     },
     "/configurations/testQueries": {
       "post": {
-        "description": "Validates the target condition query and custom metric queries for a configuration. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Validates the target condition query and custom metric queries for a configuration.",
+        "description": "Validate the target condition and custom metric queries for a configuration on IoT Hub.",
         "operationId": "Configuration_TestQueries",
         "consumes": [
           "application/json"
@@ -174,12 +175,12 @@
         "parameters": [
           {
             "name": "input",
-            "description": "Configuration query for target condition or custom metrics.",
             "in": "body",
             "required": true,
             "schema": {
               "$ref": "#/definitions/ConfigurationQueriesTestInput"
-            }
+            },
+            "description": "Configuration query for target condition or custom metrics."
           },
           {
             "$ref": "#/parameters/api-version"
@@ -187,18 +188,18 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the ConfigurationQueriesTestResponse object.",
+            "description": "Returns the configuration queries test response.",
             "schema": {
               "$ref": "#/definitions/ConfigurationQueriesTestResponse"
             }
           }
-        },
-        "summary": "Validates the target condition query and custom metric queries for a configuration."
+        }
       }
     },
     "/statistics/devices": {
       "get": {
-        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Retrieves statistics about device identities in the IoT hub's identity registry.",
+        "description": "Get statistics about device identities in the IoT hub's identity registry, such as total device count.",
         "operationId": "RegistryManager_GetDeviceStatistics",
         "consumes": [],
         "produces": [
@@ -216,13 +217,13 @@
               "$ref": "#/definitions/RegistryStatistics"
             }
           }
-        },
-        "summary": "Retrieves statistics about device identities in the IoT hub's identity registry."
+        }
       }
     },
     "/statistics/service": {
       "get": {
-        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Retrieves service statistics for this IoT hub's identity registry.",
+        "description": "Retrieves device statistics for this IoT hub, such as connected device count.",
         "operationId": "RegistryManager_GetServiceStatistics",
         "consumes": [],
         "produces": [
@@ -240,13 +241,13 @@
               "$ref": "#/definitions/ServiceStatistics"
             }
           }
-        },
-        "summary": "Retrieves service statistics for this IoT hub's identity registry."
+        }
       }
     },
     "/devices": {
       "get": {
-        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Get the identities of multiple devices from the IoT hub identity registry. Not recommended. Use the IoT Hub query language to retrieve device twin and device identity information. See https://docs.microsoft.com/en-us/rest/api/iothub/service/queryiothub and https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-query-language for more information.",
+        "description": "Get the identities of multiple devices from the IoT hub identity registry. Not recommended. Use the IoT Hub query API to retrieve device twin and device identity information. See https://docs.microsoft.com/en-us/rest/api/iothub/service/queryiothub and https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-query-language for more information.",
         "operationId": "RegistryManager_GetDevices",
         "consumes": [],
         "produces": [
@@ -275,11 +276,11 @@
               }
             }
           }
-        },
-        "summary": "Get the identities of multiple devices from the IoT hub identity registry. Not recommended. Use the IoT Hub query language to retrieve device twin and device identity information. See https://docs.microsoft.com/en-us/rest/api/iothub/service/queryiothub and https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-query-language for more information."
+        }
       },
       "post": {
-        "description": "Create, update, or delete the identiies of multiple devices from the IoT hub identity registry. A device identity can be specified only once in the list. Different operations (create, update, delete) on different devices are allowed. A maximum of 100 devices can be specified per invocation. For large scale operations, consider using the import feature using blob storage(https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities). For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Create, update, or delete the identities of multiple devices from the IoT hub identity registry.",
+        "description": "Create, update, or delete the identiies of multiple devices from the IoT hub identity registry. A device identity can be specified only once in the list. Different operations (create, update, delete) on different devices are allowed. A maximum of 100 devices can be specified per invocation. For large scale operations, consider using the import feature using blob storage(https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities).",
         "operationId": "RegistryManager_BulkDeviceCRUD",
         "consumes": [
           "application/json"
@@ -317,13 +318,13 @@
               "$ref": "#/definitions/BulkRegistryOperationResult"
             }
           }
-        },
-        "summary": "Create, update, or delete the identities of multiple devices from the IoT hub identity registry."
+        }
       }
     },
     "/devices/query": {
       "post": {
-        "description": "Query an IoT hub to retrieve information regarding device twins using a SQL-like language. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language for more information. Pagination of results is supported. This returns information about device twins only. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Query an IoT hub to retrieve information regarding device twins using a SQL-like language.",
+        "description": "Query an IoT hub to retrieve information regarding device twins using a SQL-like language. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language for more information. Pagination is supported. This returns information about device twins only.",
         "operationId": "RegistryManager_QueryIotHub",
         "consumes": [
           "application/json"
@@ -379,13 +380,13 @@
               }
             }
           }
-        },
-        "summary": "Query an IoT hub to retrieve information regarding device twins using a SQL-like language."
+        }
       }
     },
     "/devices/{id}": {
       "get": {
-        "description": "Retrieve a device from the identity registry of an IoT hub. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Retrieve a device from the identity registry of an IoT hub.",
+        "description": "Get a device from the identity registry of an IoT hub.",
         "operationId": "RegistryManager_GetDevice",
         "consumes": [],
         "produces": [
@@ -395,7 +396,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Device ID.",
+            "description": "The unique identifier of the device to retrieve.",
             "required": true,
             "type": "string"
           },
@@ -405,16 +406,16 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the Device object",
+            "description": "Returns the Device.",
             "schema": {
               "$ref": "#/definitions/Device"
             }
           }
-        },
-        "summary": "Retrieve a device from the identity registry of an IoT hub."
+        }
       },
       "put": {
-        "description": "Create or update the identity of a device in the identity registry of an IoT hub. An ETag must not be specified for the create operation. An ETag must be specified for the update operation. Note that generationId and deviceId cannot be updated by the user. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Create or update the identity of a device in the identity registry of an IoT hub.",
+        "description": "Create or update the identity of a device in the identity registry of an IoT hub.",
         "operationId": "RegistryManager_CreateOrUpdateDevice",
         "consumes": [
           "application/json"
@@ -426,7 +427,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Device ID.",
+            "description": "The unique identifier of the device to create",
             "required": true,
             "type": "string"
           },
@@ -452,16 +453,16 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the Device object",
+            "description": "Returns the Device",
             "schema": {
               "$ref": "#/definitions/Device"
             }
           }
-        },
-        "summary": "Create or update the identity of a device in the identity registry of an IoT hub."
+        }
       },
       "delete": {
-        "description": "Delete the identity of a device from the identity registry of an IoT hub. This request requires the If-Match header. The client may specify the ETag for the device identity on the request in order to compare to the ETag maintained by the service for the purpose of optimistic concurrency. The delete operation is performed only if the ETag sent by the client matches the value maintained by the server, indicating that the device identity has not been modified since it was retrieved by the client. To force an unconditional delete, set If-Match to the wildcard character (*). For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Delete the identity of a device from the identity registry of an IoT hub.",
+        "description": "Delete the identity of a device from the identity registry of an IoT hub.",
         "operationId": "RegistryManager_DeleteDevice",
         "consumes": [],
         "produces": [
@@ -471,7 +472,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Device ID.",
+            "description": "The unique identifier of the device to delete.",
             "required": true,
             "type": "string"
           },
@@ -490,13 +491,13 @@
           "204": {
             "description": "No Content"
           }
-        },
-        "summary": "Delete the identity of a device from the identity registry of an IoT hub."
+        }
       }
     },
     "/devices/{id}/applyConfigurationContent": {
       "post": {
-        "description": "Applies the provided configuration content to the specified edge device. Configuration content must have modules content For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Applies the provided configuration content to the specified edge device.",
+        "description": "Apply the provided configuration content to the specified edge device.",
         "operationId": "Configuration_ApplyOnEdgeDevice",
         "consumes": [
           "application/json"
@@ -507,8 +508,8 @@
         "parameters": [
           {
             "name": "id",
-            "description": "Device ID.",
             "in": "path",
+            "description": "The unique identifier of the device.",
             "required": true,
             "type": "string"
           },
@@ -535,13 +536,13 @@
           "204": {
             "description": "NoContent"
           }
-        },
-        "summary": "Applies the provided configuration content to the specified edge device."
+        }
       }
     },
     "/jobs/create": {
       "post": {
-        "description": "Create a new import/export job on an IoT hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Create a new import/export job on an IoT hub.",
+        "description": "Create a new import or export job on IoT Hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information.",
         "operationId": "JobClient_CreateImportExportJob",
         "consumes": [
           "application/json"
@@ -565,18 +566,18 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the JobProperties object",
+            "description": "Returns the JobProperties",
             "schema": {
               "$ref": "#/definitions/JobProperties"
             }
           }
-        },
-        "summary": "Create a new import/export job on an IoT hub."
+        }
       }
     },
     "/jobs": {
       "get": {
-        "description": "Gets the status of all import/export jobs in an iot hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Gets the status of all import/export jobs in an iot hub",
+        "description": "Get the status of all import and export jobs in IoT Hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information.",
         "operationId": "JobClient_GetImportExportJobs",
         "consumes": [],
         "produces": [
@@ -589,7 +590,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the array of JobProperties object",
+            "description": "Returns an array of JobProperties",
             "schema": {
               "type": "array",
               "items": {
@@ -597,13 +598,13 @@
               }
             }
           }
-        },
-        "summary": "Gets the status of all import/export jobs in an iot hub"
+        }
       }
     },
     "/jobs/{id}": {
       "get": {
-        "description": "Gets the status of an import or export job in an iot hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Gets the status of an import or export job in an iot hub",
+        "description": "Get the status of an import or export job in IoT Hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information.",
         "operationId": "JobClient_GetImportExportJob",
         "consumes": [],
         "produces": [
@@ -613,7 +614,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Job ID.",
+            "description": "The unique identifier of the job.",
             "required": true,
             "type": "string"
           },
@@ -623,16 +624,16 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the JobProperties object",
+            "description": "Returns the JobProperties",
             "schema": {
               "$ref": "#/definitions/JobProperties"
             }
           }
-        },
-        "summary": "Gets the status of an import or export job in an iot hub"
+        }
       },
       "delete": {
-        "description": "Cancels an import or export job in an IoT hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Cancels an import or export job in an IoT hub.",
+        "description": "Cancels an import or export job in IoT Hub.",
         "operationId": "JobClient_CancelImportExportJob",
         "consumes": [],
         "produces": [
@@ -642,7 +643,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Job ID.",
+            "description": "The unique identifier of the job.",
             "required": true,
             "type": "string"
           },
@@ -660,13 +661,13 @@
           "204": {
             "description": "NoContent"
           }
-        },
-        "summary": "Cancels an import or export job in an IoT hub."
+        }
       }
     },
     "/devices/{id}/commands": {
       "delete": {
-        "description": "Deletes all the pending commands for this device from the IoT hub For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Deletes all the pending commands for this device from the IoT hub.",
+        "description": "Deletes all the pending commands for this device from the IoT hub.",
         "operationId": "RegistryManager_PurgeCommandQueue",
         "consumes": [],
         "produces": [
@@ -676,7 +677,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Device ID.",
+            "description": "The unique identifier of the device.",
             "required": true,
             "type": "string"
           },
@@ -691,13 +692,13 @@
               "$ref": "#/definitions/PurgeMessageQueueResult"
             }
           }
-        },
-        "summary": "Deletes all the pending commands for this device from the IoT hub."
+        }
       }
     },
     "/faultInjection": {
       "get": {
-        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Get FaultInjection entity",
+        "description": "Get FaultInjection entity.",
         "operationId": "FaultInjection_Get",
         "consumes": [],
         "produces": [
@@ -710,16 +711,16 @@
         ],
         "responses": {
           "200": {
-            "description": "typeof faultInjectionProperty",
+            "description": "OK",
             "schema": {
               "$ref": "#/definitions/FaultInjectionProperties"
             }
           }
-        },
-        "summary": "Get FaultInjection entity"
+        }
       },
       "put": {
-        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Create or update FaultInjection entity",
+        "description": "Create or update FaultInjection entity.",
         "operationId": "FaultInjection_Set",
         "consumes": [
           "application/json"
@@ -744,13 +745,13 @@
           "200": {
             "description": "OK"
           }
-        },
-        "summary": "Create or update FaultInjection entity"
+        }
       }
     },
     "/twins/{id}": {
       "get": {
-        "description": "Gets a device twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Gets a device twin.",
+        "description": "Gets the device twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information.",
         "operationId": "Twin_GetDeviceTwin",
         "consumes": [],
         "produces": [
@@ -760,7 +761,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Device ID.",
+            "description": "The unique identifier of the device.",
             "required": true,
             "type": "string"
           },
@@ -770,16 +771,16 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the device twin object",
+            "description": "OK.",
             "schema": {
               "$ref": "#/definitions/Twin"
             }
           }
-        },
-        "summary": "Gets a device twin."
+        }
       },
       "put": {
-        "description": "Replaces a device twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Replaces tags and desired properties of a device twin.",
+        "description": "Replaces the tags and desired properties of a device. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information.",
         "operationId": "Twin_ReplaceDeviceTwin",
         "consumes": [
           "application/json"
@@ -791,14 +792,14 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Device ID.",
+            "description": "The unique identifier of the device.",
             "required": true,
             "type": "string"
           },
           {
             "name": "deviceTwinInfo",
             "in": "body",
-            "description": "Device twin info",
+            "description": "The twin object that will replace the current device twin.",
             "required": true,
             "schema": {
               "$ref": "#/definitions/Twin"
@@ -807,9 +808,9 @@
           {
             "name": "If-Match",
             "in": "header",
-            "description": "A string representing a weak ETag for the device twin, as per RFC7232. It determines if the replace operation should be carried out.",
             "required": false,
-            "type": "string"
+            "type": "string",
+            "description": "A string representing a weak ETag for the device twin, as per RFC7232. It determines if the replace operation should be carried out."
           },
           {
             "$ref": "#/parameters/api-version"
@@ -817,16 +818,16 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the device twin object",
+            "description": "The updated device twin.",
             "schema": {
               "$ref": "#/definitions/Twin"
             }
           }
-        },
-        "summary": "Replaces tags and desired properties of a device twin."
+        }
       },
       "patch": {
-        "description": "Updates a device twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Updates tags and desired properties of a device twin.",
+        "description": "Updates the tags and desired properties of a device. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information.",
         "operationId": "Twin_UpdateDeviceTwin",
         "consumes": [
           "application/json"
@@ -838,14 +839,14 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Device ID.",
+            "description": "The unique identifier of the device.",
             "required": true,
             "type": "string"
           },
           {
             "name": "deviceTwinInfo",
             "in": "body",
-            "description": "Device twin info",
+            "description": "The twin object containing the tags and desired properties to be updated.",
             "required": true,
             "schema": {
               "$ref": "#/definitions/Twin"
@@ -854,9 +855,9 @@
           {
             "name": "If-Match",
             "in": "header",
-            "description": "A string representing a weak ETag for the device twin, as per RFC7232. It determines if the update operation should be carried out.",
             "required": false,
-            "type": "string"
+            "type": "string",
+            "description": "A string representing a weak ETag for the device twin, as per RFC7232. It determines if the update operation should be carried out."
           },
           {
             "$ref": "#/parameters/api-version"
@@ -864,18 +865,18 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the device twin object",
+            "description": "The updated device twin.",
             "schema": {
               "$ref": "#/definitions/Twin"
             }
           }
-        },
-        "summary": "Updates tags and desired properties of a device twin."
+        }
       }
     },
     "/twins/{id}/modules/{mid}": {
       "get": {
-        "description": "Gets a module twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Gets a module twin.",
+        "description": "Gets the module twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information.",
         "operationId": "Twin_GetModuleTwin",
         "consumes": [],
         "produces": [
@@ -885,14 +886,14 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Device ID.",
+            "description": "The unique identifier of the device",
             "required": true,
             "type": "string"
           },
           {
             "name": "mid",
             "in": "path",
-            "description": "Module ID.",
+            "description": "The unique identifier of the module",
             "required": true,
             "type": "string"
           },
@@ -902,16 +903,16 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the device twin object",
+            "description": "The module state information.",
             "schema": {
               "$ref": "#/definitions/Twin"
             }
           }
-        },
-        "summary": "Gets a module twin."
+        }
       },
       "put": {
-        "description": "Replaces a module twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Replaces tags and desired properties of a module twin.",
+        "description": "Replaces the tags and desired properties of a module. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information.",
         "operationId": "Twin_ReplaceModuleTwin",
         "consumes": [
           "application/json"
@@ -923,21 +924,21 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Device ID.",
+            "description": "The unique identifier of the device.",
             "required": true,
             "type": "string"
           },
           {
             "name": "mid",
             "in": "path",
-            "description": "Module ID.",
+            "description": "The unique identifier of the module.",
             "required": true,
             "type": "string"
           },
           {
             "name": "deviceTwinInfo",
             "in": "body",
-            "description": "Device twin info",
+            "description": "The twin object that will replace the current module twin.",
             "required": true,
             "schema": {
               "$ref": "#/definitions/Twin"
@@ -946,9 +947,9 @@
           {
             "name": "If-Match",
             "in": "header",
-            "description": "A string representing a weak ETag for the device twin, as per RFC7232. It determines if the replace operation should be carried out.",
             "required": false,
-            "type": "string"
+            "type": "string",
+            "description": "A string representing a weak ETag for the device twin, as per RFC7232. It determines if the replace operation should be carried out."
           },
           {
             "$ref": "#/parameters/api-version"
@@ -956,16 +957,16 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the device twin object",
+            "description": "The updated module twin.",
             "schema": {
               "$ref": "#/definitions/Twin"
             }
           }
-        },
-        "summary": "Replaces tags and desired properties of a module twin."
+        }
       },
       "patch": {
-        "description": "Updates a module twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Updates tags and desired properties of a module twin.",
+        "description": "Updates the tags and desired properties of a module. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information.",
         "operationId": "Twin_UpdateModuleTwin",
         "consumes": [
           "application/json"
@@ -977,21 +978,21 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Device ID.",
+            "description": "The unique identifier of the device.",
             "required": true,
             "type": "string"
           },
           {
             "name": "mid",
             "in": "path",
-            "description": "Module ID.",
+            "description": "The unique identifier of the module.",
             "required": true,
             "type": "string"
           },
           {
             "name": "deviceTwinInfo",
             "in": "body",
-            "description": "Device twin information",
+            "description": "The twin object containing the tags and desired properties to be updated.",
             "required": true,
             "schema": {
               "$ref": "#/definitions/Twin"
@@ -1000,9 +1001,9 @@
           {
             "name": "If-Match",
             "in": "header",
-            "description": "A string representing a weak ETag for the device twin, as per RFC7232. It determines if the update operation should be carried out.",
             "required": false,
-            "type": "string"
+            "type": "string",
+            "description": "A string representing a weak ETag for the device twin, as per RFC7232. It determines if the update operation should be carried out."
           },
           {
             "$ref": "#/parameters/api-version"
@@ -1010,18 +1011,18 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the device twin object",
+            "description": "The updated module twin.",
             "schema": {
               "$ref": "#/definitions/Twin"
             }
           }
-        },
-        "summary": "Updates tags and desired properties of a module twin."
+        }
       }
     },
     "/digitalTwins/{digitalTwinId}/interfaces": {
       "get": {
-        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Gets the list of interfaces.",
+        "description": "Get the list of interfaces.",
         "operationId": "DigitalTwin_GetComponents",
         "consumes": [],
         "produces": [
@@ -1031,7 +1032,7 @@
           {
             "name": "digitalTwinId",
             "in": "path",
-            "description": "Digital Twin ID. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional.",
+            "description": "The unique identifier of the digital twin. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional.",
             "required": true,
             "type": "string"
           },
@@ -1041,7 +1042,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns a collection of interface objects",
+            "description": "Returns a collection of interfaces",
             "schema": {
               "$ref": "#/definitions/DigitalTwinInterfaces"
             },
@@ -1052,11 +1053,11 @@
               }
             }
           }
-        },
-        "summary": "Gets the list of interfaces."
+        }
       },
       "patch": {
-        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Updates desired properties of multiple interfaces.\r\n            Example URI: \"digitalTwins/{digitalTwinId}/interfaces\"",
+        "description": "Updates desired properties of multiple interfaces.",
         "operationId": "DigitalTwin_UpdateComponent",
         "consumes": [
           "application/json"
@@ -1068,14 +1069,14 @@
           {
             "name": "digitalTwinId",
             "in": "path",
-            "description": "Digital Twin ID. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional.",
+            "description": "The unique identifier of the digital twin. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional.",
             "required": true,
             "type": "string"
           },
           {
             "name": "interfacesPatchInfo",
             "in": "body",
-            "description": "Multiple interfaces desired properties to update.",
+            "description": "The JSON representation of the update patch",
             "required": true,
             "schema": {
               "$ref": "#/definitions/DigitalTwinInterfacesPatch"
@@ -1083,10 +1084,10 @@
           },
           {
             "name": "If-Match",
-            "description": "A string representing a weak ETag for digital twin, as per RFC7232",
             "in": "header",
             "required": false,
-            "type": "string"
+            "type": "string",
+            "description": "A string representing a weak ETag for digital twin, as per RFC7232"
           },
           {
             "$ref": "#/parameters/api-version"
@@ -1105,13 +1106,13 @@
               }
             }
           }
-        },
-        "summary": "Updates desired properties of multiple interfaces.\r\n            Example URI: \"digitalTwins/{digitalTwinId}/interfaces\""
+        }
       }
     },
     "/digitalTwins/{digitalTwinId}/interfaces/{interfaceName}": {
       "get": {
-        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Gets the interface of given interfaceId.\r\n            Example URI: \"digitalTwins/{digitalTwinId}/interfaces/{interfaceName}\"",
+        "description": "Get the interface.",
         "operationId": "DigitalTwin_GetComponent",
         "consumes": [],
         "produces": [
@@ -1121,7 +1122,7 @@
           {
             "name": "digitalTwinId",
             "in": "path",
-            "description": "Digital Twin ID. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional.",
+            "description": "The unique identifier of the digital twin. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional.",
             "required": true,
             "type": "string"
           },
@@ -1138,7 +1139,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns interface object of given id",
+            "description": "Returns the interface",
             "schema": {
               "$ref": "#/definitions/DigitalTwinInterfaces"
             },
@@ -1149,13 +1150,13 @@
               }
             }
           }
-        },
-        "summary": "Gets the interface of given interfaceId.\r\n            Example URI: \"digitalTwins/{digitalTwinId}/interfaces/{interfaceName}\""
+        }
       }
     },
     "/messages/serviceBound/feedback": {
       "get": {
-        "description": "This method is used to retrieve feedback of a cloud-to-device message See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information. This capability is only available in the standard tier IoT Hub. For more information, see [Choose the right IoT Hub tier](https://aka.ms/scaleyouriotsolution). For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "This method is used to retrieve feedback of a cloud-to-device message.",
+        "description": "This method is used to retrieve feedback for cloud-to-device messages. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information. This capability is only available in the standard tier IoT Hub. For more information, see [Choose the right IoT Hub tier](https://aka.ms/scaleyouriotsolution).",
         "operationId": "HttpRuntime_ReceiveFeedbackNotification",
         "consumes": [],
         "produces": [
@@ -1168,18 +1169,18 @@
         ],
         "responses": {
           "200": {
-            "description": "The feedback response object"
+            "description": "The feedback response of a cloud-to-device message"
           },
           "204": {
             "description": "No Content Sent if feedback queue is empty"
           }
-        },
-        "summary": "This method is used to retrieve feedback of a cloud-to-device message."
+        }
       }
     },
     "/messages/serviceBound/feedback/{lockToken}": {
       "delete": {
-        "description": "This method completes a feedback message. The lockToken obtained when the message was received must be provided to resolve race conditions when completing, a feedback message. A completed message is deleted from the feedback queue. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "This method completes a feedback message.",
+        "description": "This method completes a cloud-to-device feedback message. A completed message is deleted from the service's feedback queue. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information.",
         "operationId": "HttpRuntime_CompleteFeedbackNotification",
         "consumes": [],
         "produces": [
@@ -1189,7 +1190,7 @@
           {
             "name": "lockToken",
             "in": "path",
-            "description": "Lock token.",
+            "description": "The lock token obtained when the C2D message was received, and provided to resolve race conditions when completing a feedback message.",
             "required": true,
             "type": "string"
           },
@@ -1201,13 +1202,13 @@
           "204": {
             "description": "No Content"
           }
-        },
-        "summary": "This method completes a feedback message."
+        }
       }
     },
     "/messages/serviceBound/feedback/{lockToken}/abandon": {
       "post": {
-        "description": "This method abandons a feedback message. The lockToken obtained when the message was received must be provided to resolve race conditions when abandoning, a feedback message. A abandoned message is deleted from the feedback queue. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "This method abandons a feedback message.",
+        "description": "This method abandons a cloud-to-device feedback message. An abandoned message is deleted from the service's feedback queue. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information.",
         "operationId": "HttpRuntime_AbandonFeedbackNotification",
         "consumes": [],
         "produces": [
@@ -1217,7 +1218,7 @@
           {
             "name": "lockToken",
             "in": "path",
-            "description": "Lock Token.",
+            "description": "The lock token obtained when the C2D message was received, and provided to resolve race conditions when abandoning a feedback message.",
             "required": true,
             "type": "string"
           },
@@ -1229,13 +1230,13 @@
           "204": {
             "description": "No Content"
           }
-        },
-        "summary": "This method abandons a feedback message."
+        }
       }
     },
     "/jobs/v2/{id}": {
       "get": {
-        "description": "Retrieves details of a scheduled job from an IoT hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Retrieves details of a scheduled job from an IoT hub.",
+        "description": "Retrieves details of a scheduled job from IoT hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information.",
         "operationId": "JobClient_GetJob",
         "consumes": [],
         "produces": [
@@ -1245,7 +1246,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Job ID.",
+            "description": "The unique identifier of the job.",
             "required": true,
             "type": "string"
           },
@@ -1255,16 +1256,16 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the Job response object",
+            "description": "Returns the job details.",
             "schema": {
               "$ref": "#/definitions/JobResponse"
             }
           }
-        },
-        "summary": "Retrieves details of a scheduled job from an IoT hub."
+        }
       },
       "put": {
-        "description": "Creates a new job to schedule update twins or device direct methods on an IoT hub at a scheduled time. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Creates a new job to schedule update twins or device direct methods on an IoT hub at a scheduled time.",
+        "description": "Creates a new job to schedule twin updates or direct methods on IoT Hub at a scheduled time. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information.",
         "operationId": "JobClient_CreateJob",
         "consumes": [
           "application/json"
@@ -1276,18 +1277,18 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Job ID.",
+            "description": "The unique identifier of the job.",
             "required": true,
             "type": "string"
           },
           {
             "name": "jobRequest",
             "in": "body",
-            "description": "The job to be created.",
             "required": true,
             "schema": {
               "$ref": "#/definitions/JobRequest"
-            }
+            },
+            "description": "The job to be created."
           },
           {
             "$ref": "#/parameters/api-version"
@@ -1295,18 +1296,18 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the Job response object",
+            "description": "Returns the job response.",
             "schema": {
               "$ref": "#/definitions/JobResponse"
             }
           }
-        },
-        "summary": "Creates a new job to schedule update twins or device direct methods on an IoT hub at a scheduled time."
+        }
       }
     },
     "/jobs/v2/{id}/cancel": {
       "post": {
-        "description": "Cancels a scheduled job on an IoT hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Cancels a scheduled job on an IoT hub.",
+        "description": "Cancels a scheduled job on IoT Hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information.",
         "operationId": "JobClient_CancelJob",
         "consumes": [],
         "produces": [
@@ -1316,7 +1317,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Job ID.",
+            "description": "The unique identifier of the job.",
             "required": true,
             "type": "string"
           },
@@ -1326,18 +1327,18 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the Job response object",
+            "description": "Returns the job response",
             "schema": {
               "$ref": "#/definitions/JobResponse"
             }
           }
-        },
-        "summary": "Cancels a scheduled job on an IoT hub."
+        }
       }
     },
     "/jobs/v2/query": {
       "get": {
-        "description": "Query an IoT hub to retrieve information regarding jobs using the IoT Hub query language. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language for more information. Pagination of results is supported. This returns information about jobs only. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Query an IoT hub to retrieve information regarding jobs using the IoT Hub query language",
+        "description": "Query IoT hub to retrieve information regarding jobs using the IoT Hub query language. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language for more information.",
         "operationId": "JobClient_QueryJobs",
         "consumes": [],
         "produces": [
@@ -1347,14 +1348,14 @@
           {
             "name": "jobType",
             "in": "query",
-            "description": "Job Type.",
+            "description": "The job type. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs#querying-for-progress-on-jobs for a list of possible job types.",
             "required": false,
             "type": "string"
           },
           {
             "name": "jobStatus",
             "in": "query",
-            "description": "Job Status.",
+            "description": "The job status. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs#querying-for-progress-on-jobs for a list of possible statuses.",
             "required": false,
             "type": "string"
           },
@@ -1364,18 +1365,18 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the Query Result object",
+            "description": "Returns the Query Result.",
             "schema": {
               "$ref": "#/definitions/QueryResult"
             }
           }
-        },
-        "summary": "Query an IoT hub to retrieve information regarding jobs using the IoT Hub query language"
+        }
       }
     },
     "/devices/{id}/modules": {
       "get": {
-        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Retrieve all the module identities on the device.",
+        "description": "Get all the module identities of the device.",
         "operationId": "RegistryManager_GetModulesOnDevice",
         "consumes": [],
         "produces": [
@@ -1385,7 +1386,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Device ID.",
+            "description": "The unique identifier of the device.",
             "required": true,
             "type": "string"
           },
@@ -1395,7 +1396,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the Device object",
+            "description": "Returns all the modules of the device.",
             "schema": {
               "type": "array",
               "items": {
@@ -1403,13 +1404,13 @@
               }
             }
           }
-        },
-        "summary": "Retrieve all the module identities on the device."
+        }
       }
     },
     "/devices/{id}/modules/{mid}": {
       "get": {
-        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Retrieve the specified module identity on the device.",
+        "description": "Get the specified module identity of the device.",
         "operationId": "RegistryManager_GetModule",
         "consumes": [],
         "produces": [
@@ -1419,14 +1420,14 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Device ID.",
+            "description": "The unique identifier of the device.",
             "required": true,
             "type": "string"
           },
           {
             "name": "mid",
             "in": "path",
-            "description": "Module ID.",
+            "description": "The unique identifier of the module.",
             "required": true,
             "type": "string"
           },
@@ -1436,16 +1437,16 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the DeviceModule object",
+            "description": "Returns the module.",
             "schema": {
               "$ref": "#/definitions/Module"
             }
           }
-        },
-        "summary": "Retrieve the specified module identity on the device."
+        }
       },
       "put": {
-        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Create or update the module identity for device in IoT hub. An ETag must not be specified for the create operation. An ETag must be specified for the update operation. Note that moduleId and generation cannot be updated by the user.",
+        "description": "Create or update the module identity for device in IoT hub. The moduleId and generation cannot be updated by the user.",
         "operationId": "RegistryManager_CreateOrUpdateModule",
         "consumes": [
           "application/json"
@@ -1457,32 +1458,32 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Device ID.",
+            "description": "The unique identifier of the device.",
             "required": true,
             "type": "string"
           },
           {
             "name": "mid",
             "in": "path",
-            "description": "Module ID.",
+            "description": "The unique identifier of the module.",
             "required": true,
             "type": "string"
           },
           {
             "name": "module",
-            "description": "The module identity.",
             "in": "body",
             "required": true,
             "schema": {
               "$ref": "#/definitions/Module"
-            }
+            },
+            "description": "The module identity."
           },
           {
             "name": "If-Match",
-            "description": "A string representing a weak ETag for the module, as per RFC7232. Should not be set when creating module, but may be set when updating a module",
             "in": "header",
             "required": false,
-            "type": "string"
+            "type": "string",
+            "description": "A string representing a weak ETag for the module, as per RFC7232. Should not be set when creating module, but may be set when updating a module"
           },
           {
             "$ref": "#/parameters/api-version"
@@ -1490,22 +1491,22 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the updated DeviceModule object",
+            "description": "Returns the updated module.",
             "schema": {
               "$ref": "#/definitions/Module"
             }
           },
           "201": {
-            "description": "Returns the created DeviceModule object",
+            "description": "Returns the created module.",
             "schema": {
               "$ref": "#/definitions/Module"
             }
           }
-        },
-        "summary": "Create or update the module identity for device in IoT hub. An ETag must not be specified for the create operation. An ETag must be specified for the update operation. Note that moduleId and generation cannot be updated by the user."
+        }
       },
       "delete": {
-        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Delete the module identity for device of an IoT hub. This request requires the If-Match header. The client may specify the ETag for the device identity on the request in order to compare to the ETag maintained by the service for the purpose of optimistic concurrency. The delete operation is performed only if the ETag sent by the client matches the value maintained by the server, indicating that the device identity has not been modified since it was retrieved by the client. To force an unconditional delete, set If-Match to the wildcard character (*).",
+        "description": "Delete the module identity for device of an IoT hub.",
         "operationId": "RegistryManager_DeleteModule",
         "consumes": [],
         "produces": [
@@ -1515,23 +1516,23 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Device ID.",
+            "description": "The unique identifier of the deivce.",
             "required": true,
             "type": "string"
           },
           {
             "name": "mid",
             "in": "path",
-            "description": "Module ID.",
+            "description": "The unique identifier of the module.",
             "required": true,
             "type": "string"
           },
           {
             "name": "If-Match",
-            "description": " A string representing a weak ETag for the module, as per RFC7232. The delete operation is performed only if this ETag matches the value maintained by the server, indicating that the module has not been modified since it was last retrieved. To force an unconditional delete, set If-Match to the wildcard character (*).",
             "in": "header",
             "required": false,
-            "type": "string"
+            "type": "string",
+            "description": " A string representing a weak ETag for the module, as per RFC7232. The delete operation is performed only if this ETag matches the value maintained by the server, indicating that the module has not been modified since it was last retrieved. To force an unconditional delete, set If-Match to the wildcard character (*)."
           },
           {
             "$ref": "#/parameters/api-version"
@@ -1541,13 +1542,13 @@
           "204": {
             "description": "No Content"
           }
-        },
-        "summary": "Delete the module identity for device of an IoT hub. This request requires the If-Match header. The client may specify the ETag for the device identity on the request in order to compare to the ETag maintained by the service for the purpose of optimistic concurrency. The delete operation is performed only if the ETag sent by the client matches the value maintained by the server, indicating that the device identity has not been modified since it was retrieved by the client. To force an unconditional delete, set If-Match to the wildcard character (*)."
+        }
       }
     },
     "/digitalTwins/models/{modelId}": {
       "get": {
-        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "summary": "Returns a DigitalTwin model definition for the given id.\r\nIf \"expand\" is present in the query parameters and id is for a device capability model then it returns\r\nthe capability metamodel with expanded interface definitions.",
+        "description": "Returns a DigitalTwin model definition for the given id.\r\nIf \"expand\" is present in the query parameters and id is for a device capability model then it returns\r\nthe capability metamodel with expanded interface definitions.",
         "operationId": "DigitalTwin_GetDigitalTwinModel",
         "consumes": [],
         "produces": [
@@ -1618,12 +1619,12 @@
               }
             }
           }
-        },
-        "summary": "Returns a DigitalTwin model definition for the given id.\r\nIf \"expand\" is present in the query parameters and id is for a device capability model then it returns\r\nthe capability metamodel with expanded interface definitions."
+        }
       }
     },
     "/twins/{deviceId}/methods": {
       "post": {
+        "summary": "Invoke a direct method on a device.",
         "description": "Invoke a direct method on a device. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-direct-methods for more information.",
         "operationId": "DeviceMethod_InvokeDeviceMethod",
         "consumes": [
@@ -1636,18 +1637,18 @@
           {
             "name": "deviceId",
             "in": "path",
-            "description": "The unique identifier of the device.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "description": "The unique identifier of the device."
           },
           {
             "name": "directMethodRequest",
             "in": "body",
-            "description": "Parameters to execute a direct method on the device.",
             "required": true,
             "schema": {
               "$ref": "#/definitions/CloudToDeviceMethod"
-            }
+            },
+            "description": "Parameters to execute a direct method on the device."
           },
           {
             "$ref": "#/parameters/api-version"
@@ -1655,18 +1656,18 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the method response payload",
+            "description": "The direct method response payload.",
             "schema": {
               "$ref": "#/definitions/CloudToDeviceMethodResult"
             }
           }
-        },
-        "summary": "Invoke a direct method on a device."
+        }
       }
     },
     "/twins/{deviceId}/modules/{moduleId}/methods": {
       "post": {
-        "description": "Invoke a direct method on a module of a device. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-direct-methods for more information",
+        "summary": "Invoke a direct method on a module of a device.",
+        "description": "Invoke a direct method on a module of a device. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-direct-methods for more information.",
         "operationId": "DeviceMethod_InvokeModuleMethod",
         "consumes": [
           "application/json"
@@ -1678,25 +1679,25 @@
           {
             "name": "deviceId",
             "in": "path",
-            "description": "The unique identifier of the device.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "description": "The unique identifier of the device."
           },
           {
             "name": "moduleId",
             "in": "path",
-            "description": "The unique identifier of the module.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "description": "The unique identifier of the module."
           },
           {
             "name": "directMethodRequest",
             "in": "body",
-            "description": "Parameters to execute a direct method on the module.",
             "required": true,
             "schema": {
               "$ref": "#/definitions/CloudToDeviceMethod"
-            }
+            },
+            "description": "Parameters to execute a direct method on the module."
           },
           {
             "$ref": "#/parameters/api-version"
@@ -1704,13 +1705,12 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the method response payload",
+            "description": "The direct method response payload.",
             "schema": {
               "$ref": "#/definitions/CloudToDeviceMethodResult"
             }
           }
-        },
-        "summary": "Invoke a direct method on a module of a device."
+        }
       }
     },
     "/digitalTwins/{digitalTwinId}/interfaces/{interfaceName}/commands/{commandName}": {
@@ -1797,23 +1797,23 @@
   },
   "definitions": {
     "ConfigurationMetrics": {
-      "description": "Configuration Metrics",
+      "description": "Configuration Metrics for IotHub devices and modules.",
       "type": "object",
       "properties": {
         "results": {
           "type": "object",
-          "description": "TODO: Service to fill in",
           "additionalProperties": {
             "format": "int64",
             "type": "integer"
-          }
+          },
+          "description": "TODO: Service to fill in"
         },
         "queries": {
           "type": "object",
-          "description": "TODO: Service to fill in",
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "description": "TODO: Service to fill in"
         }
       }
     },
@@ -1822,15 +1822,15 @@
       "type": "object",
       "properties": {
         "id": {
-          "description": "Gets Identifier for the configuration",
+          "description": "The unique identifier of the configuration.",
           "type": "string"
         },
         "schemaVersion": {
-          "description": "Gets Schema version for the configuration",
+          "description": "Schema version of the configuration",
           "type": "string"
         },
         "labels": {
-          "description": "Gets or sets labels for the configuration",
+          "description": "Key-value pairs used to describe a configuration",
           "type": "object",
           "additionalProperties": {
             "type": "string"
@@ -1838,39 +1838,39 @@
         },
         "content": {
           "$ref": "#/definitions/ConfigurationContent",
-          "description": "Gets or sets Content for the configuration"
+          "description": "Content of the configuration."
         },
         "targetCondition": {
-          "description": "Gets or sets Target Condition for the configuration",
+          "description": "The query used to define targeted devices or modules. The query is based on twin tags and/or reported properties",
           "type": "string"
         },
         "createdTimeUtc": {
           "format": "date-time",
-          "description": "Gets creation time for the configuration",
+          "description": "Creation time of the configuration.",
           "type": "string",
           "readOnly": true
         },
         "lastUpdatedTimeUtc": {
           "format": "date-time",
-          "description": "Gets last update time for the configuration",
+          "description": "Update time of the configuration.",
           "type": "string",
           "readOnly": true
         },
         "priority": {
           "format": "int32",
-          "description": "Gets or sets Priority for the configuration",
+          "description": "The priority number assigned to the configuration.",
           "type": "integer"
         },
         "systemMetrics": {
           "$ref": "#/definitions/ConfigurationMetrics",
-          "description": "System Configuration Metrics"
+          "description": "Metrics calculated by IoT Hub that cannot be customized."
         },
         "metrics": {
           "$ref": "#/definitions/ConfigurationMetrics",
-          "description": "Custom Configuration Metrics"
+          "description": "Custom metrics specified by developer as queries against twin reported properties"
         },
         "etag": {
-          "description": "Gets or sets configuration's ETag",
+          "description": "ETag of the configuration",
           "type": "string"
         }
       }
@@ -1880,14 +1880,14 @@
       "type": "object",
       "properties": {
         "deviceContent": {
-          "description": "Gets or sets device Configurations",
+          "description": "Device Configurations",
           "type": "object",
           "additionalProperties": {
             "type": "object"
           }
         },
         "modulesContent": {
-          "description": "Gets or sets Modules Configurations",
+          "description": "Modules configuration content",
           "type": "object",
           "additionalProperties": {
             "type": "object",
@@ -1897,7 +1897,7 @@
           }
         },
         "moduleContent": {
-          "description": "Gets or sets Module Configurations",
+          "description": "Module configuration content",
           "type": "object",
           "additionalProperties": {
             "type": "object"
@@ -1913,11 +1913,11 @@
           "description": "The query used to define targeted devices or modules. The query is based on twin tags and/or reported properties"
         },
         "customMetricQueries": {
-          "type": "object",
-          "description": "Queries on twin reported properties",
+          "type": "string",
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "description": "Queries on twin reported properties"
         }
       }
     },
@@ -1943,20 +1943,20 @@
         "totalDeviceCount": {
           "format": "int64",
           "type": "integer",
-          "description": "The total number of devices registered for this hub.",
-          "readOnly": true
+          "readOnly": true,
+          "description": "The total number of devices registered for this hub."
         },
         "enabledDeviceCount": {
           "format": "int64",
           "type": "integer",
-          "description": "The number of currently enabled devices.",
-          "readOnly": true
+          "readOnly": true,
+          "description": "The number of currently enabled devices."
         },
         "disabledDeviceCount": {
           "format": "int64",
           "type": "integer",
-          "description": "The number of currently disabled devices.",
-          "readOnly": true
+          "readOnly": true,
+          "description": "The number of currently disabled devices."
         }
       }
     },
@@ -1966,8 +1966,8 @@
         "connectedDeviceCount": {
           "format": "int64",
           "type": "integer",
-          "description": "The number of currently connected devices.",
-          "readOnly": true
+          "readOnly": true,
+          "description": "The number of currently connected devices."
         }
       }
     },
@@ -1980,8 +1980,8 @@
         },
         "generationId": {
           "type": "string",
-          "description": "An IoT hub-generated, case-sensitive string up to 128 characters long. This value is used to distinguish devices with the same deviceId, when they have been deleted and re-created.",
-          "readOnly": true
+          "readOnly": true,
+          "description": "An IoT hub-generated, case-sensitive string up to 128 characters long. This value is used to distinguish devices with the same deviceId, when they have been deleted and re-created."
         },
         "etag": {
           "type": "string",
@@ -1993,8 +1993,8 @@
             "Connected"
           ],
           "type": "string",
-          "description": "Tells whether the device is connected or not.",
-          "readOnly": true
+          "readOnly": true,
+          "description": "Tells whether the device is connected or not."
         },
         "status": {
           "enum": [
@@ -2011,26 +2011,26 @@
         "connectionStateUpdatedTime": {
           "format": "date-time",
           "type": "string",
-          "description": "A temporal indicator, showing the date and last time the connection state was updated.",
-          "readOnly": true
+          "readOnly": true,
+          "description": "A temporal indicator, showing the date and last time the connection state was updated."
         },
         "statusUpdatedTime": {
           "format": "date-time",
           "type": "string",
-          "description": "The last timestamp of when the status field was updated.",
-          "readOnly": true
+          "readOnly": true,
+          "description": "The last timestamp of when the status field was updated."
         },
         "lastActivityTime": {
           "format": "date-time",
           "type": "string",
-          "description": "A temporal indicator, showing the date and last time the device connected, received, or sent a message.",
-          "readOnly": true
+          "readOnly": true,
+          "description": "A temporal indicator, showing the date and last time the device connected, received, or sent a message."
         },
         "cloudToDeviceMessageCount": {
           "format": "int32",
           "type": "integer",
-          "description": "The number of cloud to device messages currently queued to be sent to the device.",
-          "readOnly": true
+          "readOnly": true,
+          "description": "The number of cloud to device messages currently queued to be sent to the device."
         },
         "authentication": {
           "$ref": "#/definitions/AuthenticationMechanism",
@@ -2046,10 +2046,10 @@
         },
         "parentScopes": {
           "type": "array",
-          "description": "TODO: service team needs to explain this",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "TODO: service team needs to explain this"
         }
       },
       "required": [
@@ -2084,8 +2084,8 @@
       "type": "object",
       "properties": {
         "iotEdge": {
-          "description": "Whether or not this device is an edge device.",
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether or not this device is an edge device."
         }
       }
     },
@@ -2106,12 +2106,12 @@
       "type": "object",
       "properties": {
         "primaryThumbprint": {
-          "description": "Gets and sets the X509 client certificate primary thumbprint.",
-          "type": "string"
+          "type": "string",
+          "description": "Gets and sets the X509 client certificate primary thumbprint."
         },
         "secondaryThumbprint": {
-          "description": "Gets and sets the X509 client certificate secondary thumbprint.",
-          "type": "string"
+          "type": "string",
+          "description": "Gets and sets the X509 client certificate secondary thumbprint."
         }
       }
     },
@@ -2119,11 +2119,11 @@
       "type": "object",
       "properties": {
         "id": {
-          "description": "Device Id is always required",
+          "description": "Identifier of the device to perform this operation on.",
           "type": "string"
         },
         "moduleId": {
-          "description": "ModuleId is applicable to modules only",
+          "description": "Identifier of the module to perform this operation on, if applicable.",
           "type": "string"
         },
         "eTag": {
@@ -2144,7 +2144,7 @@
           "description": "The type of registry operation and if ETag should be ignored or not."
         },
         "status": {
-          "description": "Status is optional and defaults to enabled",
+          "description": "Flags whether a module is enabled or not. If disabled, a module cannot connect to the service.",
           "enum": [
             "enabled",
             "disabled"
@@ -2157,10 +2157,10 @@
         },
         "authentication": {
           "$ref": "#/definitions/AuthenticationMechanism",
-          "description": "Authentication parameter is optional and defaults to SAS if not provided. In that case, we auto-generate primary/secondary access keys"
+          "description": "Authentication parameter is optional and defaults to SAS if not provided. In that case, we auto-generate primary/secondary access keys."
         },
         "twinETag": {
-          "description": "twinETag parameter is only used for pre-conditioning the update when importMode is updateTwinIfMatchETag",
+          "description": "twinETag parameter is only used for pre-conditioning the update when importMode is updateTwinIfMatchETag.",
           "type": "string"
         },
         "tags": {
@@ -2172,11 +2172,11 @@
         },
         "properties": {
           "$ref": "#/definitions/PropertyContainer",
-          "description": "Properties are optional and defaults to empty object"
+          "description": "TODO need service folks to explain this."
         },
         "capabilities": {
           "$ref": "#/definitions/DeviceCapabilities",
-          "description": "Capabilities param is optional and defaults to no capability"
+          "description": "Status of capabilities enabled on the device."
         },
         "deviceScope": {
           "type": "string",
@@ -2184,11 +2184,11 @@
         },
         "parentScopes": {
           "type": "array",
-          "description": "TODO: service team needs to explain this",
           "items": {
             "type": "string",
             "description": "TODO service folks need to explain this."
-          }
+          },
+          "description": "TODO: service team needs to explain this"
         }
       },
       "required": [
@@ -2247,7 +2247,7 @@
       "type": "object",
       "properties": {
         "deviceId": {
-          "description": "The ID of the device that indicated the error.",
+          "description": "Identifier of the device that indicated the error.",
           "type": "string",
           "readOnly": true
         },
@@ -2480,13 +2480,13 @@
         },
         "moduleId": {
           "type": "string",
-          "description": "Identifier of the module associated with the error, if applicable.",
-          "readOnly": true
+          "readOnly": true,
+          "description": "Identifier of the module associated with the error, if applicable."
         },
         "operation": {
           "type": "string",
-          "description": "The type of the operation that failed.",
-          "readOnly": true
+          "readOnly": true,
+          "description": "The type of the operation that failed."
         }
       }
     },
@@ -2495,7 +2495,7 @@
       "type": "object",
       "properties": {
         "deviceId": {
-          "description": "The ID of the device that indicated the warning.",
+          "description": "Identifier of the device that indicated the warning.",
           "type": "string",
           "readOnly": true
         },
@@ -2504,8 +2504,8 @@
             "DeviceRegisteredWithoutTwin"
           ],
           "type": "string",
-          "description": "The code associated with the warning.",
-          "readOnly": true
+          "readOnly": true,
+          "description": "The code associated with the warning."
         },
         "warningStatus": {
           "description": "Additional details associated with the warning.",
@@ -2525,31 +2525,31 @@
       }
     },
     "Twin": {
-      "description": "Twin Representation",
+      "description": "The state information for a device or module. Implicitly created and deleted when the corresponding device/ module identity is created or deleted in IoT Hub.",
       "type": "object",
       "properties": {
         "deviceId": {
-          "description": "The deviceId uniquely identifies the device in the IoT hub's identity registry. A case-sensitive string (up to 128 char long) of ASCII 7-bit alphanumeric chars + {'-', ':', '.', '+', '%', '_', '#', '*', '?', '!', '(', ')', ',', '=', '@', ';', '$', '''}.",
+          "description": "The unique identifier of the device in the IoT hub's identity registry. It is a case-sensitive string (up to 128 char long) of ASCII 7-bit alphanumeric chars, and the following special characters {'-', ':', '.', '+', '%', '_', '#', '*', '?', '!', '(', ')', ',', '=', '@', ';', '$', '''}.",
           "type": "string"
         },
         "moduleId": {
-          "description": "Gets and sets the Module Id.",
+          "description": "The unique identifier of the module in the IoT hub's identity registry. It is a case-sensitive string (up to 128 char long) of ASCII 7-bit alphanumeric chars, and the following special characters {'-', ':', '.', '+', '%', '_', '#', '*', '?', '!', '(', ')', ',', '=', '@', ';', '$', '''}.",
           "type": "string"
         },
         "tags": {
-          "description": "A JSON document read and written by the solution back end. Tags are not visible to device apps.",
+          "description": "A collection of key-value pairs read and written by the solution back end. They are not visible to device apps.",
           "type": "object",
           "additionalProperties": {
-            "description": "The collection of the twin's tags as key-value pairs. They keys are UTF-8 encoded, case-sensitive and up-to 1KB in length. Allowed characters exclude UNICODE control characters (segments C0 and C1), '.', '$' and space. The values are JSON objects, up-to 4KB in length.",
-            "type": "object"
+            "type": "object",
+            "description": "The collection of the twin's tags as key-value pairs. They keys are UTF-8 encoded, case-sensitive and up-to 1KB in length. Allowed characters exclude UNICODE control characters (segments C0 and C1), '.', '$' and space. The values are JSON objects, up-to 4KB in length."
           }
         },
         "properties": {
           "$ref": "#/definitions/TwinProperties",
-          "description": "Gets and sets the Twin properties."
+          "description": "The twin's desired and reported properties."
         },
         "etag": {
-          "description": "Twin's ETag",
+          "description": "TODO - which operation does this affect - update tags/ properties etc?",
           "type": "string",
           "readOnly": true
         },
@@ -2560,12 +2560,12 @@
           "readOnly": true
         },
         "deviceEtag": {
-          "description": "Device's ETag",
+          "description": "TODO - which operation does this affect?",
           "type": "string",
           "readOnly": true
         },
         "status": {
-          "description": "Gets the corresponding Device's Status.",
+          "description": "Flags whether a device is enabled or not. If disabled, a device cannot connect to the service.",
           "enum": [
             "enabled",
             "disabled"
@@ -2573,17 +2573,17 @@
           "type": "string"
         },
         "statusReason": {
-          "description": "Reason, if any, for the corresponding Device to be in specified Status",
+          "description": "Reason, if any, for the device's current status.",
           "type": "string"
         },
         "statusUpdateTime": {
           "format": "date-time",
-          "description": "Time when the corresponding Device's Status was last updated",
+          "description": "Time when the corresponding device's status was last updated.",
           "type": "string",
           "readOnly": true
         },
         "connectionState": {
-          "description": "Corresponding Device's ConnectionState",
+          "description": "The device's connection state.",
           "enum": [
             "Disconnected",
             "Connected"
@@ -2621,15 +2621,15 @@
           "$ref": "#/definitions/DeviceCapabilities"
         },
         "deviceScope": {
-          "description": "Scope to which this device instance belongs to",
-          "type": "string"
+          "type": "string",
+          "description": "Scope to which this device instance belongs to"
         },
         "parentScopes": {
-          "description": "TODO: new property added - need explanation",
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "TODO: new property added - need explanation"
         }
       },
       "required": [
@@ -2637,25 +2637,25 @@
       ]
     },
     "TwinProperties": {
-      "description": "Represents Twin properties",
+      "description": "The twin's desired and reported properties. The maximum depth of twin property objects is 10.",
       "type": "object",
       "properties": {
         "desired": {
-          "description": "Used in conjunction with reported properties to synchronize device configuration or condition. Desired properties can only be set by the solution back end and can be read by the device app. The device app can also be notified in real time of changes on the desired properties.",
+          "description": "Properties that are set by the solution back end and read by the device.",
           "type": "object",
           "additionalProperties": {
-            "description": "The collection of desired property key-value pairs. The keys are UTF-8 encoded, case-sensitive and up-to 1KB in length. Allowed characters exclude UNICODE control characters (segments C0 and C1), '.', '$' and space. The desired porperty values are JSON objects, up-to 4KB in length.",
-            "type": "object"
+            "type": "object",
+            "description": "The collection of desired property key-value pairs. The keys are UTF-8 encoded, case-sensitive and up-to 1KB in length. Allowed characters exclude UNICODE control characters (segments C0 and C1), '.', '$' and space. The desired porperty values are JSON objects, up-to 4KB in length."
           }
         },
         "reported": {
-          "description": "Used in conjunction with desired properties to synchronize device configuration or condition. Reported properties can only be set by the device app and can be read and queried by the solution back end.",
+          "description": "Properties that are set by the device, and read and queried by the solution back end.",
           "type": "object",
+          "readOnly": true,
           "additionalProperties": {
-            "description": "The collection of reported property key-value pairs. The keys are UTF-8 encoded, case-sensitive and up-to 1KB in length. Allowed characters exclude UNICODE control characters (segments C0 and C1), '.', '$' and space. The reported property values are JSON objects, up-to 4KB in length.",
-            "type": "object"
-          },
-          "readOnly": true
+            "type": "object",
+            "description": "The collection of reported property key-value pairs. The keys are UTF-8 encoded, case-sensitive and up-to 1KB in length. Allowed characters exclude UNICODE control characters (segments C0 and C1), '.', '$' and space. The reported property values are JSON objects, up-to 4KB in length."
+          }
         }
       }
     },
@@ -2663,24 +2663,24 @@
       "type": "object",
       "properties": {
         "jobId": {
-          "description": "System generated.  Ignored at creation.",
+          "description": "The unique identifier of the job.",
           "type": "string",
           "readOnly": true
         },
         "startTimeUtc": {
           "format": "date-time",
-          "description": "System generated.  Ignored at creation.",
+          "description": "The start time of the job in UTC.",
           "type": "string",
           "readOnly": true
         },
         "endTimeUtc": {
           "format": "date-time",
-          "description": "System generated.  Ignored at creation.\r\nRepresents the time the job stopped processing.",
+          "description": "The time the job stopped.",
           "type": "string",
           "readOnly": true
         },
         "type": {
-          "description": "Required.\r\nThe type of job to execute.",
+          "description": "The type of job to execute.",
           "enum": [
             "unknown",
             "export",
@@ -2700,7 +2700,7 @@
           "type": "string"
         },
         "status": {
-          "description": "System generated.  Ignored at creation.",
+          "description": "The status of the job.",
           "enum": [
             "unknown",
             "enqueued",
@@ -2716,7 +2716,7 @@
         },
         "progress": {
           "format": "int32",
-          "description": "System generated.  Ignored at creation.\r\nRepresents the percentage of completion.",
+          "description": "Represents the percentage of completion.",
           "type": "integer",
           "readOnly": true
         },
@@ -2729,15 +2729,15 @@
           "type": "string"
         },
         "outputBlobContainerUri": {
-          "description": "URI containing SAS token to a blob container.  This is used to output the status of the job and the results.",
+          "description": "SAS token to access a blob container. This is used to output the status of the job and the results.",
           "type": "string"
         },
         "outputBlobName": {
-          "description": "The name of the blob that will be created in the provided output blob container.  This blob will contain\r\nthe exported device registry information for the IoT Hub.",
+          "description": "The name of the blob that will be created in the provided output blob container. This blob will contain the exported device registry information for the IoT Hub.",
           "type": "string"
         },
         "excludeKeysInExport": {
-          "description": "Optional for export jobs; ignored for other jobs.  Default: false.  If false, authorization keys are included\r\nin export output.  Keys are exported as null otherwise.",
+          "description": "Optional for export jobs; ignored for other jobs. If not specified, the service defaults to false. If false, authorization keys are included in export output. Keys are exported as null otherwise.",
           "type": "boolean"
         },
         "storageAuthenticationType": {
@@ -2749,7 +2749,7 @@
           "type": "string"
         },
         "failureReason": {
-          "description": "System genereated.  Ignored at creation.\r\nIf status == failure, this represents a string containing the reason.",
+          "description": "Contains the reason for the failure, if a failure occurred.",
           "type": "string",
           "readOnly": true
         }
@@ -2763,10 +2763,10 @@
       "type": "object",
       "properties": {
         "totalMessagesPurged": {
-          "description": "The total number of messages purged.",
           "format": "int32",
           "type": "integer",
-          "readOnly": true
+          "readOnly": true,
+          "description": "The total number of messages purged."
         },
         "deviceId": {
           "description": "The ID of the device whose messages are being purged.",
@@ -2788,8 +2788,8 @@
           "description": "Name of the IotHub."
         },
         "connection": {
-          "description": "TODO: to be filled by the service team.",
-          "$ref": "#/definitions/FaultInjectionConnectionProperties"
+          "$ref": "#/definitions/FaultInjectionConnectionProperties",
+          "description": "TODO: to be filled by the service team."
         },
         "lastUpdatedTimeUtc": {
           "format": "date-time",
@@ -2802,18 +2802,18 @@
       "type": "object",
       "properties": {
         "action": {
-          "description": "Action to perform",
           "enum": [
             "None",
             "CloseAll",
             "Periodic"
           ],
-          "type": "string"
+          "type": "string",
+          "description": "Action to perform"
         },
         "blockDurationInMinutes": {
-          "description": "TODO: to be filled by the service team",
           "format": "int32",
-          "type": "integer"
+          "type": "integer",
+          "description": "TODO: to be filled by the service team"
         }
       }
     },
@@ -2909,7 +2909,7 @@
           "type": "string"
         },
         "type": {
-          "description": "Required.\r\nThe type of job to execute.",
+          "description": "The type of job to execute.",
           "enum": [
             "unknown",
             "export",
@@ -2930,13 +2930,13 @@
         },
         "cloudToDeviceMethod": {
           "$ref": "#/definitions/CloudToDeviceMethod",
-          "description": "Required if jobType is cloudToDeviceMethod.\r\nThe method type and parameters."
+          "description": "Required if jobType is cloudToDeviceMethod. The method type and parameters."
         },
         "updateTwin": {
           "$ref": "#/definitions/Twin"
         },
         "queryCondition": {
-          "description": "Required if jobType is updateTwin or cloudToDeviceMethod.\r\nCondition for device query to get devices to execute the job on",
+          "description": "Required if jobType is updateTwin or cloudToDeviceMethod. Condition for device query to get devices to execute the job on.",
           "type": "string"
         },
         "startTime": {
@@ -2955,26 +2955,26 @@
       ]
     },
     "CloudToDeviceMethod": {
-      "description": "Parameters to execute a direct method on the device",
+      "description": "Parameters to execute a direct method on the device.",
       "type": "object",
       "properties": {
         "methodName": {
-          "description": "Method to run",
+          "description": "Name of the method to be executed.",
           "type": "string"
         },
         "payload": {
-          "description": "Payload",
+          "description": "The JSON-formatted direct method payload, up to 128kb in size.",
           "type": "object"
         },
         "responseTimeoutInSeconds": {
-          "description": "Time (in seconds) that the service waits for the method invocation to return a response. It defaults to 30 seconds. Minimum allowed value is 5 seconds, maximum allowed value is 300 seconds.",
           "format": "int32",
-          "type": "integer"
+          "type": "integer",
+          "description": "Time (in seconds) that the service waits for the method invocation to return a response. It defaults to 30 seconds. Minimum allowed value is 5 seconds, maximum allowed value is 300 seconds."
         },
         "connectTimeoutInSeconds": {
-          "description": "Time (in seconds) that the service waits for the device to come online. It defaults to 0, meaning the device must already be online. Maximum allowed value is 300 seconds.",
           "format": "int32",
-          "type": "integer"
+          "type": "integer",
+          "description": "Time (in seconds) that the service waits for the device to come online. It defaults to 0, meaning the device must already be online. Maximum allowed value is 300 seconds."
         }
       },
       "required": [
@@ -2985,7 +2985,7 @@
       "type": "object",
       "properties": {
         "jobId": {
-          "description": "System generated.  Ignored at creation.",
+          "description": "The unique identifier of the job.",
           "type": "string",
           "readOnly": true
         },
@@ -2996,7 +2996,7 @@
         },
         "createdTime": {
           "format": "date-time",
-          "description": "System generated.  Ignored at creation.",
+          "description": "The creation time of the job.",
           "type": "string",
           "readOnly": true
         },
@@ -3008,7 +3008,7 @@
         },
         "endTime": {
           "format": "date-time",
-          "description": "System generated.  Ignored at creation.\r\nRepresents the time the job stopped processing.",
+          "description": "The time the job stopped.",
           "type": "string",
           "readOnly": true
         },
@@ -3019,7 +3019,7 @@
           "readOnly": true
         },
         "type": {
-          "description": "Required.\r\nThe type of job to execute.",
+          "description": "The type of job to execute.",
           "enum": [
             "unknown",
             "export",
@@ -3040,7 +3040,7 @@
         },
         "cloudToDeviceMethod": {
           "$ref": "#/definitions/CloudToDeviceMethod",
-          "description": "Required if jobType is cloudToDeviceMethod.\r\nThe method type and parameters.",
+          "description": "Required if jobType is cloudToDeviceMethod. The method type and parameters.",
           "readOnly": true
         },
         "updateTwin": {
@@ -3048,7 +3048,7 @@
           "readOnly": true
         },
         "status": {
-          "description": "System generated.  Ignored at creation.",
+          "description": "The status of the job.",
           "enum": [
             "unknown",
             "enqueued",
@@ -3063,7 +3063,7 @@
           "readOnly": true
         },
         "failureReason": {
-          "description": "System generated.  Ignored at creation.\r\nIf status == failure, this represents a string containing the reason.",
+          "description": "Contains the reason for the failure, if a failure occurred.",
           "type": "string",
           "readOnly": true
         },
@@ -3145,7 +3145,7 @@
       }
     },
     "Module": {
-      "description": "Module identity on a device",
+      "description": "Module identity on a device.",
       "type": "object",
       "properties": {
         "moduleId": {
@@ -3162,39 +3162,39 @@
         },
         "generationId": {
           "type": "string",
-          "description": "An IoT hub-generated, case-sensitive string up to 128 characters long. This value is used to distinguish modules with the same moduleId, when they have been deleted and re-created.",
-          "readOnly": true
+          "readOnly": true,
+          "description": "An IoT hub-generated, case-sensitive string up to 128 characters long. This value is used to distinguish modules with the same moduleId, when they have been deleted and re-created."
         },
         "etag": {
           "type": "string",
           "description": "A string representing a weak ETag for the module identity, as per RFC7232."
         },
         "connectionState": {
-          "description": "Tells whether the module is connected or not.",
           "enum": [
             "Disconnected",
             "Connected"
           ],
           "type": "string",
-          "readOnly": true
+          "readOnly": true,
+          "description": "Tells whether the module is connected or not."
         },
         "connectionStateUpdatedTime": {
           "format": "date-time",
           "type": "string",
-          "description": "A temporal indicator, showing the date and last time the connection state was updated.",
-          "readOnly": true
+          "readOnly": true,
+          "description": "A temporal indicator, showing the date and last time the connection state was updated."
         },
         "lastActivityTime": {
           "format": "date-time",
           "type": "string",
-          "description": "A temporal indicator, showing the date and last time the device connected, received, or sent a message.",
-          "readOnly": true
+          "readOnly": true,
+          "description": "A temporal indicator, showing the date and last time the device connected, received, or sent a message."
         },
         "cloudToDeviceMessageCount": {
           "format": "int32",
           "type": "integer",
-          "description": "The number of cloud to module messages currently queued to be sent to the module.",
-          "readOnly": true
+          "readOnly": true,
+          "description": "The number of cloud to module messages currently queued to be sent to the module."
         },
         "authentication": {
           "$ref": "#/definitions/AuthenticationMechanism",
@@ -3212,12 +3212,12 @@
       "properties": {
         "status": {
           "format": "int32",
-          "description": "Method invocation result status.",
+          "description": "Method invocation result status, provided by the device.",
           "type": "integer",
           "readOnly": true
         },
         "payload": {
-          "description": "Method invocation result payload.",
+          "description": "The JSON-formatted direct method result payload, up to 128kb in size; provided by the device.",
           "type": "object",
           "readOnly": true
         }
@@ -3240,13 +3240,13 @@
                   "properties": {
                     "desired": {
                       "type": "object",
-                      "description": "The desired property of the interface",
                       "properties": {
                         "value": {
                           "description": "The desired value of the interface property to set in a digitalTwin.",
                           "type": "object"
                         }
-                      }
+                      },
+                      "description": "The desired property of the interface"
                     }
                   }
                 }

--- a/sdk/iot/Azure.Iot.Hub.Service/src/swagger/iothubservice_modified.json
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/swagger/iothubservice_modified.json
@@ -1,0 +1,3270 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "version": "2020-03-13",
+    "title": "IotHub Gateway Service APIs"
+  },
+  "host": "fully-qualified-iothubname.azure-devices.net",
+  "schemes": [
+    "https"
+  ],
+  "paths": {
+    "/configurations/{id}": {
+      "get": {
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "Configuration_Get",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "description": "The unique identifier of the configuration.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the Configuration object",
+            "schema": {
+              "$ref": "#/definitions/Configuration"
+            }
+          }
+        },
+        "summary": "Retrieve a configuration for Iot Hub devices and modules by it identifier."
+      },
+      "put": {
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "Configuration_CreateOrUpdate",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "description": "The unique identifier of the configuration.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "configuration",
+            "description": "The configuration to be created or updated.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Configuration"
+            }
+          },
+          {
+            "name": "If-Match",
+            "description": "A string representing a weak ETag for configuration, as per RFC7232. Should not be set when creating a configuration, but may be set when updating a configuration.",
+            "in": "header",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the updated Configuration object",
+            "schema": {
+              "$ref": "#/definitions/Configuration"
+            }
+          },
+          "201": {
+            "description": "Returns the created Configuration object",
+            "schema": {
+              "$ref": "#/definitions/Configuration"
+            }
+          }
+        },
+        "summary": "Create or update the configuration for devices or modules of an IoT hub. An ETag must not be specified for the create operation. An ETag must be specified for the update operation. Note that configuration Id and Content cannot be updated by the user."
+      },
+      "delete": {
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "Configuration_Delete",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "description": "The unique identifier of the configuration.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "If-Match",
+            "description": "A string representing a weak ETag for configuration, as per RFC7232. The delete operation is performed only if this ETag matches the value maintained by the server, indicating that the configuration has not been modified since it was last retrieved. To force an unconditional delete, set If-Match to the wildcard character (*).",
+            "in": "header",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "Delete the configuration for devices or modules of an IoT hub. This request requires the If-Match header. The client may specify the ETag for the device identity on the request in order to compare to the ETag maintained by the service for the purpose of optimistic concurrency. The delete operation is performed only if the ETag sent by the client matches the value maintained by the server, indicating that the device identity has not been modified since it was retrieved by the client. To force an unconditional delete, set If-Match to the wildcard character (*)."
+      }
+    },
+    "/configurations": {
+      "get": {
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "Configuration_GetConfigurations",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "top",
+            "description": "Number of configurations to retrieve. TODO: Ask service team if this value can be overriden if too large",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the list of Configuration objects",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Configuration"
+              }
+            }
+          }
+        },
+        "summary": "Get multiple configurations for devices or modules of an IoT Hub. Returns the specified number of configurations for Iot Hub. Pagination is not supported."
+      }
+    },
+    "/configurations/testQueries": {
+      "post": {
+        "description": "Validates the target condition query and custom metric queries for a configuration. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "Configuration_TestQueries",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "input",
+            "description": "Configuration query for target condition or custom metrics.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ConfigurationQueriesTestInput"
+            }
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the ConfigurationQueriesTestResponse object.",
+            "schema": {
+              "$ref": "#/definitions/ConfigurationQueriesTestResponse"
+            }
+          }
+        },
+        "summary": "Validates the target condition query and custom metric queries for a configuration."
+      }
+    },
+    "/statistics/devices": {
+      "get": {
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "RegistryManager_GetDeviceStatistics",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/RegistryStatistics"
+            }
+          }
+        },
+        "summary": "Retrieves statistics about device identities in the IoT hub's identity registry."
+      }
+    },
+    "/statistics/service": {
+      "get": {
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "RegistryManager_GetServiceStatistics",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ServiceStatistics"
+            }
+          }
+        },
+        "summary": "Retrieves service statistics for this IoT hub's identity registry."
+      }
+    },
+    "/devices": {
+      "get": {
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "RegistryManager_GetDevices",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "top",
+            "in": "query",
+            "description": "This parameter when specified, defines the maximum number of device identities that are returned. Any value outside the range of 1-1000 is considered to be 1000.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Device"
+              }
+            }
+          }
+        },
+        "summary": "Get the identities of multiple devices from the IoT hub identity registry. Not recommended. Use the IoT Hub query language to retrieve device twin and device identity information. See https://docs.microsoft.com/en-us/rest/api/iothub/service/queryiothub and https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-query-language for more information."
+      },
+      "post": {
+        "description": "Create, update, or delete the identiies of multiple devices from the IoT hub identity registry. A device identity can be specified only once in the list. Different operations (create, update, delete) on different devices are allowed. A maximum of 100 devices can be specified per invocation. For large scale operations, consider using the import feature using blob storage(https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities). For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "RegistryManager_BulkDeviceCRUD",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "devices",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ExportImportDevice"
+              },
+              "description": "The set of registry operations to perform."
+            }
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/BulkRegistryOperationResult"
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "schema": {
+              "$ref": "#/definitions/BulkRegistryOperationResult"
+            }
+          }
+        },
+        "summary": "Create, update, or delete the identities of multiple devices from the IoT hub identity registry."
+      }
+    },
+    "/devices/query": {
+      "post": {
+        "description": "Query an IoT hub to retrieve information regarding device twins using a SQL-like language. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language for more information. Pagination of results is supported. This returns information about device twins only. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "RegistryManager_QueryIotHub",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "querySpecification",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/QuerySpecification"
+            },
+            "description": "The query string to run. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language for more information."
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "name": "x-ms-continuation",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "description": "The continuation token to get the next page of results."
+          },
+          {
+            "name": "x-ms-max-item-count",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "description": "The maximum number of items to return per page. The service may use a different value if the value specified is not acceptable."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Query result with continuation token if appropriate.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Twin"
+              }
+            },
+            "headers": {
+              "x-ms-item-type": {
+                "description": "Type of the list of items.",
+                "type": "string"
+              },
+              "x-ms-continuation": {
+                "description": "Continuation token",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "summary": "Query an IoT hub to retrieve information regarding device twins using a SQL-like language."
+      }
+    },
+    "/devices/{id}": {
+      "get": {
+        "description": "Retrieve a device from the identity registry of an IoT hub. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "RegistryManager_GetDevice",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Device ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the Device object",
+            "schema": {
+              "$ref": "#/definitions/Device"
+            }
+          }
+        },
+        "summary": "Retrieve a device from the identity registry of an IoT hub."
+      },
+      "put": {
+        "description": "Create or update the identity of a device in the identity registry of an IoT hub. An ETag must not be specified for the create operation. An ETag must be specified for the update operation. Note that generationId and deviceId cannot be updated by the user. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "RegistryManager_CreateOrUpdateDevice",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Device ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "device",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Device"
+            },
+            "description": "The contents of the device to create."
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "description": "A string representing a weak ETag for the device identity, as per RFC7232. Should not be set when creating a device, but may be set when updating a device."
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the Device object",
+            "schema": {
+              "$ref": "#/definitions/Device"
+            }
+          }
+        },
+        "summary": "Create or update the identity of a device in the identity registry of an IoT hub."
+      },
+      "delete": {
+        "description": "Delete the identity of a device from the identity registry of an IoT hub. This request requires the If-Match header. The client may specify the ETag for the device identity on the request in order to compare to the ETag maintained by the service for the purpose of optimistic concurrency. The delete operation is performed only if the ETag sent by the client matches the value maintained by the server, indicating that the device identity has not been modified since it was retrieved by the client. To force an unconditional delete, set If-Match to the wildcard character (*). For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "RegistryManager_DeleteDevice",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Device ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "required": false,
+            "type": "string",
+            "description": "A string representing a weak ETag for the device identity, as per RFC7232. The delete operation is performed only if this ETag matches the value maintained by the server, indicating that the device identity has not been modified since it was last retrieved. To force an unconditional delete, set If-Match to the wildcard character (*)."
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "Delete the identity of a device from the identity registry of an IoT hub."
+      }
+    },
+    "/devices/{id}/applyConfigurationContent": {
+      "post": {
+        "description": "Applies the provided configuration content to the specified edge device. Configuration content must have modules content For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "Configuration_ApplyOnEdgeDevice",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "description": "Device ID.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "content",
+            "in": "body",
+            "description": "Configuration Content.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ConfigurationContent"
+            }
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "204": {
+            "description": "NoContent"
+          }
+        },
+        "summary": "Applies the provided configuration content to the specified edge device."
+      }
+    },
+    "/jobs/create": {
+      "post": {
+        "description": "Create a new import/export job on an IoT hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "JobClient_CreateImportExportJob",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "jobProperties",
+            "in": "body",
+            "description": "Specifies the job specification.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/JobProperties"
+            }
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the JobProperties object",
+            "schema": {
+              "$ref": "#/definitions/JobProperties"
+            }
+          }
+        },
+        "summary": "Create a new import/export job on an IoT hub."
+      }
+    },
+    "/jobs": {
+      "get": {
+        "description": "Gets the status of all import/export jobs in an iot hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "JobClient_GetImportExportJobs",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the array of JobProperties object",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/JobProperties"
+              }
+            }
+          }
+        },
+        "summary": "Gets the status of all import/export jobs in an iot hub"
+      }
+    },
+    "/jobs/{id}": {
+      "get": {
+        "description": "Gets the status of an import or export job in an iot hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "JobClient_GetImportExportJob",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Job ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the JobProperties object",
+            "schema": {
+              "$ref": "#/definitions/JobProperties"
+            }
+          }
+        },
+        "summary": "Gets the status of an import or export job in an iot hub"
+      },
+      "delete": {
+        "description": "Cancels an import or export job in an IoT hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "JobClient_CancelImportExportJob",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Job ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "204": {
+            "description": "NoContent"
+          }
+        },
+        "summary": "Cancels an import or export job in an IoT hub."
+      }
+    },
+    "/devices/{id}/commands": {
+      "delete": {
+        "description": "Deletes all the pending commands for this device from the IoT hub For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "RegistryManager_PurgeCommandQueue",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Device ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/PurgeMessageQueueResult"
+            }
+          }
+        },
+        "summary": "Deletes all the pending commands for this device from the IoT hub."
+      }
+    },
+    "/faultInjection": {
+      "get": {
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "FaultInjection_Get",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "typeof faultInjectionProperty",
+            "schema": {
+              "$ref": "#/definitions/FaultInjectionProperties"
+            }
+          }
+        },
+        "summary": "Get FaultInjection entity"
+      },
+      "put": {
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "FaultInjection_Set",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "value",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FaultInjectionProperties"
+            }
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "summary": "Create or update FaultInjection entity"
+      }
+    },
+    "/twins/{id}": {
+      "get": {
+        "description": "Gets a device twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "Twin_GetDeviceTwin",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Device ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the device twin object",
+            "schema": {
+              "$ref": "#/definitions/Twin"
+            }
+          }
+        },
+        "summary": "Gets a device twin."
+      },
+      "put": {
+        "description": "Replaces a device twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "Twin_ReplaceDeviceTwin",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Device ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deviceTwinInfo",
+            "in": "body",
+            "description": "Device twin info",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Twin"
+            }
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "A string representing a weak ETag for the device twin, as per RFC7232. It determines if the replace operation should be carried out.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the device twin object",
+            "schema": {
+              "$ref": "#/definitions/Twin"
+            }
+          }
+        },
+        "summary": "Replaces tags and desired properties of a device twin."
+      },
+      "patch": {
+        "description": "Updates a device twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "Twin_UpdateDeviceTwin",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Device ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deviceTwinInfo",
+            "in": "body",
+            "description": "Device twin info",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Twin"
+            }
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "A string representing a weak ETag for the device twin, as per RFC7232. It determines if the update operation should be carried out.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the device twin object",
+            "schema": {
+              "$ref": "#/definitions/Twin"
+            }
+          }
+        },
+        "summary": "Updates tags and desired properties of a device twin."
+      }
+    },
+    "/twins/{id}/modules/{mid}": {
+      "get": {
+        "description": "Gets a module twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "Twin_GetModuleTwin",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Device ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "mid",
+            "in": "path",
+            "description": "Module ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the device twin object",
+            "schema": {
+              "$ref": "#/definitions/Twin"
+            }
+          }
+        },
+        "summary": "Gets a module twin."
+      },
+      "put": {
+        "description": "Replaces a module twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "Twin_ReplaceModuleTwin",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Device ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "mid",
+            "in": "path",
+            "description": "Module ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deviceTwinInfo",
+            "in": "body",
+            "description": "Device twin info",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Twin"
+            }
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "A string representing a weak ETag for the device twin, as per RFC7232. It determines if the replace operation should be carried out.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the device twin object",
+            "schema": {
+              "$ref": "#/definitions/Twin"
+            }
+          }
+        },
+        "summary": "Replaces tags and desired properties of a module twin."
+      },
+      "patch": {
+        "description": "Updates a module twin. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-device-twins for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "Twin_UpdateModuleTwin",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Device ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "mid",
+            "in": "path",
+            "description": "Module ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deviceTwinInfo",
+            "in": "body",
+            "description": "Device twin information",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Twin"
+            }
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "A string representing a weak ETag for the device twin, as per RFC7232. It determines if the update operation should be carried out.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the device twin object",
+            "schema": {
+              "$ref": "#/definitions/Twin"
+            }
+          }
+        },
+        "summary": "Updates tags and desired properties of a module twin."
+      }
+    },
+    "/digitalTwins/{digitalTwinId}/interfaces": {
+      "get": {
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "DigitalTwin_GetComponents",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "digitalTwinId",
+            "in": "path",
+            "description": "Digital Twin ID. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns a collection of interface objects",
+            "schema": {
+              "$ref": "#/definitions/DigitalTwinInterfaces"
+            },
+            "headers": {
+              "ETag": {
+                "description": "ETag of the digital twin.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "summary": "Gets the list of interfaces."
+      },
+      "patch": {
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "DigitalTwin_UpdateComponent",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "digitalTwinId",
+            "in": "path",
+            "description": "Digital Twin ID. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "interfacesPatchInfo",
+            "in": "body",
+            "description": "Multiple interfaces desired properties to update.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DigitalTwinInterfacesPatch"
+            }
+          },
+          {
+            "name": "If-Match",
+            "description": "A string representing a weak ETag for digital twin, as per RFC7232",
+            "in": "header",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns multiple interfaces",
+            "schema": {
+              "$ref": "#/definitions/DigitalTwinInterfaces"
+            },
+            "headers": {
+              "ETag": {
+                "description": "ETag of the digital twin.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "summary": "Updates desired properties of multiple interfaces.\r\n            Example URI: \"digitalTwins/{digitalTwinId}/interfaces\""
+      }
+    },
+    "/digitalTwins/{digitalTwinId}/interfaces/{interfaceName}": {
+      "get": {
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "DigitalTwin_GetComponent",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "digitalTwinId",
+            "in": "path",
+            "description": "Digital Twin ID. Format of digitalTwinId is DeviceId[~ModuleId]. ModuleId is optional.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "interfaceName",
+            "in": "path",
+            "description": "The interface name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns interface object of given id",
+            "schema": {
+              "$ref": "#/definitions/DigitalTwinInterfaces"
+            },
+            "headers": {
+              "ETag": {
+                "description": "ETag of the digital twin.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "summary": "Gets the interface of given interfaceId.\r\n            Example URI: \"digitalTwins/{digitalTwinId}/interfaces/{interfaceName}\""
+      }
+    },
+    "/messages/serviceBound/feedback": {
+      "get": {
+        "description": "This method is used to retrieve feedback of a cloud-to-device message See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information. This capability is only available in the standard tier IoT Hub. For more information, see [Choose the right IoT Hub tier](https://aka.ms/scaleyouriotsolution). For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "HttpRuntime_ReceiveFeedbackNotification",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The feedback response object"
+          },
+          "204": {
+            "description": "No Content Sent if feedback queue is empty"
+          }
+        },
+        "summary": "This method is used to retrieve feedback of a cloud-to-device message."
+      }
+    },
+    "/messages/serviceBound/feedback/{lockToken}": {
+      "delete": {
+        "description": "This method completes a feedback message. The lockToken obtained when the message was received must be provided to resolve race conditions when completing, a feedback message. A completed message is deleted from the feedback queue. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "HttpRuntime_CompleteFeedbackNotification",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "lockToken",
+            "in": "path",
+            "description": "Lock token.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "This method completes a feedback message."
+      }
+    },
+    "/messages/serviceBound/feedback/{lockToken}/abandon": {
+      "post": {
+        "description": "This method abandons a feedback message. The lockToken obtained when the message was received must be provided to resolve race conditions when abandoning, a feedback message. A abandoned message is deleted from the feedback queue. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-messaging for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "HttpRuntime_AbandonFeedbackNotification",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "lockToken",
+            "in": "path",
+            "description": "Lock Token.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "This method abandons a feedback message."
+      }
+    },
+    "/jobs/v2/{id}": {
+      "get": {
+        "description": "Retrieves details of a scheduled job from an IoT hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "JobClient_GetJob",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Job ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the Job response object",
+            "schema": {
+              "$ref": "#/definitions/JobResponse"
+            }
+          }
+        },
+        "summary": "Retrieves details of a scheduled job from an IoT hub."
+      },
+      "put": {
+        "description": "Creates a new job to schedule update twins or device direct methods on an IoT hub at a scheduled time. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "JobClient_CreateJob",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Job ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "jobRequest",
+            "in": "body",
+            "description": "The job to be created.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/JobRequest"
+            }
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the Job response object",
+            "schema": {
+              "$ref": "#/definitions/JobResponse"
+            }
+          }
+        },
+        "summary": "Creates a new job to schedule update twins or device direct methods on an IoT hub at a scheduled time."
+      }
+    },
+    "/jobs/v2/{id}/cancel": {
+      "post": {
+        "description": "Cancels a scheduled job on an IoT hub. See https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-jobs for more information. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "JobClient_CancelJob",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Job ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the Job response object",
+            "schema": {
+              "$ref": "#/definitions/JobResponse"
+            }
+          }
+        },
+        "summary": "Cancels a scheduled job on an IoT hub."
+      }
+    },
+    "/jobs/v2/query": {
+      "get": {
+        "description": "Query an IoT hub to retrieve information regarding jobs using the IoT Hub query language. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language for more information. Pagination of results is supported. This returns information about jobs only. For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "JobClient_QueryJobs",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "jobType",
+            "in": "query",
+            "description": "Job Type.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "jobStatus",
+            "in": "query",
+            "description": "Job Status.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the Query Result object",
+            "schema": {
+              "$ref": "#/definitions/QueryResult"
+            }
+          }
+        },
+        "summary": "Query an IoT hub to retrieve information regarding jobs using the IoT Hub query language"
+      }
+    },
+    "/devices/{id}/modules": {
+      "get": {
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "RegistryManager_GetModulesOnDevice",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Device ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the Device object",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Module"
+              }
+            }
+          }
+        },
+        "summary": "Retrieve all the module identities on the device."
+      }
+    },
+    "/devices/{id}/modules/{mid}": {
+      "get": {
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "RegistryManager_GetModule",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Device ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "mid",
+            "in": "path",
+            "description": "Module ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the DeviceModule object",
+            "schema": {
+              "$ref": "#/definitions/Module"
+            }
+          }
+        },
+        "summary": "Retrieve the specified module identity on the device."
+      },
+      "put": {
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "RegistryManager_CreateOrUpdateModule",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Device ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "mid",
+            "in": "path",
+            "description": "Module ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "module",
+            "description": "The module identity.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Module"
+            }
+          },
+          {
+            "name": "If-Match",
+            "description": "A string representing a weak ETag for the module, as per RFC7232. Should not be set when creating module, but may be set when updating a module",
+            "in": "header",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the updated DeviceModule object",
+            "schema": {
+              "$ref": "#/definitions/Module"
+            }
+          },
+          "201": {
+            "description": "Returns the created DeviceModule object",
+            "schema": {
+              "$ref": "#/definitions/Module"
+            }
+          }
+        },
+        "summary": "Create or update the module identity for device in IoT hub. An ETag must not be specified for the create operation. An ETag must be specified for the update operation. Note that moduleId and generation cannot be updated by the user."
+      },
+      "delete": {
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "RegistryManager_DeleteModule",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Device ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "mid",
+            "in": "path",
+            "description": "Module ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "If-Match",
+            "description": " A string representing a weak ETag for the module, as per RFC7232. The delete operation is performed only if this ETag matches the value maintained by the server, indicating that the module has not been modified since it was last retrieved. To force an unconditional delete, set If-Match to the wildcard character (*).",
+            "in": "header",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "summary": "Delete the module identity for device of an IoT hub. This request requires the If-Match header. The client may specify the ETag for the device identity on the request in order to compare to the ETag maintained by the service for the purpose of optimistic concurrency. The delete operation is performed only if the ETag sent by the client matches the value maintained by the server, indicating that the device identity has not been modified since it was retrieved by the client. To force an unconditional delete, set If-Match to the wildcard character (*)."
+      }
+    },
+    "/digitalTwins/models/{modelId}": {
+      "get": {
+        "description": " For IoT Hub VNET related features(https://docs.microsoft.com/en-us/azure/iot-hub/virtual-network-support) please use API version '2020-03-13'.These features are currently in general availability in the East US, West US 2, and Southcentral US regions only. We are actively working to expand the availability of these features to all regions by end of month May. For rest of the APIs please continue using API version '2019-10-01'",
+        "operationId": "DigitalTwin_GetDigitalTwinModel",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "modelId",
+            "in": "path",
+            "description": "Model id Ex: <example>urn:contoso:TemperatureSensor:1</example>",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "expand",
+            "in": "query",
+            "description": "Indicates whether to expand the device capability model's interface definitions inline or not.\r\nThis query parameter ONLY applies to Capability model.",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the digital twin model",
+            "schema": {
+              "type": "object"
+            },
+            "headers": {
+              "ETag": {
+                "description": "ETag of the digital twin.",
+                "type": "string"
+              },
+              "x-ms-model-id": {
+                "description": "Digital twin model id.",
+                "type": "string"
+              },
+              "x-ms-model-resolution-status": {
+                "description": "Digital twin model resolution status: enum [Pending, Success, NotFound, Failed, Resolved, Deleted]",
+                "type": "string"
+              },
+              "x-ms-model-resolution-description": {
+                "description": "Digital twin model resolution status description.",
+                "type": "string"
+              }
+            }
+          },
+          "204": {
+            "description": "Model is not resolved, See the 'x-ms-model-resolution-description' and 'x-ms-model-resolution-status' for the resolution status code and description.",
+            "headers": {
+              "ETag": {
+                "description": "ETag of the digital twin.",
+                "type": "string"
+              },
+              "x-ms-model-id": {
+                "description": "Digital twin model id.",
+                "type": "string"
+              },
+              "x-ms-model-resolution-status": {
+                "description": "Digital twin model resolution status: enum [Pending, Success, NotFound, Failed, Resolved, Deleted]",
+                "type": "string"
+              },
+              "x-ms-model-resolution-description": {
+                "description": "Digital twin model resolution status description.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "summary": "Returns a DigitalTwin model definition for the given id.\r\nIf \"expand\" is present in the query parameters and id is for a device capability model then it returns\r\nthe capability metamodel with expanded interface definitions."
+      }
+    },
+    "/twins/{deviceId}/methods": {
+      "post": {
+        "description": "Invoke a direct method on a device. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-direct-methods for more information.",
+        "operationId": "DeviceMethod_InvokeDeviceMethod",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "deviceId",
+            "in": "path",
+            "description": "The unique identifier of the device.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "directMethodRequest",
+            "in": "body",
+            "description": "Parameters to execute a direct method on the device.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CloudToDeviceMethod"
+            }
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the method response payload",
+            "schema": {
+              "$ref": "#/definitions/CloudToDeviceMethodResult"
+            }
+          }
+        },
+        "summary": "Invoke a direct method on a device."
+      }
+    },
+    "/twins/{deviceId}/modules/{moduleId}/methods": {
+      "post": {
+        "description": "Invoke a direct method on a module of a device. See https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-direct-methods for more information",
+        "operationId": "DeviceMethod_InvokeModuleMethod",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "deviceId",
+            "in": "path",
+            "description": "The unique identifier of the device.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "moduleId",
+            "in": "path",
+            "description": "The unique identifier of the module.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "directMethodRequest",
+            "in": "body",
+            "description": "Parameters to execute a direct method on the module.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CloudToDeviceMethod"
+            }
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the method response payload",
+            "schema": {
+              "$ref": "#/definitions/CloudToDeviceMethodResult"
+            }
+          }
+        },
+        "summary": "Invoke a direct method on a module of a device."
+      }
+    },
+    "/digitalTwins/{digitalTwinId}/interfaces/{interfaceName}/commands/{commandName}": {
+      "post": {
+        "summary": "Invoke a digital twin interface command.",
+        "description": "Invoke a digital twin interface command.",
+        "operationId": "DigitalTwin_InvokeComponentCommand",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "digitalTwinId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "interfaceName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "commandName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "payload",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "description": "The Request Payload",
+              "type": "object"
+            }
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "name": "connectTimeoutInSeconds",
+            "in": "query",
+            "description": "Connect timeout in seconds.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "responseTimeoutInSeconds",
+            "in": "query",
+            "description": "Response timeout in seconds.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the digital twin command response payload",
+            "schema": {
+              "description": "The Response Payload",
+              "type": "object"
+            },
+            "headers": {
+              "x-ms-command-statuscode": {
+                "description": "Device Generated Status Code for this Operation",
+                "type": "integer",
+                "format": "int32"
+              },
+              "x-ms-request-id": {
+                "description": "Server Generated Request Id (GUID), to uniquely identify this request in the service",
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "ConfigurationMetrics": {
+      "description": "Configuration Metrics",
+      "type": "object",
+      "properties": {
+        "results": {
+          "type": "object",
+          "description": "TODO: Service to fill in",
+          "additionalProperties": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "queries": {
+          "type": "object",
+          "description": "TODO: Service to fill in",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Configuration": {
+      "description": "Configuration for IotHub devices and modules.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Gets Identifier for the configuration",
+          "type": "string"
+        },
+        "schemaVersion": {
+          "description": "Gets Schema version for the configuration",
+          "type": "string"
+        },
+        "labels": {
+          "description": "Gets or sets labels for the configuration",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "content": {
+          "$ref": "#/definitions/ConfigurationContent",
+          "description": "Gets or sets Content for the configuration"
+        },
+        "targetCondition": {
+          "description": "Gets or sets Target Condition for the configuration",
+          "type": "string"
+        },
+        "createdTimeUtc": {
+          "format": "date-time",
+          "description": "Gets creation time for the configuration",
+          "type": "string",
+          "readOnly": true
+        },
+        "lastUpdatedTimeUtc": {
+          "format": "date-time",
+          "description": "Gets last update time for the configuration",
+          "type": "string",
+          "readOnly": true
+        },
+        "priority": {
+          "format": "int32",
+          "description": "Gets or sets Priority for the configuration",
+          "type": "integer"
+        },
+        "systemMetrics": {
+          "$ref": "#/definitions/ConfigurationMetrics",
+          "description": "System Configuration Metrics"
+        },
+        "metrics": {
+          "$ref": "#/definitions/ConfigurationMetrics",
+          "description": "Custom Configuration Metrics"
+        },
+        "etag": {
+          "description": "Gets or sets configuration's ETag",
+          "type": "string"
+        }
+      }
+    },
+    "ConfigurationContent": {
+      "description": "Configuration Content for Devices or Modules on Edge Devices.",
+      "type": "object",
+      "properties": {
+        "deviceContent": {
+          "description": "Gets or sets device Configurations",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "modulesContent": {
+          "description": "Gets or sets Modules Configurations",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
+            }
+          }
+        },
+        "moduleContent": {
+          "description": "Gets or sets Module Configurations",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "ConfigurationQueriesTestInput": {
+      "type": "object",
+      "properties": {
+        "targetCondition": {
+          "type": "string",
+          "description": "The query used to define targeted devices or modules. The query is based on twin tags and/or reported properties"
+        },
+        "customMetricQueries": {
+          "type": "object",
+          "description": "Queries on twin reported properties",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ConfigurationQueriesTestResponse": {
+      "type": "object",
+      "properties": {
+        "targetConditionError": {
+          "type": "string",
+          "description": "Errors running the target condition query."
+        },
+        "customMetricQueryErrors": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "description": "Errors running the custom metric query."
+          }
+        }
+      }
+    },
+    "RegistryStatistics": {
+      "type": "object",
+      "properties": {
+        "totalDeviceCount": {
+          "format": "int64",
+          "type": "integer",
+          "description": "The total number of devices registered for this hub.",
+          "readOnly": true
+        },
+        "enabledDeviceCount": {
+          "format": "int64",
+          "type": "integer",
+          "description": "The number of currently enabled devices.",
+          "readOnly": true
+        },
+        "disabledDeviceCount": {
+          "format": "int64",
+          "type": "integer",
+          "description": "The number of currently disabled devices.",
+          "readOnly": true
+        }
+      }
+    },
+    "ServiceStatistics": {
+      "type": "object",
+      "properties": {
+        "connectedDeviceCount": {
+          "format": "int64",
+          "type": "integer",
+          "description": "The number of currently connected devices.",
+          "readOnly": true
+        }
+      }
+    },
+    "Device": {
+      "type": "object",
+      "properties": {
+        "deviceId": {
+          "type": "string",
+          "description": "The unique identifier of this device."
+        },
+        "generationId": {
+          "type": "string",
+          "description": "An IoT hub-generated, case-sensitive string up to 128 characters long. This value is used to distinguish devices with the same deviceId, when they have been deleted and re-created.",
+          "readOnly": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A string representing a weak ETag for the device identity, as per RFC7232."
+        },
+        "connectionState": {
+          "enum": [
+            "Disconnected",
+            "Connected"
+          ],
+          "type": "string",
+          "description": "Tells whether the device is connected or not.",
+          "readOnly": true
+        },
+        "status": {
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
+          "type": "string",
+          "description": "Flags whether a device is enabled or not. If disabled, a device cannot connect to the service."
+        },
+        "statusReason": {
+          "type": "string",
+          "description": "A 128 character-long string that stores the reason for the device identity status. All UTF-8 characters are allowed."
+        },
+        "connectionStateUpdatedTime": {
+          "format": "date-time",
+          "type": "string",
+          "description": "A temporal indicator, showing the date and last time the connection state was updated.",
+          "readOnly": true
+        },
+        "statusUpdatedTime": {
+          "format": "date-time",
+          "type": "string",
+          "description": "The last timestamp of when the status field was updated.",
+          "readOnly": true
+        },
+        "lastActivityTime": {
+          "format": "date-time",
+          "type": "string",
+          "description": "A temporal indicator, showing the date and last time the device connected, received, or sent a message.",
+          "readOnly": true
+        },
+        "cloudToDeviceMessageCount": {
+          "format": "int32",
+          "type": "integer",
+          "description": "The number of cloud to device messages currently queued to be sent to the device.",
+          "readOnly": true
+        },
+        "authentication": {
+          "$ref": "#/definitions/AuthenticationMechanism",
+          "description": "The details on what authentication mechanisms are used by this device."
+        },
+        "capabilities": {
+          "$ref": "#/definitions/DeviceCapabilities",
+          "description": "The set of capabilities that this device has. For example, if this device is an edge device or not."
+        },
+        "deviceScope": {
+          "type": "string",
+          "description": "The scope that this device belongs to."
+        },
+        "parentScopes": {
+          "type": "array",
+          "description": "TODO: service team needs to explain this",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "AuthenticationMechanism": {
+      "type": "object",
+      "properties": {
+        "symmetricKey": {
+          "$ref": "#/definitions/SymmetricKey",
+          "description": "The primary and secondary keys used for SAS based authentication."
+        },
+        "x509Thumbprint": {
+          "$ref": "#/definitions/X509Thumbprint",
+          "description": "The primary and secondary x509 thumbprints used for x509 based authentication."
+        },
+        "type": {
+          "enum": [
+            "sas",
+            "selfSigned",
+            "certificateAuthority",
+            "none"
+          ],
+          "type": "string",
+          "description": "The type of authentication used when connecting to the service."
+        }
+      }
+    },
+    "DeviceCapabilities": {
+      "description": "Status of Capabilities enabled on the device",
+      "type": "object",
+      "properties": {
+        "iotEdge": {
+          "description": "Whether or not this device is an edge device.",
+          "type": "boolean"
+        }
+      }
+    },
+    "SymmetricKey": {
+      "type": "object",
+      "properties": {
+        "primaryKey": {
+          "type": "string",
+          "description": "The base 64 encoded primary key of your device."
+        },
+        "secondaryKey": {
+          "type": "string",
+          "description": "The base 64 encoded secondary key of your device."
+        }
+      }
+    },
+    "X509Thumbprint": {
+      "type": "object",
+      "properties": {
+        "primaryThumbprint": {
+          "description": "Gets and sets the X509 client certificate primary thumbprint.",
+          "type": "string"
+        },
+        "secondaryThumbprint": {
+          "description": "Gets and sets the X509 client certificate secondary thumbprint.",
+          "type": "string"
+        }
+      }
+    },
+    "ExportImportDevice": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Device Id is always required",
+          "type": "string"
+        },
+        "moduleId": {
+          "description": "ModuleId is applicable to modules only",
+          "type": "string"
+        },
+        "eTag": {
+          "description": "ETag parameter is only used for pre-conditioning the update when importMode is updateIfMatchETag",
+          "type": "string"
+        },
+        "importMode": {
+          "enum": [
+            "create",
+            "update",
+            "updateIfMatchETag",
+            "delete",
+            "deleteIfMatchETag",
+            "updateTwin",
+            "updateTwinIfMatchETag"
+          ],
+          "type": "string",
+          "description": "The type of registry operation and if ETag should be ignored or not."
+        },
+        "status": {
+          "description": "Status is optional and defaults to enabled",
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
+          "type": "string"
+        },
+        "statusReason": {
+          "type": "string",
+          "description": "A 128 character-long string that stores the reason for the device identity status. All UTF-8 characters are allowed."
+        },
+        "authentication": {
+          "$ref": "#/definitions/AuthenticationMechanism",
+          "description": "Authentication parameter is optional and defaults to SAS if not provided. In that case, we auto-generate primary/secondary access keys"
+        },
+        "twinETag": {
+          "description": "twinETag parameter is only used for pre-conditioning the update when importMode is updateTwinIfMatchETag",
+          "type": "string"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "description": "A JSON document read and written by the solution back end. Tags are not visible to device apps."
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/PropertyContainer",
+          "description": "Properties are optional and defaults to empty object"
+        },
+        "capabilities": {
+          "$ref": "#/definitions/DeviceCapabilities",
+          "description": "Capabilities param is optional and defaults to no capability"
+        },
+        "deviceScope": {
+          "type": "string",
+          "description": "The scope that this identity belongs to."
+        },
+        "parentScopes": {
+          "type": "array",
+          "description": "TODO: service team needs to explain this",
+          "items": {
+            "type": "string",
+            "description": "TODO service folks need to explain this."
+          }
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "PropertyContainer": {
+      "description": "Represents Twin properties",
+      "type": "object",
+      "properties": {
+        "desired": {
+          "description": "Used in conjunction with reported properties to synchronize device configuration or condition. Desired properties can only be set by the solution back end and can be read by the device app. The device app can also be notified in real time of changes on the desired properties.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "reported": {
+          "description": "Used in conjunction with desired properties to synchronize device configuration or condition. Reported properties can only be set by the device app and can be read and queried by the solution back end.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "BulkRegistryOperationResult": {
+      "description": "Encapsulates the result of a bulk registry operation.",
+      "type": "object",
+      "properties": {
+        "isSuccessful": {
+          "description": "Whether or not the operation was successful.",
+          "type": "boolean",
+          "readOnly": true
+        },
+        "errors": {
+          "description": "If the operation was not successful, this contains an array of DeviceRegistryOperationError objects.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DeviceRegistryOperationError"
+          },
+          "readOnly": true
+        },
+        "warnings": {
+          "description": "If the operation was partially successful, this contains an array of DeviceRegistryOperationWarning objects.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DeviceRegistryOperationWarning"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "DeviceRegistryOperationError": {
+      "description": "Encapsulates device registry operation error details.",
+      "type": "object",
+      "properties": {
+        "deviceId": {
+          "description": "The ID of the device that indicated the error.",
+          "type": "string",
+          "readOnly": true
+        },
+        "errorCode": {
+          "description": "ErrorCode associated with the error.",
+          "enum": [
+            "InvalidErrorCode",
+            "GenericBadRequest",
+            "InvalidProtocolVersion",
+            "DeviceInvalidResultCount",
+            "InvalidOperation",
+            "ArgumentInvalid",
+            "ArgumentNull",
+            "IotHubFormatError",
+            "DeviceStorageEntitySerializationError",
+            "BlobContainerValidationError",
+            "ImportWarningExistsError",
+            "InvalidSchemaVersion",
+            "DeviceDefinedMultipleTimes",
+            "DeserializationError",
+            "BulkRegistryOperationFailure",
+            "DefaultStorageEndpointNotConfigured",
+            "InvalidFileUploadCorrelationId",
+            "ExpiredFileUploadCorrelationId",
+            "InvalidStorageEndpoint",
+            "InvalidMessagingEndpoint",
+            "InvalidFileUploadCompletionStatus",
+            "InvalidStorageEndpointOrBlob",
+            "RequestCanceled",
+            "InvalidStorageEndpointProperty",
+            "EtagDoesNotMatch",
+            "RequestTimedOut",
+            "UnsupportedOperationOnReplica",
+            "NullMessage",
+            "ConnectionForcefullyClosedOnNewConnection",
+            "InvalidDeviceScope",
+            "ConnectionForcefullyClosedOnFaultInjection",
+            "ConnectionRejectedOnFaultInjection",
+            "InvalidEndpointAuthenticationType",
+            "ManagedIdentityNotEnabled",
+            "InvalidRouteTestInput",
+            "InvalidSourceOnRoute",
+            "RoutingNotEnabled",
+            "InvalidContentEncodingOrType",
+            "InvalidEndorsementKey",
+            "InvalidRegistrationId",
+            "InvalidStorageRootKey",
+            "InvalidEnrollmentGroupId",
+            "TooManyEnrollments",
+            "RegistrationIdDefinedMultipleTimes",
+            "CustomAllocationFailed",
+            "CustomAllocationIotHubNotSpecified",
+            "CustomAllocationUnauthorizedAccess",
+            "CannotRegisterModuleToModule",
+            "TenantHubRoutingNotEnabled",
+            "InvalidConfigurationTargetCondition",
+            "InvalidConfigurationContent",
+            "CannotModifyImmutableConfigurationContent",
+            "InvalidConfigurationCustomMetricsQuery",
+            "InvalidPnPInterfaceDefinition",
+            "InvalidPnPDesiredProperties",
+            "InvalidPnPReportedProperties",
+            "InvalidPnPWritableReportedProperties",
+            "InvalidDigitalTwinJsonPatch",
+            "InvalidDigitalTwinPayload",
+            "InvalidDigitalTwinPatch",
+            "InvalidDigitalTwinPatchPath",
+            "GenericUnauthorized",
+            "IotHubNotFound",
+            "IotHubUnauthorizedAccess",
+            "IotHubUnauthorized",
+            "ElasticPoolNotFound",
+            "SystemModuleModifyUnauthorizedAccess",
+            "GenericForbidden",
+            "IotHubSuspended",
+            "IotHubQuotaExceeded",
+            "JobQuotaExceeded",
+            "DeviceMaximumQueueDepthExceeded",
+            "IotHubMaxCbsTokenExceeded",
+            "DeviceMaximumActiveFileUploadLimitExceeded",
+            "DeviceMaximumQueueSizeExceeded",
+            "RoutingEndpointResponseForbidden",
+            "InvalidMessageExpiryTime",
+            "OperationNotAvailableInCurrentTier",
+            "KeyEncryptionKeyRevoked",
+            "DeviceModelMaxPropertiesExceeded",
+            "DeviceModelMaxIndexablePropertiesExceeded",
+            "IotDpsSuspended",
+            "IotDpsSuspending",
+            "GenericNotFound",
+            "DeviceNotFound",
+            "JobNotFound",
+            "QuotaMetricNotFound",
+            "SystemPropertyNotFound",
+            "AmqpAddressNotFound",
+            "RoutingEndpointResponseNotFound",
+            "CertificateNotFound",
+            "ElasticPoolTenantHubNotFound",
+            "ModuleNotFound",
+            "AzureTableStoreNotFound",
+            "IotHubFailingOver",
+            "FeatureNotSupported",
+            "DigitalTwinInterfaceNotFound",
+            "QueryStoreClusterNotFound",
+            "DeviceNotOnline",
+            "DeviceConnectionClosedRemotely",
+            "EnrollmentNotFound",
+            "DeviceRegistrationNotFound",
+            "AsyncOperationNotFound",
+            "EnrollmentGroupNotFound",
+            "DeviceRecordNotFound",
+            "GroupRecordNotFound",
+            "DeviceGroupNotFound",
+            "ProvisioningSettingsNotFound",
+            "ProvisioningRecordNotFound",
+            "LinkedHubNotFound",
+            "CertificateAuthorityNotFound",
+            "ConfigurationNotFound",
+            "GroupNotFound",
+            "DigitalTwinModelNotFound",
+            "InterfaceNameModelNotFound",
+            "GenericMethodNotAllowed",
+            "OperationNotAllowedInCurrentState",
+            "ImportDevicesNotSupported",
+            "BulkAddDevicesNotSupported",
+            "GenericConflict",
+            "DeviceAlreadyExists",
+            "LinkCreationConflict",
+            "CallbackSubscriptionConflict",
+            "ModelAlreadyExists",
+            "DeviceLocked",
+            "DeviceJobAlreadyExists",
+            "JobAlreadyExists",
+            "EnrollmentConflict",
+            "EnrollmentGroupConflict",
+            "RegistrationStatusConflict",
+            "DeviceRecordConflict",
+            "GroupRecordConflict",
+            "DeviceGroupConflict",
+            "ProvisioningSettingsConflict",
+            "ProvisioningRecordConflict",
+            "LinkedHubConflict",
+            "CertificateAuthorityConflict",
+            "ModuleAlreadyExistsOnDevice",
+            "ConfigurationAlreadyExists",
+            "ApplyConfigurationAlreadyInProgressOnDevice",
+            "DigitalTwinModelAlreadyExists",
+            "DigitalTwinModelExistsWithOtherModelType",
+            "InterfaceNameModelAlreadyExists",
+            "GenericPreconditionFailed",
+            "PreconditionFailed",
+            "DeviceMessageLockLost",
+            "JobRunPreconditionFailed",
+            "InflightMessagesInLink",
+            "GenericRequestEntityTooLarge",
+            "MessageTooLarge",
+            "TooManyDevices",
+            "TooManyModulesOnDevice",
+            "ConfigurationCountLimitExceeded",
+            "DigitalTwinModelCountLimitExceeded",
+            "InterfaceNameCompressionModelCountLimitExceeded",
+            "GenericUnsupportedMediaType",
+            "IncompatibleDataType",
+            "GenericTooManyRequests",
+            "ThrottlingException",
+            "ThrottleBacklogLimitExceeded",
+            "ThrottlingBacklogTimeout",
+            "ThrottlingMaxActiveJobCountExceeded",
+            "DeviceThrottlingLimitExceeded",
+            "ClientClosedRequest",
+            "GenericServerError",
+            "ServerError",
+            "JobCancelled",
+            "StatisticsRetrievalError",
+            "ConnectionForcefullyClosed",
+            "InvalidBlobState",
+            "BackupTimedOut",
+            "AzureStorageTimeout",
+            "GenericTimeout",
+            "InvalidThrottleParameter",
+            "EventHubLinkAlreadyClosed",
+            "ReliableBlobStoreError",
+            "RetryAttemptsExhausted",
+            "AzureTableStoreError",
+            "CheckpointStoreNotFound",
+            "DocumentDbInvalidReturnValue",
+            "ReliableDocDbStoreStoreError",
+            "ReliableBlobStoreTimeoutError",
+            "ConfigReadFailed",
+            "InvalidContainerReceiveLink",
+            "InvalidPartitionEpoch",
+            "RestoreTimedOut",
+            "StreamReservationFailure",
+            "SerializationError",
+            "UnexpectedPropertyValue",
+            "OrchestrationOperationFailed",
+            "ModelRepoEndpointError",
+            "ResolutionError",
+            "UnableToFetchCredentials",
+            "UnableToFetchTenantInfo",
+            "UnableToShareIdentity",
+            "UnableToExpandDiscoveryInfo",
+            "UnableToExpandComponentInfo",
+            "UnableToCompressDiscoveryInfo",
+            "UnableToCompressComponentInfo",
+            "GenericBadGateway",
+            "InvalidResponseWhileProxying",
+            "GenericServiceUnavailable",
+            "ServiceUnavailable",
+            "PartitionNotFound",
+            "IotHubActivationFailed",
+            "ServerBusy",
+            "IotHubRestoring",
+            "ReceiveLinkOpensThrottled",
+            "ConnectionUnavailable",
+            "DeviceUnavailable",
+            "ConfigurationNotAvailable",
+            "GroupNotAvailable",
+            "HostingServiceNotAvailable",
+            "GenericGatewayTimeout",
+            "GatewayTimeout"
+          ],
+          "type": "string",
+          "readOnly": true
+        },
+        "errorStatus": {
+          "description": "Additional details associated with the error.",
+          "type": "string",
+          "readOnly": true
+        },
+        "moduleId": {
+          "type": "string",
+          "description": "Identifier of the module associated with the error, if applicable.",
+          "readOnly": true
+        },
+        "operation": {
+          "type": "string",
+          "description": "The type of the operation that failed.",
+          "readOnly": true
+        }
+      }
+    },
+    "DeviceRegistryOperationWarning": {
+      "description": "Encapsulates device registry operation error details.",
+      "type": "object",
+      "properties": {
+        "deviceId": {
+          "description": "The ID of the device that indicated the warning.",
+          "type": "string",
+          "readOnly": true
+        },
+        "warningCode": {
+          "enum": [
+            "DeviceRegisteredWithoutTwin"
+          ],
+          "type": "string",
+          "description": "The code associated with the warning.",
+          "readOnly": true
+        },
+        "warningStatus": {
+          "description": "Additional details associated with the warning.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "QuerySpecification": {
+      "description": "A Json query request",
+      "type": "object",
+      "properties": {
+        "query": {
+          "description": "The query.",
+          "type": "string"
+        }
+      }
+    },
+    "Twin": {
+      "description": "Twin Representation",
+      "type": "object",
+      "properties": {
+        "deviceId": {
+          "description": "The deviceId uniquely identifies the device in the IoT hub's identity registry. A case-sensitive string (up to 128 char long) of ASCII 7-bit alphanumeric chars + {'-', ':', '.', '+', '%', '_', '#', '*', '?', '!', '(', ')', ',', '=', '@', ';', '$', '''}.",
+          "type": "string"
+        },
+        "moduleId": {
+          "description": "Gets and sets the Module Id.",
+          "type": "string"
+        },
+        "tags": {
+          "description": "A JSON document read and written by the solution back end. Tags are not visible to device apps.",
+          "type": "object",
+          "additionalProperties": {
+            "description": "The collection of the twin's tags as key-value pairs. They keys are UTF-8 encoded, case-sensitive and up-to 1KB in length. Allowed characters exclude UNICODE control characters (segments C0 and C1), '.', '$' and space. The values are JSON objects, up-to 4KB in length.",
+            "type": "object"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/TwinProperties",
+          "description": "Gets and sets the Twin properties."
+        },
+        "etag": {
+          "description": "Twin's ETag",
+          "type": "string",
+          "readOnly": true
+        },
+        "version": {
+          "format": "int64",
+          "description": "Version for device twin, including tags and desired properties",
+          "type": "integer",
+          "readOnly": true
+        },
+        "deviceEtag": {
+          "description": "Device's ETag",
+          "type": "string",
+          "readOnly": true
+        },
+        "status": {
+          "description": "Gets the corresponding Device's Status.",
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
+          "type": "string"
+        },
+        "statusReason": {
+          "description": "Reason, if any, for the corresponding Device to be in specified Status",
+          "type": "string"
+        },
+        "statusUpdateTime": {
+          "format": "date-time",
+          "description": "Time when the corresponding Device's Status was last updated",
+          "type": "string",
+          "readOnly": true
+        },
+        "connectionState": {
+          "description": "Corresponding Device's ConnectionState",
+          "enum": [
+            "Disconnected",
+            "Connected"
+          ],
+          "type": "string",
+          "readOnly": true
+        },
+        "lastActivityTime": {
+          "format": "date-time",
+          "description": "The last time the device connected, received or sent a message. In ISO8601 datetime format in UTC, for example, 2015-01-28T16:24:48.789Z. This does not update if the device uses the HTTP/1 protocol to perform messaging operations.",
+          "type": "string",
+          "readOnly": true
+        },
+        "cloudToDeviceMessageCount": {
+          "format": "int32",
+          "description": "Number of messages sent to the corresponding Device from the Cloud",
+          "type": "integer",
+          "readOnly": true
+        },
+        "authenticationType": {
+          "description": "Corresponding Device's authentication type",
+          "enum": [
+            "sas",
+            "selfSigned",
+            "certificateAuthority",
+            "none"
+          ],
+          "type": "string"
+        },
+        "x509Thumbprint": {
+          "$ref": "#/definitions/X509Thumbprint",
+          "description": "Corresponding Device's X509 thumbprint"
+        },
+        "capabilities": {
+          "$ref": "#/definitions/DeviceCapabilities"
+        },
+        "deviceScope": {
+          "description": "Scope to which this device instance belongs to",
+          "type": "string"
+        },
+        "parentScopes": {
+          "description": "TODO: new property added - need explanation",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "deviceId"
+      ]
+    },
+    "TwinProperties": {
+      "description": "Represents Twin properties",
+      "type": "object",
+      "properties": {
+        "desired": {
+          "description": "Used in conjunction with reported properties to synchronize device configuration or condition. Desired properties can only be set by the solution back end and can be read by the device app. The device app can also be notified in real time of changes on the desired properties.",
+          "type": "object",
+          "additionalProperties": {
+            "description": "The collection of desired property key-value pairs. The keys are UTF-8 encoded, case-sensitive and up-to 1KB in length. Allowed characters exclude UNICODE control characters (segments C0 and C1), '.', '$' and space. The desired porperty values are JSON objects, up-to 4KB in length.",
+            "type": "object"
+          }
+        },
+        "reported": {
+          "description": "Used in conjunction with desired properties to synchronize device configuration or condition. Reported properties can only be set by the device app and can be read and queried by the solution back end.",
+          "type": "object",
+          "additionalProperties": {
+            "description": "The collection of reported property key-value pairs. The keys are UTF-8 encoded, case-sensitive and up-to 1KB in length. Allowed characters exclude UNICODE control characters (segments C0 and C1), '.', '$' and space. The reported property values are JSON objects, up-to 4KB in length.",
+            "type": "object"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "JobProperties": {
+      "type": "object",
+      "properties": {
+        "jobId": {
+          "description": "System generated.  Ignored at creation.",
+          "type": "string",
+          "readOnly": true
+        },
+        "startTimeUtc": {
+          "format": "date-time",
+          "description": "System generated.  Ignored at creation.",
+          "type": "string",
+          "readOnly": true
+        },
+        "endTimeUtc": {
+          "format": "date-time",
+          "description": "System generated.  Ignored at creation.\r\nRepresents the time the job stopped processing.",
+          "type": "string",
+          "readOnly": true
+        },
+        "type": {
+          "description": "Required.\r\nThe type of job to execute.",
+          "enum": [
+            "unknown",
+            "export",
+            "import",
+            "backup",
+            "readDeviceProperties",
+            "writeDeviceProperties",
+            "updateDeviceConfiguration",
+            "rebootDevice",
+            "factoryResetDevice",
+            "firmwareUpdate",
+            "scheduleDeviceMethod",
+            "scheduleUpdateTwin",
+            "restoreFromBackup",
+            "failoverDataCopy"
+          ],
+          "type": "string"
+        },
+        "status": {
+          "description": "System generated.  Ignored at creation.",
+          "enum": [
+            "unknown",
+            "enqueued",
+            "running",
+            "completed",
+            "failed",
+            "cancelled",
+            "scheduled",
+            "queued"
+          ],
+          "type": "string",
+          "readOnly": true
+        },
+        "progress": {
+          "format": "int32",
+          "description": "System generated.  Ignored at creation.\r\nRepresents the percentage of completion.",
+          "type": "integer",
+          "readOnly": true
+        },
+        "inputBlobContainerUri": {
+          "description": "URI containing SAS token to a blob container that contains registry data to sync.",
+          "type": "string"
+        },
+        "inputBlobName": {
+          "description": "The blob name to be used when importing from the provided input blob container.",
+          "type": "string"
+        },
+        "outputBlobContainerUri": {
+          "description": "URI containing SAS token to a blob container.  This is used to output the status of the job and the results.",
+          "type": "string"
+        },
+        "outputBlobName": {
+          "description": "The name of the blob that will be created in the provided output blob container.  This blob will contain\r\nthe exported device registry information for the IoT Hub.",
+          "type": "string"
+        },
+        "excludeKeysInExport": {
+          "description": "Optional for export jobs; ignored for other jobs.  Default: false.  If false, authorization keys are included\r\nin export output.  Keys are exported as null otherwise.",
+          "type": "boolean"
+        },
+        "storageAuthenticationType": {
+          "description": "Specifies authentication type being used for connecting to storage account.",
+          "enum": [
+            "keyBased",
+            "identityBased"
+          ],
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "System genereated.  Ignored at creation.\r\nIf status == failure, this represents a string containing the reason.",
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "PurgeMessageQueueResult": {
+      "description": "Result of a device message queue purge operation.",
+      "type": "object",
+      "properties": {
+        "totalMessagesPurged": {
+          "description": "The total number of messages purged.",
+          "format": "int32",
+          "type": "integer",
+          "readOnly": true
+        },
+        "deviceId": {
+          "description": "The ID of the device whose messages are being purged.",
+          "type": "string",
+          "readOnly": true
+        },
+        "moduleId": {
+          "description": "The ID of the device whose messages are being purged.",
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    },
+    "FaultInjectionProperties": {
+      "type": "object",
+      "properties": {
+        "IotHubName": {
+          "type": "string",
+          "description": "Name of the IotHub."
+        },
+        "connection": {
+          "description": "TODO: to be filled by the service team.",
+          "$ref": "#/definitions/FaultInjectionConnectionProperties"
+        },
+        "lastUpdatedTimeUtc": {
+          "format": "date-time",
+          "description": "Service generated.",
+          "type": "string"
+        }
+      }
+    },
+    "FaultInjectionConnectionProperties": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "description": "Action to perform",
+          "enum": [
+            "None",
+            "CloseAll",
+            "Periodic"
+          ],
+          "type": "string"
+        },
+        "blockDurationInMinutes": {
+          "description": "TODO: to be filled by the service team",
+          "format": "int32",
+          "type": "integer"
+        }
+      }
+    },
+    "DigitalTwinInterfaces": {
+      "type": "object",
+      "properties": {
+        "interfaces": {
+          "description": "Interface(s) data on the digital twin.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Interface"
+          }
+        },
+        "version": {
+          "format": "int64",
+          "description": "Version of digital twin.",
+          "type": "integer"
+        }
+      }
+    },
+    "Interface": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Full name of digital twin interface.",
+          "type": "string"
+        },
+        "properties": {
+          "description": "List of all properties in an interface.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Property"
+          }
+        }
+      }
+    },
+    "Property": {
+      "type": "object",
+      "properties": {
+        "reported": {
+          "$ref": "#/definitions/Reported"
+        },
+        "desired": {
+          "$ref": "#/definitions/Desired"
+        }
+      }
+    },
+    "Reported": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "The current interface property value in a digitalTwin.",
+          "type": "object"
+        },
+        "desiredState": {
+          "$ref": "#/definitions/DesiredState"
+        }
+      }
+    },
+    "Desired": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "The desired value of the interface property to set in a digitalTwin.",
+          "type": "object"
+        }
+      }
+    },
+    "DesiredState": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "format": "int32",
+          "description": "Status code for the operation.",
+          "type": "integer"
+        },
+        "version": {
+          "format": "int64",
+          "description": "Version of the desired value received.",
+          "type": "integer"
+        },
+        "description": {
+          "description": "Description of the status.",
+          "type": "string"
+        }
+      }
+    },
+    "JobRequest": {
+      "type": "object",
+      "properties": {
+        "jobId": {
+          "description": "Job identifier",
+          "type": "string"
+        },
+        "type": {
+          "description": "Required.\r\nThe type of job to execute.",
+          "enum": [
+            "unknown",
+            "export",
+            "import",
+            "backup",
+            "readDeviceProperties",
+            "writeDeviceProperties",
+            "updateDeviceConfiguration",
+            "rebootDevice",
+            "factoryResetDevice",
+            "firmwareUpdate",
+            "scheduleDeviceMethod",
+            "scheduleUpdateTwin",
+            "restoreFromBackup",
+            "failoverDataCopy"
+          ],
+          "type": "string"
+        },
+        "cloudToDeviceMethod": {
+          "$ref": "#/definitions/CloudToDeviceMethod",
+          "description": "Required if jobType is cloudToDeviceMethod.\r\nThe method type and parameters."
+        },
+        "updateTwin": {
+          "$ref": "#/definitions/Twin"
+        },
+        "queryCondition": {
+          "description": "Required if jobType is updateTwin or cloudToDeviceMethod.\r\nCondition for device query to get devices to execute the job on",
+          "type": "string"
+        },
+        "startTime": {
+          "format": "date-time",
+          "description": "ISO 8601 date time to start the job",
+          "type": "string"
+        },
+        "maxExecutionTimeInSeconds": {
+          "format": "int64",
+          "description": "Max execution time in secounds (ttl duration)",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "CloudToDeviceMethod": {
+      "description": "Parameters to execute a direct method on the device",
+      "type": "object",
+      "properties": {
+        "methodName": {
+          "description": "Method to run",
+          "type": "string"
+        },
+        "payload": {
+          "description": "Payload",
+          "type": "object"
+        },
+        "responseTimeoutInSeconds": {
+          "description": "Time (in seconds) that the service waits for the method invocation to return a response. It defaults to 30 seconds. Minimum allowed value is 5 seconds, maximum allowed value is 300 seconds.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "connectTimeoutInSeconds": {
+          "description": "Time (in seconds) that the service waits for the device to come online. It defaults to 0, meaning the device must already be online. Maximum allowed value is 300 seconds.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "methodName"
+      ]
+    },
+    "JobResponse": {
+      "type": "object",
+      "properties": {
+        "jobId": {
+          "description": "System generated.  Ignored at creation.",
+          "type": "string",
+          "readOnly": true
+        },
+        "queryCondition": {
+          "description": "Device query condition.",
+          "type": "string",
+          "readOnly": true
+        },
+        "createdTime": {
+          "format": "date-time",
+          "description": "System generated.  Ignored at creation.",
+          "type": "string",
+          "readOnly": true
+        },
+        "startTime": {
+          "format": "date-time",
+          "description": "Scheduled job start time in UTC.",
+          "type": "string",
+          "readOnly": true
+        },
+        "endTime": {
+          "format": "date-time",
+          "description": "System generated.  Ignored at creation.\r\nRepresents the time the job stopped processing.",
+          "type": "string",
+          "readOnly": true
+        },
+        "maxExecutionTimeInSeconds": {
+          "format": "int64",
+          "description": "Max execution time in secounds (ttl duration)",
+          "type": "integer",
+          "readOnly": true
+        },
+        "type": {
+          "description": "Required.\r\nThe type of job to execute.",
+          "enum": [
+            "unknown",
+            "export",
+            "import",
+            "backup",
+            "readDeviceProperties",
+            "writeDeviceProperties",
+            "updateDeviceConfiguration",
+            "rebootDevice",
+            "factoryResetDevice",
+            "firmwareUpdate",
+            "scheduleDeviceMethod",
+            "scheduleUpdateTwin",
+            "restoreFromBackup",
+            "failoverDataCopy"
+          ],
+          "type": "string"
+        },
+        "cloudToDeviceMethod": {
+          "$ref": "#/definitions/CloudToDeviceMethod",
+          "description": "Required if jobType is cloudToDeviceMethod.\r\nThe method type and parameters.",
+          "readOnly": true
+        },
+        "updateTwin": {
+          "$ref": "#/definitions/Twin",
+          "readOnly": true
+        },
+        "status": {
+          "description": "System generated.  Ignored at creation.",
+          "enum": [
+            "unknown",
+            "enqueued",
+            "running",
+            "completed",
+            "failed",
+            "cancelled",
+            "scheduled",
+            "queued"
+          ],
+          "type": "string",
+          "readOnly": true
+        },
+        "failureReason": {
+          "description": "System generated.  Ignored at creation.\r\nIf status == failure, this represents a string containing the reason.",
+          "type": "string",
+          "readOnly": true
+        },
+        "statusMessage": {
+          "description": "Status message for the job",
+          "type": "string",
+          "readOnly": true
+        },
+        "deviceJobStatistics": {
+          "$ref": "#/definitions/DeviceJobStatistics",
+          "description": "Job details",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "DeviceJobStatistics": {
+      "description": "The job counts, e.g., number of failed/succeeded devices",
+      "type": "object",
+      "properties": {
+        "deviceCount": {
+          "format": "int32",
+          "description": "Number of devices in the job",
+          "type": "integer"
+        },
+        "failedCount": {
+          "format": "int32",
+          "description": "The number of failed jobs",
+          "type": "integer"
+        },
+        "succeededCount": {
+          "format": "int32",
+          "description": "The number of Successed jobs",
+          "type": "integer"
+        },
+        "runningCount": {
+          "format": "int32",
+          "description": "The number of running jobs",
+          "type": "integer"
+        },
+        "pendingCount": {
+          "format": "int32",
+          "description": "The number of pending (scheduled) jobs",
+          "type": "integer"
+        }
+      }
+    },
+    "QueryResult": {
+      "description": "The query result.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The query result type.",
+          "enum": [
+            "unknown",
+            "twin",
+            "deviceJob",
+            "jobResponse",
+            "raw",
+            "enrollment",
+            "enrollmentGroup",
+            "deviceRegistration"
+          ],
+          "type": "string"
+        },
+        "items": {
+          "description": "The query result items, as a collection.",
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "continuationToken": {
+          "description": "Request continuation token.",
+          "type": "string"
+        }
+      }
+    },
+    "Module": {
+      "description": "Module identity on a device",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "type": "string",
+          "description": "The unique identifier of this module."
+        },
+        "managedBy": {
+          "type": "string",
+          "description": "Identifies who manages this module. For instance, this value is \"IotEdge\" if the edge runtime owns this module."
+        },
+        "deviceId": {
+          "type": "string",
+          "description": "The unique identifier of the device that has this module."
+        },
+        "generationId": {
+          "type": "string",
+          "description": "An IoT hub-generated, case-sensitive string up to 128 characters long. This value is used to distinguish modules with the same moduleId, when they have been deleted and re-created.",
+          "readOnly": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A string representing a weak ETag for the module identity, as per RFC7232."
+        },
+        "connectionState": {
+          "description": "Tells whether the module is connected or not.",
+          "enum": [
+            "Disconnected",
+            "Connected"
+          ],
+          "type": "string",
+          "readOnly": true
+        },
+        "connectionStateUpdatedTime": {
+          "format": "date-time",
+          "type": "string",
+          "description": "A temporal indicator, showing the date and last time the connection state was updated.",
+          "readOnly": true
+        },
+        "lastActivityTime": {
+          "format": "date-time",
+          "type": "string",
+          "description": "A temporal indicator, showing the date and last time the device connected, received, or sent a message.",
+          "readOnly": true
+        },
+        "cloudToDeviceMessageCount": {
+          "format": "int32",
+          "type": "integer",
+          "description": "The number of cloud to module messages currently queued to be sent to the module.",
+          "readOnly": true
+        },
+        "authentication": {
+          "$ref": "#/definitions/AuthenticationMechanism",
+          "description": "The details on what authentication mechanisms are used by this module when connecting to the service and edgehub."
+        }
+      },
+      "required": [
+        "moduleId",
+        "deviceId"
+      ]
+    },
+    "CloudToDeviceMethodResult": {
+      "description": "Represents the Device Method Invocation Results.",
+      "type": "object",
+      "properties": {
+        "status": {
+          "format": "int32",
+          "description": "Method invocation result status.",
+          "type": "integer",
+          "readOnly": true
+        },
+        "payload": {
+          "description": "Method invocation result payload.",
+          "type": "object",
+          "readOnly": true
+        }
+      }
+    },
+    "DigitalTwinInterfacesPatch": {
+      "type": "object",
+      "properties": {
+        "interfaces": {
+          "description": "Interface(s) data to patch in the digital twin.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "properties": {
+                "description": "List of properties to update in an interface.",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "desired": {
+                      "type": "object",
+                      "description": "The desired property of the interface",
+                      "properties": {
+                        "value": {
+                          "description": "The desired value of the interface property to set in a digitalTwin.",
+                          "type": "object"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "api-version": {
+      "name": "api-version",
+      "in": "query",
+      "description": "Version of the Api.",
+      "required": true,
+      "type": "string",
+      "default": "2020-03-13"
+    }
+  }
+}

--- a/sdk/iot/Azure.Iot.Hub.Service/src/swagger/iothubservice_modified.json
+++ b/sdk/iot/Azure.Iot.Hub.Service/src/swagger/iothubservice_modified.json
@@ -11,7 +11,7 @@
   "paths": {
     "/configurations/{id}": {
       "get": {
-        "summary": "Retrieve a configuration for Iot Hub devices and modules by it identifier.",
+        "summary": "Retrieve a configuration for Iot Hub devices and modules by its identifier.",
         "description": "Get a configuration on IoT Hub for automatic device/module management.",
         "operationId": "Configuration_Get",
         "consumes": [],
@@ -362,7 +362,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Query result with continuation token if appropriate.",
+            "description": "Query result with continuation token, if applicable.",
             "schema": {
               "type": "array",
               "items": {


### PR DESCRIPTION
- Revert the swagger we use for code gen to be the swagger that is currently deployed

- Regenerate the PL based on the currently deployed swagger

- Add new swagger file that has all of our suggested edits.

This PR re-introduces some compile time errors since the swagger revert takes away some comments. As discussed earlier though, we never should have had a hand edited swagger being code gen'd from anyways