### PR TITLE
[FormRecognizer] Whitelist redacted query parameters for logging

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 - `FormRecognizerClient` and `FormTrainingClient` support authentication with Azure Active Directory.
 - Support to copy a custom model from one Form Recognizer resource to another.
-- Headers that were marked as `REDACTED` in error messages and logs are now exposed by default.
+- Headers and query parameters that were marked as `REDACTED` in error messages and logs are now exposed by default.
 
 ### Fixes
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClientOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClientOptions.cs
@@ -22,7 +22,7 @@ namespace Azure.AI.FormRecognizer
         public FormRecognizerClientOptions(ServiceVersion version = LatestVersion)
         {
             Version = version;
-            AddLoggedHeaders();
+            AddLoggedHeadersAndQueryParameters();
         }
 
         /// <summary>
@@ -53,10 +53,10 @@ namespace Azure.AI.FormRecognizer
         }
 
         /// <summary>
-        /// Add headers that are considered safe for logging or including in error messages
-        /// by default.
+        /// Add headers and query parameters that are considered safe for logging or including in
+        /// error messages by default.
         /// </summary>
-        private void AddLoggedHeaders()
+        private void AddLoggedHeadersAndQueryParameters()
         {
             Diagnostics.LoggedHeaderNames.Add("apim-request-id");
             Diagnostics.LoggedHeaderNames.Add("Location");
@@ -64,6 +64,10 @@ namespace Azure.AI.FormRecognizer
             Diagnostics.LoggedHeaderNames.Add("Strict-Transport-Security");
             Diagnostics.LoggedHeaderNames.Add("X-Content-Type-Options");
             Diagnostics.LoggedHeaderNames.Add("x-envoy-upstream-service-time");
+
+            Diagnostics.LoggedQueryParameters.Add("includeKeys");
+            Diagnostics.LoggedQueryParameters.Add("includeTextDetails");
+            Diagnostics.LoggedQueryParameters.Add("op");
         }
     }
 }


### PR DESCRIPTION
Missing changes that were not included in #12285, as pointed out [here](https://github.com/Azure/azure-sdk-for-js/pull/9149#issuecomment-635157497).

The query parameters being exposed can only assume a discrete amount of values (true, false, "summary" and "full"), and won't include information that's unsafe to log.