### PR TITLE
BlobCheckpointStore event source bug

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobEventStoreEventSource.cs
@@ -43,16 +43,18 @@ namespace Azure.Messaging.EventHubs.Processor.Diagnostics
         ///   Indicates that a <see cref="BlobsCheckpointStore" /> was created.
         /// </summary>
         ///
+        /// <param name="typeName">The type name for the checkpoint store.</param>
         /// <param name="accountName">The Storage account name corresponding to the associated container client.</param>
         /// <param name="containerName">The name of the associated container client.</param>
         ///
         [Event(20, Level = EventLevel.Verbose, Message = "{0} created. AccountName: '{1}'; ContainerName: '{2}'.")]
-        public virtual void BlobsCheckpointStoreCreated(string accountName,
+        public virtual void BlobsCheckpointStoreCreated(string typeName,
+                                                        string accountName,
                                                         string containerName)
         {
             if (IsEnabled())
             {
-                WriteEvent(20, nameof(BlobsCheckpointStore), accountName ?? string.Empty, containerName ?? string.Empty);
+                WriteEvent(20, typeName, accountName ?? string.Empty, containerName ?? string.Empty);
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Storage/BlobsCheckpointStore.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Storage/BlobsCheckpointStore.cs
@@ -73,7 +73,7 @@ namespace Azure.Messaging.EventHubs.Processor
 
             ContainerClient = blobContainerClient;
             RetryPolicy = retryPolicy;
-            Logger.BlobsCheckpointStoreCreated(blobContainerClient.AccountName, blobContainerClient.Name);
+            Logger.BlobsCheckpointStoreCreated(nameof(BlobsCheckpointStore), blobContainerClient.AccountName, blobContainerClient.Name);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes an issue where the number of arguments passed to the WriteEvent call did not match the number of parameters on the Event method. This results in this silent error: 

> EventSource Error: Event 20 was called with 3 argument(s), but it is defined with 2 parameter(s).

The runtime error is caused by the mismatch in the number of arguments in the Message string:
> EventSource Error: ERROR: Exception during EventSource.OnEventWritten: Index (zero based) must be greater than or equal to zero and less than the size of the argument list.
> Exception thrown: 'System.Diagnostics.Tracing.EventSourceException' in System.Private.CoreLib.dll

I noticed this when trying to update the LineCounter app to the latest release of EH.