### PR TITLE
[FormRecognizer] Fix: failing live test (wrong form)

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample2_RecognizeReceiptsFromUri.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/samples/Sample2_RecognizeReceiptsFromUri.cs
@@ -21,7 +21,7 @@ namespace Azure.AI.FormRecognizer.Samples
 
             FormRecognizerClient client = new FormRecognizerClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
-            string receiptUri = FormRecognizerTestEnvironment.CreateUriString("contoso-allinone.png");
+            string receiptUri = FormRecognizerTestEnvironment.CreateUriString("contoso-receipt.jpg");
 
             #region Snippet:FormRecognizerSampleRecognizeReceiptFileFromUri
             RecognizedReceiptCollection receipts = await client.StartRecognizeReceiptsFromUri(new Uri(receiptUri)).WaitForCompletionAsync();


### PR DESCRIPTION
Fixing a [test failure](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=404621&view=logs&j=ad07b744-5a1a-5d54-7693-fcb02e666633&t=88540a4e-0b51-541f-e623-7b2636eab300) that was introduced in one of the PRs merged yesterday. The file used in a sample was accidentally changed.