### PR TITLE
Add Azure.Core.Experimental

### DIFF
--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -125,6 +125,7 @@ known_content_issues:
   - ['README.md','Root readme']
   - ['doc/README.md','Doc readme']
   - ['sdk/core/Azure.Core/README.md', '#5499']
+  - ['sdk/core/Azure.Core.Experimental/README.md', '#5499']
   - ['sdk/core/Microsoft.Extensions.Azure/README.md','#5499']
   - ['sdk/keyvault/Microsoft.Azure.KeyVault/README.md','#5499']
   - ['sdk/servicebus/Microsoft.Azure.ServiceBus/README.md','#5499']

--- a/sdk/core/Azure.Core.Experimental/README.md
+++ b/sdk/core/Azure.Core.Experimental/README.md
@@ -1,0 +1,3 @@
+# Azure Core Experimental shared client library for .NET
+
+Azure.Core.Experimental contains types that are being evaluated and might eventually become part of Azure.Core, this library would always stay in a preview version and might allow breaking changes.

--- a/sdk/core/Azure.Core.Experimental/src/Azure.Core.Experimental.csproj
+++ b/sdk/core/Azure.Core.Experimental/src/Azure.Core.Experimental.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>Experimental types that might eventually move to Azure.Core</Description>
+    <AssemblyTitle>Microsoft Azure Client Pipeline Experimental Extensions</AssemblyTitle>
+    <Version>0.1.0-preview.1</Version>
+    <PackageTags>Microsoft Azure Client Pipeline</PackageTags>
+    <Nullable>enable</Nullable>
+    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
+    <EnableApiCompat>false</EnableApiCompat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Core" />
+  </ItemGroup>
+
+</Project>

--- a/sdk/core/Azure.Core.Experimental/tests/Azure.Core.Experimental.Tests.csproj
+++ b/sdk/core/Azure.Core.Experimental/tests/Azure.Core.Experimental.Tests.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="nunit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(AzureCoreTestFramework)" />
+    <ProjectReference Include="..\src\Azure.Core.Experimental.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -48,5 +48,7 @@ stages:
     Artifacts:
     - name: Azure.Core
       safeName: AzureCore
+    - name: Azure.Core.Experimental
+      safeName: AzureCoreExperimental
     - name: Microsoft.Extensions.Azure
       safeName: MicrosoftExtensionsAzure


### PR DESCRIPTION
We are working on multiple experimental features for Azure.Core that would need to be evaluated by partner teams and don't align with Azure.Core shipping schedule.

Add a separate package where these features would go into before they move to Azure.Core and GA.