### PR TITLE
Reading TTL as the difference between absoluteexpirytime and creationtime

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Amqp/AmqpMessageConverter.cs
@@ -274,6 +274,12 @@ namespace Microsoft.Azure.ServiceBus.Amqp
                 {
                     sbMessage.ReplyToSessionId = amqpMessage.Properties.ReplyToGroupId;
                 }
+
+                if (amqpMessage.Properties.CreationTime.HasValue && amqpMessage.Properties.AbsoluteExpiryTime.HasValue)
+                {
+                    // Overwrite TimeToLive from AbsoluteExpiryTime
+                    sbMessage.TimeToLive = amqpMessage.Properties.AbsoluteExpiryTime.Value - amqpMessage.Properties.CreationTime.Value;
+                }
             }
 
             // Do application properties before message annotations, because the application properties

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Amqp/AmqpMessageConverter.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
 
             if (sbMessage.TimeToLive != TimeSpan.MaxValue)
             {
-                amqpMessage.Header.Ttl = (uint)sbMessage.TimeToLive.TotalMilliseconds;
+                amqpMessage.Header.Ttl = sbMessage.TimeToLive.TotalMilliseconds < UInt32.MaxValue ? (uint)sbMessage.TimeToLive.TotalMilliseconds : UInt32.MaxValue;
                 amqpMessage.Properties.CreationTime = DateTime.UtcNow;
 
                 if (AmqpConstants.MaxAbsoluteExpiryTime - amqpMessage.Properties.CreationTime.Value > sbMessage.TimeToLive)


### PR DESCRIPTION
TTL field in the message header is of type unsigned integer, so it cannot support TTL values
larger than 50 days when converted to milliseconds. So reading TTL as the difference between AbsoluteExpiryTime and CreationTime properties on the AMQP message.