### PR TITLE
[FormRecognizer] Whitelist redacted headers for logging

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - `FormRecognizerClient` and `FormTrainingClient` support authentication with Azure Active Directory.
 - Support to copy a custom model from one Form Recognizer resource to another.
+- Headers that were marked as `REDACTED` in error messages and logs are now exposed by default.
 
 ### Fixes
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClientOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClientOptions.cs
@@ -22,6 +22,7 @@ namespace Azure.AI.FormRecognizer
         public FormRecognizerClientOptions(ServiceVersion version = LatestVersion)
         {
             Version = version;
+            AddLoggedHeaders();
         }
 
         /// <summary>
@@ -49,6 +50,20 @@ namespace Azure.AI.FormRecognizer
                 ServiceVersion.V2_0_Preview => "v2.0-preview",
                 _ => throw new NotSupportedException($"The service version {version} is not supported."),
             };
+        }
+
+        /// <summary>
+        /// Add headers that are considered safe for logging or including in error messages
+        /// by default.
+        /// </summary>
+        private void AddLoggedHeaders()
+        {
+            Diagnostics.LoggedHeaderNames.Add("apim-request-id");
+            Diagnostics.LoggedHeaderNames.Add("Location");
+            Diagnostics.LoggedHeaderNames.Add("Operation-Location");
+            Diagnostics.LoggedHeaderNames.Add("Strict-Transport-Security");
+            Diagnostics.LoggedHeaderNames.Add("X-Content-Type-Options");
+            Diagnostics.LoggedHeaderNames.Add("x-envoy-upstream-service-time");
         }
     }
 }


### PR DESCRIPTION
Fixes #11660.

Headers descriptions, grabbed from the internet and from internal sources:

- **x-envoy-upstream-service-time:** contains the time in milliseconds spent by the upstream host processing the request.
- **apim-request-id:** GUID request Id generated from APIM side.
- **Strict-Transport-Security:** lets a web site tell user agents that it should only be accessed using HTTPS, instead of using HTTP.
- **X-Content-Type-Options:** a marker used by the server to indicate that the MIME types advertised in the Content-Type headers should not be changed and be followed.

**Location** and **Operation-Location** headers expose the endpoint, which means resource names are exposed as well. Resource names are not considered PII and are safe to log.

EDIT: PR for adding query parameters [here](https://github.com/Azure/azure-sdk-for-net/pull/12344).