### PR TITLE
exposed internal constructor of RetryExponential

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/RetryExponential.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/RetryExponential.cs
@@ -23,11 +23,17 @@ namespace Microsoft.Azure.ServiceBus
         {
         }
 
-        internal RetryExponential(TimeSpan minBackoff, TimeSpan maxBackoff, TimeSpan deltaBackoff, int maxRetryCount)
+        /// <summary>
+        /// Returns a new RetryExponential retry policy object.
+        /// </summary>
+        /// <param name="minimumBackoff">Minimum backoff interval.</param>
+        /// <param name="maximumBackoff">Maximum backoff interval.</param>
+        /// <param name="deltaBackoff">Delta backoff interval.</param>
+        public RetryExponential(TimeSpan minimumBackoff, TimeSpan maximumBackoff, TimeSpan deltaBackoff, int maxRetryCount)
         {
             TimeoutHelper.ThrowIfNonPositiveArgument(deltaBackoff, nameof(deltaBackoff));
-            TimeoutHelper.ThrowIfNegativeArgument(minBackoff, nameof(minBackoff));
-            TimeoutHelper.ThrowIfNonPositiveArgument(maxBackoff, nameof(maxBackoff));
+            TimeoutHelper.ThrowIfNegativeArgument(minimumBackoff, nameof(minimumBackoff));
+            TimeoutHelper.ThrowIfNonPositiveArgument(maximumBackoff, nameof(maximumBackoff));
 
             if (maxRetryCount <= 0)
             {
@@ -36,13 +42,13 @@ namespace Microsoft.Azure.ServiceBus
                     Resources.ArgumentMustBePositive.FormatForUser(nameof(maxRetryCount)));
             }
 
-            if (minBackoff >= maxBackoff)
+            if (minimumBackoff >= maximumBackoff)
             {
-                throw new ArgumentException(Resources.ExponentialRetryBackoffRange.FormatForUser(minBackoff, maxBackoff));
+                throw new ArgumentException(Resources.ExponentialRetryBackoffRange.FormatForUser(minimumBackoff, maximumBackoff));
             }
 
-            this.MinimalBackoff = minBackoff;
-            this.MaximumBackoff = maxBackoff;
+            this.MinimalBackoff = minimumBackoff;
+            this.MaximumBackoff = maximumBackoff;
             this.DeltaBackoff = deltaBackoff;
             this.MaxRetryCount = maxRetryCount;
         }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -256,7 +256,7 @@ namespace Microsoft.Azure.ServiceBus
     public sealed class RetryExponential : Microsoft.Azure.ServiceBus.RetryPolicy
     {
         public RetryExponential(System.TimeSpan minimumBackoff, System.TimeSpan maximumBackoff, int maximumRetryCount) { }
-        public RetryExponential(TimeSpan minimumBackoff, TimeSpan maximumBackoff, TimeSpan deltaBackoff, int maxRetryCount) { }
+        public RetryExponential(System.TimeSpan minimumBackoff, System.TimeSpan maximumBackoff, System.TimeSpan deltaBackoff, int maxRetryCount) { }
         public System.TimeSpan DeltaBackoff { get; }
         public int MaxRetryCount { get; }
         public System.TimeSpan MaximumBackoff { get; }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -256,6 +256,7 @@ namespace Microsoft.Azure.ServiceBus
     public sealed class RetryExponential : Microsoft.Azure.ServiceBus.RetryPolicy
     {
         public RetryExponential(System.TimeSpan minimumBackoff, System.TimeSpan maximumBackoff, int maximumRetryCount) { }
+        public RetryExponential(TimeSpan minimumBackoff, TimeSpan maximumBackoff, TimeSpan deltaBackoff, int maxRetryCount) { }
         public System.TimeSpan DeltaBackoff { get; }
         public int MaxRetryCount { get; }
         public System.TimeSpan MaximumBackoff { get; }


### PR DESCRIPTION
Expose the internal constructor of the `RetryExponential` class in order to allow for the configuration of the `DeltaBackoff` property.

I've renamed the constructor arguments to be consistent with the existing public constructor and I've added xml doc comments