### PR TITLE
Make Search base classes non-instantiatable

### DIFF
--- a/sdk/search/Azure.Search.Documents/api/Azure.Search.Documents.netstandard2.0.cs
+++ b/sdk/search/Azure.Search.Documents/api/Azure.Search.Documents.netstandard2.0.cs
@@ -1378,7 +1378,7 @@ namespace Azure.Search.Documents.Indexes.Models
     }
     public partial class SimilarityAlgorithm
     {
-        public SimilarityAlgorithm() { }
+        internal SimilarityAlgorithm() { }
     }
     public partial class SimpleField : Azure.Search.Documents.Indexes.Models.SearchFieldTemplate
     {

--- a/sdk/search/Azure.Search.Documents/src/Generated/Models/SimilarityAlgorithm.cs
+++ b/sdk/search/Azure.Search.Documents/src/Generated/Models/SimilarityAlgorithm.cs
@@ -10,11 +10,6 @@ namespace Azure.Search.Documents.Indexes.Models
     /// <summary> Base type for similarity algorithms. Similarity algorithms are used to calculate scores that tie queries to documents. The higher the score, the more relevant the document is to that specific query. Those scores are used to rank the search results. </summary>
     public partial class SimilarityAlgorithm
     {
-        /// <summary> Initializes a new instance of SimilarityAlgorithm. </summary>
-        public SimilarityAlgorithm()
-        {
-            ODataType = null;
-        }
 
         /// <summary> Initializes a new instance of SimilarityAlgorithm. </summary>
         /// <param name="oDataType"> . </param>

--- a/sdk/search/Azure.Search.Documents/src/Indexes/Models/CharFilter.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/Models/CharFilter.cs
@@ -9,6 +9,7 @@ namespace Azure.Search.Documents.Indexes.Models
     {
         /// <summary> Initializes a new instance of CharFilter. </summary>
         /// <param name="name"> The name of the char filter. It must only contain letters, digits, spaces, dashes or underscores, can only start and end with alphanumeric characters, and is limited to 128 characters. </param>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> is null.</exception>
         private protected CharFilter(string name)
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));

--- a/sdk/search/Azure.Search.Documents/src/Indexes/Models/CognitiveServicesAccount.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/Models/CognitiveServicesAccount.cs
@@ -5,6 +5,7 @@ namespace Azure.Search.Documents.Indexes.Models
 {
     public partial class CognitiveServicesAccount
     {
+        /// <summary> Initializes a new instance of CognitiveServicesAccount. </summary>
         private protected CognitiveServicesAccount()
         {
         }

--- a/sdk/search/Azure.Search.Documents/src/Indexes/Models/DataChangeDetectionPolicy.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/Models/DataChangeDetectionPolicy.cs
@@ -5,6 +5,7 @@ namespace Azure.Search.Documents.Indexes.Models
 {
     public partial class DataChangeDetectionPolicy
     {
+        /// <summary> Initializes a new instance of DataChangeDetectionPolicy. </summary>
         private protected DataChangeDetectionPolicy()
         {
         }

--- a/sdk/search/Azure.Search.Documents/src/Indexes/Models/DataDeletionDetectionPolicy.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/Models/DataDeletionDetectionPolicy.cs
@@ -5,6 +5,7 @@ namespace Azure.Search.Documents.Indexes.Models
 {
     public partial class DataDeletionDetectionPolicy
     {
+        /// <summary> Initializes a new instance of DataDeletionDetectionPolicy. </summary>
         private protected DataDeletionDetectionPolicy()
         {
         }

--- a/sdk/search/Azure.Search.Documents/src/Indexes/Models/LexicalAnalyzer.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/Models/LexicalAnalyzer.cs
@@ -9,6 +9,7 @@ namespace Azure.Search.Documents.Indexes.Models
     {
         /// <summary> Initializes a new instance of LexicalAnalyzer. </summary>
         /// <param name="name"> The name of the analyzer. It must only contain letters, digits, spaces, dashes or underscores, can only start and end with alphanumeric characters, and is limited to 128 characters. </param>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> is null.</exception>
         private protected LexicalAnalyzer(string name)
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));

--- a/sdk/search/Azure.Search.Documents/src/Indexes/Models/LexicalTokenizer.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/Models/LexicalTokenizer.cs
@@ -9,6 +9,7 @@ namespace Azure.Search.Documents.Indexes.Models
     {
         /// <summary> Initializes a new instance of LexicalTokenizer. </summary>
         /// <param name="name"> The name of the tokenizer. It must only contain letters, digits, spaces, dashes or underscores, can only start and end with alphanumeric characters, and is limited to 128 characters. </param>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> is null.</exception>
         private protected LexicalTokenizer(string name)
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));

--- a/sdk/search/Azure.Search.Documents/src/Indexes/Models/ScoringFunction.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/Models/ScoringFunction.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Core;
+using System;
 
 namespace Azure.Search.Documents.Indexes.Models
 {
@@ -12,11 +12,10 @@ namespace Azure.Search.Documents.Indexes.Models
         /// </summary>
         /// <param name="fieldName">The name of the field used as input to the scoring function.</param>
         /// <param name="boost">A multiplier for the raw score. Must be a positive number not equal to 1.0.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="fieldName"/> is null.</exception>
         private protected ScoringFunction(string fieldName, double boost)
         {
-            Argument.AssertNotNullOrEmpty(fieldName, nameof(fieldName));
-
-            FieldName = fieldName;
+            FieldName = fieldName ?? throw new ArgumentNullException(nameof(fieldName));
             Boost = boost;
         }
     }

--- a/sdk/search/Azure.Search.Documents/src/Indexes/Models/SearchIndexerSkill.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/Models/SearchIndexerSkill.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Azure.Core;
@@ -12,6 +13,7 @@ namespace Azure.Search.Documents.Indexes.Models
         /// <summary> Initializes a new instance of SearchIndexerSkill. </summary>
         /// <param name="inputs"> Inputs of the skills could be a column in the source data set, or the output of an upstream skill. </param>
         /// <param name="outputs"> The output of a skill is either a field in a search index, or a value that can be consumed as an input by another skill. </param>
+        /// <exception cref="ArgumentNullException"><paramref name="inputs"/> or <paramref name="outputs"/> is null.</exception>
         private protected SearchIndexerSkill(IEnumerable<InputFieldMappingEntry> inputs, IEnumerable<OutputFieldMappingEntry> outputs)
         {
             Argument.AssertNotNull(inputs, nameof(inputs));

--- a/sdk/search/Azure.Search.Documents/src/Indexes/Models/SimilarityAlgorithm.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/Models/SimilarityAlgorithm.cs
@@ -8,5 +8,9 @@ namespace Azure.Search.Documents.Indexes.Models
     [CodeGenModel("Similarity")]
     public partial class SimilarityAlgorithm
     {
+        /// <summary> Initializes a new instance of SimilarityAlgorithm. </summary>
+        private protected SimilarityAlgorithm()
+        {
+        }
     }
 }

--- a/sdk/search/Azure.Search.Documents/src/Indexes/Models/TokenFilter.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/Models/TokenFilter.cs
@@ -9,6 +9,7 @@ namespace Azure.Search.Documents.Indexes.Models
     {
         /// <summary> Initializes a new instance of TokenFilter. </summary>
         /// <param name="name"> The name of the token filter. It must only contain letters, digits, spaces, dashes or underscores, can only start and end with alphanumeric characters, and is limited to 128 characters. </param>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> is null.</exception>
         private protected TokenFilter(string name)
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));


### PR DESCRIPTION
Resolves #9686 without making the classes abstract, given that a fix for Azure/autorest.csharp#650 is further out.